### PR TITLE
fix #36: infix function calls weren't being processed correctly.

### DIFF
--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -184,7 +184,7 @@ where
         match self.peek() {
             Some(token) => token.span,
             None => {
-                let Token {span, kind: _} = self.current_token();
+                let Token { span, kind: _ } = self.current_token();
                 Location::span(span.end(), span.end() + 1)
             }
         }


### PR DESCRIPTION
This fixes #56.

Infix function calls that follow the shape of a.b() where the function b is applied onto the argument a wasn't being properly parsed in the pest parsing backend.

This patch fixes the issue and unifies the behaviour of the pest and self hosted parser.