### PR TITLE
Create the AST type definitions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ name = "hash"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "num",
 ]
 
 [[package]]
@@ -107,6 +108,82 @@ name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash"
 version = "0.1.0"
-authors = ["Alex <alexander.fedotov.uk@gmail.com>"]
+authors = ["The Hash Language authors"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 clap = "3.0.0-beta.2"
+num = "0.4"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+//! Frontent-agnostic Hash abstract syntax tree type definitions.
 #![allow(dead_code)]
 
 use crate::modules::ModuleIdx;
@@ -18,12 +19,14 @@ pub struct AstNode<T> {
     pub module: ModuleIdx,
 }
 
+/// [AstNode] hashes as its inner `body` type.
 impl<T: Hash> Hash for AstNode<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.body.hash(state);
     }
 }
 
+/// [AstNode] dereferences to its inner `body` type.
 impl<T> Deref for AstNode<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -31,28 +34,28 @@ impl<T> Deref for AstNode<T> {
     }
 }
 
-/// Node for an intrinsic identifier.
+/// An intrinsic identifier.
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub struct IntrinsicKey {
     /// The name of the intrinsic (without the "#").
     pub name: &'static str,
 }
 
-/// Node for a single name/symbol.
+/// A single name/symbol.
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub struct Name {
     // The name of the symbol.
     pub string: &'static str,
 }
 
-/// Node for a namespaced name, i.e.. access name.
+/// A namespaced name, i.e. access name.
 #[derive(Debug, Clone)]
 pub struct AccessName {
     /// The list of names that make up the access name.
     pub names: Vec<AstNode<Name>>,
 }
 
-/// Node for a concrete/"named" type.
+/// A concrete/"named" type.
 #[derive(Debug, Clone)]
 pub struct NamedType {
     /// The name of the type.
@@ -61,14 +64,14 @@ pub struct NamedType {
     pub type_args: Vec<AstNode<Type>>,
 }
 
-/// Node for a type variable.
+/// A type variable.
 #[derive(Debug, Clone)]
 pub struct TypeVar {
     /// The name of the type variable.
     pub name: AstNode<Name>,
 }
 
-/// Node for a type.
+/// A type.
 #[derive(Debug, Clone)]
 pub enum Type {
     /// A concrete/"named" type.
@@ -81,35 +84,35 @@ pub enum Type {
     Infer,
 }
 
-/// Node for a set literal, e.g. `{1, 2, 3}`.
+/// A set literal, e.g. `{1, 2, 3}`.
 #[derive(Debug, Clone)]
 pub struct SetLiteral {
     /// The elements of the set literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a list literal, e.g. `[1, 2, 3]`.
+/// A list literal, e.g. `[1, 2, 3]`.
 #[derive(Debug, Clone)]
 pub struct ListLiteral {
     /// The elements of the list literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a tuple literal, e.g. `(1, 'A', "foo")`.
+/// A tuple literal, e.g. `(1, 'A', "foo")`.
 #[derive(Debug, Clone)]
 pub struct TupleLiteral {
     /// The elements of the tuple literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a map literal, e.g. `{"foo": 1, "bar": 2}`.
+/// A map literal, e.g. `{"foo": 1, "bar": 2}`.
 #[derive(Debug, Clone)]
 pub struct MapLiteral {
     /// The elements of the map literal (key-value pairs).
     pub elements: Vec<(AstNode<Expression>, AstNode<Expression>)>,
 }
 
-/// Node for a struct literal entry (struct field in struct literal), e.g. `name = "Nani"`.
+/// A struct literal entry (struct field in struct literal), e.g. `name = "Nani"`.
 #[derive(Debug, Clone)]
 pub struct StructLiteralEntry {
     /// The name of the struct field.
@@ -118,7 +121,7 @@ pub struct StructLiteralEntry {
     pub value: AstNode<Expression>,
 }
 
-/// Node for a struct literal, e.g. `Dog { name = "Adam", age = 12 }`
+/// A struct literal, e.g. `Dog { name = "Adam", age = 12 }`
 #[derive(Debug, Clone)]
 pub struct StructLiteral {
     /// The name of the struct literal.
@@ -129,7 +132,7 @@ pub struct StructLiteral {
     pub entries: Vec<AstNode<StructLiteralEntry>>,
 }
 
-/// Node for a function definition argument.
+/// A function definition argument.
 #[derive(Debug, Clone)]
 pub struct FunctionDefArg {
     /// The name of the argument.
@@ -140,7 +143,7 @@ pub struct FunctionDefArg {
     pub ty: Option<AstNode<Type>>,
 }
 
-/// Node for a function definition.
+/// A function definition.
 #[derive(Debug, Clone)]
 pub struct FunctionDef {
     /// The arguments of the function definition.
@@ -153,7 +156,7 @@ pub struct FunctionDef {
     pub fn_body: AstNode<Expression>,
 }
 
-/// Node for a literal.
+/// A literal.
 #[derive(Debug, Clone)]
 pub enum Literal {
     /// A string literal.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,4 @@
-//! Frontent-agnostic Hash abstract syntax tree type definitions.
+//! Frontend-agnostic Hash abstract syntax tree type definitions.
 #![allow(dead_code)]
 
 use crate::modules::ModuleIdx;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,11 +1,9 @@
 #![allow(dead_code)]
 
+use crate::modules::ModuleIdx;
+use num::BigInt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-
-use num::BigInt;
-
-use crate::modules::ModuleIdx;
 
 /// Represents an abstract syntax tree node.
 ///
@@ -16,7 +14,7 @@ pub struct AstNode<T> {
     pub body: Box<T>,
     /// Position of the node in the input.
     pub pos: (usize, usize),
-    /// Module that this node is part of. Index into `Modules`.
+    /// Module that this node is part of. Index into [`Modules`](crate::modules::Modules).
     pub module: ModuleIdx,
 }
 
@@ -108,7 +106,7 @@ pub struct TupleLiteral {
 #[derive(Debug, Clone)]
 pub struct MapLiteral {
     /// The elements of the map literal (key-value pairs).
-    pub elements: Vec<AstNode<(Expression, Expression)>>,
+    pub elements: Vec<(AstNode<Expression>, AstNode<Expression>)>,
 }
 
 /// Node for a struct literal entry (struct field in struct literal), e.g. `name = "Nani"`.
@@ -138,7 +136,7 @@ pub struct FunctionDefArg {
     pub name: AstNode<Name>,
     /// The type of the argument, if any.
     ///
-    /// Will be inferred if `None`.
+    /// Will be inferred if [None].
     pub ty: Option<AstNode<Type>>,
 }
 
@@ -149,235 +147,398 @@ pub struct FunctionDef {
     pub args: Vec<AstNode<FunctionDefArg>>,
     /// The return type of the function definition.
     ///
-    /// Will be inferred if `None`.
+    /// Will be inferred if [None].
     pub return_ty: Option<AstNode<Type>>,
+    /// The body/contents of the function, in the form of an expression.
     pub fn_body: AstNode<Expression>,
 }
 
+/// Node for a literal.
 #[derive(Debug, Clone)]
 pub enum Literal {
+    /// A string literal.
     Str(String),
+    /// A character literal.
     Char(char),
+    /// An integer literal.
     Int(BigInt),
+    /// A float literal.
     Float(f64),
+    /// A set literal.
     Set(SetLiteral),
+    /// A map literal.
     Map(MapLiteral),
+    /// A list literal.
     List(ListLiteral),
+    /// A tuple literal.
     Tuple(TupleLiteral),
+    /// A struct literal.
     Struct(StructLiteral),
+    /// A function definition.
     Function(FunctionDef),
 }
 
+/// An alternative pattern, e.g. `Red | Blue`.
 #[derive(Debug, Clone)]
 pub struct OrPattern {
+    /// The first pattern in the "or".
     pub a: AstNode<Pattern>,
+    /// The second pattern in the "or".
     pub b: AstNode<Pattern>,
 }
 
+/// A conditional pattern, e.g. `x if x == 42`.
 #[derive(Debug, Clone)]
 pub struct IfPattern {
+    /// The pattern part of the conditional.
     pub pattern: AstNode<Pattern>,
+    /// The expression part of the conditional.
     pub condition: AstNode<Expression>,
 }
 
+/// An enum pattern, e.g. `Some((x, y))`.
 #[derive(Debug, Clone)]
 pub struct EnumPattern {
+    /// The name of the enum variant.
     pub name: AstNode<AccessName>,
-    pub variants: Vec<AstNode<Pattern>>,
+    /// The arguments of the enum variant as patterns.
+    pub args: Vec<AstNode<Pattern>>,
 }
 
+/// A pattern destructuring, e.g. `name: (fst, snd)`.
+///
+/// Used in struct and namespace patterns.
 #[derive(Debug, Clone)]
 pub struct DestructuringPattern {
+    /// The name of the field.
     pub name: AstNode<Name>,
+    /// The pattern to match the field's value with.
     pub patterns: AstNode<Pattern>,
 }
 
+/// A struct pattern, e.g. `Dog { name = "Frank"; age; }`
 #[derive(Debug, Clone)]
 pub struct StructPattern {
+    /// The name of the struct.
     pub name: AstNode<AccessName>,
+    /// The entries of the struct, as [DestructuringPattern] entries.
     pub entries: Vec<AstNode<DestructuringPattern>>,
 }
 
+/// A namespace pattern, e.g. `{ fgets; fputs; }`
 #[derive(Debug, Clone)]
 pub struct NamespacePattern {
+    /// The entries of the namespace, as [DestructuringPattern] entries.
     pub patterns: Vec<AstNode<DestructuringPattern>>,
 }
 
+/// A tuple pattern, e.g. `(1, 2, x)`
 #[derive(Debug, Clone)]
 pub struct TuplePattern {
+    /// The element of the tuple, as patterns.
     pub elements: Vec<AstNode<Pattern>>,
 }
 
+/// A literal pattern, e.g. `1`, `3.4`, `"foo"`.
 #[derive(Debug, Clone)]
 pub enum LiteralPattern {
+    /// A string literal pattern.
     Str(String),
+    /// A character literal pattern.
     Char(char),
+    /// An integer literal pattern.
     Int(BigInt),
+    /// A float literal pattern.
     Float(f64),
-    Tuple(TuplePattern),
 }
 
+/// A pattern. e.g. `Ok(Dog {props = (1, x)})`.
 #[derive(Debug, Clone)]
 pub enum Pattern {
+    /// An enum pattern.
     Enum(EnumPattern),
+    /// A struct pattern.
     Struct(StructPattern),
+    /// A namespace pattern.
     Namespace(NamespacePattern),
+    /// A tuple pattern.
     Tuple(TuplePattern),
+    /// A literal pattern.
     Literal(LiteralPattern),
+    /// An alternative/"or" pattern.
     Or(OrPattern),
+    /// A conditional/"if" pattern.
     If(IfPattern),
+    /// A pattern name binding.
     Binding(AstNode<Name>),
+    /// The catch-all, i.e "ignore" pattern.
     Ignore,
 }
 
+/// A trait bound, e.g. "where eq<T>"
 #[derive(Debug, Clone)]
 pub struct TraitBound {
+    /// The name of the trait.
     pub name: AstNode<AccessName>,
+    /// The type arguments of the trait.
     pub type_args: Vec<AstNode<Type>>,
 }
 
+/// A bound, e.g. "<T, U> where conv<U, T>".
+///
+/// Used in struct, enum, trait definitions.
 #[derive(Debug, Clone)]
 pub struct Bound {
+    /// The type arguments of the bound.
     pub type_args: Vec<AstNode<Type>>,
+    /// The traits that constrain the bound, if any.
     pub trait_bounds: Vec<AstNode<TraitBound>>,
 }
 
+/// A let statement, e.g. `let x = 3;`.
 #[derive(Debug, Clone)]
 pub struct LetStatement {
+    /// The pattern to bind the right-hand side to.
     pub pattern: AstNode<Pattern>,
+    /// The bound of the let, if any.
+    ///
+    /// Used for trait implementations.
     pub bound: Option<AstNode<Bound>>,
 }
 
+/// An assign statement, e.g. `x = 4;`.
 #[derive(Debug, Clone)]
 pub struct AssignStatement {
+    /// The left-hand side of the assignment.
+    ///
+    /// This should resolve to either a variable or a struct field.
     pub lhs: AstNode<Expression>,
+    /// The right-hand side of the assignment.
+    ///
+    /// The value will be assigned to the left-hand side.
     pub rhs: AstNode<Expression>,
 }
 
+/// A field of a struct definition, e.g. "name: str".
 #[derive(Debug, Clone)]
 pub struct StructDefEntry {
+    /// The name of the struct field.
     pub name: AstNode<Name>,
+    /// The type of the struct field.
+    ///
+    /// Will be inferred if [None].
     pub ty: Option<AstNode<Type>>,
+    /// The default value of the struct field, if any.
     pub default: Option<AstNode<Expression>>,
 }
 
+/// A struct definition, e.g. `struct Foo = { bar: int; };`.
 #[derive(Debug, Clone)]
 pub struct StructDef {
+    /// The name of the struct.
     pub name: AstNode<Name>,
+    /// The bound of the struct.
     pub bound: AstNode<Bound>,
+    /// The fields of the struct, in the form of [StructDefEntry].
     pub entries: Vec<AstNode<StructDefEntry>>,
 }
 
+/// A variant of an enum definition, e.g. `Some(T)`.
 #[derive(Debug, Clone)]
 pub struct EnumDefEntry {
+    /// The name of the enum variant.
     pub name: AstNode<Name>,
+    /// The arguments of the enum variant, if any.
     pub args: Vec<AstNode<Type>>,
 }
 
+/// An enum definition, e.g. `enum Option = <T> => { Some(T); None; };`.
 #[derive(Debug, Clone)]
 pub struct EnumDef {
+    /// The name of the enum.
     pub name: AstNode<Name>,
+    /// The bounds of the enum.
     pub bound: AstNode<Bound>,
+    /// The variants of the enum, in the form of [EnumDefEntry].
     pub entries: Vec<AstNode<EnumDefEntry>>,
 }
 
+/// A trait definition, e.g. `trait add = <T> => (T, T) => T;`.
 #[derive(Debug, Clone)]
 pub struct TraitDef {
+    /// The name of the trait.
     pub name: AstNode<Name>,
+    /// The bound of the trait.
     pub bound: AstNode<Bound>,
+    /// The inner type of the trait. Expected to be a `Function` type.
     pub trait_type: AstNode<Type>,
 }
 
+/// A statement.
 #[derive(Debug, Clone)]
 pub enum Statement {
+    /// An expression statement, e.g. `my_func();`
     Expr(AstNode<Expression>),
+    /// An return statement.
+    ///
+    /// Has an optional return expression, which becomes `void` if [None] is given.
     Return(Option<AstNode<Expression>>),
+    /// A block statement.
     Block(AstNode<Block>),
+    /// Break statement (only in loop context).
     Break,
+    /// Continue statement (only in loop context).
     Continue,
+    /// A let statement.
     Let(LetStatement),
+    /// An assign statement.
     Assign(AssignStatement),
+    /// A struct definition.
     StructDef(StructDef),
+    /// An enum definition.
     EnumDef(EnumDef),
+    /// A trait definition.
     TraitDef(TraitDef),
 }
 
+/// A branch/"case" of a `match` block.
 #[derive(Debug, Clone)]
 pub struct MatchCase {
+    /// The pattern of the `match` case.
     pub pattern: AstNode<Pattern>,
+    /// The expression corresponding to the match case.
+    ///
+    /// Will be executed if the pattern succeeeds.
     pub expr: AstNode<Expression>,
 }
 
+/// A `match` block.
 #[derive(Debug, Clone)]
 pub struct MatchBlock {
+    /// The expression to match on.
     pub subject: AstNode<Expression>,
+    /// The match cases to execute.
     pub cases: Vec<AstNode<MatchCase>>,
 }
 
+/// A body block.
 #[derive(Debug, Clone)]
 pub struct BodyBlock {
+    /// Zero or more statements.
     pub statements: Vec<AstNode<Statement>>,
+    /// Zero or one expression.
     pub expr: Option<AstNode<Expression>>,
 }
 
+/// A block.
 #[derive(Debug, Clone)]
 pub enum Block {
+    /// A match block.
     Match(MatchBlock),
+    /// A loop block.
+    ///
+    /// The inner block is the loop body.
     Loop(AstNode<Block>),
+    /// A body block.
     Body(BodyBlock),
 }
 
+/// Function call arguments.
 #[derive(Debug, Clone)]
 pub struct FunctionCallArgs {
+    /// Each argument of the function call, as an expression.
     pub entries: Vec<AstNode<Expression>>,
 }
 
+/// A function call expression.
 #[derive(Debug, Clone)]
 pub struct FunctionCallExpr {
+    /// An expression which evaluates to a function value.
     pub subject: AstNode<Expression>,
+    /// Arguments to the function, in the form of [FunctionCallArgs].
     pub args: AstNode<FunctionCallArgs>,
 }
 
+/// A logical operator.
+///
+/// These are treated differently from all other operators due to short-circuiting.
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+pub enum LogicalOp {
+    /// The logical-and operator.
+    And,
+    /// The logical-or operator.
+    Or,
+}
+
+/// A logical operation expression.
 #[derive(Debug, Clone)]
 pub struct LogicalOpExpr {
+    /// The operator of the logical operation.
+    pub op: AstNode<LogicalOp>,
+    /// The left-hand side of the operation.
     pub lhs: AstNode<Expression>,
+    /// The right-hand side of the operation.
     pub rhs: AstNode<Expression>,
 }
 
+/// A property access exprssion.
 #[derive(Debug, Clone)]
 pub struct PropertyAccessExpr {
+    /// An expression which evaluates to a struct or tuple value.
     pub subject: AstNode<Expression>,
+    /// The property of the subject to access.
     pub property: AstNode<Name>,
 }
 
+/// A typed expression, e.g. `foo as int`.
 #[derive(Debug, Clone)]
 pub struct TypedExpr {
+    /// The annotated type of the expression.
     pub ty: AstNode<Type>,
+    /// The expression being typed.
     pub expr: AstNode<Expression>,
 }
 
+/// Represents a path to a module, given as a string literal to an `import` call.
 type ImportPath = String;
 
+/// A variable expression.
 #[derive(Debug, Clone)]
 pub struct VariableExpr {
+    /// The name of the variable.
     pub name: AstNode<AccessName>,
+    /// Any type arguments of the variable. Only valid for traits.
     pub type_args: Vec<AstNode<Type>>,
 }
 
+/// An expression.
 #[derive(Debug, Clone)]
 pub enum Expression {
+    /// A function call.
     FunctionCall(FunctionCallExpr),
+    /// An intrinsic symbol.
     Intrinsic(IntrinsicKey),
+    /// A logical operation.
     LogicalOp(LogicalOpExpr),
+    /// A variable.
     Variable(VariableExpr),
+    /// A property access.
     PropertyAccess(PropertyAccessExpr),
+    /// A literal.
     LiteralExpr(Literal),
+    /// A typed expression.
     Typed(TypedExpr),
+    /// A block.
     Block(AstNode<Block>),
+    /// An `import` call.
     Import(AstNode<ImportPath>),
 }
 
+/// A module.
+///
+/// Represents a parsed `.hash` file.
 #[derive(Debug, Clone)]
 pub struct Module {
+    /// The contents of the module, as a list of statements.
     pub contents: Vec<AstNode<Statement>>,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,10 +7,16 @@ use num::BigInt;
 
 use crate::modules::ModuleIdx;
 
+/// Represents an abstract syntax tree node.
+///
+/// Contains an inner type, as well as begin and end positions in the input.
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct AstNode<T> {
+    /// The actual value contained within this node.
     pub body: Box<T>,
-    pub pos: (u32, u32),
+    /// Position of the node in the input.
+    pub pos: (usize, usize),
+    /// Module that this node is part of. Index into `Modules`.
     pub module: ModuleIdx,
 }
 
@@ -31,77 +37,101 @@ impl<T> Deref for AstNode<T> {
     }
 }
 
+/// Node for an intrinsic identifier.
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub struct IntrinsicKey {
+    /// The name of the intrinsic (without the "#").
     pub name: &'static str,
 }
 
+/// Node for a single name/symbol.
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub struct Name {
-    pub symbol: &'static str,
+    // The name of the symbol.
+    pub string: &'static str,
 }
 
+/// Node for a namespaced name, i.e. access name.
 #[derive(Debug, Clone)]
 pub struct AccessName {
+    /// The list of names that make up the access name.
     pub names: Vec<AstNode<Name>>,
 }
 
+/// Node for a concrete/"named" type.
 #[derive(Debug, Clone)]
 pub struct NamedType {
+    /// The name of the type.
     pub name: AstNode<AccessName>,
+    /// The type arguments of the type, if any.
     pub type_args: Vec<AstNode<Type>>,
 }
 
+/// Node for a type variable.
 #[derive(Debug, Clone)]
 pub struct TypeVar {
+    /// The name of the type variable.
     pub name: AstNode<Name>,
 }
 
+/// Node for a type.
 #[derive(Debug, Clone)]
 pub enum Type {
+    /// A concrete/"named" type.
     Named(NamedType),
+    /// A type variable.
     TypeVar(TypeVar),
+    /// The existential type ("?").
     Existential,
+    /// The type infer operator.
     Infer,
 }
 
+/// Node for a set literal, i.e. {1, 2, 3}.
 #[derive(Debug, Clone)]
 pub struct SetLiteral {
+    /// The elements of the set literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
+/// Node for a list literal, i.e. [1, 2, 3].
 #[derive(Debug, Clone)]
 pub struct ListLiteral {
+    /// The elements of the list literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
+/// Node for a tuple literal, i.e. (1, 'A', "foo").
 #[derive(Debug, Clone)]
 pub struct TupleLiteral {
+    /// The elements of the tuple literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
+/// Node for a map literal, i.e. {"foo": 1, "bar": 2}.
 #[derive(Debug, Clone)]
 pub struct MapLiteral {
+    /// The elements of the map literal (key-value pairs).
     pub elements: Vec<AstNode<(Expression, Expression)>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct StructLiteralEntry {
-    name: AstNode<Name>,
-    value: AstNode<Expression>,
+    pub name: AstNode<Name>,
+    pub value: AstNode<Expression>,
 }
 
 #[derive(Debug, Clone)]
 pub struct StructLiteral {
-    name: AstNode<AccessName>,
-    type_args: Vec<AstNode<Type>>,
-    entries: Vec<AstNode<StructLiteralEntry>>,
+    pub name: AstNode<AccessName>,
+    pub type_args: Vec<AstNode<Type>>,
+    pub entries: Vec<AstNode<StructLiteralEntry>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct FunctionDefArg {
-    name: AstNode<Name>,
-    ty: Option<AstNode<Type>>,
+    pub name: AstNode<Name>,
+    pub ty: Option<AstNode<Type>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,340 @@
+#![allow(dead_code)]
+
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+use num::BigInt;
+
+use crate::modules::ModuleIdx;
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct AstNode<T> {
+    pub body: Box<T>,
+    pub pos: (u32, u32),
+    pub module: ModuleIdx,
+}
+
+impl<T> Hash for AstNode<T>
+where
+    T: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.body.hash(state);
+    }
+}
+
+impl<T> Deref for AstNode<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.body
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
+pub struct IntrinsicKey {
+    pub name: &'static str,
+}
+
+#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
+pub struct Name {
+    pub symbol: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub struct AccessName {
+    pub names: Vec<AstNode<Name>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedType {
+    pub name: AstNode<AccessName>,
+    pub type_args: Vec<AstNode<Type>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeVar {
+    pub name: AstNode<Name>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Type {
+    Named(NamedType),
+    TypeVar(TypeVar),
+    Existential,
+    Infer,
+}
+
+#[derive(Debug, Clone)]
+pub struct SetLiteral {
+    pub elements: Vec<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListLiteral {
+    pub elements: Vec<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TupleLiteral {
+    pub elements: Vec<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MapLiteral {
+    pub elements: Vec<AstNode<(Expression, Expression)>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructLiteralEntry {
+    name: AstNode<Name>,
+    value: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructLiteral {
+    name: AstNode<AccessName>,
+    type_args: Vec<AstNode<Type>>,
+    entries: Vec<AstNode<StructLiteralEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionDefArg {
+    name: AstNode<Name>,
+    ty: Option<AstNode<Type>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionDef {
+    pub args: Vec<AstNode<FunctionDefArg>>,
+    pub return_ty: Option<AstNode<Type>>,
+    pub fn_body: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Literal {
+    Str(String),
+    Char(char),
+    Int(BigInt),
+    Float(f64),
+    Set(SetLiteral),
+    Map(MapLiteral),
+    List(ListLiteral),
+    Tuple(TupleLiteral),
+    Struct(StructLiteral),
+    Function(FunctionDef),
+}
+
+#[derive(Debug, Clone)]
+pub struct OrPattern {
+    pub a: AstNode<Pattern>,
+    pub b: AstNode<Pattern>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IfPattern {
+    pub pattern: AstNode<Pattern>,
+    pub condition: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnumPattern {
+    pub name: AstNode<AccessName>,
+    pub variants: Vec<AstNode<Pattern>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DestructuringPattern {
+    pub name: AstNode<Name>,
+    pub patterns: AstNode<Pattern>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructPattern {
+    pub name: AstNode<AccessName>,
+    pub entries: Vec<AstNode<DestructuringPattern>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamespacePattern {
+    pub patterns: Vec<AstNode<DestructuringPattern>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TuplePattern {
+    pub elements: Vec<AstNode<Pattern>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum LiteralPattern {
+    Str(String),
+    Char(char),
+    Int(BigInt),
+    Float(f64),
+    Tuple(TuplePattern),
+}
+
+#[derive(Debug, Clone)]
+pub enum Pattern {
+    Enum(EnumPattern),
+    Struct(StructPattern),
+    Namespace(NamespacePattern),
+    Tuple(TuplePattern),
+    Literal(LiteralPattern),
+    Or(OrPattern),
+    If(IfPattern),
+    Binding(AstNode<Name>),
+    Ignore,
+}
+
+#[derive(Debug, Clone)]
+pub struct TraitBound {
+    pub name: AstNode<AccessName>,
+    pub type_args: Vec<AstNode<Type>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Bound {
+    pub type_args: Vec<AstNode<Type>>,
+    pub trait_bounds: Vec<AstNode<TraitBound>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LetStatement {
+    pub pattern: AstNode<Pattern>,
+    pub bound: Option<AstNode<Bound>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AssignStatement {
+    pub lhs: AstNode<Expression>,
+    pub rhs: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructDefEntry {
+    pub name: AstNode<Name>,
+    pub ty: Option<AstNode<Type>>,
+    pub default: Option<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructDef {
+    pub name: AstNode<Name>,
+    pub bound: AstNode<Bound>,
+    pub entries: Vec<AstNode<StructDefEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnumDefEntry {
+    pub name: AstNode<Name>,
+    pub args: Vec<AstNode<Type>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnumDef {
+    pub name: AstNode<Name>,
+    pub bound: AstNode<Bound>,
+    pub entries: Vec<AstNode<EnumDefEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TraitDef {
+    pub name: AstNode<Name>,
+    pub bound: AstNode<Bound>,
+    pub trait_type: AstNode<Type>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Statement {
+    Expr(AstNode<Expression>),
+    Return(Option<AstNode<Expression>>),
+    Block(AstNode<Block>),
+    Break,
+    Continue,
+    Let(LetStatement),
+    Assign(AssignStatement),
+    StructDef(StructDef),
+    EnumDef(EnumDef),
+    TraitDef(TraitDef),
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchCase {
+    pub pattern: AstNode<Pattern>,
+    pub expr: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchBlock {
+    pub subject: AstNode<Expression>,
+    pub cases: Vec<AstNode<MatchCase>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BodyBlock {
+    pub statements: Vec<AstNode<Statement>>,
+    pub expr: Option<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Block {
+    Match(MatchBlock),
+    Loop(AstNode<Block>),
+    Body(BodyBlock),
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionCallArgs {
+    pub entries: Vec<AstNode<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionCallExpr {
+    pub subject: AstNode<Expression>,
+    pub args: AstNode<FunctionCallArgs>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogicalOpExpr {
+    pub lhs: AstNode<Expression>,
+    pub rhs: AstNode<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PropertyAccessExpr {
+    pub subject: AstNode<Expression>,
+    pub property: AstNode<Name>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypedExpr {
+    pub ty: AstNode<Type>,
+    pub expr: AstNode<Expression>,
+}
+
+type ImportPath = String;
+
+#[derive(Debug, Clone)]
+pub struct VariableExpr {
+    pub name: AstNode<AccessName>,
+    pub type_args: Vec<AstNode<Type>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Expression {
+    FunctionCall(FunctionCallExpr),
+    Intrinsic(IntrinsicKey),
+    LogicalOp(LogicalOpExpr),
+    Variable(VariableExpr),
+    PropertyAccess(PropertyAccessExpr),
+    LiteralExpr(Literal),
+    Typed(TypedExpr),
+    Block(AstNode<Block>),
+    Import(AstNode<ImportPath>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub contents: Vec<AstNode<Statement>>,
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,6 @@
 //! Frontend-agnostic Hash abstract syntax tree type definitions.
+// 
+// All rights reserved 2021 (c) The Hash Language authors
 #![allow(dead_code)]
 
 use crate::modules::ModuleIdx;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,10 +20,7 @@ pub struct AstNode<T> {
     pub module: ModuleIdx,
 }
 
-impl<T> Hash for AstNode<T>
-where
-    T: Hash,
-{
+impl<T: Hash> Hash for AstNode<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.body.hash(state);
     }
@@ -31,7 +28,6 @@ where
 
 impl<T> Deref for AstNode<T> {
     type Target = T;
-
     fn deref(&self) -> &Self::Target {
         &self.body
     }
@@ -51,7 +47,7 @@ pub struct Name {
     pub string: &'static str,
 }
 
-/// Node for a namespaced name, i.e. access name.
+/// Node for a namespaced name, i.e.. access name.
 #[derive(Debug, Clone)]
 pub struct AccessName {
     /// The list of names that make up the access name.
@@ -81,62 +77,79 @@ pub enum Type {
     Named(NamedType),
     /// A type variable.
     TypeVar(TypeVar),
-    /// The existential type ("?").
+    /// The existential type (`?`).
     Existential,
     /// The type infer operator.
     Infer,
 }
 
-/// Node for a set literal, i.e. {1, 2, 3}.
+/// Node for a set literal, e.g. `{1, 2, 3}`.
 #[derive(Debug, Clone)]
 pub struct SetLiteral {
     /// The elements of the set literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a list literal, i.e. [1, 2, 3].
+/// Node for a list literal, e.g. `[1, 2, 3]`.
 #[derive(Debug, Clone)]
 pub struct ListLiteral {
     /// The elements of the list literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a tuple literal, i.e. (1, 'A', "foo").
+/// Node for a tuple literal, e.g. `(1, 'A', "foo")`.
 #[derive(Debug, Clone)]
 pub struct TupleLiteral {
     /// The elements of the tuple literal.
     pub elements: Vec<AstNode<Expression>>,
 }
 
-/// Node for a map literal, i.e. {"foo": 1, "bar": 2}.
+/// Node for a map literal, e.g. `{"foo": 1, "bar": 2}`.
 #[derive(Debug, Clone)]
 pub struct MapLiteral {
     /// The elements of the map literal (key-value pairs).
     pub elements: Vec<AstNode<(Expression, Expression)>>,
 }
 
+/// Node for a struct literal entry (struct field in struct literal), e.g. `name = "Nani"`.
 #[derive(Debug, Clone)]
 pub struct StructLiteralEntry {
+    /// The name of the struct field.
     pub name: AstNode<Name>,
+    /// The value given to the struct field.
     pub value: AstNode<Expression>,
 }
 
+/// Node for a struct literal, e.g. `Dog { name = "Adam", age = 12 }`
 #[derive(Debug, Clone)]
 pub struct StructLiteral {
+    /// The name of the struct literal.
     pub name: AstNode<AccessName>,
+    /// Type arguments to the struct literal, if any.
     pub type_args: Vec<AstNode<Type>>,
+    /// The fields (entries) of the struct literal.
     pub entries: Vec<AstNode<StructLiteralEntry>>,
 }
 
+/// Node for a function definition argument.
 #[derive(Debug, Clone)]
 pub struct FunctionDefArg {
+    /// The name of the argument.
     pub name: AstNode<Name>,
+    /// The type of the argument, if any.
+    ///
+    /// Will be inferred if `None`.
     pub ty: Option<AstNode<Type>>,
 }
 
+/// Node for a function definition.
 #[derive(Debug, Clone)]
 pub struct FunctionDef {
+    /// The arguments of the function definition.
     pub args: Vec<AstNode<FunctionDefArg>>,
+    /// The return type of the function definition.
+    ///
+    /// Will be inferred if `None`.
     pub return_ty: Option<AstNode<Type>>,
     pub fn_body: AstNode<Expression>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod ast;
 mod modules;
+// mod typecheck;
 
 use clap::{AppSettings, Clap, crate_version};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod ast;
+mod modules;
+
 use clap::{AppSettings, Clap, crate_version};
 
 /// This doc string acts as a help message when the user runs '--help'
@@ -28,7 +31,6 @@ fn main() {
     let opts: CompilerOptions = CompilerOptions::parse();
 
     println!("Stack_size is {}", opts.stack_size);
-
 
     for path in opts.includes.into_iter() {
         println!("Running with {}", path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+//! Main module.
+// 
+// All rights reserved 2021 (c) The Hash Language authors
 mod ast;
 mod modules;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 mod ast;
 mod modules;
-// mod typecheck;
 
 use clap::{AppSettings, Clap, crate_version};
 

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,27 +1,35 @@
+//! Module-related containers and utilities.
+
+/// A module identifier which is an index into [Modules].
 pub type ModuleIdx = usize;
 
+/// Represents a single module.
 pub struct Module<'a> {
     idx: usize,
     modules: &'a Modules,
 }
 
 impl Module<'_> {
+    /// Get the content (source text) of the module.
     pub fn content(&self) -> &str {
         self.modules.contents[self.idx].as_ref()
     }
 
+    /// Get the filename (full path) of the module.
     pub fn filename(&self) -> &str {
         self.modules.filenames[self.idx].as_ref()
     }
 }
 
+/// Represents a set of loaded modules.
 pub struct Modules {
     filenames: Vec<String>,
     contents: Vec<String>,
 }
 
 impl Modules {
-    pub fn get_module<'a>(&'a self, idx: usize) -> Module<'a> {
+    /// Get the module at the given index.
+    pub fn get_module<'a>(&'a self, idx: ModuleIdx) -> Module<'a> {
         Module { idx, modules: self }
     }
 }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,4 +1,6 @@
 //! Module-related containers and utilities.
+// 
+// All rights reserved 2021 (c) The Hash Language authors
 
 /// A module identifier which is an index into [Modules].
 pub type ModuleIdx = usize;

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,0 +1,27 @@
+pub type ModuleIdx = usize;
+
+pub struct Module<'a> {
+    idx: usize,
+    modules: &'a Modules,
+}
+
+impl Module<'_> {
+    pub fn content(&self) -> &str {
+        self.modules.contents[self.idx].as_ref()
+    }
+
+    pub fn filename(&self) -> &str {
+        self.modules.filenames[self.idx].as_ref()
+    }
+}
+
+pub struct Modules {
+    filenames: Vec<String>,
+    contents: Vec<String>,
+}
+
+impl Modules {
+    pub fn get_module<'a>(&'a self, idx: usize) -> Module<'a> {
+        Module { idx, modules: self }
+    }
+}


### PR DESCRIPTION
This is the frontend-agnostic AST that we will use to perform typechecking and code emitting.
Loosely modelled after the Haskell version.