### PR TITLE
Docs: update documentation on error report style and fix spelling mistakes.

### DIFF
--- a/docs/src/advanced/if-statement-transpilation.md
+++ b/docs/src/advanced/if-statement-transpilation.md
@@ -1,7 +1,7 @@
 # If Statement transpilation
 
 As mentioned at the start of the conditionals section in the basics chapter, if statements can be
-represnted as `match` statements. This is especially adviced when you have many `if` branched and 
+represented as `match` statements. This is especially advised when you have many `if` branched and 
 more complicated branch conditions.
 
 Internally, the compiler will convert `if` statements into match cases so that it has to do
@@ -31,7 +31,7 @@ match true {
 ```
 
 
-For example, the following `if` statment will be converted as follows:
+For example, the following `if` statement will be converted as follows:
 
 ```rust
 if conditionA {

--- a/docs/src/advanced/intro.md
+++ b/docs/src/advanced/intro.md
@@ -1,3 +1,3 @@
 # Advanced Concepts
 
-This chapter of the book is dedicated to documenting advanced concepts for developers and contributers.
+This chapter of the book is dedicated to documenting advanced concepts for developers and contributors.

--- a/docs/src/advanced/loop-transpilation.md
+++ b/docs/src/advanced/loop-transpilation.md
@@ -4,14 +4,14 @@ As mentioned at the start of the [loops](./../basics/loops.md) section in the [b
 is the most universal control flow since to you can use `loop` to represent 
 both the `for` and `while` loops. 
 
-### for loop transpillation
+### for loop transpilation
 
 Since `for` loops are used for iterators in hash, we transpile the construct into
 a primitive loop. An iterator can be traversed by calling the `next` function on the
 iterator. Since `next` returns a `Option` type, we need to check if there is a value
 or if it returns `None`. If a value does exist, we essentially perform an assignment
-to the pattern provided. If `None`, the branch immediatelly breaks the `for` loop.
-A rough outline of what the transpillation process for a `for` loop looks like:
+to the pattern provided. If `None`, the branch immediately breaks the `for` loop.
+A rough outline of what the transpilation process for a `for` loop looks like:
 
 For example, the `for` loop can be expressed using `loop` as:
 
@@ -29,7 +29,7 @@ For example, the `for` loop can be expressed using `loop` as:
  }
 ```
 
-An example of the transpillation process:
+An example of the transpilation process:
 
 ```rust
 let i = [1,2,3,5].into_iter();
@@ -54,8 +54,8 @@ loop {
 
  In general, a while loop transpilation process occurs by transferring the looping 
  condition into a match block, which compares a boolean condition. If the boolean
- conditionb evaluates to `false`, the loop will immediatelly `break`. Otherwise
- the body expression is exected. A rough outline of what the transpillation process for a `while` loop looks like:
+ condition evaluates to `false`, the loop will immediately `break`. Otherwise
+ the body expression is expected. A rough outline of what the transpilation process for a `while` loop looks like:
 
  ```
  while <condition> {

--- a/docs/src/advanced/type-inference.md
+++ b/docs/src/advanced/type-inference.md
@@ -1,1 +1,3 @@
 # Type inference
+
+🚧 Still under construction! 🚧 

--- a/docs/src/basics/conditionals.md
+++ b/docs/src/basics/conditionals.md
@@ -62,6 +62,11 @@ can also specifically return a type as you would normally do within a function b
 let abs: (i64: x) => i64 = if x < 0 { -x } else { x }
 ```
 
+You can also assign values since `if` statements are just blocks
+```rust
+let my_value: i32 = if some_condition == x { 3 } else { 5 };
+```
+
 However, you cannot do something like this:
 
 ```rust
@@ -72,7 +77,7 @@ let abs: (i64: x) => i64 = if x < 0 { -x }
 of what should happen for the `else` case.
 
 ## If statements and Enums 🚧
-You can destruct enum values within if statments using the `if-let` syntax, like so:
+You can destruct enum values within if statements using the `if-let` syntax, like so:
 
 ```rust
 enum Result = <T, E> => {

--- a/docs/src/basics/enum-types.md
+++ b/docs/src/basics/enum-types.md
@@ -25,7 +25,7 @@ They can be `match`ed to discover what they contain:
 let handle_error = (error: NetworkError) => match error {
    NoBytesReceived => print("No bytes received, stopping");
    ConnectionTerminated => print("Connection was terminated");
-   Unexpected(err, code) => print("An unexpected error occured: " + err + " (" + conv(code) + ") ");
+   Unexpected(err, code) => print("An unexpected error occurred: " + err + " (" + conv(code) + ") ");
 };
 ```
 

--- a/docs/src/basics/loops.md
+++ b/docs/src/basics/loops.md
@@ -1,7 +1,7 @@
 # Loop constructs
 
 Hash contains 3 distinct loop control constructs: `for`, `while` and `loop`. Each construct has
-a distinct usage case, but they can often be used interchangebly without hastle and are merely
+a distinct usage case, but they can often be used interchangeably without hassle and are merely
 a style choice.
 
 ## General
@@ -9,10 +9,10 @@ a style choice.
 Each construct supports the basic `break` and `continue` loop control flow statements. These statements
 have the same properties as in many other languages like C, Rust, Python etc.
 
-`break` - Using this control flow statements immediatelly terminates the loop and continues
+`break` - Using this control flow statements immediately terminates the loop and continues
 to any statement after the loop (if any).
 
-`continue` - Using this control flow statement will immediatelly skip the current iteration
+`continue` - Using this control flow statement will immediately skip the current iteration
 of the loop body and move on to the next iteration (if any). Obviously, if no iterations
 remain, `continue` behaves just like `break`.
 
@@ -64,7 +64,7 @@ More details about generics are [here](./generics-polymorphism.md).
 
 While loops are identical to 'while' constructs in other languages such as Java, C, JavaScript, etc.
 The loop will check a given conditional expression ( must evaluate to a `bool`), and if it evaluates
-to `true`, the loop body is executed, oterhwise the interpreter moves on. The loop body can also
+to `true`, the loop body is executed, otherwise the interpreter moves on. The loop body can also
 use loop control flow statements like `break` or `continue` to prematurely stop looping for a
 given condition.
 
@@ -133,18 +133,20 @@ while c -= 1 {
 ```
 Running the following code snippet produces the following error:
 ```
-error: Failed to Typecheck:
+error[0052]: Failed to Typecheck: Mismatching types.
  --> 3:7 - 3:12
-  |
+1 | let c: u32 = 100;
+2 |
 3 | while c -= 1 {
-  |       ^^^^^^
-  |       Expression does not have a boolean type 
+  |       ^^^^^^  Expression does not have a 'boolean' type 
+  |
+  = note: The type of the expression was `(,)` but expected an explicit `boolean`.
 ```
 
 
 ## Loop
 
-The loop consturct is the simplest of the three. The basic syntax for a loop is as follows:
+The loop construct is the simplest of the three. The basic syntax for a loop is as follows:
 
 ```rust
 
@@ -180,122 +182,3 @@ loop {
     print("I loop and I print when I get a  " + c);
 } // this will loop 10 times, and print only when c is even
 ```
-<<<<<<< HEAD:docs/loops.md
-
-## Miscellaneous
-
-As mentioned at the start of the introduction, the `loop` control flow keyword
-is the most universal control flow since to you can use `loop` to represent 
-both the `for` and `while` loops. 
-
-### for loop transpillation
-
-Since `for` loops are used for iterators in hash, we transpile the construct into
-a primitive loop. An iterator can be traversed by calling the `next` function on the
-iterator. Since `next` returns a `Option` type, we need to check if there is a value
-or if it returns `None`. If a value does exist, we essentially perform an assignment
-to the pattern provided. If `None`, the branch immediatelly breaks the `for` loop.
-A rough outline of what the transpillation process for a `for` loop looks like:
-
-For example, the `for` loop can be expressed using `loop` as:
-
- ```
- for <pat> in <iterator> {
-     <block>
- }
-
- // converted to
- loop {
-     match next(<iterator>) {
-         Some(<pat>) => <block>;
-         None        => break;
-     }
- }
-```
-
-An example of the transpillation process:
-
-```rust
-let i = [1,2,3,5].into_iter();
-
-for x in i {
-    print("x is " + x);
-}
-
-
-// the same as...
-let i = [1,2,3,5].into_iter();
-
-loop {
-  match next(i) {
-    Some(x) => {print("x is " + x)};
-    None => break;
-  }
-}
-```
-
-### While loop internal representation
-
- In general, a while loop transpilation process occurs by transferring the looping 
- condition into a match block, which compares a boolean condition. If the boolean
- conditionb evaluates to `false`, the loop will immediatelly `break`. Otherwise
- the body expression is exected. A rough outline of what the transpillation process for a `while` loop looks like:
-
- ```
- while <condition> {
-     <block>
- }
-
- // converted to
- loop {
-     match <condition> {
-         true  => <block>;
-         false => break;
-     }
- }
- ```
-
-This is why the condition must explicitly return a boolean value.
-
-An example of a transpilation:
-
-And the `while` loop can be written using the `loop` directive
-like so:
-
-```rust
-let c = 0;
-
-loop {
-    match c < 5 { // where 'x' is the condition for the while loop
-        true  => c += 1;
-        false => break;
-    }
-}
-
-// same as...
-let c = 0;
-
-while c < 5 {
-    c+=1;
-}
-```
-
-
-### Loop construct
-
-Similarly, the `loop` keyword is equivalent of someone writing a `while` loop that has
-a conditional expression that always evaluate to `true`; like so,
-
-```rust
-while true {
-    // do something
-}
-
-// is the same as...
-
-loop {
-    // do something
-}
-```
-=======
->>>>>>> main:docs/src/basics/loops.md

--- a/docs/src/basics/modules.md
+++ b/docs/src/basics/modules.md
@@ -15,7 +15,7 @@ Given the project structure:
 └── main.hash
 ```
 
-Modules in hash allow for a source to be split up into smaller code fragments, allowing for better source code organisation and maintainance.
+Modules in hash allow for a source to be split up into smaller code fragments, allowing for better source code organisation and maintenance.
 
 You can import modules by specifying the path relative to the current path. 
 
@@ -79,17 +79,4 @@ let p1 = LibPoint { x=2; y=3 };
 ```
 
 > **Note**: Naming is entirely up to the developer, there are no restrictions on naming
-> except the language naming 
-
-### Cyclic imports 🚧
-
-Hash does not currently support cyclical dependencies within a project. Two modules within a project cannot be dependent on each other. As much as this might be an inconvienience, this is done to avoid "behaviour" which is implied by supporting cyclical imports. Other languages such as JavaScript support cyclical imports but can sometimes exhibit strange behaviour when using modules with cyclical imports.
-
-It is currently under consideration to lift this restriction, but at the same time avoid strange behaviours when supporting cyclical imports.
-
-If you attempt to run a module which has a cyclical import, the compiler will error and refuse to run the module like so:
-
-```sh
-$ hash -e ./module_with_cyclic_imports.hash
-error: Found circular dependency in "./module_with_cyclic_imports.hash"
-```
+> except the language naming.

--- a/docs/src/basics/operators.md
+++ b/docs/src/basics/operators.md
@@ -10,7 +10,6 @@ a specific group of operations or are used to convey meaning within the language
 
 | Operator             | Example              | Description                   | Overloadable trait |
 |----------------------|----------------------|-------------------------------|--------------------|
-| `===`, `!==`         | `a === b`, `a !== c` | Referential equality          | `ref_eq`           |
 | `->`                 | N/A                  | `Reserved`                    | N/A                |
 | `=>`                 | `(a) => a + 2`       | Function notation             | N/A                |
 | `==`, `!=`           | `a == 2`, `b != 'a'` | Equality                      | `eq`               |
@@ -61,4 +60,5 @@ This table represents the syntax for different types of comments in Hash:
 |-----------|-----------------------------|
 | `//...`   | Line comment                |
 | `/*...*/` | Block comment               |
-| N/A       | Module/function doc comment |
+| `///`     | function doc comment    🚧  |
+| `//!`     | module doc comment      🚧  |

--- a/docs/src/basics/pattern-matching.md
+++ b/docs/src/basics/pattern-matching.md
@@ -29,7 +29,7 @@ to the literal.
 
 ## Destructuring patterns
 
-Destructuring patterns are used to assign parts of an object to seperate variables within `let`, `for`, and
+Destructuring patterns are used to assign parts of an object to separate variables within `let`, `for`, and
 `match`statements. A very simple example of a destructuring pattern in a `let` statement would be:
 
 ```rust
@@ -64,12 +64,12 @@ for Point {x, y} in points.iter() {
 }
 ```
 As you can see within the `for` loop, the pattern `Point{x, y}` is being used to
-destruct each point in the array into the seperate fields.
+destruct each point in the array into the separate fields.
 
 ## Struct patterns
 
-Struct patterns follow a simiar syntax to struct literals in Hash. You can discard and
-access fields available within a struct by specifiying the field name and then followed
+Struct patterns follow a similar syntax to struct literals in Hash. You can discard and
+access fields available within a struct by specifying the field name and then followed
 by an optional right-hand side pattern to either rename the field or use a literal pattern.
 
 ### Basic
@@ -134,11 +134,11 @@ let compare_id = (car: Car, id: int) => {
 ```
 
 So, in the above example (which is admittedly unrealistic) we rename the cars `id` field to
-`car_id` by specifing the right-hand side binding pattern `= car_id`.
+`car_id` by specifying the right-hand side binding pattern `= car_id`.
 
 ## Namespace patterns
 
-Namspace patterns are very similar to struct patterns, but they can only be used within `let`
+Namespace patterns are very similar to struct patterns, but they can only be used within `let`
 statements and when importing symbols from other modules. They follow a simple syntax:
 
 ```rust
@@ -186,7 +186,7 @@ let [a, b] = arr;
 ```
 
 Now in this example, the compiler will assume that the size of `arr` is of length 2, and if not it will error since
-parts of the array are essentially unhandeled. To circumvent this issue you can use the `...`, (spread) operator which
+parts of the array are essentially unhandled. To circumvent this issue you can use the `...`, (spread) operator which
 used as a capturing group for some elements. With the example above, you can ignore all of the following elements after
 the first two by writing:
 

--- a/docs/src/basics/primitive-types.md
+++ b/docs/src/basics/primitive-types.md
@@ -23,7 +23,7 @@ like `3.0`, `3e2`, `30e-1`, etc.
 
 ### Number types like `usize` & `isize` & `ibig` & `ubig`
 
-These number primitives are added for convienience when working with a variety of
+These number primitives are added for convenience when working with a variety of
 problems and host operating systems. The primitives `usize` and `isize` are intended
 for list indexing. This is because on some systems (which are 32bit) may not be able
 to support indexing a contiguous region of memory that is larger than '32bit' max value. So, the `usize` and `isize` primitives are host system dependent. 
@@ -32,7 +32,7 @@ The `ibig` and `ubig` number primitives are integer types that have no upper
 or lower bound and will grow until the host operating system memory is exhausted 
 when storing them. These types are intended to be used when working with heavy mathematical problems which may exceed the maximum '64bit' integer boundary.
 
-## Bracketted type syntax
+## Bracketed type syntax
 
 ### List
 Lists are denoted using the the common square bracket syntax where the values are
@@ -44,7 +44,7 @@ let y = [];
 let z = [1,]; // optional trailing comma
 ```
 
-To explictly declare a variable is of a `list` type, you do so:
+To explicitly declare a variable is of a `list` type, you do so:
 
 ```rs
 let some_list: [u64] = [];
@@ -62,7 +62,7 @@ differences between the common syntax. These differences are:
 - Singleton tuple : `(A,)`
 - Many membered tuple: `(A, B, C)` or `(A, B, C,)` 
 
-To explictly declare a variable is of a `tuple` type, you do so:
+To explicitly declare a variable is of a `tuple` type, you do so:
 
 ```rs
 let empty_tuple: (,) = (,);
@@ -73,7 +73,7 @@ let some_tuple: (str, u32) = ("string", 12);
 //              ^^^^^^^^^^
 //                 type
 ```
-**Note**: Trailing commas are not allowed within type defintions.
+**Note**: Trailing commas are not allowed within type definitions.
 
 
 It's worth noting that tuples are fancy syntax for structures and are indexed
@@ -91,7 +91,7 @@ Like tuples, sets have the same syntactic differences:
 - Singleton set : `{A,}`
 - Many membered set: `{A, B, C}` or `{A, B, C,}` 
 
-To explictly declare a variable is of a `set` type, you do so:
+To explicitly declare a variable is of a `set` type, you do so:
 
 ```rs
 let some_map: {str} = {,};
@@ -107,7 +107,7 @@ Like tuples, sets have the same syntactic differences:
 - Singleton map : `{A:1}` or `{A:1,}`
 - Many membered map: `{A: 1, B: 2, C: 3}` or `{A: 1, B: 2, C: 3,}` 
 
-To explictly declare a variable is of a `map` type, you do so:
+To explicitly declare a variable is of a `map` type, you do so:
 
 ```rs
 let some_map: {str: u8} = {:};

--- a/docs/src/basics/types-assertions.md
+++ b/docs/src/basics/types-assertions.md
@@ -43,17 +43,15 @@ For example, if you were to specify the expression:
 The compiler will report this error as:
 
 ```
-error: Failed to typecheck:
+error[0052]: Failed to typecheck: Mismatching types
 --> 1:1 - 1:3
   |
-  |
 1 | "2" as char
-  | ^^^    
+  | ^^^  Cannot match type 'char' with 'str'.
   |
-Cannot match type 'char' with 'str'.
 ```
 
-## Usefullness
+## Usefulness
  
 Why are type assertions when there is already type inference within the language? Well, sometimes the type inference
 system does not have enough information to infer the types of variables and declarations. 

--- a/docs/src/basics/variables.md
+++ b/docs/src/basics/variables.md
@@ -21,18 +21,18 @@ print(x) // :^( error
 Will result in the compiler error:
 
 ```
-error: Failed to typecheck:
- --> 1:5
+error[0057]: Failed to typecheck: Un-initialised symbol
+ --> src/file.hash:3:7
   |
 1 | let x:u8;
-  |     ^--- symbol 'x' declared here without initialisation.
+  |     ^ symbol 'x' declared here without initialisation.
   |
+  = note: Consider giving 'x' an initial value.
 
- --> 3:7
+ --> src/file.hash:3:7
   |
 3 | print(x)
-  |       ^
-  |   symbol 'x' is uninitialised.
+  |       ^ symbol 'x' is uninitialised.
 ```
 
 ## Type inference

--- a/docs/src/interpreter/backends.md
+++ b/docs/src/interpreter/backends.md
@@ -15,12 +15,12 @@ However, there are advantages to having a VM implementation for the language, wh
 primarily:
 
 - We can have an interactive mode, execute code on the fly (with a minor performance hit)
-- We can run compile-time code functions that are beyound just templates and constant
+- We can run compile-time code functions that are beyond just templates and constant
 folding expressions.
 
 ## Planned backends
 
-Here are the currently planned backends, that will be worked on and stabalised some time in the future:
+Here are the currently planned backends, that will be worked on and stabilised some time in the future:
 
 | Name            | Description                                                                         | Target platform | Status |
 |-----------------|-------------------------------------------------------------------------------------|-----------------|--------|

--- a/docs/src/interpreter/intro.md
+++ b/docs/src/interpreter/intro.md
@@ -1,4 +1,4 @@
 # Interpreter
 
 This chapter is dedicated to documenting the current interpreter implementation, future plans and a
-very basic manual for how to use the interpeter (via commandline arguments).
+very basic manual for how to use the interpreter (via commandline arguments).

--- a/docs/src/interpreter/options.md
+++ b/docs/src/interpreter/options.md
@@ -38,5 +38,13 @@ Adjust the stack size of the Virtual Machine. Default value is `10,0000`
 ## `ast-gen`: Generate AST from input file only
 This mode tells the compiler to finish at the Abstract Syntax Tree stage and not produce any other kind of output.
 
+### `-v` : Whilst generating AST, output a visual representation of the AST.
+
+### `-d` : Run in debug mode.
+
 ## `ir-gen`: : Generate IR from input file only
 This mode tells the compiler to finish at the IR stage and not produce any other kind of output.
+
+### `-v` : Whilst generating IR, output a visual representation of the IR.
+
+### `-d` : Run in debug mode.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This book is dedicated to documenting and teaching the `Hash` programming language to newcommers.
+This book is dedicated to documenting and teaching the `Hash` programming language to newcomers.
 
 Firstly, Hash is an interpreted, garbage collected, strongly and statically typed language.
 

--- a/docs/src/standard-library/intro.md
+++ b/docs/src/standard-library/intro.md
@@ -14,6 +14,6 @@ The standard library included the following modules:
 
 These modules are currently under construction or proposed:
 
-- `time`: Useful constrcuts for time orientated data
+- `time`: Useful constructs for time orientated data
 - `sys`: System information about the host OS
 - `path`: Path utilities


### PR DESCRIPTION
This PR fixes all spelling mistakes and updates the style of error reporting as per the work done in `hash-reporting`.