### PR TITLE
Use ADTs for errors in the parser.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,11 +397,13 @@ name = "hash-parser"
 version = "0.1.0"
 dependencies = [
  "dashmap",
+ "derive_more",
  "hash-alloc",
  "hash-ast",
  "hash-utils",
  "lazy_static",
  "log",
+ "thiserror",
 ]
 
 [[package]]

--- a/compiler/hash-alloc/src/collections/row.rs
+++ b/compiler/hash-alloc/src/collections/row.rs
@@ -57,12 +57,12 @@ impl<'c, T> Row<'c, T> {
     /// - Panics if `new_capacity` is less than the current length of the `Row`.
     pub fn reserve(&mut self, new_capacity: usize, wall: &Wall<'c>) {
         assert!(
-            !(new_capacity > isize::MAX as usize),
+            new_capacity <= isize::MAX as usize,
             "Reallocation target capacity is too large"
         );
 
         assert!(
-            !(new_capacity < self.len()),
+            new_capacity >= self.len(),
             "Tried to reallocate with a capacity smaller than length"
         );
 

--- a/compiler/hash-ast/src/location.rs
+++ b/compiler/hash-ast/src/location.rs
@@ -22,7 +22,7 @@ impl Location {
     /// Create a 'Span' variant by providing a start and end byte position.
     pub fn span(start: usize, end: usize) -> Self {
         assert!(
-            !(end <= start),
+            end > start,
             "Got invalid span for Location::span. Start needs to be smaller than end."
         );
 

--- a/compiler/hash-ast/src/location.rs
+++ b/compiler/hash-ast/src/location.rs
@@ -41,7 +41,7 @@ impl Location {
     ///
     /// Then the two locations are joined into one, otherwise the lhs is returned
     pub fn join(&self, end: Self) -> Self {
-        if self.end() < end.start() {
+        if self.end() <= end.start() {
             return Location::span(self.start(), end.end());
         }
 

--- a/compiler/hash-ast/src/parse.rs
+++ b/compiler/hash-ast/src/parse.rs
@@ -177,7 +177,7 @@ where
                             module_builder.set_entry_point(index);
                         }
                         Err(err) => {
-                            error_handler.add_error(err);
+                            error_handler.add_error(err.into());
                         }
                     }
 

--- a/compiler/hash-parser/Cargo.toml
+++ b/compiler/hash-parser/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 log = "0.4"
 lazy_static = "1.4.0"
 dashmap = "4.0"
+thiserror = "1.0"
+derive_more = "0.99"
 hash-ast = {path = "../hash-ast" }
 hash-utils = {path = "../hash-utils" }
 hash-alloc = {path = "../hash-alloc" }

--- a/compiler/hash-parser/src/backend.rs
+++ b/compiler/hash-parser/src/backend.rs
@@ -45,7 +45,10 @@ impl<'c> ParserBackend<'c> for HashParser<'c> {
         let gen = AstGen::new(&tokens, &resolver, wall);
 
         timed(
-            || gen.parse_module(),
+            || match gen.parse_module() {
+                Err(err) => Err(err.into()),
+                Ok(module) => Ok(module),
+            },
             log::Level::Debug,
             |elapsed| println!("translation: {:?}", elapsed),
         )
@@ -63,7 +66,10 @@ impl<'c> ParserBackend<'c> for HashParser<'c> {
         let tokens = Lexer::new(contents, index, &wall).tokenise()?;
         let gen = AstGen::new(&tokens, &resolver, wall);
 
-        gen.parse_expression_from_interactive()
+        match gen.parse_expression_from_interactive() {
+            Err(err) => Err(err.into()),
+            Ok(block) => Ok(block),
+        }
     }
 }
 

--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -1,0 +1,190 @@
+//! Hash compiler parser error data types.
+//!
+//! All rights reserved 2021 (c) The Hash Language authors
+
+use hash_ast::{
+    error::ParseError,
+    location::{Location, SourceLocation},
+    module::ModuleIdx,
+};
+
+use crate::token::{Delimiter, TokenAtom, TokenKindVector};
+
+/// A [TokenError] represents a encountered error during tokenisation, which includes an optional message
+/// with the error, the [TokenErrorKind] which classifies the error, and a [Location] that represents
+/// where the tokenisation error occurred.
+#[derive(Debug)]
+pub struct TokenError {
+    pub(crate) message: Option<String>,
+    kind: TokenErrorKind,
+    location: Location,
+}
+
+/// A [TokenErrorKind] represents the kind of [TokenError] which gives additional context to the error
+/// with the provided message in [TokenError]
+#[derive(Debug)]
+pub enum TokenErrorKind {
+    /// Occurs when a escape sequence (within a character or a string) is malformed.
+    BadEscapeSequence,
+    /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
+    MalformedNumericalLiteral,
+    /// Occurs when a char is unexpected in the current context
+    Unexpected(char),
+    /// Occurs when the tokeniser expects a particular token next, but could not derive one.
+    Expected(TokenAtom),
+    /// Unclosed tree block
+    Unclosed(Delimiter),
+}
+
+/// Utility methods for [TokenError]
+impl TokenError {
+    /// Create a new [TokenError] from a message, kind and a span location.
+    pub fn new(message: Option<String>, kind: TokenErrorKind, location: Location) -> Self {
+        TokenError {
+            message,
+            kind,
+            location,
+        }
+    }
+
+    /// Convert a [TokenError] into a printable message.
+    pub fn as_message(&self) -> String {
+        let sub_message = match self.kind {
+            TokenErrorKind::BadEscapeSequence => "Invalid character escape sequence.".to_owned(),
+            TokenErrorKind::MalformedNumericalLiteral => "Malformed numerical literal.".to_owned(),
+            TokenErrorKind::Unexpected(ch) => {
+                format!("Encountered unexpected character '{}'", ch)
+            }
+            TokenErrorKind::Expected(atom) => format!("Expected token '{}' here.", atom),
+            TokenErrorKind::Unclosed(delim) => {
+                format!("Encountered unclosed delimiter '{}'", delim)
+            }
+        };
+
+        match &self.message {
+            Some(message) => {
+                let copy = message.to_owned();
+                format!("{} {}", copy, sub_message)
+            }
+            None => sub_message,
+        }
+    }
+}
+
+/// This implementation exists since we can't use tuples that are un-named
+/// with foreign module types.
+pub struct TokenErrorWrapper(pub ModuleIdx, pub TokenError);
+
+impl From<TokenErrorWrapper> for ParseError {
+    fn from(TokenErrorWrapper(idx, err): TokenErrorWrapper) -> Self {
+        ParseError::Parsing {
+            message: err.as_message(),
+            src: SourceLocation {
+                location: err.location,
+                module_index: idx,
+            },
+        }
+    }
+}
+
+/// A GeneratorError represents possible errors that occur when transforming the token
+/// stream into the AST.
+pub struct AstGenError<'a> {
+    kind: GeneratorErrorKind,
+    location: SourceLocation,
+    expected: Option<TokenKindVector<'a>>,
+    received: Option<TokenAtom>,
+}
+
+/// Utility methods for creating AstGenErrors
+impl<'a> AstGenError<'a> {
+    pub fn new(
+        kind: GeneratorErrorKind,
+        expected: Option<TokenKindVector<'a>>, // @@Nocheckin: maybe make this a TokenKindVector for multiple options?
+        received: Option<TokenAtom>,
+        location: SourceLocation,
+    ) -> Self {
+        Self {
+            kind,
+            expected,
+            location,
+            received,
+        }
+    }
+}
+
+pub enum ExpectedTyArguments {
+    Struct,
+    Enum,
+}
+
+pub enum GeneratorErrorKind {
+    Keyword,
+    Atom,
+    Either,
+
+    /// Nocheckin:
+    /// Expecting ';' at the end of a statement, but got
+    Expected,
+
+    /// "Expected block body, which begins with a '{', but reached end of input",
+    /// "Expected block body, which begins with a '{{' but got a {}",
+    Block,
+    EOF,
+    ReAssignmentOp,
+
+    /// NOCHECKIN:
+    /// 1. Expected struct type args or struct definition entries here"
+    /// 2. Expected Enum type args or struct definition entries here"
+    TypeArguments(ExpectedTyArguments),
+
+    /// Expected statement.
+    ExpectedStatement,
+
+    /// Expected an expression.
+    ExpectedExpression,
+
+    /// "Expected an arrow '=>' here."
+    ExpectedArrow,
+
+    /// "Expected an arrow '=>' after type arguments denoting a function type.",
+    ExpectedFnArrow,
+
+    /// Expected a function body here.
+    ExpectedFnBody,
+
+    /// "Expected a type here."
+    ExpectedType,
+
+    /// "Expected field name or an infix function call"
+    /// "Expecting field name after property access.")
+    InfixCall,
+
+    /// Expected an import path.
+    ImportPath,
+
+    ///  "Expected identifier after a name access qualifier"
+    AccessName,
+}
+
+/// This implementation exists since we can't use tuples that are un-named
+/// with foreign module types.
+pub struct GeneratorErrorWrapper<'a>(pub ModuleIdx, pub AstGenError<'a>);
+
+impl<'a> From<AstGenError<'a>> for ParseError {
+    fn from(_: AstGenError) -> Self {
+        todo!()
+    }
+}
+
+// impl<'a, T> From<AstGenResult<'a, T>> for ParseResult<T> {
+//     fn from(_: AstGenError) -> Self {
+//         todo!()
+//     }
+// }
+
+impl<'a> From<ParseError> for AstGenError<'a> {
+    fn from(_: ParseError) -> Self {
+        todo!()
+    }
+}

--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -97,7 +97,7 @@ pub enum AstGenErrorKind {
     EOF,
     /// Expecting a re-assignment operator at the specified location. Re-assignment operators
     /// are like normal operators, but they expect an 'equals' sign after the specified
-    /// operator. It
+    /// operator.
     ReAssignmentOp,
     /// Error representing expected type arguments. This error has two variants, it can
     /// either be 'struct' or 'enum' type arguments. The reason why there are two variants

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -173,8 +173,8 @@ where
         }
     }
 
-    /// get the location of the next token, if there is no token after, we use the
-    /// next character offset to determine the location.
+    /// Get the next location of the token, if there is no token after, we use the 
+    /// next character offset to determine the location. 
     pub(crate) fn next_location(&self) -> Location {
         match self.peek() {
             Some(token) => token.span,

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -10,7 +10,6 @@ use hash_alloc::{collections::row::Row, row};
 
 use hash_ast::{
     ast::*,
-    error::{ParseError, ParseResult},
     ident::{Identifier, IDENTIFIER_MAP},
     keyword::Keyword,
     literal::STRING_LITERAL_MAP,
@@ -20,11 +19,17 @@ use hash_ast::{
     resolve::ModuleResolver,
 };
 
-use crate::{operator::Operator, token::TokenAtom};
+use crate::{
+    error::{AstGenError, ExpectedTyArguments, GeneratorErrorKind},
+    operator::Operator,
+    token::TokenAtom,
+};
 use crate::{
     operator::OperatorKind,
     token::{Delimiter, Token, TokenKind, TokenKindVector},
 };
+
+pub type AstGenResult<'a, T> = Result<T, AstGenError<'a>>;
 
 pub struct AstGen<'c, 'stream, 'resolver, R> {
     /// Current token stream offset.
@@ -173,8 +178,8 @@ where
         }
     }
 
-    /// Get the next location of the token, if there is no token after, we use the 
-    /// next character offset to determine the location. 
+    /// Get the next location of the token, if there is no token after, we use the
+    /// next character offset to determine the location.
     pub(crate) fn next_location(&self) -> Location {
         match self.peek() {
             Some(token) => token.span,
@@ -195,69 +200,54 @@ where
         AstNode::new(inner, location, &self.wall)
     }
 
-    /// Function to create a token error at the current location with a
-    /// vector of tokens that the parser was accepting in the current state.
-    pub(crate) fn unexpected_token_error<T>(
+    /// Create an error at the current location.
+    pub fn error<T>(
         &self,
-        kind: &TokenKind,
-        expected: &TokenKindVector,
-        location: &Location,
-    ) -> ParseResult<T> {
-        // we need to convert a token-tree into just the delimiter since we don't want
-        // to print the whole tree...
-        let atom = kind.to_atom();
-
-        if expected.is_empty() {
-            self.error_with_location(format!("Unexpected token '{}'", atom), location)
-        } else {
-            self.error_with_location(
-                format!("Unexpected token '{}', expecting {}", atom, expected),
-                location,
-            )
-        }
+        kind: GeneratorErrorKind,
+        expected: Option<TokenKindVector<'c>>,
+        received: Option<TokenAtom>,
+    ) -> AstGenResult<'c, T> {
+        Err(AstGenError::new(
+            kind,
+            expected,
+            received,
+            self.source_location(&self.current_location()),
+        ))
     }
 
     /// Create an error at the current location.
-    pub fn error<T, S: Into<String>>(&self, message: S) -> ParseResult<T> {
-        Err(ParseError::Parsing {
-            message: message.into(),
-            src: self.source_location(&self.current_location()),
-        })
-    }
-
-    /// Create an error at the current location.
-    pub fn error_with_location<T, S: Into<String>>(
+    pub fn error_with_location<T>(
         &self,
-        message: S,
+        kind: GeneratorErrorKind,
+        expected: Option<TokenKindVector<'c>>,
+        received: Option<TokenAtom>,
         location: &Location,
-    ) -> ParseResult<T> {
-        Err(ParseError::Parsing {
-            message: message.into(),
-            src: self.source_location(location),
-        })
+    ) -> AstGenResult<'c, T> {
+        Err(AstGenError::new(
+            kind,
+            expected,
+            received,
+            self.source_location(location),
+        ))
     }
 
-    pub(crate) fn expected_eof<T>(&self) -> ParseResult<T> {
+    pub(crate) fn expected_eof<T>(&self) -> AstGenResult<'c, T> {
         // move onto the next token
         self.offset.set(self.offset.get() + 1);
 
-        self.error(format!(
-            "Expected the end of a definition, but got '{}'.",
-            self.current_token().kind
-        ))
+        self.error(
+            GeneratorErrorKind::EOF,
+            Some(TokenKindVector::singleton(
+                &self.wall,
+                self.current_token().to_atom(),
+            )),
+            None,
+        )
     }
 
     /// Create a generalised "Reached end of file..." error.
-    pub(crate) fn unexpected_eof<T>(&self) -> ParseResult<T> {
-        self.error("Unexpectedly reached the end of file.")
-    }
-
-    /// Create a generalised "Reached end of file..." error.
-    pub(crate) fn unexpected_eof_with_ctx<T>(&self, ctx: impl Into<String>) -> ParseResult<T> {
-        self.error(format!(
-            "{}: but unexpectedly reached the end of file.",
-            ctx.into()
-        ))
+    pub(crate) fn unexpected_eof<T>(&self) -> AstGenResult<'c, T> {
+        self.error(GeneratorErrorKind::EOF, None, None)
     }
 
     /// Make an [Expression] with kind [ExpressionKind::Variable] from a specified identifier
@@ -367,12 +357,12 @@ where
     }
 
     /// Function to peek ahead and match some parsing function that returns a [Option<T>] wrapped
-    /// in a [ParseResult]. If The result is an error, or the option is [None], the function will
+    /// in a [AstGenResult]. If The result is an error, or the option is [None], the function will
     /// reset the current offset of the token stream to where it was the function was peeked.
     pub fn peek_fn<T>(
         &self,
-        parse_fn: impl Fn() -> ParseResult<Option<T>>,
-    ) -> ParseResult<Option<T>> {
+        parse_fn: impl Fn() -> AstGenResult<'c, Option<T>>,
+    ) -> AstGenResult<'c, Option<T>> {
         let start = self.offset();
 
         match parse_fn() {
@@ -386,7 +376,7 @@ where
 
     /// Function to peek ahead and match some parsing function that returns a [Option<T>].
     /// If The result is an error, the function wil reset the current offset of the token stream
-    /// to where it was the function was peeked. This is essentially a convertor from a [ParseResult<T>]
+    /// to where it was the function was peeked. This is essentially a convertor from a [AstGenResult<T>]
     /// into an [Option<T>] with the side effect of resetting the parser state back to it's original
     /// settings.
     pub fn peek_resultant_fn<T, E>(&self, parse_fn: impl Fn() -> Result<T, E>) -> Option<T> {
@@ -402,7 +392,7 @@ where
     }
 
     /// Parse a [Module] which is simply made of a list of statements
-    pub fn parse_module(&self) -> ParseResult<Module<'c>> {
+    pub fn parse_module(&self) -> AstGenResult<'c, Module<'c>> {
         let mut contents = row![&self.wall];
 
         while self.has_token() {
@@ -413,7 +403,7 @@ where
     }
 
     /// Parse a statement.
-    pub fn parse_statement(&self) -> ParseResult<AstNode<'c, Statement<'c>>> {
+    pub fn parse_statement(&self) -> AstGenResult<'c, AstNode<'c, Statement<'c>>> {
         let start = self.current_location();
 
         match self.peek() {
@@ -455,14 +445,12 @@ where
                     Some(token) if token.has_atom(TokenAtom::Semi) => {
                         Ok(self.node_from_joined_location(statement, &start))
                     }
-                    Some(token) => self.error(format!(
-                        "Expecting ';' at the end of a statement, but got '{}' ",
-                        token.kind
-                    )),
-                    None => self.unexpected_eof_with_ctx(format!(
-                        "'{}', Expecting ';' ending a statement",
-                        atom
-                    ))?,
+                    Some(token) => self.error(
+                        GeneratorErrorKind::Expected,
+                        Some(TokenKindVector::singleton(&self.wall, TokenAtom::Semi)),
+                        Some(token.to_atom()),
+                    ),
+                    None => self.error(GeneratorErrorKind::EOF, None, Some(atom))?,
                 }
             }
             Some(_) => {
@@ -514,15 +502,16 @@ where
                         (_, ExpressionKind::Block(block)) => {
                             Ok(self.node_from_location(Statement::Block(block), &start))
                         }
-                        (Some(token), _) => self.error(format!(
-                            "Expecting ';' at the end of a statement, but got '{}' ",
-                            token.kind
-                        ))?,
+                        (Some(token), _) => self.error(
+                            GeneratorErrorKind::Expected,
+                            Some(TokenKindVector::singleton(&self.wall, TokenAtom::Semi)),
+                            Some(token.to_atom()),
+                        ),
                         (None, _) => unreachable!(),
                     },
                 }
             }
-            _ => self.error("Expected statement.")?,
+            _ => self.error(GeneratorErrorKind::ExpectedStatement, None, None)?, // @@Cleanup: is this even right?
         }
     }
 
@@ -531,7 +520,9 @@ where
     /// without the actual braces to begin with. It follows that there are an arbitrary
     /// number of statements, followed by an optional final expression which doesn't
     /// need to be completed by a comma...
-    pub fn parse_expression_from_interactive(&self) -> ParseResult<AstNode<'c, BodyBlock<'c>>> {
+    pub fn parse_expression_from_interactive(
+        &self,
+    ) -> AstGenResult<'c, AstNode<'c, BodyBlock<'c>>> {
         // get the starting position
         let start = self.current_location();
 
@@ -720,9 +711,9 @@ where
     /// is intended to be used with a nested generator.
     pub fn parse_separated_fn<T>(
         &self,
-        parse_fn: impl Fn() -> ParseResult<AstNode<'c, T>>,
-        separator_fn: impl Fn() -> ParseResult<()>,
-    ) -> ParseResult<AstNodes<'c, T>> {
+        parse_fn: impl Fn() -> AstGenResult<'c, AstNode<'c, T>>,
+        separator_fn: impl Fn() -> AstGenResult<'c, ()>,
+    ) -> AstGenResult<'c, AstNodes<'c, T>> {
         let mut args = row![&self.wall;];
 
         // so parse the arguments to the function here... with potential type annotations
@@ -746,7 +737,7 @@ where
     /// This will parse an operator and check that it is re-assignable, if the operator is not
     /// re-assignable then the result of the function is an [ParseError] since it expects there
     /// to be this operator.
-    pub fn parse_re_assignment_op(&self) -> ParseResult<Operator> {
+    pub fn parse_re_assignment_op(&self) -> AstGenResult<'c, Operator> {
         let (operator, consumed_tokens) = Operator::from_token_stream(self);
 
         match operator {
@@ -762,7 +753,7 @@ where
                     assignable: true,
                 })
             }
-            _ => self.error("Expected re-assignment operator here."),
+            _ => self.error(GeneratorErrorKind::ReAssignmentOp, None, None), // TODO: actually add information here
         }
     }
 
@@ -773,7 +764,7 @@ where
     /// trait eq<T> => (T, T) => bool;
     ///     ┌─^^ ^─┐   ^─ ─ ─ ─ ─ ─ ─ ┐
     ///   name   Generic type args    Function type definition
-    pub fn parse_trait_defn(&self) -> ParseResult<TraitDef<'c>> {
+    pub fn parse_trait_defn(&self) -> AstGenResult<'c, TraitDef<'c>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::Trait)));
@@ -802,7 +793,7 @@ where
     ///        ^^^^    ^──────^^─┬──^   ^^^
     /// Name of struct        For all  fields
     ///
-    pub fn parse_struct_defn(&self) -> ParseResult<StructDef<'c>> {
+    pub fn parse_struct_defn(&self) -> AstGenResult<'c, StructDef<'c>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::Struct)));
@@ -824,7 +815,11 @@ where
 
                 (None, entries)
             }
-            _ => self.error("Expected struct type args or struct definition entries here")?,
+            _ => self.error(
+                GeneratorErrorKind::TypeArguments(ExpectedTyArguments::Struct),
+                None,
+                None,
+            )?,
         };
 
         Ok(StructDef {
@@ -843,7 +838,7 @@ where
     ///      ^^^^  ^──────^^─┬──^       ^^^
     /// Name of enum      For all      fields
     ///
-    pub fn parse_enum_defn(&self) -> ParseResult<EnumDef<'c>> {
+    pub fn parse_enum_defn(&self) -> AstGenResult<'c, EnumDef<'c>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::Enum)));
@@ -870,7 +865,11 @@ where
 
                 (None, entries)
             }
-            _ => self.error("Expected struct type args or struct definition entries here")?,
+            _ => self.error(
+                GeneratorErrorKind::TypeArguments(ExpectedTyArguments::Enum),
+                None,
+                None,
+            )?,
         };
 
         Ok(EnumDef {
@@ -880,7 +879,7 @@ where
         })
     }
 
-    pub fn parse_enum_def_entries(&self) -> ParseResult<AstNodes<'c, EnumDefEntry<'c>>> {
+    pub fn parse_enum_def_entries(&self) -> AstGenResult<'c, AstNodes<'c, EnumDefEntry<'c>>> {
         match self.peek() {
             Some(Token {
                 kind: TokenKind::Tree(Delimiter::Brace, tree),
@@ -894,19 +893,20 @@ where
                     || gen.parse_token_atom(TokenAtom::Comma),
                 )
             }
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(
+            Some(token) => {
+                let atom = token.to_atom();
+                let expected = TokenKindVector::from_row(
                     row![&self.wall; TokenAtom::Delimiter(Delimiter::Brace, false)],
-                ),
-                &self.current_location(),
-            )?,
+                );
+
+                self.error(GeneratorErrorKind::Expected, Some(expected), Some(atom))?
+            }
             None => self.unexpected_eof(),
         }
     }
 
     /// Parse an Enum definition entry.
-    pub fn parse_enum_def_entry(&self) -> ParseResult<AstNode<'c, EnumDefEntry<'c>>> {
+    pub fn parse_enum_def_entry(&self) -> AstGenResult<'c, AstNode<'c, EnumDefEntry<'c>>> {
         let start = self.current_location();
         let name = self.parse_ident()?;
 
@@ -933,7 +933,7 @@ where
     }
 
     /// Parse struct definition field entries.
-    pub fn parse_struct_def_entries(&self) -> ParseResult<AstNodes<'c, StructDefEntry<'c>>> {
+    pub fn parse_struct_def_entries(&self) -> AstGenResult<'c, AstNodes<'c, StructDefEntry<'c>>> {
         match self.peek() {
             Some(Token {
                 kind: TokenKind::Tree(Delimiter::Brace, tree),
@@ -948,19 +948,20 @@ where
                     || gen.parse_token_atom(TokenAtom::Comma),
                 )
             }
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(
+            Some(token) => {
+                let atom = token.to_atom();
+                let expected = TokenKindVector::from_row(
                     row![&self.wall; TokenAtom::Delimiter(Delimiter::Brace, true)],
-                ),
-                &self.current_location(),
-            )?,
+                );
+
+                self.error(GeneratorErrorKind::Expected, Some(expected), Some(atom))?
+            }
             None => self.unexpected_eof(),
         }
     }
 
     /// Parse struct definition field.
-    pub fn parse_struct_def_entry(&self) -> ParseResult<AstNode<'c, StructDefEntry<'c>>> {
+    pub fn parse_struct_def_entry(&self) -> AstGenResult<'c, AstNode<'c, StructDefEntry<'c>>> {
         let start = self.current_location();
         let name = self.parse_ident()?;
 
@@ -986,7 +987,7 @@ where
 
     /// Parse a type bound. Type bounds can occur in traits, function, struct and enum
     /// definitions.
-    pub fn parse_type_bound(&self) -> ParseResult<AstNode<'c, Bound<'c>>> {
+    pub fn parse_type_bound(&self) -> AstGenResult<'c, AstNode<'c, Bound<'c>>> {
         let start = self.current_location();
         let type_args = self.parse_type_args()?;
 
@@ -1064,7 +1065,7 @@ where
     /// >>>         None        => break;
     /// >>>     }
     /// >>> }
-    pub fn parse_for_loop(&self) -> ParseResult<AstNode<'c, Block<'c>>> {
+    pub fn parse_for_loop(&self) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::For)));
@@ -1156,7 +1157,7 @@ where
     /// >>>         false => break;
     /// >>>     }
     /// >>> }
-    pub fn parse_while_loop(&self) -> ParseResult<AstNode<'c, Block<'c>>> {
+    pub fn parse_while_loop(&self) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::While)));
@@ -1204,7 +1205,7 @@ where
 
     /// Parse a match case. A match case involves handling the pattern and the
     /// expression branch.
-    pub fn parse_match_case(&self) -> ParseResult<AstNode<'c, MatchCase<'c>>> {
+    pub fn parse_match_case(&self) -> AstGenResult<'c, AstNode<'c, MatchCase<'c>>> {
         let start = self.current_location();
         let pattern = self.parse_pattern()?;
 
@@ -1216,7 +1217,7 @@ where
 
     /// Parse a match block statement, which is composed of a subject and an arbitrary
     /// number of match cases that are surrounded in braces.
-    pub fn parse_match_block(&self) -> ParseResult<AstNode<'c, Block<'c>>> {
+    pub fn parse_match_block(&self) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         debug_assert!(self
             .current_token()
             .has_atom(TokenAtom::Keyword(Keyword::Match)));
@@ -1240,13 +1241,14 @@ where
                     gen.parse_token_atom(TokenAtom::Semi)?;
                 }
             }
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(
+            Some(token) => {
+                let atom = token.to_atom();
+                let expected = TokenKindVector::from_row(
                     row![&self.wall; TokenAtom::Delimiter(Delimiter::Brace, true)],
-                ),
-                &self.current_location(),
-            )?,
+                );
+
+                self.error(GeneratorErrorKind::Expected, Some(expected), Some(atom))?
+            }
             _ => self.unexpected_eof()?,
         };
 
@@ -1272,7 +1274,7 @@ where
     /// Additionally, if no 'else' clause is specified, we fill it with an
     /// empty block since an if-block could be assigned to any variable and therefore
     /// we need to know the outcome of all branches for typechecking.
-    pub fn parse_if_statement(&self) -> ParseResult<AstNode<'c, Block<'c>>> {
+    pub fn parse_if_statement(&self) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         debug_assert!(matches!(
             self.current_token().kind,
             TokenKind::Atom(TokenAtom::Keyword(Keyword::If))
@@ -1391,17 +1393,16 @@ where
     }
 
     /// Function to parse a fat arrow component '=>' in any given context.
-    fn parse_arrow(&self) -> ParseResult<()> {
-        // map error into 'Expecting '=>' instead of just individual components.
-        let err = |loc| ParseError::Parsing {
-            message: "Expected an arrow '=>' here.".to_string(),
-            src: self.source_location(&loc),
-        };
+    fn parse_arrow(&self) -> AstGenResult<'c, ()> {
+        // Essentially, we want to re-map the error into a more concise one given
+        // the parsing context.
+        if self.parse_token_atom(TokenAtom::Eq).is_err() {
+            return self.error(GeneratorErrorKind::ExpectedArrow, None, None)?;
+        }
 
-        self.parse_token_atom(TokenAtom::Eq)
-            .map_err(|_| err(self.current_location()))?;
-        self.parse_token_atom(TokenAtom::Gt)
-            .map_err(|_| err(self.current_location()))?;
+        if self.parse_token_atom(TokenAtom::Gt).is_err() {
+            return self.error(GeneratorErrorKind::ExpectedArrow, None, None)?;
+        }
 
         Ok(())
     }
@@ -1418,7 +1419,7 @@ where
     ///     ^^^^^^^^   ^^^^^  ^^^^^   ^^^─────┐
     ///    pattern     bound   type    the right hand-side expr
     /// ```
-    pub fn parse_let_statement(&self) -> ParseResult<LetStatement<'c>> {
+    pub fn parse_let_statement(&self) -> AstGenResult<'c, LetStatement<'c>> {
         debug_assert!(matches!(
             self.current_token().kind,
             TokenKind::Atom(TokenAtom::Keyword(Keyword::Let))
@@ -1461,7 +1462,7 @@ where
         &self,
         tree: &Row<'c, Token<'c>>,
         span: Location,
-    ) -> ParseResult<AstNodes<'c, Pattern<'c>>> {
+    ) -> AstGenResult<'c, AstNodes<'c, Pattern<'c>>> {
         let gen = self.from_stream(tree, span);
 
         gen.parse_separated_fn(
@@ -1477,7 +1478,7 @@ where
     pub fn parse_destructuring_pattern(
         &self,
         assigning_op: TokenAtom,
-    ) -> ParseResult<AstNode<'c, DestructuringPattern<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, DestructuringPattern<'c>>> {
         let start = self.current_location();
         let name = self.parse_ident()?;
 
@@ -1502,7 +1503,7 @@ where
         tree: &Row<'c, Token<'c>>,
         span: Location,
         struct_syntax: bool,
-    ) -> ParseResult<AstNodes<'c, DestructuringPattern<'c>>> {
+    ) -> AstGenResult<'c, AstNodes<'c, DestructuringPattern<'c>>> {
         let gen = self.from_stream(tree, span);
 
         // Since struct and namespace destructuring patterns use different operators
@@ -1527,15 +1528,16 @@ where
 
     /// Parse a singular pattern. Singular patterns cannot have any grouped pattern
     /// operators such as a '|', if guards or any form of compound pattern.
-    pub fn parse_singular_pattern(&self) -> ParseResult<AstNode<'c, Pattern<'c>>> {
-        let token = self.peek().ok_or(ParseError::Parsing {
-            message: "Unexpected eof".to_string(),
-            src: self.source_location(&self.current_location()),
-        })?;
+    pub fn parse_singular_pattern(&self) -> AstGenResult<'c, AstNode<'c, Pattern<'c>>> {
+        let token = self.peek();
+
+        if token.is_none() {
+            return self.unexpected_eof()?;
+        }
 
         let start = self.current_location();
 
-        let pattern = match token {
+        let pattern = match token.unwrap() {
             Token {
                 kind: TokenKind::Atom(TokenAtom::Ident(k)),
                 span,
@@ -1567,10 +1569,10 @@ where
                             args: self.parse_pattern_collection(tree, span)?,
                         })
                     }
-                    Some(token) if name.path.len() > 1 => self.unexpected_token_error(
-                        &token.kind,
-                        &TokenKindVector::begin_pattern_collection(&self.wall),
-                        &self.current_location(),
+                    Some(token) if name.path.len() > 1 => self.error(
+                        GeneratorErrorKind::Expected,
+                        Some(TokenKindVector::begin_pattern_collection(&self.wall)),
+                        Some(token.to_atom()),
                     )?,
                     _ => {
                         // @@Speed: Always performing a lookup?
@@ -1613,9 +1615,10 @@ where
             //     // this is a list pattern
             //
             // }
-            token => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::begin_pattern(&self.wall),
+            token => self.error_with_location(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::begin_pattern(&self.wall)),
+                Some(token.to_atom()),
                 &token.span,
             )?,
         };
@@ -1624,7 +1627,7 @@ where
     }
 
     /// Parse a block.
-    pub fn parse_block(&self) -> ParseResult<AstNode<'c, Block<'c>>> {
+    pub fn parse_block(&self) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         let (gen, start) = match self.peek() {
             Some(Token {
                 kind: TokenKind::Tree(Delimiter::Brace, tree),
@@ -1634,13 +1637,12 @@ where
 
                 (self.from_stream(tree, self.current_location()), *span)
             }
-            Some(token) => self.error(format!(
-                "Expected block body, which begins with a '{{' but got a {}",
-                token
-            ))?,
+            Some(token) => self.error(GeneratorErrorKind::Block, None, Some(token.to_atom()))?,
             // @@ErrorReporting
             None => self.error_with_location(
-                "Expected block body, which begins with a '{', but reached end of input",
+                GeneratorErrorKind::Block,
+                None,
+                None,
                 &self.next_location(),
             )?,
         };
@@ -1654,7 +1656,7 @@ where
         gen: &Self,
         start: Location,
         initial_statement: Option<AstNode<'c, Statement<'c>>>,
-    ) -> ParseResult<AstNode<'c, Block<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Block<'c>>> {
         // Edge case where the statement is parsed and the 'last_statement_is_expr' is set, here
         // we take the expression and return a block that has the expression left here.
 
@@ -1748,10 +1750,12 @@ where
                                     ),
                                     &self.wall,
                                 ),
-                                _ => gen.unexpected_token_error(
-                                    &token.kind,
-                                    &TokenKindVector::from_row(row![&self.wall; TokenAtom::Semi]),
-                                    &gen.current_location(),
+                                _ => gen.error(
+                                    GeneratorErrorKind::Expected,
+                                    Some(TokenKindVector::from_row(
+                                        row![&self.wall; TokenAtom::Semi],
+                                    )),
+                                    Some(token.to_atom()),
                                 )?,
                             };
                         }
@@ -1768,12 +1772,11 @@ where
     }
 
     /// Parse an expression which can be compound.
-    pub fn parse_expression(&self) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    pub fn parse_expression(&self) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let token = self.next_token();
 
         if token.is_none() {
-            return self
-                .unexpected_eof_with_ctx("Expected the beginning of an expression here.")?;
+            return self.unexpected_eof()?;
         }
 
         let token = token.unwrap();
@@ -1864,17 +1867,21 @@ where
                 }
             }
 
-            TokenKind::Atom(TokenAtom::Keyword(kw)) => {
-                return Err(ParseError::Parsing {
-                    message: format!("Unexpected keyword '{}' in place of an expression.", kw),
-                    src: self.source_location(&token.span),
-                })
+            kind @ TokenKind::Atom(TokenAtom::Keyword(_)) => {
+                return self.error_with_location(
+                    GeneratorErrorKind::Keyword,
+                    None,
+                    Some(kind.to_atom()),
+                    &token.span,
+                )
             }
             kind => {
-                return Err(ParseError::Parsing {
-                    message: format!("Unexpected token '{}' in the place of an expression.", kind),
-                    src: self.source_location(&token.span),
-                })
+                return self.error_with_location(
+                    GeneratorErrorKind::ExpectedExpression,
+                    None,
+                    Some(kind.to_atom()),
+                    &token.span,
+                )
             }
         };
 
@@ -1887,7 +1894,7 @@ where
     pub fn parse_singular_expression(
         &self,
         subject: AstNode<'c, Expression<'c>>,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         // record the starting span
         let start = self.current_location();
 
@@ -1950,13 +1957,7 @@ where
                                 &self.wall,
                             );
                         }
-                        _ => {
-                            return Err(ParseError::Parsing {
-                                message: "Expected field name or an infix function call"
-                                    .to_string(),
-                                src: self.source_location(&self.current_location()),
-                            })
-                        }
+                        _ => self.error(GeneratorErrorKind::InfixCall, None, None)?,
                     }
                 }
                 // Array index access syntax: ident[...]
@@ -2011,17 +2012,17 @@ where
     /// The path argument to imports automatically assumes that the path you provide
     /// is references '.hash' extension file or a directory with a 'index.hash' file
     /// contained within the directory.
-    pub fn parse_import(&self) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    pub fn parse_import(&self) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let start = self.current_location();
 
         let (tree, span) = match self.peek() {
             Some(token) if token.is_paren_tree() => token.into_tree(),
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(
+            Some(token) => self.error(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::from_row(
                     row![&self.wall; TokenAtom::Delimiter(Delimiter::Paren, true)],
-                ),
-                &self.current_location(),
+                )),
+                Some(token.to_atom()),
             )?,
             None => self.unexpected_eof()?,
         };
@@ -2033,7 +2034,7 @@ where
                 kind: TokenKind::Atom(TokenAtom::StrLiteral(str)),
                 span,
             }) => (str, STRING_LITERAL_MAP.lookup(*str), span),
-            _ => gen.error("Expected an import path.")?,
+            _ => gen.error(GeneratorErrorKind::ImportPath, None, None)?,
         };
 
         gen.skip_token(); // eat the string argument
@@ -2065,7 +2066,7 @@ where
         ident: AstNode<'c, Expression<'c>>,
         tree: &Row<'c, Token<'c>>,
         span: Location,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let gen = self.from_stream(tree, span);
         let mut args = AstNode::new(
             FunctionCallArgs {
@@ -2113,20 +2114,23 @@ where
     /// Function to parse the next token with the same kind as the specified kind, this
     /// is a useful utility function for parsing singular tokens in the place of more complex
     /// compound statements and expressions.
-    pub fn parse_token_atom(&self, atom: TokenAtom) -> ParseResult<()> {
+    pub fn parse_token_atom(&self, atom: TokenAtom) -> AstGenResult<'c, ()> {
         match self.peek() {
             Some(token) if token.has_atom(atom) => {
                 self.skip_token();
                 Ok(())
             }
-            Some(token) => Err(ParseError::Parsing {
-                message: format!("Expected a '{}', but got a '{}'", atom, token.kind),
-                src: self.source_location(&token.span),
-            }),
-            _ => Err(ParseError::Parsing {
-                message: format!("Expected a '{}', but reached end of input", atom),
-                src: self.source_location(&self.current_location()),
-            }),
+            Some(token) => self.error_with_location(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::singleton(&self.wall, atom)),
+                Some(token.to_atom()),
+                &token.span,
+            ),
+            _ => self.error(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::singleton(&self.wall, atom)),
+                None,
+            ),
         }
     }
 
@@ -2136,7 +2140,7 @@ where
         name: AstNode<'c, AccessName<'c>>,
         type_args: Row<'c, AstNode<'c, Type<'c>>>,
         tree: &Row<'c, Token<'c>>,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let start = self.current_location();
         let gen = self.from_stream(tree, start);
 
@@ -2186,7 +2190,7 @@ where
         ident: AstNode<'c, Expression<'c>>,
         tree: &Row<'c, Token<'c>>,
         span: Location,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let gen = self.from_stream(tree, span);
         let start = gen.current_location();
 
@@ -2217,7 +2221,7 @@ where
     /// Parses a unary operator followed by a singular expression. Once the unary operator
     /// is picked up, the expression is transformed into a function call to the corresponding
     /// trait that implements the unary operator operation.
-    pub fn parse_unary_expression(&self) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    pub fn parse_unary_expression(&self) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let token = self.current_token();
         let start = self.current_location();
 
@@ -2305,7 +2309,7 @@ where
     pub fn parse_trait_bound(
         &self,
         ident: &Identifier,
-    ) -> ParseResult<(AstNode<'c, AccessName<'c>>, AstNodes<'c, Type<'c>>)> {
+    ) -> AstGenResult<'c, (AstNode<'c, AccessName<'c>>, AstNodes<'c, Type<'c>>)> {
         let name = self.parse_access_name(ident)?;
         let args = self.parse_type_args()?;
 
@@ -2316,7 +2320,7 @@ where
     pub fn parse_name_with_type_args(
         &self,
         ident: &Identifier,
-    ) -> ParseResult<(AstNode<'c, AccessName<'c>>, Option<AstNodes<'c, Type<'c>>>)> {
+    ) -> AstGenResult<'c, (AstNode<'c, AccessName<'c>>, Option<AstNodes<'c, Type<'c>>>)> {
         let name = self.parse_access_name(ident)?;
 
         // @@Speed: so here we want to be efficient about type_args, we'll just try to
@@ -2335,7 +2339,7 @@ where
 
     /// Parses a single identifier, essentially converting the current [TokenAtom::Ident] into
     /// an [AstNode<Name>], assuming that the next token is an identifier.
-    pub fn parse_ident(&self) -> ParseResult<AstNode<'c, Name>> {
+    pub fn parse_ident(&self) -> AstGenResult<'c, AstNode<'c, Name>> {
         match self.peek() {
             Some(Token {
                 kind: TokenKind::Atom(TokenAtom::Ident(ident)),
@@ -2345,10 +2349,12 @@ where
 
                 Ok(AstNode::new(Name { ident: *ident }, *span, &self.wall))
             }
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(row![&self.wall; TokenAtom::GenericIdent]),
-                &self.current_location(),
+            Some(token) => self.error(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::from_row(
+                    row![&self.wall; TokenAtom::GenericIdent],
+                )),
+                Some(token.to_atom()),
             ),
             None => self.unexpected_eof(),
         }
@@ -2360,7 +2366,7 @@ where
     pub fn parse_access_name(
         &self,
         start_id: &Identifier,
-    ) -> ParseResult<AstNode<'c, AccessName<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, AccessName<'c>>> {
         let start = self.current_location();
         let mut path = row![&self.wall; *start_id];
 
@@ -2381,13 +2387,7 @@ where
                                     self.skip_token();
                                     path.push(*id, &self.wall);
                                 }
-                                _ => {
-                                    return Err(ParseError::Parsing {
-                                        message: "Expected identifier after a name access"
-                                            .to_string(),
-                                        src: self.source_location(&self.current_location()),
-                                    })
-                                }
+                                _ => self.error(GeneratorErrorKind::AccessName, None, None)?,
                             }
                         }
                         _ => {
@@ -2412,7 +2412,7 @@ where
     /// semi-colons for some statements.
     pub fn generate_expression_from_interactive(
         &mut self,
-    ) -> ParseResult<AstNode<'c, BodyBlock<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, BodyBlock<'c>>> {
         Ok(AstNode::new(
             BodyBlock {
                 statements: row![&self.wall],
@@ -2430,7 +2430,7 @@ where
     pub fn parse_expression_with_precedence(
         &self,
         mut min_prec: u8,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         // first of all, we want to get the lhs...
         let mut lhs = self.parse_expression()?;
 
@@ -2497,7 +2497,7 @@ where
     /// lookahead to see if there is another type followed by either a comma (which locks the
     /// type_args) or a closing `TokenKind::Gt`. Otherwise, we back track and let the expression
     /// be parsed as an order comparison.
-    pub fn parse_type_args(&self) -> ParseResult<AstNodes<'c, Type<'c>>> {
+    pub fn parse_type_args(&self) -> AstGenResult<'c, AstNodes<'c, Type<'c>>> {
         self.parse_token_atom(TokenAtom::Lt)?;
         let mut type_args = row![&self.wall];
 
@@ -2518,10 +2518,12 @@ where
                     self.skip_token();
                     break;
                 }
-                Some(token) => self.unexpected_token_error(
-                    &token.kind,
-                    &TokenKindVector::from_row(row![&self.wall; TokenAtom::Comma, TokenAtom::Gt]),
-                    &self.current_location(),
+                Some(token) => self.error(
+                    GeneratorErrorKind::Expected,
+                    Some(TokenKindVector::from_row(
+                        row![&self.wall; TokenAtom::Comma, TokenAtom::Gt],
+                    )),
+                    Some(token.to_atom()),
                 )?,
                 None => self.unexpected_eof()?,
             }
@@ -2539,7 +2541,7 @@ where
     pub fn parse_function_or_tuple_type(
         &self,
         must_be_function: bool,
-    ) -> ParseResult<AstNode<'c, Type<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Type<'c>>> {
         let start = self.current_location();
 
         let mut type_args = row![&self.wall; ];
@@ -2566,12 +2568,12 @@ where
                     }
                 };
             }
-            Some(token) => self.unexpected_token_error(
-                &token.kind,
-                &TokenKindVector::from_row(
+            Some(token) => self.error(
+                GeneratorErrorKind::Expected,
+                Some(TokenKindVector::from_row(
                     row![&self.wall; TokenAtom::Delimiter(Delimiter::Paren, false)],
-                ),
-                &self.current_location(),
+                )),
+                Some(token.to_atom()),
             )?,
             None => self.unexpected_eof()?,
         };
@@ -2585,9 +2587,7 @@ where
             }
             None => {
                 if must_be_function {
-                    self.error(
-                        "Expected an arrow '=>' after type arguments denoting a function type.",
-                    )?;
+                    self.error(GeneratorErrorKind::ExpectedFnArrow, None, None)?;
                 }
 
                 IDENTIFIER_MAP.create_ident(TUPLE_TYPE_NAME)
@@ -2605,7 +2605,7 @@ where
     }
 
     /// Function to parse a type
-    pub fn parse_type(&self) -> ParseResult<AstNode<'c, Type<'c>>> {
+    pub fn parse_type(&self) -> AstGenResult<'c, AstNode<'c, Type<'c>>> {
         let start = self.current_location();
         let token = self
             .peek()
@@ -2738,12 +2738,7 @@ where
                 .parse_function_or_tuple_type(false)?
                 .into_body()
                 .move_out(),
-            _ => {
-                return Err(ParseError::Parsing {
-                    message: "Expected type here.".to_string(),
-                    src: self.source_location(&self.current_location()),
-                })
-            }
+            _ => self.error(GeneratorErrorKind::ExpectedType, None, None)?,
         };
 
         Ok(self.node_from_joined_location(variant, &start))
@@ -2752,7 +2747,7 @@ where
     /// Parse an single name or a function call that is applied on the left hand side
     /// expression. Infix calls and name are only separated by infix calls having
     /// parenthesees at the end of the name.
-    pub fn parse_name_or_infix_call(&self) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    pub fn parse_name_or_infix_call(&self) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         debug_assert!(self.current_token().has_atom(TokenAtom::Dot));
 
         let start = self.current_location();
@@ -2804,7 +2799,7 @@ where
                 }
                 _ => Ok(self.make_variable_from_identifier(*id, *id_span)),
             },
-            _ => self.error("Expecting field name after property access.")?,
+            _ => self.error(GeneratorErrorKind::InfixCall, None, None)?,
         }
     }
 
@@ -2815,7 +2810,7 @@ where
         &self,
         tree: &Row<'c, Token<'c>>,
         span: &Location,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let gen = self.from_stream(tree, *span);
 
         // handle two special cases for empty map and set literals, if the only token
@@ -2958,7 +2953,7 @@ where
     }
 
     /// Parse a single map entry in a literal.
-    pub fn parse_map_entry(&self) -> ParseResult<AstNode<'c, MapLiteralEntry<'c>>> {
+    pub fn parse_map_entry(&self) -> AstGenResult<'c, AstNode<'c, MapLiteralEntry<'c>>> {
         let start = self.current_location();
 
         let key = self.parse_expression_with_precedence(0)?;
@@ -2974,7 +2969,7 @@ where
         &self,
         gen: Self,
         initial_entry: AstNode<'c, MapLiteralEntry<'c>>,
-    ) -> ParseResult<AstNode<'c, Literal<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Literal<'c>>> {
         let start = gen.current_location();
         let mut elements = gen.parse_separated_fn(
             || gen.parse_map_entry(),
@@ -2992,7 +2987,7 @@ where
         &self,
         gen: Self,
         initial_entry: AstNode<'c, Expression<'c>>,
-    ) -> ParseResult<AstNode<'c, Literal<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Literal<'c>>> {
         let start = self.current_location();
 
         let mut elements = gen.parse_separated_fn(
@@ -3007,7 +3002,7 @@ where
     }
 
     /// Parse a pattern with an optional if guard after the singular pattern.
-    pub fn parse_pattern_with_if(&self) -> ParseResult<AstNode<'c, Pattern<'c>>> {
+    pub fn parse_pattern_with_if(&self) -> AstGenResult<'c, AstNode<'c, Pattern<'c>>> {
         let start = self.current_location();
         let pattern = self.parse_singular_pattern()?;
 
@@ -3027,7 +3022,7 @@ where
     }
 
     /// Parse a compound pattern.
-    pub fn parse_pattern(&self) -> ParseResult<AstNode<'c, Pattern<'c>>> {
+    pub fn parse_pattern(&self) -> AstGenResult<'c, AstNode<'c, Pattern<'c>>> {
         let start = self.current_location();
 
         // Parse the first pattern, but throw away the location information since that will be
@@ -3059,7 +3054,7 @@ where
     }
 
     /// Parse a function definition argument, which is made of an identifier and a function type.
-    pub fn parse_function_def_arg(&self) -> ParseResult<AstNode<'c, FunctionDefArg<'c>>> {
+    pub fn parse_function_def_arg(&self) -> AstGenResult<'c, AstNode<'c, FunctionDefArg<'c>>> {
         let start = self.current_location();
         let name = self.parse_ident()?;
 
@@ -3077,7 +3072,10 @@ where
 
     /// Parse a function literal. Function literals are essentially definitions of lambdas
     /// that can be assigned to variables or passed as arguments into other functions.
-    pub fn parse_function_literal(&self, gen: &Self) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    pub fn parse_function_literal(
+        &self,
+        gen: &Self,
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let start = self.current_location();
 
         // parse function definition arguments.
@@ -3096,7 +3094,7 @@ where
 
         let fn_body = match self.peek() {
             Some(_) => self.parse_expression_with_precedence(0)?,
-            None => self.error("Expected function body here.")?,
+            None => self.error(GeneratorErrorKind::ExpectedFnBody, None, None)?,
         };
 
         Ok(self.node_from_joined_location(
@@ -3128,7 +3126,7 @@ where
         &self,
         tree: &Row<'c, Token<'c>>,
         span: &Location,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let gen = self.from_stream(tree, *span);
         let start = self.current_location();
 
@@ -3175,12 +3173,7 @@ where
 
                     elements.push(gen.parse_expression_with_precedence(0)?, &self.wall)
                 }
-                Some(_) => {
-                    return Err(ParseError::Parsing {
-                        message: "Unexpected expression in place of a comma.".to_string(),
-                        src: gen.source_location(&start),
-                    });
-                }
+                Some(_) => gen.error(GeneratorErrorKind::ExpectedStatement, None, None)?,
                 None => break,
             }
         }
@@ -3199,7 +3192,7 @@ where
         &self,
         tree: &Row<'c, Token<'c>>,
         span: &Location,
-    ) -> ParseResult<AstNode<'c, Expression<'c>>> {
+    ) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let gen = self.from_stream(tree, *span);
         let start = gen.current_location();
 
@@ -3216,12 +3209,10 @@ where
                 Some(token) => {
                     // if we haven't exhausted the whole token stream, then report this as a unexpected
                     // token error
-                    return self.error_with_location(
-                        format!(
-                            "Unexpected token '{}' in the place of an comma.",
-                            token.kind
-                        ),
-                        &gen.current_location(),
+                    return gen.error(
+                        GeneratorErrorKind::Expected,
+                        Some(TokenKindVector::singleton(&self.wall, TokenAtom::Comma)),
+                        Some(token.to_atom()),
                     );
                 }
                 None => break,

--- a/compiler/hash-parser/src/lexer.rs
+++ b/compiler/hash-parser/src/lexer.rs
@@ -10,10 +10,8 @@ use hash_ast::{error::ParseResult, ident::Identifier};
 use hash_ast::{ident::IDENTIFIER_MAP, module::ModuleIdx};
 
 use crate::{
-    token::{
-        Delimiter, Token, TokenAtom, TokenError, TokenErrorKind, TokenErrorWrapper, TokenKind,
-        TokenResult,
-    },
+    error::{TokenError, TokenErrorKind, TokenErrorWrapper},
+    token::{Delimiter, Token, TokenAtom, TokenKind, TokenResult},
     utils::*,
 };
 use std::{cell::Cell, iter};

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(cell_update)]
 
 pub mod backend;
+pub mod error;
 pub mod gen;
 pub mod lexer;
 mod operator;

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -396,13 +396,21 @@ impl fmt::Display for TokenAtom {
     }
 }
 
-/// TODO(alex): Instead of using a TokenAtom, we should use an enum to custom
-/// variants or descriptors such as 'operator'.
+/// This is a wrapper around a vector of token atoms that can represent the expected
+/// tokens in a given context when transforming the token tree into and an AST.
+/// The wrapper exists because once again you cannot specify implementations for types
+/// that don't originate from the current crate.
+///
+/// TODO(alex): Instead of using a [TokenAtom], we should use an enum to custom
+/// variants or descriptors such as 'operator'. Instead of token atoms we can just
+/// the display representations of the token atoms. Or even better, we can use the
+/// [IntoString] trait and just auto cast into a string, whilst holding a vector of
+/// strings.
 #[derive(Debug)]
 pub struct TokenAtomVector<'c>(Row<'c, TokenAtom>);
 
 impl<'c> TokenAtomVector<'c> {
-    /// Create a new empty [TokenKindVector].
+    /// Create a new empty [TokenAtomVector].
     pub fn empty(wall: &Wall<'c>) -> Self {
         Self(row![wall;])
     }
@@ -411,7 +419,7 @@ impl<'c> TokenAtomVector<'c> {
         &self.0
     }
 
-    /// Create a [TokenKindVector] from a provided row of expected atoms.
+    /// Create a [TokenAtomVector] from a provided row of expected atoms.
     pub fn from_row(items: Row<'c, TokenAtom>) -> Self {
         Self(items)
     }
@@ -421,7 +429,7 @@ impl<'c> TokenAtomVector<'c> {
         self.0.is_empty()
     }
 
-    /// Create a [TokenKindVector] with a single atom.
+    /// Create a [TokenAtomVector] with a single atom.
     pub fn singleton(wall: &Wall<'c>, atom: TokenAtom) -> Self {
         Self(row![wall; atom])
     }

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -399,9 +399,9 @@ impl fmt::Display for TokenAtom {
 /// TODO(alex): Instead of using a TokenAtom, we should use an enum to custom
 /// variants or descriptors such as 'operator'.
 #[derive(Debug)]
-pub struct TokenKindVector<'c>(Row<'c, TokenAtom>);
+pub struct TokenAtomVector<'c>(Row<'c, TokenAtom>);
 
-impl<'c> TokenKindVector<'c> {
+impl<'c> TokenAtomVector<'c> {
     /// Create a new empty [TokenKindVector].
     pub fn empty(wall: &Wall<'c>) -> Self {
         Self(row![wall;])
@@ -459,7 +459,7 @@ impl<'c> TokenKindVector<'c> {
 /// places when parsing. We use conjunctives to display multiple variants together, so they are readable. If the
 /// length of the vector kind is one, we don't use conjunctives to glue kinds together.
 /// @@Improvement: Multiple language support ???
-impl fmt::Display for TokenKindVector<'_> {
+impl fmt::Display for TokenAtomVector<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // This is where Haskell would really shine...
         match self.0.len() {

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -2,7 +2,6 @@
 //! Hash source file.
 //!
 //! All rights reserved 2021 (c) The Hash Language authors
-#![allow(dead_code)]
 
 use std::fmt;
 
@@ -55,7 +54,7 @@ impl<'c> Token<'c> {
     /// tree is used as the atom.
     pub fn to_atom(&self) -> TokenAtom {
         match self.kind {
-            TokenKind::Tree(delim, _) => TokenAtom::Delimiter(delim, false), // NoCheckin
+            TokenKind::Tree(delim, _) => TokenAtom::Delimiter(delim, true),
             TokenKind::Atom(atom) => atom,
         }
     }
@@ -354,7 +353,7 @@ impl fmt::Display for TokenAtom {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TokenAtom::Eq => write!(f, "="),
-            TokenAtom::Lt => write!(f, ">"),
+            TokenAtom::Lt => write!(f, "<"),
             TokenAtom::Gt => write!(f, ">"),
             TokenAtom::Plus => write!(f, "+"),
             TokenAtom::Minus => write!(f, "-"),
@@ -397,6 +396,8 @@ impl fmt::Display for TokenAtom {
     }
 }
 
+/// TODO(alex): Instead of using a TokenAtom, we should use an enum to custom
+/// variants or descriptors such as 'operator'.
 #[derive(Debug)]
 pub struct TokenKindVector<'c>(Row<'c, TokenAtom>);
 
@@ -404,6 +405,10 @@ impl<'c> TokenKindVector<'c> {
     /// Create a new empty [TokenKindVector].
     pub fn empty(wall: &Wall<'c>) -> Self {
         Self(row![wall;])
+    }
+
+    pub fn inner(&self) -> &Row<'c, TokenAtom> {
+        &self.0
     }
 
     /// Create a [TokenKindVector] from a provided row of expected atoms.
@@ -419,6 +424,15 @@ impl<'c> TokenKindVector<'c> {
     /// Create a [TokenKindVector] with a single atom.
     pub fn singleton(wall: &Wall<'c>, atom: TokenAtom) -> Self {
         Self(row![wall; atom])
+    }
+
+    /// Tokens that can act as a expression connective
+    pub fn begin_expression(wall: &Wall<'c>) -> Self {
+        Self(row![wall;
+            TokenAtom::Delimiter(Delimiter::Paren, true),
+            TokenAtom::Dot, // OR an operator, OR '::'
+            TokenAtom::Semi,
+        ])
     }
 
     /// Tokens expected when the parser expects a collection of patterns to be present.

--- a/compiler/hash-reporting/src/errors.rs
+++ b/compiler/hash-reporting/src/errors.rs
@@ -55,28 +55,6 @@ impl From<ParseError> for Report {
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(src, "here")))
                     .add_element(ReportElement::Note(ReportNote::new("note", message)));
             }
-            ParseError::IoError { filename, message } => {
-                builder
-                    .add_element(ReportElement::Note(ReportNote::new("note", message)))
-                    .add_element(ReportElement::Note(ReportNote::new(
-                        "note",
-                        format!("file path '{}'", filename.to_string_lossy()),
-                    )));
-            }
-            ParseError::ImportError {
-                import_name: _,
-                src,
-            } => {
-                builder
-                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        src,
-                        "Unknown path",
-                    )))
-                    .add_element(ReportElement::Note(ReportNote::new(
-                        "note",
-                        "Couldn't import this file path.",
-                    )));
-            }
         };
 
         // @@ErrorReporting: we might want to properly handle incomplete reports?
@@ -92,8 +70,6 @@ pub enum CompilerError {
     IoError(#[from] io::Error),
     #[error("{message}")]
     ArgumentError { message: String },
-    #[error("{0}")]
-    ParseError(#[from] ParseError),
     #[error("{0}")]
     InterpreterError(#[from] InteractiveCommandError),
 }

--- a/compiler/hash-reporting/src/errors.rs
+++ b/compiler/hash-reporting/src/errors.rs
@@ -15,16 +15,17 @@ use crate::{
 /// Enum representing the variants of error that can occur when running an interactive session
 #[derive(Error, Debug)]
 pub enum InteractiveCommandError {
+    /// Encountering an unknown command.
     #[error("Unknown command `{0}`.")]
     UnrecognisedCommand(String),
-
+    /// When a command received arguments it wasn't expecting.
     #[error("Command `{0}` does not take any arguments.")]
     ZeroArguments(String),
-
+    /// When a command received an invalid number of arguments.
     // @Future: Maybe provide a second parameter to support multiple argument command
     #[error("Command `{0}` requires one argument.")]
     ArgumentMismatchError(String),
-
+    /// An unknown error occurred.
     #[error("Unexpected error: `{0}`")]
     InternalError(String),
 }

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -1,9 +1,0 @@
-//! Hash Compiler error and warning reporting module
-//!
-//! All rights reserved 2021 (c) The Hash Language authors
-
-/// Error message prefix
-pub const ERR: &str = "\x1b[31m\x1b[1merror\x1b[0m";
-
-/// Warning message prefix
-pub const WARN: &str = "\x1b[35x1b[1mwarn\x1b[0m";


### PR DESCRIPTION
Using ADTs to represent errors in the parser is a better solution in the long run and avoids a significant amount of redundant string allocations.

This fixes #71.