### PR TITLE
Visualising AST

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -185,10 +185,8 @@ pub enum Literal {
 /// An alternative pattern, e.g. `Red | Blue`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct OrPattern {
-    /// The first pattern in the "or".
-    pub a: AstNode<Pattern>,
-    /// The second pattern in the "or".
-    pub b: AstNode<Pattern>,
+    /// The variants of the "or" pattern
+    pub variants: AstNodes<Pattern>,
 }
 
 /// A conditional pattern, e.g. `x if x == 42`.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -472,28 +472,6 @@ pub struct FunctionCallExpr {
     pub args: AstNode<FunctionCallArgs>,
 }
 
-/// A logical operator.
-///
-/// These are treated differently from all other operators due to short-circuiting.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum LogicalOp {
-    /// The logical-and operator.
-    And,
-    /// The logical-or operator.
-    Or,
-}
-
-/// A logical operation expression.
-#[derive(Debug, PartialEq, Clone)]
-pub struct LogicalOpExpr {
-    /// The operator of the logical operation.
-    pub op: AstNode<LogicalOp>,
-    /// The left-hand side of the operation.
-    pub lhs: AstNode<Expression>,
-    /// The right-hand side of the operation.
-    pub rhs: AstNode<Expression>,
-}
-
 /// A property access exprssion.
 #[derive(Debug, PartialEq, Clone)]
 pub struct PropertyAccessExpr {
@@ -544,8 +522,6 @@ pub enum Expression {
     FunctionCall(FunctionCallExpr),
     /// An intrinsic symbol.
     Intrinsic(IntrinsicKey),
-    /// A logical operation.
-    LogicalOp(LogicalOpExpr),
     /// A variable.
     Variable(VariableExpr),
     /// A property access.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -526,8 +526,6 @@ pub enum Expression {
     Variable(VariableExpr),
     /// A property access.
     PropertyAccess(PropertyAccessExpr),
-    /// An index.
-    Index(IndexExpr),
     /// A reference expression.
     Ref(AstNode<Expression>),
     /// A dereference expression.

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -158,7 +158,7 @@ impl NodeCount for Pattern {
             Pattern::Namespace(pat) => pat.patterns.iter().map(|p| p.node_count()).sum(),
             Pattern::Tuple(pat) => pat.elements.iter().map(|e| e.node_count()).sum(),
             Pattern::Literal(_) => 1,
-            Pattern::Or(pat) => pat.a.node_count() + pat.b.node_count(),
+            Pattern::Or(pat) => pat.variants.iter().map(|e| e.node_count()).sum(),
             Pattern::If(pat) => {
                 let count = pat.pattern.node_count();
                 count + pat.condition.node_count()

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -86,7 +86,7 @@ impl NodeCount for Expression {
                 let fn_args: usize = e.args.entries.iter().map(|a| a.node_count()).sum();
                 e.subject.node_count() + fn_args
             }
-            Expression::Intrinsic(_) => 1,
+            Expression::Intrinsic(_) => 0,
             Expression::Variable(e) => {
                 let ty_args: usize = e.type_args.iter().map(|t| t.node_count()).sum();
 
@@ -98,7 +98,7 @@ impl NodeCount for Expression {
             Expression::Block(e) => e.node_count(),
             Expression::Deref(e) => e.node_count(),
             Expression::Ref(e) => e.node_count(),
-            Expression::Import(_) => 1,
+            Expression::Import(_) => 0,
         }
     }
 }
@@ -157,14 +157,14 @@ impl NodeCount for Pattern {
             }
             Pattern::Namespace(pat) => pat.patterns.iter().map(|p| p.node_count()).sum(),
             Pattern::Tuple(pat) => pat.elements.iter().map(|e| e.node_count()).sum(),
-            Pattern::Literal(_) => 1,
+            Pattern::Literal(_) => 0,
             Pattern::Or(pat) => pat.variants.iter().map(|e| e.node_count()).sum(),
             Pattern::If(pat) => {
                 let count = pat.pattern.node_count();
                 count + pat.condition.node_count()
             }
-            Pattern::Binding(_) => 1,
-            Pattern::Ignore => 1,
+            Pattern::Binding(_) => 0,
+            Pattern::Ignore => 0,
         }
     }
 }
@@ -215,7 +215,7 @@ impl NodeCount for Type {
 
             // TypeVar variant just counts for one node since it just wrapper for Name,
             // which is of made of a single AstNode.
-            _ => 1,
+            _ => 0,
         }
     }
 }

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -87,7 +87,6 @@ impl NodeCount for Expression {
                 e.subject.node_count() + fn_args
             }
             Expression::Intrinsic(_) => 1,
-            Expression::LogicalOp(e) => 1 + e.lhs.node_count() + e.rhs.node_count(),
             Expression::Variable(e) => {
                 let ty_args: usize = e.type_args.iter().map(|t| t.node_count()).sum();
 

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -98,11 +98,6 @@ impl NodeCount for Expression {
             Expression::Block(e) => e.node_count(),
             Expression::Deref(e) => e.node_count(),
             Expression::Ref(e) => e.node_count(),
-            Expression::Index(e) => {
-                let indices: usize = e.index.iter().map(|node| node.node_count()).sum();
-
-                e.subject.node_count() + indices
-            }
             Expression::Import(_) => 1,
         }
     }

--- a/compiler/hash-ast/src/parse.rs
+++ b/compiler/hash-ast/src/parse.rs
@@ -328,6 +328,9 @@ fn parse_file(
         |elapsed| debug!("ast: {:.2?}", elapsed),
     )?;
 
+    // @@Temp: remove me
+    println!("{}", module);
+
     Ok((module, source))
 }
 

--- a/compiler/hash-ast/src/parse.rs
+++ b/compiler/hash-ast/src/parse.rs
@@ -328,9 +328,6 @@ fn parse_file(
         |elapsed| debug!("ast: {:.2?}", elapsed),
     )?;
 
-    // @@Temp: remove me
-    println!("{}", module);
-
     Ok((module, source))
 }
 

--- a/compiler/hash-ast/src/visualise.rs
+++ b/compiler/hash-ast/src/visualise.rs
@@ -722,12 +722,17 @@ impl NodeDisplay for Block {
                     components.push(case_lines);
                 }
 
-                iter::once("match".to_string())
+                let lines = iter::once("match".to_string())
                     .chain(draw_branches_for_children(&components))
-                    .collect()
+                    .collect::<Vec<String>>();
+
+                child_branch(&lines)
             }
             Block::Loop(loop_body) => {
                 let mut lines = vec!["loop".to_string()];
+
+                // @@Cleanup: This is a block but we don't display this as a block with the branch because
+                // it doesn't go through the Statement implementation which deals with the block
                 lines.extend(pad_lines(loop_body.node_display(), 2));
                 draw_branches_for_lines(&lines, END_PIPE, "")
             }
@@ -844,11 +849,14 @@ impl NodeDisplay for Pattern {
                 .chain(child_branch(&lit.node_display()))
                 .collect()],
             Pattern::Or(pat) => {
-                let left = pat.a.node_display();
-                let right = pat.b.node_display();
+                let variants = pat
+                    .variants
+                    .iter()
+                    .map(|pat| pat.node_display())
+                    .collect::<Vec<Vec<String>>>();
 
                 vec![iter::once("or".to_string())
-                    .chain(draw_branches_for_children(&[left, right]))
+                    .chain(draw_branches_for_children(&variants))
                     .collect()]
             }
             Pattern::If(pat) => {

--- a/compiler/hash-ast/src/visualise.rs
+++ b/compiler/hash-ast/src/visualise.rs
@@ -312,7 +312,6 @@ impl NodeDisplay for Expression {
                 }
             }
             Expression::PropertyAccess(_) => todo!(),
-            Expression::Index(_) => todo!(),
             Expression::Ref(expr) | Expression::Deref(expr) => {
                 // Match again to determine whether it is a deref or a ref!
                 match &self {
@@ -323,6 +322,7 @@ impl NodeDisplay for Expression {
 
                 let next_lines = draw_branches_for_lines(&expr.node_display(indent), END_PIPE, "");
                 lines.extend(pad_lines(&next_lines, 1));
+
                 lines
             }
             Expression::LiteralExpr(literal) => literal.node_display(indent),

--- a/compiler/hash-ast/src/visualise.rs
+++ b/compiler/hash-ast/src/visualise.rs
@@ -6,9 +6,8 @@ use std::{fmt::Alignment, iter};
 
 use crate::ast::*;
 
-// @@FIXME: REMOVE IDENT!
-
-const VERT_PIPE: &str = "│";
+const VERT_PIPE: &str = "│ ";
+const PADDING: &str = "  ";
 const END_PIPE: &str = "└─";
 const MID_PIPE: &str = "├─";
 
@@ -24,9 +23,9 @@ const fn which_connector(index: usize, max_index: usize) -> &'static str {
 
 const fn which_pipe(index: usize, max_index: usize) -> &'static str {
     if max_index == 0 || index == max_index - 1 {
-        "  "
+        PADDING
     } else {
-        "│ "
+        VERT_PIPE
     }
 }
 
@@ -69,7 +68,6 @@ fn draw_branches_for_lines(lines: &[String], connector: &str, branch: &str) -> V
     let mut next_lines = vec![];
 
     for (child_index, line) in lines.iter().enumerate() {
-        // @@Speed: is this really the best way to deal with string concatination.
         if child_index == 0 {
             next_lines.push(format!("{}{}", connector, line));
         } else {
@@ -82,12 +80,12 @@ fn draw_branches_for_lines(lines: &[String], connector: &str, branch: &str) -> V
 }
 
 fn child_branch(lines: &[String]) -> Vec<String> {
-    draw_branches_for_lines(lines, END_PIPE, "  ")
+    draw_branches_for_lines(lines, END_PIPE, PADDING)
 }
 
 /// Function to draw branches for a Vector of lines, connecting each line with the appropriate
 /// connector and vertical connector
-fn draw_lines_for_children(line_collections: &[Vec<String>]) -> Vec<String> {
+fn draw_branches_for_children(line_collections: &[Vec<String>]) -> Vec<String> {
     let mut lines = vec![];
 
     for (index, collection) in line_collections.iter().enumerate() {
@@ -105,24 +103,13 @@ fn draw_lines_for_children(line_collections: &[Vec<String>]) -> Vec<String> {
     lines
 }
 
-/// Utility function to draw a single line for a given vector of lines, essentially padding
-/// them with a vertical branch at the start of each line. This is a useful function for
-/// drawing children nodes of [AstNode]s that have potential children nodes with a specific
-/// context.
-fn draw_vertical_branch(lines: &[String]) -> Vec<String> {
-    lines
-        .iter()
-        .map(|line| format!("{} {}", VERT_PIPE, line))
-        .collect()
-}
-
 pub trait NodeDisplay {
-    fn node_display(&self, indent: usize) -> Vec<String>;
+    fn node_display(&self) -> Vec<String>;
 }
 
 impl<T: NodeDisplay> NodeDisplay for AstNode<T> {
-    fn node_display(&self, indent: usize) -> Vec<String> {
-        self.body.node_display(indent)
+    fn node_display(&self) -> Vec<String> {
+        self.body.node_display()
     }
 }
 
@@ -134,7 +121,7 @@ where
         write!(
             f,
             "{}",
-            self.node_display(0)
+            self.node_display()
                 .into_iter()
                 .map(|mut line| {
                     line.push('\n');
@@ -151,27 +138,27 @@ where
 ///
 impl std::fmt::Display for Module {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let nodes: Vec<Vec<String>> = self.contents.iter().map(|s| s.node_display(0)).collect();
+        let nodes: Vec<Vec<String>> = self.contents.iter().map(|s| s.node_display()).collect();
 
         writeln!(f, "module")?;
-        write!(f, "{}", draw_lines_for_children(&nodes).join("\n"))
+        write!(f, "{}", draw_branches_for_children(&nodes).join("\n"))
     }
 }
 
 /// Implementation for Type_Args specifically!
 impl NodeDisplay for AstNodes<Type> {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
-        let args: Vec<Vec<String>> = self.iter().map(|arg| arg.node_display(0)).collect();
+    fn node_display(&self) -> Vec<String> {
+        let args: Vec<Vec<String>> = self.iter().map(|arg| arg.node_display()).collect();
 
         iter::once("type_args".to_string())
             .into_iter()
-            .chain(draw_lines_for_children(&args))
+            .chain(draw_branches_for_children(&args))
             .collect()
     }
 }
 
 impl NodeDisplay for Type {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         // special case for reference type, the name of the parent node has the prefix 'ref_'
         let lines = if let Type::Ref(_) = &self {
             vec!["ref_type".to_string()]
@@ -188,16 +175,16 @@ impl NodeDisplay for Type {
                 let NamedType { name, type_args } = &named_ty;
 
                 // add the name_lines into components
-                components.push(vec![format!("name {}", name.node_display(0).join(""))]);
+                components.push(vec![format!("name {}", name.node_display().join(""))]);
 
                 if !type_args.is_empty() {
-                    components.push(type_args.node_display(0));
+                    components.push(type_args.node_display());
                 }
 
                 // components
-                draw_lines_for_children(&components)
+                draw_branches_for_children(&components)
             }
-            Type::Ref(ref_ty) => child_branch(&ref_ty.node_display(2)),
+            Type::Ref(ref_ty) => child_branch(&ref_ty.node_display()),
             Type::TypeVar(var) => child_branch(&[format!("var \"{}\"", var.name)]),
             Type::Existential => child_branch(&["existential".to_string()]),
             Type::Infer => child_branch(&["infer".to_string()]),
@@ -208,7 +195,7 @@ impl NodeDisplay for Type {
 }
 
 impl NodeDisplay for Literal {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let mut lines = vec![];
         let mut next_lines = vec![];
 
@@ -239,7 +226,7 @@ impl NodeDisplay for Literal {
                     let branch = which_pipe(index, elements.len());
 
                     // reset the indent here since we'll be doing indentation here...
-                    let child_lines = element.node_display(1);
+                    let child_lines = element.node_display();
                     next_lines.extend(draw_branches_for_lines(&child_lines, connector, branch));
                 }
             }
@@ -257,47 +244,47 @@ impl NodeDisplay for Literal {
                         // deal with they key, and then value
                         let key_lines = vec!["key".to_string()]
                             .into_iter()
-                            .chain(child_branch(&key.node_display(0)))
+                            .chain(child_branch(&key.node_display()))
                             .collect();
                         let value_lines = vec!["value".to_string()]
                             .into_iter()
-                            .chain(child_branch(&value.node_display(0)))
+                            .chain(child_branch(&value.node_display()))
                             .collect();
 
-                        entry.extend(draw_lines_for_children(&[key_lines, value_lines]));
+                        entry.extend(draw_branches_for_children(&[key_lines, value_lines]));
                         entry
                     })
                     .collect();
 
-                next_lines.extend(draw_lines_for_children(&entries));
+                next_lines.extend(draw_branches_for_children(&entries));
             }
             Literal::Struct(struct_lit) => {
                 lines.push("struct".to_string());
 
-                let mut components = vec![struct_lit.name.node_display(0)];
+                let mut components = vec![struct_lit.name.node_display()];
 
                 // now deal with type_arguments here
                 if !struct_lit.type_args.is_empty() {
-                    components.push(struct_lit.type_args.node_display(0));
+                    components.push(struct_lit.type_args.node_display());
                 }
 
                 if !struct_lit.entries.is_empty() {
                     let entries: Vec<Vec<String>> = struct_lit
                         .entries
                         .iter()
-                        .map(|arg| arg.node_display(0))
+                        .map(|arg| arg.node_display())
                         .collect();
 
                     // @@Naming: change this to 'fields' rather than 'entries'?
                     let entry_lines = iter::once("entries".to_string())
                         .into_iter()
-                        .chain(draw_lines_for_children(&entries))
+                        .chain(draw_branches_for_children(&entries))
                         .collect();
 
                     components.push(entry_lines);
                 }
 
-                next_lines.extend(draw_lines_for_children(&components));
+                next_lines.extend(draw_branches_for_children(&components));
             }
             Literal::Function(fn_defn) => {
                 lines.push("function_defn".to_string());
@@ -306,26 +293,13 @@ impl NodeDisplay for Literal {
 
                 // deal with the args
                 if !fn_defn.args.is_empty() {
-                    let arg_lines: Vec<Vec<String>> = fn_defn
+                    let arg_lines = fn_defn
                         .args
                         .iter()
-                        .map(|arg| {
-                            let lines = vec!["arg".to_string()];
+                        .map(|arg| arg.node_display())
+                        .collect::<Vec<Vec<String>>>();
 
-                            // deal with the name and type as seperate branches
-                            let mut arg_components =
-                                vec![vec![format!("name {}", arg.name.body.string)]];
-
-                            if let Some(ty) = &arg.ty {
-                                arg_components.push(ty.node_display(0))
-                            }
-
-                            let component_lines = draw_lines_for_children(&arg_components);
-                            lines.into_iter().chain(component_lines).collect()
-                        })
-                        .collect();
-
-                    let args = draw_lines_for_children(&arg_lines);
+                    let args = draw_branches_for_children(&arg_lines);
                     components.push(vec!["args".to_string()].into_iter().chain(args).collect());
                 }
 
@@ -333,7 +307,7 @@ impl NodeDisplay for Literal {
                 if let Some(return_ty) = &fn_defn.return_ty {
                     let return_ty_lines = vec!["return_type".to_string()]
                         .into_iter()
-                        .chain(child_branch(&return_ty.node_display(1)))
+                        .chain(child_branch(&return_ty.node_display()))
                         .collect();
 
                     components.push(return_ty_lines);
@@ -344,49 +318,66 @@ impl NodeDisplay for Literal {
                     .into_iter()
                     // we don't need to deal with branches here since the block will already add a parental
                     // branch
-                    .chain(child_branch(&fn_defn.fn_body.node_display(0)))
+                    .chain(child_branch(&fn_defn.fn_body.node_display()))
                     .collect();
 
                 components.push(body);
 
-                next_lines.extend(pad_lines(draw_lines_for_children(&components), 2));
+                next_lines.extend(draw_branches_for_children(&components));
             }
         };
 
-        lines.extend(pad_lines(next_lines, indent));
+        lines.extend(next_lines);
         lines
     }
 }
 
+impl NodeDisplay for FunctionDefArg {
+    fn node_display(&self) -> Vec<String> {
+        // deal with the name and type as seperate branches
+        let mut arg_components = vec![vec![format!("name {}", self.name.node_display().join(""))]];
+
+        if let Some(ty) = &self.ty {
+            arg_components.push(ty.node_display())
+        }
+
+        let component_lines = draw_branches_for_children(&arg_components);
+        iter::once("arg".to_string())
+            .into_iter()
+            .chain(component_lines)
+            .collect()
+    }
+}
+
 impl NodeDisplay for StructLiteralEntry {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
-        let name = self.name.node_display(0);
+    fn node_display(&self) -> Vec<String> {
+        let name = self.name.node_display();
 
         let value = iter::once("value".to_string())
-            .chain(child_branch(&self.value.node_display(0)))
+            .chain(child_branch(&self.value.node_display()))
             .collect();
 
         iter::once("entry".to_string())
-            .chain(draw_lines_for_children(&[name, value]))
+            .chain(draw_branches_for_children(&[name, value]))
             .collect()
     }
 }
 
 impl NodeDisplay for AccessName {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let names: Vec<&str> = self.names.iter().map(|n| n.body.string.as_ref()).collect();
         vec![format!("\"{}\"", names.join("::"))]
     }
 }
 
 impl NodeDisplay for Name {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         vec![format!("\"{}\"", self.string)]
     }
 }
 
 impl NodeDisplay for Statement {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let node_name = match &self {
             Statement::Expr(_) => None,
             Statement::Return(_) => Some("ret".to_string()),
@@ -401,58 +392,58 @@ impl NodeDisplay for Statement {
         };
 
         let child_lines: Vec<String> = match &self {
-            Statement::Expr(expr) => expr.node_display(indent + 1),
+            Statement::Expr(expr) => expr.node_display(),
             Statement::Return(expr) => match expr {
-                Some(ret) => draw_branches_for_lines(&ret.node_display(indent + 1), END_PIPE, ""),
+                Some(ret) => child_branch(&ret.node_display()),
                 None => vec![],
             },
-            Statement::Block(block) => block.node_display(indent),
+            Statement::Block(block) => block.node_display(),
             Statement::Break => vec![],
             Statement::Continue => vec![],
             Statement::Let(decl) => {
-                let mut components = vec![decl.pattern.node_display(0)];
+                let mut components = vec![decl.pattern.node_display()];
 
                 // optionally add the type of the argument, as specified by the user
                 if let Some(ty) = &decl.ty {
-                    components.push(ty.node_display(0));
+                    components.push(ty.node_display());
                 }
 
                 // optionally deal with the bound of the let statement
                 if let Some(bound) = &decl.bound {
-                    components.push(bound.node_display(0))
+                    components.push(bound.node_display())
                 }
 
                 // optionally deal with the value of the let statement
                 if let Some(value) = &decl.value {
                     components.push(
                         iter::once("value".to_string())
-                            .chain(child_branch(&value.node_display(0)))
+                            .chain(child_branch(&value.node_display()))
                             .collect(),
                     );
                 }
 
-                draw_lines_for_children(&components)
+                draw_branches_for_children(&components)
             }
             Statement::Assign(decl) => {
                 // add a mid connector for the lhs section, and then add vertical pipe
                 // to the lhs so that it can be joined with the rhs of the assign expr
                 let lhs_lines = iter::once("lhs".to_string())
-                    .chain(child_branch(&decl.lhs.node_display(0)))
+                    .chain(child_branch(&decl.lhs.node_display()))
                     .collect();
 
                 // now deal with the rhs
                 let rhs_lines = iter::once("rhs".to_string())
-                    .chain(child_branch(&decl.rhs.node_display(0)))
+                    .chain(child_branch(&decl.rhs.node_display()))
                     .collect();
 
-                draw_lines_for_children(&[lhs_lines, rhs_lines])
+                draw_branches_for_children(&[lhs_lines, rhs_lines])
             }
             Statement::StructDef(defn) => {
                 let mut components =
-                    vec![vec![format!("name {}", defn.name.node_display(0).join(""))]];
+                    vec![vec![format!("name {}", defn.name.node_display().join(""))]];
 
                 if let Some(bound) = &defn.bound {
-                    components.push(bound.node_display(0))
+                    components.push(bound.node_display())
                 }
 
                 // append the entries if there is more than one
@@ -460,26 +451,26 @@ impl NodeDisplay for Statement {
                     let lines = defn
                         .entries
                         .iter()
-                        .map(|entry| entry.node_display(0))
+                        .map(|entry| entry.node_display())
                         .collect::<Vec<Vec<String>>>();
 
                     // the enum definition entries
                     let entries = iter::once("entries".to_string())
                         .into_iter()
-                        .chain(draw_lines_for_children(&lines))
+                        .chain(draw_branches_for_children(&lines))
                         .collect();
 
                     components.push(entries);
                 }
 
-                draw_lines_for_children(&components)
+                draw_branches_for_children(&components)
             }
             Statement::EnumDef(defn) => {
                 let mut components =
-                    vec![vec![format!("name {}", defn.name.node_display(0).join(""))]];
+                    vec![vec![format!("name {}", defn.name.node_display().join(""))]];
 
                 if let Some(bound) = &defn.bound {
-                    components.push(bound.node_display(0))
+                    components.push(bound.node_display())
                 }
 
                 // append the entries if there is more than one
@@ -487,28 +478,28 @@ impl NodeDisplay for Statement {
                     let lines = defn
                         .entries
                         .iter()
-                        .map(|entry| entry.node_display(0))
+                        .map(|entry| entry.node_display())
                         .collect::<Vec<Vec<String>>>();
 
                     // the enum definition entries
                     let entries = iter::once("entries".to_string())
                         .into_iter()
-                        .chain(draw_lines_for_children(&lines))
+                        .chain(draw_branches_for_children(&lines))
                         .collect();
 
                     components.push(entries);
                 }
 
-                draw_lines_for_children(&components)
+                draw_branches_for_children(&components)
             }
             Statement::TraitDef(defn) => {
                 let components = vec![
-                    vec![format!("name {}", defn.name.node_display(0).join(""))],
-                    defn.bound.node_display(0),
-                    defn.trait_type.node_display(0),
+                    vec![format!("name {}", defn.name.node_display().join(""))],
+                    defn.bound.node_display(),
+                    defn.trait_type.node_display(),
                 ];
 
-                draw_lines_for_children(&components)
+                draw_branches_for_children(&components)
             }
         };
 
@@ -517,50 +508,50 @@ impl NodeDisplay for Statement {
 }
 
 impl NodeDisplay for EnumDefEntry {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let components = vec![
-            vec![format!("name {}", self.name.node_display(0).join(""))],
-            self.args.node_display(0),
+            vec![format!("name {}", self.name.node_display().join(""))],
+            self.args.node_display(),
         ];
 
         iter::once("field".to_string())
-            .chain(draw_lines_for_children(&components))
+            .chain(draw_branches_for_children(&components))
             .collect()
     }
 }
 
 impl NodeDisplay for StructDefEntry {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
-        let mut components = vec![vec![format!("name {}", self.name.node_display(0).join(""))]];
+    fn node_display(&self) -> Vec<String> {
+        let mut components = vec![vec![format!("name {}", self.name.node_display().join(""))]];
 
         if let Some(ty) = &self.ty {
-            components.push(ty.node_display(0))
+            components.push(ty.node_display())
         }
 
         if let Some(default) = &self.default {
             components.push(
                 iter::once("default".to_string())
-                    .chain(child_branch(&default.node_display(0)))
+                    .chain(child_branch(&default.node_display()))
                     .collect(),
             )
         }
 
         iter::once("field".to_string())
-            .chain(draw_lines_for_children(&components))
+            .chain(draw_branches_for_children(&components))
             .collect()
     }
 }
 
 impl NodeDisplay for Bound {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
-        let mut components = vec![self.type_args.node_display(0)];
+    fn node_display(&self) -> Vec<String> {
+        let mut components = vec![self.type_args.node_display()];
 
         if !self.trait_bounds.is_empty() {
-            let trait_bounds = draw_lines_for_children(
+            let trait_bounds = draw_branches_for_children(
                 &self
                     .trait_bounds
                     .iter()
-                    .map(|bound| bound.node_display(0))
+                    .map(|bound| bound.node_display())
                     .collect::<Vec<Vec<String>>>(),
             );
 
@@ -572,32 +563,32 @@ impl NodeDisplay for Bound {
         }
 
         iter::once("bound".to_string())
-            .chain(draw_lines_for_children(&components))
+            .chain(draw_branches_for_children(&components))
             .collect()
     }
 }
 
 impl NodeDisplay for TraitBound {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let components = vec![
-            vec![format!("name {}", self.name.node_display(0).join(""))],
-            self.type_args.node_display(0),
+            vec![format!("name {}", self.name.node_display().join(""))],
+            self.type_args.node_display(),
         ];
 
         iter::once("trait_bound".to_string())
-            .chain(draw_lines_for_children(&components))
+            .chain(draw_branches_for_children(&components))
             .collect()
     }
 }
 
 impl NodeDisplay for Import {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         vec![format!("import \"{}\"", self.path)]
     }
 }
 
 impl NodeDisplay for Expression {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let mut lines = vec![];
 
         match &self {
@@ -605,25 +596,30 @@ impl NodeDisplay for Expression {
                 lines.push("function_call".to_string());
 
                 let mut components = vec![iter::once("subject".to_string())
-                    .chain(child_branch(&func.subject.node_display(indent)))
+                    .chain(child_branch(&func.subject.node_display()))
                     .collect()];
 
                 let arguments = &func.args.body.entries;
 
                 // now deal with the function args if there are any
                 if !arguments.is_empty() {
-                    // @@TODO: add 'arg' prefix to each branch
-
-                    let args: Vec<Vec<String>> =
-                        arguments.iter().map(|arg| arg.node_display(0)).collect();
+                    let args: Vec<Vec<String>> = arguments
+                        .iter()
+                        .map(|arg| {
+                            // Add 'arg' prefix to each part of the function call argument
+                            iter::once("arg".to_string())
+                                .chain(child_branch(&arg.node_display()))
+                                .collect()
+                        })
+                        .collect();
 
                     let arg_lines = iter::once("args".to_string())
-                        .chain(draw_lines_for_children(&args))
+                        .chain(draw_branches_for_children(&args))
                         .collect();
 
                     components.push(arg_lines);
                 }
-                lines.extend(draw_lines_for_children(&components));
+                lines.extend(draw_branches_for_children(&components));
                 lines
             }
             Expression::Intrinsic(intrinsic) => {
@@ -633,15 +629,15 @@ impl NodeDisplay for Expression {
             Expression::Variable(var) => {
                 // check if the length of type_args to this ident, if not
                 // we don't produce any children nodes for it
-                let name = var.name.node_display(0).join("");
+                let name = var.name.node_display().join("");
                 let ident_lines = vec![format!("ident {}", name)];
 
                 if !var.type_args.is_empty() {
                     lines.push("variable".to_string());
 
-                    let components = vec![ident_lines, var.type_args.node_display(0)];
+                    let components = vec![ident_lines, var.type_args.node_display()];
 
-                    lines.extend(draw_lines_for_children(&components));
+                    lines.extend(draw_branches_for_children(&components));
                 } else {
                     // we don't construct a complex tree structure here since we want to avoid
                     // verbosity as much, since most of the time variales aren't going to have
@@ -657,13 +653,13 @@ impl NodeDisplay for Expression {
                 // deal with the subject
                 let subject_lines = vec!["subject".to_string()]
                     .into_iter()
-                    .chain(child_branch(&expr.subject.node_display(0)))
+                    .chain(child_branch(&expr.subject.node_display()))
                     .collect();
 
                 // now deal with the field
                 let field_lines = vec![format!("field \"{}\"", expr.property.body.string)];
 
-                lines.extend(draw_lines_for_children(&[subject_lines, field_lines]));
+                lines.extend(draw_branches_for_children(&[subject_lines, field_lines]));
                 lines
             }
             Expression::Ref(expr) | Expression::Deref(expr) => {
@@ -674,114 +670,93 @@ impl NodeDisplay for Expression {
                     _ => unreachable!(),
                 };
 
-                let next_lines = draw_branches_for_lines(&expr.node_display(indent), END_PIPE, "");
+                let next_lines = child_branch(&expr.node_display());
                 lines.extend(pad_lines(next_lines, 1));
 
                 lines
             }
-            Expression::LiteralExpr(literal) => literal.node_display(indent),
+            Expression::LiteralExpr(literal) => literal.node_display(),
             Expression::Typed(expr) => {
                 lines.push("typed_expr".to_string());
 
                 let TypedExpr { expr, ty } = expr;
 
                 // the type line is handeled by the implementation
-                let type_lines = ty.node_display(0);
+                let type_lines = ty.node_display();
 
                 // now deal with the expression
                 let mut expr_lines = vec!["subject".to_string()];
-                expr_lines.extend(draw_branches_for_lines(&expr.node_display(0), END_PIPE, ""));
+                expr_lines.extend(child_branch(&expr.node_display()));
 
-                let next_lines = draw_lines_for_children(&[expr_lines, type_lines]);
+                let next_lines = draw_branches_for_children(&[expr_lines, type_lines]);
 
                 lines.extend(pad_lines(next_lines, 1));
                 lines
             }
-            Expression::Block(block) => block.node_display(indent),
-            Expression::Import(import) => import.node_display(indent),
+            Expression::Block(block) => block.node_display(),
+            Expression::Import(import) => import.node_display(),
         }
     }
 }
 
 impl NodeDisplay for Block {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         match &self {
             Block::Match(match_block) => {
-                let mut lines = vec!["match".to_string()];
-
-                let MatchBlock { cases, subject } = &match_block;
-
-                // apply the subject, this is esentially @@Copied from the FunctionCall
-                let connector = if cases.is_empty() { END_PIPE } else { MID_PIPE };
-
-                lines.push(format!(" {}subject", connector));
-
-                // deal with the 'subject' as a child and then append it to the next lines
-                let subject_lines =
-                    draw_branches_for_lines(&subject.node_display(2), END_PIPE, " ");
+                let mut components: Vec<Vec<String>> = vec![iter::once("subject".to_string())
+                    .chain(child_branch(&match_block.subject.node_display()))
+                    .collect()];
 
                 // now consider the cases
-                if !cases.is_empty() {
-                    // we need to add a vertical line to the subject in order to connect the 'args'
-                    // and subject component of the function AST node...
-                    let subject_lines = draw_vertical_branch(&subject_lines);
-                    lines.extend(pad_lines(subject_lines, 1));
+                if !match_block.cases.is_empty() {
+                    let cases = match_block
+                        .cases
+                        .iter()
+                        .map(|case| case.node_display())
+                        .collect::<Vec<Vec<String>>>();
 
-                    lines.push(format!(" {}cases", END_PIPE));
+                    let case_lines = iter::once("cases".to_string())
+                        .chain(draw_branches_for_children(&cases))
+                        .collect();
 
-                    let mut arg_lines = vec![];
-
-                    // draw the children on onto the arguments
-                    for (index, element) in cases.iter().enumerate() {
-                        let connector = which_connector(index, cases.len());
-                        let branch = which_pipe(index, cases.len());
-
-                        // reset the indent here since we'll be doing indentation here...
-                        let child_lines = element.node_display(1);
-                        arg_lines.extend(draw_branches_for_lines(&child_lines, connector, branch));
-                    }
-
-                    // add the lines to parent...
-                    lines.extend(pad_lines(arg_lines, 3))
-                } else {
-                    // no arguments, hence we should pad the lines by 3 characters instead of one,
-                    // counting for a phantom verticla line...
-                    lines.extend(pad_lines(subject_lines, 3));
+                    components.push(case_lines);
                 }
 
-                draw_branches_for_lines(&lines, END_PIPE, " ")
+                iter::once("match".to_string())
+                    .chain(draw_branches_for_children(&components))
+                    .collect()
             }
             Block::Loop(loop_body) => {
                 let mut lines = vec!["loop".to_string()];
-                lines.extend(pad_lines(loop_body.node_display(indent), 2));
+                lines.extend(pad_lines(loop_body.node_display(), 2));
                 draw_branches_for_lines(&lines, END_PIPE, "")
             }
-            Block::Body(body) => body.node_display(indent),
+            Block::Body(body) => body.node_display(),
         }
     }
 }
 
 impl NodeDisplay for MatchCase {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let mut lines = vec!["case".to_string()];
 
         // deal with the pattern for this case
-        let pattern_lines = self.pattern.node_display(indent);
+        let pattern_lines = self.pattern.node_display();
 
         // deal with the block for this case
         let branch_lines = vec!["branch".to_string()]
             .into_iter()
-            .chain(child_branch(&self.expr.node_display(0)))
+            .chain(child_branch(&self.expr.node_display()))
             .collect();
 
         // append child_lines with padding and vertical lines being drawn
-        lines.extend(draw_lines_for_children(&[pattern_lines, branch_lines]));
+        lines.extend(draw_branches_for_children(&[pattern_lines, branch_lines]));
         lines
     }
 }
 
 impl NodeDisplay for LiteralPattern {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         vec![match &self {
             LiteralPattern::Str(s) => format!("string \"{}\"", s),
             LiteralPattern::Char(c) => format!("char \'{}\'", c),
@@ -792,128 +767,124 @@ impl NodeDisplay for LiteralPattern {
 }
 
 impl NodeDisplay for DestructuringPattern {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
-        let name = vec![format!("ident {}", self.name.node_display(0).join(""))];
-        let pat = self.pattern.node_display(0);
+    fn node_display(&self) -> Vec<String> {
+        let name = vec![format!("ident {}", self.name.node_display().join(""))];
+        let pat = self.pattern.node_display();
 
-        draw_lines_for_children(&[name, pat])
+        draw_branches_for_children(&[name, pat])
     }
 }
 
 impl NodeDisplay for Pattern {
-    fn node_display(&self, _indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let mut lines = vec!["pattern".to_string()];
 
         let child_components = match &self {
             Pattern::Enum(enum_pat) => {
                 let mut components = vec![vec![format!(
                     "ident {}",
-                    enum_pat.name.node_display(0).join("")
+                    enum_pat.name.node_display().join("")
                 )]];
 
-                let patterns: Vec<Vec<String>> = enum_pat
-                    .args
-                    .iter()
-                    .map(|pat| pat.node_display(0))
-                    .collect();
+                let patterns: Vec<Vec<String>> =
+                    enum_pat.args.iter().map(|pat| pat.node_display()).collect();
 
                 components.push(
                     iter::once("patterns".to_string())
-                        .chain(draw_lines_for_children(&patterns))
+                        .chain(draw_branches_for_children(&patterns))
                         .collect(),
                 );
 
                 vec![iter::once("enum".to_string())
-                    .chain(draw_lines_for_children(&components))
+                    .chain(draw_branches_for_children(&components))
                     .collect()]
             }
             Pattern::Struct(struct_pat) => {
                 let mut components = vec![vec![format!(
                     "ident {}",
-                    struct_pat.name.node_display(0).join("")
+                    struct_pat.name.node_display().join("")
                 )]];
 
                 let patterns: Vec<Vec<String>> = struct_pat
                     .entries
                     .iter()
-                    .map(|pat| pat.node_display(0))
+                    .map(|pat| pat.node_display())
                     .collect();
 
                 components.push(
                     iter::once("patterns".to_string())
-                        .chain(draw_lines_for_children(&patterns))
+                        .chain(draw_branches_for_children(&patterns))
                         .collect(),
                 );
 
                 vec![iter::once("struct".to_string())
-                    .chain(draw_lines_for_children(&components))
+                    .chain(draw_branches_for_children(&components))
                     .collect()]
             }
             Pattern::Namespace(namespace) => {
                 let patterns: Vec<Vec<String>> = namespace
                     .patterns
                     .iter()
-                    .map(|pat| pat.node_display(0))
+                    .map(|pat| pat.node_display())
                     .collect();
 
                 vec![iter::once("namespace".to_string())
-                    .chain(draw_lines_for_children(&patterns))
+                    .chain(draw_branches_for_children(&patterns))
                     .collect()]
             }
             Pattern::Tuple(tup) => {
                 let patterns: Vec<Vec<String>> =
-                    tup.elements.iter().map(|pat| pat.node_display(0)).collect();
+                    tup.elements.iter().map(|pat| pat.node_display()).collect();
 
                 vec![iter::once("tuple".to_string())
-                    .chain(draw_lines_for_children(&patterns))
+                    .chain(draw_branches_for_children(&patterns))
                     .collect()]
             }
             Pattern::Literal(lit) => vec![iter::once("literal".to_string())
-                .chain(child_branch(&lit.node_display(0)))
+                .chain(child_branch(&lit.node_display()))
                 .collect()],
             Pattern::Or(pat) => {
-                let left = pat.a.node_display(0);
-                let right = pat.b.node_display(0);
+                let left = pat.a.node_display();
+                let right = pat.b.node_display();
 
                 vec![iter::once("or".to_string())
-                    .chain(draw_lines_for_children(&[left, right]))
+                    .chain(draw_branches_for_children(&[left, right]))
                     .collect()]
             }
             Pattern::If(pat) => {
-                let pattern = pat.pattern.node_display(0);
+                let pattern = pat.pattern.node_display();
 
                 // add a 'condition' prefix branch to the expression
                 let condition = iter::once("condition".to_string())
-                    .chain(child_branch(&pat.condition.node_display(0)))
+                    .chain(child_branch(&pat.condition.node_display()))
                     .collect();
 
                 vec![iter::once("if".to_string())
-                    .chain(draw_lines_for_children(&[pattern, condition]))
+                    .chain(draw_branches_for_children(&[pattern, condition]))
                     .collect()]
             }
-            Pattern::Binding(x) => vec![vec![format!("bind {}", x.node_display(0).join(""))]],
+            Pattern::Binding(x) => vec![vec![format!("bind {}", x.node_display().join(""))]],
             Pattern::Ignore => vec![vec!["ignore".to_string()]],
         };
 
-        lines.extend(draw_lines_for_children(&child_components));
+        lines.extend(draw_branches_for_children(&child_components));
         lines
     }
 }
 
 impl NodeDisplay for BodyBlock {
-    fn node_display(&self, indent: usize) -> Vec<String> {
+    fn node_display(&self) -> Vec<String> {
         let mut statements: Vec<Vec<String>> = self
             .statements
             .iter()
-            .map(|statement| statement.node_display(0))
+            .map(|statement| statement.node_display())
             .collect();
 
         // check if body block has an expression at the end
         if let Some(expr) = &self.expr {
-            statements.push(expr.node_display(0));
+            statements.push(expr.node_display());
         }
 
-        let next_lines = draw_lines_for_children(&statements);
-        pad_lines(next_lines, indent)
+        draw_branches_for_children(&statements)
     }
 }

--- a/compiler/hash-pest-parser/src/grammar.pest
+++ b/compiler/hash-pest-parser/src/grammar.pest
@@ -389,10 +389,10 @@ literal_pattern = {
 
 /// Single pattern (used in binding positions)
 single_pattern = {
+    struct_pattern  |
     enum_pattern    |
     binding_pattern |
     ignore_pattern  |
-    struct_pattern  |
     literal_pattern |
     tuple_pattern   |
     grouped_pattern |

--- a/compiler/hash-pest-parser/src/grammar.pest
+++ b/compiler/hash-pest-parser/src/grammar.pest
@@ -400,7 +400,7 @@ single_pattern = {
 }
 
 /// Compound pattern (matches a series of single patterns)
-compound_pattern = _{ single_pattern ~ (pipe_op ~ single_pattern)* }
+compound_pattern = { single_pattern ~ (pipe_op ~ single_pattern)* }
 
 /// Any pattern (includes optional if condition)
 pattern = { compound_pattern ~ (if_kw ~ expr)? }

--- a/compiler/hash-pest-parser/src/translate.rs
+++ b/compiler/hash-pest-parser/src/translate.rs
@@ -1140,6 +1140,7 @@ where
                 // empty block since an if-block could be assigned to any variable and therefore
                 // we need to know the outcome of all branches for typechecking.
                 let append_else = Cell::new(true);
+
                 let cases = ab.try_collect(
                     pair.into_inner()
                         .map(|if_condition| {
@@ -1184,7 +1185,10 @@ where
                             }
                         })
                         .chain(
-                            {
+                            // @@Dumbness: use this to run the append at the end of the iterator, otherwise this will be computed
+                            // when the expression is evaluated, hence the `append_else` might be true when it should
+                            // be false!
+                            iter::from_fn(|| {
                                 if append_else.get() {
                                     Some(Ok(ab.node(MatchCase {
                                         pattern: ab.node(Pattern::Ignore),
@@ -1198,8 +1202,8 @@ where
                                 } else {
                                     None
                                 }
-                            }
-                            .into_iter(),
+                            })
+                            .take(1),
                         ),
                 )?;
 

--- a/compiler/hash-pest-parser/src/translate.rs
+++ b/compiler/hash-pest-parser/src/translate.rs
@@ -237,8 +237,6 @@ pub(crate) fn build_binary(
 
     match subject_name {
         OperatorFn::Named { name, assigning } => {
-            // @@Copied
-
             Ok(ab.node(Expression::FunctionCall(FunctionCallExpr {
                 subject: ab.node(Expression::Variable(VariableExpr {
                     name: ab.make_single_access_name(AstString::Borrowed(name)),
@@ -250,8 +248,6 @@ pub(crate) fn build_binary(
             })))
         }
         OperatorFn::Compound { name, assigning } => {
-            // @@Copied
-            //
             // for compound functions that include ordering, we essentially transpile
             // into a match block that checks the result of the 'ord' fn call to the
             // 'Ord' enum variants. This also happens for operators such as '>=' which
@@ -260,8 +256,6 @@ pub(crate) fn build_binary(
             Ok(ab.transfrom_compound_ord_fn(name, assigning, lhs?, rhs?))
         }
         OperatorFn::LazyNamed { name, assigning } => {
-            // @@Copied: transform lhs into ref if assinging
-
             let fn_call = ab.node(Expression::FunctionCall(FunctionCallExpr {
                 subject: ab.node(Expression::Variable(VariableExpr {
                     name: ab.make_single_access_name(AstString::Borrowed(name)),
@@ -1538,8 +1532,6 @@ where
                                 Ok(ab.node(Statement::Expr(fn_call)))
                             }
                             Some(OperatorFn::Compound { name, assigning }) => {
-                                // @@Copied
-                                //
                                 // for compound functions that include ordering, we essentially transpile
                                 // into a match block that checks the result of the 'ord' fn call to the
                                 // 'Ord' enum variants. This also happens for operators such as '>=' which

--- a/compiler/hash/src/interactive/mod.rs
+++ b/compiler/hash/src/interactive/mod.rs
@@ -114,6 +114,7 @@ fn execute(input: &str) {
         }
         Ok(InteractiveCommand::Display(expr)) => {
             if let Some((block, _)) = parse_interactive(expr) {
+                println!("{:#?}", block);
                 println!("{}", block);
             }
         }

--- a/compiler/hash/src/interactive/mod.rs
+++ b/compiler/hash/src/interactive/mod.rs
@@ -114,7 +114,6 @@ fn execute(input: &str) {
         }
         Ok(InteractiveCommand::Display(expr)) => {
             if let Some((block, _)) = parse_interactive(expr) {
-                println!("{:#?}", block);
                 println!("{}", block);
             }
         }

--- a/compiler/hash/src/interactive/mod.rs
+++ b/compiler/hash/src/interactive/mod.rs
@@ -114,8 +114,7 @@ fn execute(input: &str) {
         }
         Ok(InteractiveCommand::Display(expr)) => {
             if let Some((block, _)) = parse_interactive(expr) {
-                //@@Todo(alex) change this to node_display when it's ready.
-                println!("{:?}", block);
+                println!("{}", block);
             }
         }
         Ok(InteractiveCommand::Count(expr)) => {

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -109,12 +109,11 @@ fn main() {
                 let filename = fs::canonicalize(&path)?;
                 let parser = SeqParser::new(HashGrammar);
                 let directory = env::current_dir().unwrap();
-                let result = timed(
+                let _result = timed(
                     || parser.parse(&filename, &directory),
                     log::Level::Debug,
                     |elapsed| println!("total: {:?}", elapsed),
-                )?;
-                println!("{:#?}", result);
+                );
                 Ok(())
             }
             None => {

--- a/examples/lang_manifest.hash
+++ b/examples/lang_manifest.hash
@@ -88,7 +88,7 @@ let c = {1,2,3,4,5,6,7,};
 let d = (1,2,3,4,5);
 
 // Import
-// let num = import("num");
+let num = import("../stdlib/num");
 
 // A character
 let ch: char = 'c';

--- a/examples/visual.hash
+++ b/examples/visual.hash
@@ -1,2 +1,6 @@
-let some_var: int = 3;
-let conv<T, str> = (x) => "<unknown>";
+// let some_var: int = 3;
+// let conv<T, str> = (x) => "<unknown>";
+
+match x {
+    // 2 => k;
+}

--- a/examples/visual.hash
+++ b/examples/visual.hash
@@ -1,0 +1,2 @@
+let some_var: int = 3;
+let conv<T, str> = (x) => "<unknown>";


### PR DESCRIPTION
This PR essentially brings an AST visualiser that can display AST nodes into a tree format. This visualiser can be invoked via the interactive console by specifying the command `:d` and then visualising the following expression.