### PR TITLE
Implementation of AST Visitor

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -67,7 +67,7 @@ impl<'c, T> AstNode<'c, T> {
         self.body
     }
 
-    pub fn ast_ref<'s>(&'s self) -> AstNodeRef<'s, T> {
+    pub fn ast_ref(&self) -> AstNodeRef<T> {
         AstNodeRef {
             body: self.body.as_ref(),
             location: self.location,

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -67,6 +67,22 @@ impl<'c, T> AstNode<'c, T> {
         self.body
     }
 
+    pub fn ast_ref<'s>(&'s self) -> AstNodeRef<'s, T> {
+        AstNodeRef {
+            body: self.body.as_ref(),
+            location: self.location,
+            id: self.id,
+        }
+    }
+
+    pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
+        AstNodeRef {
+            body,
+            location: self.location,
+            id: self.id,
+        }
+    }
+
     /// Get the location of this node in the input.
     pub fn location(&self) -> Location {
         self.location
@@ -75,6 +91,46 @@ impl<'c, T> AstNode<'c, T> {
     /// Get the ID of this node.
     pub fn id(&self) -> AstNodeId {
         self.id
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct AstNodeRef<'t, T> {
+    body: &'t T,
+    location: Location,
+    id: AstNodeId,
+}
+
+impl<'t, T> AstNodeRef<'t, T> {
+    /// Get a reference to the reference contained within this node.
+    pub fn body(&self) -> &T {
+        self.body
+    }
+
+    pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
+        AstNodeRef {
+            body,
+            location: self.location,
+            id: self.id,
+        }
+    }
+
+    /// Get the location of this node in the input.
+    pub fn location(&self) -> Location {
+        self.location
+    }
+
+    /// Get the ID of this node.
+    pub fn id(&self) -> AstNodeId {
+        self.id
+    }
+}
+
+/// [AstNode] dereferences to its inner `body` type.
+impl<T> Deref for AstNodeRef<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.body()
     }
 }
 
@@ -149,21 +205,31 @@ pub enum RefKind {
     Normal,
 }
 
+/// A reference type.
+#[derive(Debug, PartialEq)]
+pub struct RefType<'c>(pub AstNode<'c, Type<'c>>);
+
+/// A raw reference type
+#[derive(Debug, PartialEq)]
+pub struct RawRefType<'c>(pub AstNode<'c, Type<'c>>);
+
+/// The existential type (`?`).
+#[derive(Debug, PartialEq)]
+pub struct ExistentialType;
+
+/// The type infer operator.
+#[derive(Debug, PartialEq)]
+pub struct InferType;
+
 /// A type.
 #[derive(Debug, PartialEq)]
 pub enum Type<'c> {
-    /// A concrete/"named" type.
     Named(NamedType<'c>),
-    /// A reference type.
-    Ref(AstNode<'c, Type<'c>>),
-    /// A raw reference type
-    RawRef(AstNode<'c, Type<'c>>),
-    /// A type variable.
+    Ref(RefType<'c>),
+    RawRef(RawRefType<'c>),
     TypeVar(TypeVar<'c>),
-    /// The existential type (`?`).
-    Existential,
-    /// The type infer operator.
-    Infer,
+    Existential(ExistentialType),
+    Infer(InferType),
 }
 
 /// A set literal, e.g. `{1, 2, 3}`.
@@ -245,28 +311,34 @@ pub struct FunctionDef<'c> {
     pub fn_body: AstNode<'c, Expression<'c>>,
 }
 
+/// A string literal.
+#[derive(Debug, PartialEq)]
+pub struct StrLiteral(pub StringLiteral);
+
+/// A character literal.
+#[derive(Debug, PartialEq)]
+pub struct CharLiteral(pub char);
+
+/// An integer literal.
+#[derive(Debug, PartialEq)]
+pub struct IntLiteral(pub u64);
+
+/// A float literal.
+#[derive(Debug, PartialEq)]
+pub struct FloatLiteral(pub f64);
+
 /// A literal.
 #[derive(Debug, PartialEq)]
 pub enum Literal<'c> {
-    /// A string literal.
-    Str(StringLiteral),
-    /// A character literal.
-    Char(char),
-    /// An integer literal.
-    Int(u64),
-    /// A float literal.
-    Float(f64),
-    /// A set literal.
+    Str(StrLiteral),
+    Char(CharLiteral),
+    Int(IntLiteral),
+    Float(FloatLiteral),
     Set(SetLiteral<'c>),
-    /// A map literal.
     Map(MapLiteral<'c>),
-    /// A list literal.
     List(ListLiteral<'c>),
-    /// A tuple literal.
     Tuple(TupleLiteral<'c>),
-    /// A struct literal.
     Struct(StructLiteral<'c>),
-    /// A function definition.
     Function(FunctionDef<'c>),
 }
 
@@ -329,40 +401,51 @@ pub struct TuplePattern<'c> {
     pub elements: AstNodes<'c, Pattern<'c>>,
 }
 
+/// A string literal pattern.
+#[derive(Debug, PartialEq)]
+pub struct StrLiteralPattern(pub StringLiteral);
+
+/// A character literal pattern.
+#[derive(Debug, PartialEq)]
+pub struct CharLiteralPattern(pub char);
+
+/// An integer literal pattern.
+#[derive(Debug, PartialEq)]
+pub struct IntLiteralPattern(pub u64);
+
+/// A float literal pattern.
+#[derive(Debug, PartialEq)]
+pub struct FloatLiteralPattern(pub f64);
+
 /// A literal pattern, e.g. `1`, `3.4`, `"foo"`.
 #[derive(Debug, PartialEq)]
 pub enum LiteralPattern {
-    /// A string literal pattern.
-    Str(StringLiteral),
-    /// A character literal pattern.
-    Char(char),
-    /// An integer literal pattern.
-    Int(u64),
-    /// A float literal pattern.
-    Float(f64),
+    Str(StrLiteralPattern),
+    Char(CharLiteralPattern),
+    Int(IntLiteralPattern),
+    Float(FloatLiteralPattern),
 }
+
+/// A pattern name binding.
+#[derive(Debug, PartialEq)]
+pub struct BindingPattern<'c>(pub AstNode<'c, Name>);
+
+/// The catch-all, i.e "ignore" pattern.
+#[derive(Debug, PartialEq)]
+pub struct IgnorePattern;
 
 /// A pattern. e.g. `Ok(Dog {props = (1, x)})`.
 #[derive(Debug, PartialEq)]
 pub enum Pattern<'c> {
-    /// An enum pattern.
     Enum(EnumPattern<'c>),
-    /// A struct pattern.
     Struct(StructPattern<'c>),
-    /// A namespace pattern.
     Namespace(NamespacePattern<'c>),
-    /// A tuple pattern.
     Tuple(TuplePattern<'c>),
-    /// A literal pattern.
     Literal(LiteralPattern),
-    /// An alternative/"or" pattern.
     Or(OrPattern<'c>),
-    /// A conditional/"if" pattern.
     If(IfPattern<'c>),
-    /// A pattern name binding.
-    Binding(AstNode<'c, Name>),
-    /// The catch-all, i.e "ignore" pattern.
-    Ignore,
+    Binding(BindingPattern<'c>),
+    Ignore(IgnorePattern),
 }
 
 /// A trait bound, e.g. "where eq<T>"
@@ -473,30 +556,40 @@ pub struct TraitDef<'c> {
     pub trait_type: AstNode<'c, Type<'c>>,
 }
 
+/// An expression statement, e.g. `my_func();`
+#[derive(Debug, PartialEq)]
+pub struct ExprStatement<'c>(pub AstNode<'c, Expression<'c>>);
+
+/// An return statement.
+///
+/// Has an optional return expression, which becomes `void` if [None] is given.
+#[derive(Debug, PartialEq)]
+pub struct ReturnStatement<'c>(pub Option<AstNode<'c, Expression<'c>>>);
+
+/// A block statement.
+#[derive(Debug, PartialEq)]
+pub struct BlockStatement<'c>(pub AstNode<'c, Block<'c>>);
+
+/// Break statement (only in loop context).
+#[derive(Debug, PartialEq)]
+pub struct BreakStatement;
+
+/// Continue statement (only in loop context).
+#[derive(Debug, PartialEq)]
+pub struct ContinueStatement;
+
 /// A statement.
 #[derive(Debug, PartialEq)]
 pub enum Statement<'c> {
-    /// An expression statement, e.g. `my_func();`
-    Expr(AstNode<'c, Expression<'c>>),
-    /// An return statement.
-    ///
-    /// Has an optional return expression, which becomes `void` if [None] is given.
-    Return(Option<AstNode<'c, Expression<'c>>>),
-    /// A block statement.
-    Block(AstNode<'c, Block<'c>>),
-    /// Break statement (only in loop context).
-    Break,
-    /// Continue statement (only in loop context).
-    Continue,
-    /// A let statement.
+    Expr(ExprStatement<'c>),
+    Return(ReturnStatement<'c>),
+    Block(BlockStatement<'c>),
+    Break(BreakStatement),
+    Continue(ContinueStatement),
     Let(LetStatement<'c>),
-    /// An assign statement.
     Assign(AssignStatement<'c>),
-    /// A struct definition.
     StructDef(StructDef<'c>),
-    /// An enum definition.
     EnumDef(EnumDef<'c>),
-    /// A trait definition.
     TraitDef(TraitDef<'c>),
 }
 
@@ -529,6 +622,9 @@ pub struct BodyBlock<'c> {
     pub expr: Option<AstNode<'c, Expression<'c>>>,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct LoopBlock<'c>(pub AstNode<'c, Block<'c>>);
+
 /// A block.
 #[derive(Debug, PartialEq)]
 pub enum Block<'c> {
@@ -537,7 +633,7 @@ pub enum Block<'c> {
     /// A loop block.
     ///
     /// The inner block is the loop body.
-    Loop(AstNode<'c, Block<'c>>),
+    Loop(LoopBlock<'c>),
     /// A body block.
     Body(BodyBlock<'c>),
 }
@@ -592,29 +688,41 @@ pub struct VariableExpr<'c> {
     pub type_args: AstNodes<'c, Type<'c>>,
 }
 
+/// A reference expression with a flag denoting whether it is a raw ref or not
+#[derive(Debug, PartialEq)]
+pub struct RefExpr<'c> {
+    pub inner_expr: AstNode<'c, Expression<'c>>,
+    pub kind: RefKind,
+}
+/// A dereference expression.
+#[derive(Debug, PartialEq)]
+pub struct DerefExpr<'c>(pub AstNode<'c, Expression<'c>>);
+
+/// A literal.
+#[derive(Debug, PartialEq)]
+pub struct LiteralExpr<'c>(pub AstNode<'c, Literal<'c>>);
+
+/// A block.
+#[derive(Debug, PartialEq)]
+pub struct BlockExpr<'c>(pub AstNode<'c, Block<'c>>);
+
+/// An `import` call.
+#[derive(Debug, PartialEq)]
+pub struct ImportExpr<'c>(pub AstNode<'c, Import>);
+
 /// The kind of an expression.
 #[derive(Debug, PartialEq)]
 pub enum ExpressionKind<'c> {
-    /// A function call.
     FunctionCall(FunctionCallExpr<'c>),
-    /// An intrinsic symbol.
     Intrinsic(IntrinsicKey),
-    /// A variable.
     Variable(VariableExpr<'c>),
-    /// A property access.
     PropertyAccess(PropertyAccessExpr<'c>),
-    /// A reference expression with a flag denoting whether it is a raw ref or not
-    Ref(AstNode<'c, Expression<'c>>, RefKind),
-    /// A dereference expression.
-    Deref(AstNode<'c, Expression<'c>>),
-    /// A literal.
-    LiteralExpr(AstNode<'c, Literal<'c>>),
-    /// A typed expression.
+    Ref(RefExpr<'c>),
+    Deref(DerefExpr<'c>),
+    LiteralExpr(LiteralExpr<'c>),
     Typed(TypedExpr<'c>),
-    /// A block.
-    Block(AstNode<'c, Block<'c>>),
-    /// An `import` call.
-    Import(AstNode<'c, Import>),
+    Block(BlockExpr<'c>),
+    Import(ImportExpr<'c>),
 }
 
 /// An expression.

--- a/compiler/hash-ast/src/lib.rs
+++ b/compiler/hash-ast/src/lib.rs
@@ -1,6 +1,8 @@
 //! Hash Compiler AST library file
 //!
 //! All rights reserved 2021 (c) The Hash Language authors
+#![feature(generic_associated_types)]
+#![feature(iter_intersperse)]
 
 extern crate strum;
 #[macro_use]
@@ -21,3 +23,5 @@ pub mod resolve;
 pub mod storage;
 pub mod tests;
 pub mod visualise;
+pub mod tree;
+pub mod visitor;

--- a/compiler/hash-ast/src/lib.rs
+++ b/compiler/hash-ast/src/lib.rs
@@ -22,6 +22,6 @@ pub mod parse;
 pub mod resolve;
 pub mod storage;
 pub mod tests;
-pub mod visualise;
 pub mod tree;
 pub mod visitor;
+pub mod visualise;

--- a/compiler/hash-ast/src/location.rs
+++ b/compiler/hash-ast/src/location.rs
@@ -40,6 +40,7 @@ impl Location {
     /// > --------------------------------------------------------------
     ///
     /// Then the two locations are joined into one, otherwise the lhs is returned
+    #[must_use]
     pub fn join(&self, end: Self) -> Self {
         if self.end() <= end.start() {
             return Location::span(self.start(), end.end());

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -6,8 +6,19 @@ use crate::ident::IDENTIFIER_MAP;
 use crate::literal::STRING_LITERAL_MAP;
 use crate::{ast, visitor::walk, visitor::AstVisitor};
 
+/// Struct implementing [AstVisitor], for the purpose of transforming the AST tree into a
+/// [TreeNode] tree, for visualisation purposes. It is meant to replace [crate::ast::visualise].
 struct AstTreeGenerator;
 
+/// Easy way to format a [TreeNode] label with a main label as well as short contents, and a
+/// quoting string.
+///
+///
+/// # Examples
+///
+/// ```
+/// assert_eq(labeled("foo", "bar", "\""), "foo \"bar\"")
+/// ```
 fn labeled(label: impl ToString, contents: impl ToString, quote_str: &str) -> String {
     format!(
         "{} {}{}{}",

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -1,0 +1,788 @@
+use std::iter;
+
+use hash_utils::tree_writing::TreeNode;
+
+use crate::ident::IDENTIFIER_MAP;
+use crate::literal::STRING_LITERAL_MAP;
+use crate::{ast, visitor::walk, visitor::AstVisitor};
+
+struct AstTreeGenerator;
+
+fn labeled(label: impl ToString, contents: impl ToString, quote_str: &str) -> String {
+    format!(
+        "{} {}{}{}",
+        label.to_string(),
+        quote_str,
+        contents.to_string(),
+        quote_str
+    )
+}
+
+impl<'c> AstVisitor<'c> for AstTreeGenerator {
+    type CollectionContainer<T> = Vec<T>;
+
+    type ImportRet = TreeNode;
+    fn visit_import(&mut self, node: ast::AstNodeRef<ast::Import>) -> Self::ImportRet {
+        TreeNode::leaf(labeled(
+            "import",
+            STRING_LITERAL_MAP.lookup(node.path),
+            "\"",
+        ))
+    }
+
+    type NameRet = TreeNode;
+    fn visit_name(&mut self, node: ast::AstNodeRef<ast::Name>) -> Self::NameRet {
+        TreeNode::leaf(IDENTIFIER_MAP.ident_name(node.ident))
+    }
+
+    type AccessNameRet = TreeNode;
+    fn visit_access_name(
+        &mut self,
+        node: ast::AstNodeRef<ast::AccessName<'c>>,
+    ) -> Self::AccessNameRet {
+        TreeNode::leaf(
+            node.path
+                .iter()
+                .map(|p| IDENTIFIER_MAP.ident_name(*p))
+                .intersperse("::")
+                .collect::<String>(),
+        )
+    }
+
+    type LiteralRet = TreeNode;
+    fn visit_literal(&mut self, node: ast::AstNodeRef<ast::Literal<'c>>) -> Self::LiteralRet {
+        walk::walk_literal_same_children(self, node)
+    }
+
+    type ExpressionRet = TreeNode;
+    fn visit_expression(
+        &mut self,
+        node: ast::AstNodeRef<ast::Expression<'c>>,
+    ) -> Self::ExpressionRet {
+        walk::walk_expression_same_children(self, node)
+    }
+
+    type VariableExprRet = TreeNode;
+    fn visit_variable_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::VariableExpr<'c>>,
+    ) -> Self::VariableExprRet {
+        let walk::VariableExpr { name, type_args } = walk::walk_variable_expr(self, node);
+        TreeNode::branch(
+            "variable",
+            vec![name, TreeNode::branch("type_args", type_args)],
+        )
+    }
+
+    type IntrinsicKeyRet = TreeNode;
+    fn visit_intrinsic_key(
+        &mut self,
+        node: ast::AstNodeRef<ast::IntrinsicKey>,
+    ) -> Self::IntrinsicKeyRet {
+        TreeNode::leaf(labeled(
+            "intrinsic",
+            IDENTIFIER_MAP.ident_name(node.name),
+            "\"",
+        ))
+    }
+
+    type FunctionCallArgsRet = TreeNode;
+    fn visit_function_call_args(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionCallArgs<'c>>,
+    ) -> Self::FunctionCallArgsRet {
+        TreeNode::branch("args", walk::walk_function_call_args(self, node).entries)
+    }
+
+    type FunctionCallExprRet = TreeNode;
+    fn visit_function_call_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionCallExpr<'c>>,
+    ) -> Self::FunctionCallExprRet {
+        let walk::FunctionCallExpr { subject, args } = walk::walk_function_call_expr(self, node);
+        TreeNode::branch(
+            "function_call",
+            vec![TreeNode::branch("subject", vec![subject]), args],
+        )
+    }
+
+    type PropertyAccessExprRet = TreeNode;
+    fn visit_property_access_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::PropertyAccessExpr<'c>>,
+    ) -> Self::PropertyAccessExprRet {
+        let walk::PropertyAccessExpr { subject, property } =
+            walk::walk_property_access_expr(self, node);
+        TreeNode::branch(
+            "property_access",
+            vec![
+                TreeNode::branch("subject", vec![subject]),
+                TreeNode::branch("property", vec![property]),
+            ],
+        )
+    }
+
+    type RefExprRet = TreeNode;
+    fn visit_ref_expr(&mut self, node: ast::AstNodeRef<ast::RefExpr<'c>>) -> Self::RefExprRet {
+        let walk::RefExpr { inner_expr } = walk::walk_ref_expr(self, node);
+        TreeNode::branch("ref", vec![inner_expr])
+    }
+
+    type DerefExprRet = TreeNode;
+    fn visit_deref_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::DerefExpr<'c>>,
+    ) -> Self::DerefExprRet {
+        let walk::DerefExpr(inner_expr) = walk::walk_deref_expr(self, node);
+        TreeNode::branch("deref", vec![inner_expr])
+    }
+
+    type LiteralExprRet = TreeNode;
+    fn visit_literal_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::LiteralExpr<'c>>,
+    ) -> Self::LiteralExprRet {
+        let walk::LiteralExpr(literal) = walk::walk_literal_expr(self, node);
+        literal
+    }
+
+    type TypedExprRet = TreeNode;
+    fn visit_typed_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
+    ) -> Self::TypedExprRet {
+        let walk::TypedExpr { ty, expr } = walk::walk_typed_expr(self, node);
+        TreeNode::branch(
+            "typed_expr",
+            vec![
+                TreeNode::branch("subject", vec![expr]),
+                TreeNode::branch("type", vec![ty]),
+            ],
+        )
+    }
+
+    type BlockExprRet = TreeNode;
+    fn visit_block_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::BlockExpr<'c>>,
+    ) -> Self::BlockExprRet {
+        walk::walk_block_expr(self, node).0
+    }
+
+    type ImportExprRet = TreeNode;
+    fn visit_import_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::ImportExpr<'c>>,
+    ) -> Self::ImportExprRet {
+        walk::walk_import_expr(self, node).0
+    }
+
+    type TypeRet = TreeNode;
+    fn visit_type(&mut self, node: ast::AstNodeRef<ast::Type<'c>>) -> Self::TypeRet {
+        walk::walk_type_same_children(self, node)
+    }
+
+    type NamedTypeRet = TreeNode;
+    fn visit_named_type(
+        &mut self,
+        node: ast::AstNodeRef<ast::NamedType<'c>>,
+    ) -> Self::NamedTypeRet {
+        let walk::NamedType { name, type_args } = walk::walk_named_type(self, node);
+        let children = {
+            if type_args.is_empty() {
+                vec![]
+            } else {
+                vec![TreeNode::branch("type_args", type_args)]
+            }
+        };
+        TreeNode::branch(labeled("name", name.label, ""), children)
+    }
+
+    type RefTypeRet = TreeNode;
+    fn visit_ref_type(&mut self, node: ast::AstNodeRef<ast::RefType<'c>>) -> Self::RefTypeRet {
+        let walk::RefType(inner) = walk::walk_ref_type(self, node);
+        TreeNode::branch("ref", vec![inner])
+    }
+
+    type RawRefTypeRet = TreeNode;
+    fn visit_raw_ref_type(
+        &mut self,
+        node: ast::AstNodeRef<ast::RawRefType<'c>>,
+    ) -> Self::RawRefTypeRet {
+        let walk::RawRefType(inner) = walk::walk_raw_ref_type(self, node);
+        TreeNode::branch("raw_ref", vec![inner])
+    }
+
+    type TypeVarRet = TreeNode;
+    fn visit_type_var(&mut self, node: ast::AstNodeRef<ast::TypeVar<'c>>) -> Self::TypeVarRet {
+        let walk::TypeVar { name } = walk::walk_type_var(self, node);
+        TreeNode::leaf(labeled("var", name.label, ""))
+    }
+
+    type ExistentialTypeRet = TreeNode;
+    fn visit_existential_type(
+        &mut self,
+        node: ast::AstNodeRef<ast::ExistentialType>,
+    ) -> Self::ExistentialTypeRet {
+        TreeNode::leaf("existential")
+    }
+
+    type InferTypeRet = TreeNode;
+    fn visit_infer_type(&mut self, node: ast::AstNodeRef<ast::InferType>) -> Self::InferTypeRet {
+        TreeNode::leaf("infer")
+    }
+
+    type MapLiteralRet = TreeNode;
+    fn visit_map_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::MapLiteral<'c>>,
+    ) -> Self::MapLiteralRet {
+        TreeNode::branch("map", walk::walk_map_literal(self, node).entries)
+    }
+
+    type MapLiteralEntryRet = TreeNode;
+    fn visit_map_literal_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::MapLiteralEntry<'c>>,
+    ) -> Self::MapLiteralEntryRet {
+        let walk::MapLiteralEntry { key, value } = walk::walk_map_literal_entry(self, node);
+        TreeNode::branch(
+            "entry",
+            vec![
+                TreeNode::branch("key", vec![key]),
+                TreeNode::branch("value", vec![value]),
+            ],
+        )
+    }
+
+    type ListLiteralRet = TreeNode;
+    fn visit_list_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::ListLiteral<'c>>,
+    ) -> Self::ListLiteralRet {
+        let children = walk::walk_list_literal(self, node);
+        TreeNode::branch("list", children.elements)
+    }
+
+    type SetLiteralRet = TreeNode;
+    fn visit_set_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::SetLiteral<'c>>,
+    ) -> Self::SetLiteralRet {
+        let children = walk::walk_set_literal(self, node);
+        TreeNode::branch("set", children.elements)
+    }
+
+    type TupleLiteralRet = TreeNode;
+    fn visit_tuple_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::TupleLiteral<'c>>,
+    ) -> Self::TupleLiteralRet {
+        let children = walk::walk_tuple_literal(self, node);
+        TreeNode::branch("tuple", children.elements)
+    }
+
+    type StrLiteralRet = TreeNode;
+    fn visit_str_literal(&mut self, node: ast::AstNodeRef<ast::StrLiteral>) -> Self::StrLiteralRet {
+        TreeNode::leaf(labeled("str", STRING_LITERAL_MAP.lookup(node.0), "\""))
+    }
+
+    type CharLiteralRet = TreeNode;
+    fn visit_char_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::CharLiteral>,
+    ) -> Self::CharLiteralRet {
+        TreeNode::leaf(labeled("char", node.0, "'"))
+    }
+
+    type FloatLiteralRet = TreeNode;
+    fn visit_float_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::FloatLiteral>,
+    ) -> Self::FloatLiteralRet {
+        TreeNode::leaf(labeled("float", node.0, ""))
+    }
+
+    type IntLiteralRet = TreeNode;
+    fn visit_int_literal(&mut self, node: ast::AstNodeRef<ast::IntLiteral>) -> Self::IntLiteralRet {
+        TreeNode::leaf(labeled("int", node.0, ""))
+    }
+
+    type StructLiteralRet = TreeNode;
+    fn visit_struct_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructLiteral<'c>>,
+    ) -> Self::StructLiteralRet {
+        let walk::StructLiteral {
+            name,
+            type_args,
+            entries,
+        } = walk::walk_struct_literal(self, node);
+        TreeNode::branch(
+            "struct",
+            vec![
+                TreeNode::branch("type_args", type_args),
+                TreeNode::branch("entries", entries),
+            ],
+        )
+    }
+
+    type StructLiteralEntryRet = TreeNode;
+    fn visit_struct_literal_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructLiteralEntry<'c>>,
+    ) -> Self::StructLiteralEntryRet {
+        let walk::StructLiteralEntry { name, value } = walk::walk_struct_literal_entry(self, node);
+        TreeNode::branch(
+            "entry",
+            vec![
+                TreeNode::branch("name", vec![name]),
+                TreeNode::branch("value", vec![value]),
+            ],
+        )
+    }
+
+    type FunctionDefRet = TreeNode;
+    fn visit_function_def(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionDef<'c>>,
+    ) -> Self::FunctionDefRet {
+        let walk::FunctionDef {
+            args,
+            fn_body,
+            return_ty,
+        } = walk::walk_function_def(self, node);
+
+        TreeNode::branch(
+            "function_def",
+            iter::once(TreeNode::branch("args", args))
+                .chain(
+                    return_ty
+                        .map(|r| TreeNode::branch("return_type", vec![r]))
+                        .into_iter(),
+                )
+                .chain(iter::once(TreeNode::branch("body", vec![fn_body])))
+                .collect(),
+        )
+    }
+
+    type FunctionDefArgRet = TreeNode;
+    fn visit_function_def_arg(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionDefArg<'c>>,
+    ) -> Self::FunctionDefArgRet {
+        let walk::FunctionDefArg { name, ty } = walk::walk_function_def_arg(self, node);
+        TreeNode::branch(
+            "arg",
+            iter::once(TreeNode::branch("name", vec![name]))
+                .chain(ty.into_iter())
+                .collect(),
+        )
+    }
+
+    type BlockRet = TreeNode;
+    fn visit_block(&mut self, node: ast::AstNodeRef<ast::Block<'c>>) -> Self::BlockRet {
+        walk::walk_block_same_children(self, node)
+    }
+
+    type MatchCaseRet = TreeNode;
+    fn visit_match_case(
+        &mut self,
+        node: ast::AstNodeRef<ast::MatchCase<'c>>,
+    ) -> Self::MatchCaseRet {
+        let walk::MatchCase { expr, pattern } = walk::walk_match_case(self, node);
+        TreeNode::branch(
+            "case",
+            vec![pattern, TreeNode::branch("branch", vec![expr])],
+        )
+    }
+
+    type MatchBlockRet = TreeNode;
+    fn visit_match_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::MatchBlock<'c>>,
+    ) -> Self::MatchBlockRet {
+        let walk::MatchBlock { cases, subject } = walk::walk_match_block(self, node);
+
+        TreeNode::branch(
+            "match",
+            vec![
+                TreeNode::branch("subject", vec![subject]),
+                TreeNode::branch("cases", cases),
+            ],
+        )
+    }
+
+    type LoopBlockRet = TreeNode;
+    fn visit_loop_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::LoopBlock<'c>>,
+    ) -> Self::LoopBlockRet {
+        let walk::LoopBlock(inner) = walk::walk_loop_block(self, node);
+        TreeNode::branch("loop", inner.children)
+    }
+
+    type BodyBlockRet = TreeNode;
+    fn visit_body_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::BodyBlock<'c>>,
+    ) -> Self::BodyBlockRet {
+        let walk::BodyBlock { statements, expr } = walk::walk_body_block(self, node);
+
+        let mut children = Vec::new();
+        if !statements.is_empty() {
+            children.push(TreeNode::branch("statements", statements));
+        }
+        if expr.is_some() {
+            children.push(TreeNode::branch("statements", statements));
+        }
+
+        TreeNode::branch("body", children)
+    }
+
+    type StatementRet = TreeNode;
+    fn visit_statement(&mut self, node: ast::AstNodeRef<ast::Statement<'c>>) -> Self::StatementRet {
+        walk::walk_statement_same_children(self, node)
+    }
+
+    type ExprStatementRet = TreeNode;
+    fn visit_expr_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ExprStatement<'c>>,
+    ) -> Self::ExprStatementRet {
+        walk::walk_expr_statement(self, node).0
+    }
+
+    type ReturnStatementRet = TreeNode;
+    fn visit_return_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ReturnStatement<'c>>,
+    ) -> Self::ReturnStatementRet {
+        let walk::ReturnStatement(inner) = walk::walk_return_statement(self, node);
+        TreeNode::branch("return", inner.into_iter().collect())
+    }
+
+    type BlockStatementRet = TreeNode;
+    fn visit_block_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::BlockStatement<'c>>,
+    ) -> Self::BlockStatementRet {
+        walk::walk_block_statement(self, node).0
+    }
+
+    type BreakStatementRet = TreeNode;
+    fn visit_break_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::BreakStatement>,
+    ) -> Self::BreakStatementRet {
+        TreeNode::leaf("break")
+    }
+
+    type ContinueStatementRet = TreeNode;
+    fn visit_continue_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ContinueStatement>,
+    ) -> Self::ContinueStatementRet {
+        TreeNode::leaf("continue")
+    }
+
+    type LetStatementRet = TreeNode;
+    fn visit_let_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::LetStatement<'c>>,
+    ) -> Self::LetStatementRet {
+        let walk::LetStatement {
+            pattern,
+            ty,
+            bound,
+            value,
+        } = walk::walk_let_statement(self, node);
+        TreeNode::branch(
+            "let",
+            iter::once(TreeNode::branch("pattern", vec![pattern]))
+                .chain(ty.map(|t| TreeNode::branch("type", vec![t])).into_iter())
+                .chain(bound.map(|b| b).into_iter())
+                .chain(
+                    value
+                        .map(|v| TreeNode::branch("value", vec![v]))
+                        .into_iter(),
+                )
+                .collect(),
+        )
+    }
+
+    type AssignStatementRet = TreeNode;
+    fn visit_assign_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::AssignStatement<'c>>,
+    ) -> Self::AssignStatementRet {
+        let walk::AssignStatement { lhs, rhs } = walk::walk_assign_statement(self, node);
+        TreeNode::branch(
+            "assign",
+            vec![
+                TreeNode::branch("lhs", vec![lhs]),
+                TreeNode::branch("rhs", vec![rhs]),
+            ],
+        )
+    }
+
+    type StructDefEntryRet = TreeNode;
+    fn visit_struct_def_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructDefEntry<'c>>,
+    ) -> Self::StructDefEntryRet {
+        let walk::StructDefEntry { name, ty, default } = walk::walk_struct_def_entry(self, node);
+        TreeNode::branch(
+            labeled("field", name.label, "\""),
+            ty.map(|t| TreeNode::branch("type", vec![t]))
+                .into_iter()
+                .chain(default.map(|d| TreeNode::branch("default", vec![d])))
+                .collect(),
+        )
+    }
+
+    type StructDefRet = TreeNode;
+    fn visit_struct_def(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructDef<'c>>,
+    ) -> Self::StructDefRet {
+        let walk::StructDef {
+            name,
+            entries,
+            bound,
+        } = walk::walk_struct_def(self, node);
+        TreeNode::branch(
+            "struct_def",
+            bound
+                .into_iter()
+                .chain(iter::once(TreeNode::branch("fields", entries)))
+                .collect(),
+        )
+    }
+
+    type EnumDefEntryRet = TreeNode;
+    fn visit_enum_def_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::EnumDefEntry<'c>>,
+    ) -> Self::EnumDefEntryRet {
+        let walk::EnumDefEntry { name, args } = walk::walk_enum_def_entry(self, node);
+        TreeNode::branch(
+            labeled("variant", name.label, "\""),
+            if args.is_empty() { vec![] } else { vec![TreeNode::branch("args", args)] },
+        )
+    }
+
+    type EnumDefRet = TreeNode;
+    fn visit_enum_def(&mut self, node: ast::AstNodeRef<ast::EnumDef<'c>>) -> Self::EnumDefRet {
+        let walk::EnumDef {
+            name,
+            entries,
+            bound,
+        } = walk::walk_enum_def(self, node);
+        TreeNode::branch(
+            "enum_def",
+            iter::once(TreeNode::leaf(labeled("name", name.label, "\"")))
+                .chain(bound.into_iter())
+                .chain(iter::once(TreeNode::branch("variants", entries)))
+                .collect(),
+        )
+    }
+
+    type TraitDefRet = TreeNode;
+    fn visit_trait_def(&mut self, node: ast::AstNodeRef<ast::TraitDef<'c>>) -> Self::TraitDefRet {
+        let walk::TraitDef {
+            name,
+            bound,
+            trait_type,
+        } = walk::walk_trait_def(self, node);
+        TreeNode::branch(
+            "trait_def",
+            vec![bound, TreeNode::branch("type", vec![trait_type])],
+        )
+    }
+
+    type PatternRet = TreeNode;
+    fn visit_pattern(&mut self, node: ast::AstNodeRef<ast::Pattern<'c>>) -> Self::PatternRet {
+        walk::walk_pattern_same_children(self, node)
+    }
+
+    type TraitBoundRet = TreeNode;
+    fn visit_trait_bound(
+        &mut self,
+        node: ast::AstNodeRef<ast::TraitBound<'c>>,
+    ) -> Self::TraitBoundRet {
+        let walk::TraitBound { name, type_args } = walk::walk_trait_bound(self, node);
+        TreeNode::branch(
+            labeled("requires", name.label, "\""),
+            vec![TreeNode::branch("args", type_args)],
+        )
+    }
+
+    type BoundRet = TreeNode;
+    fn visit_bound(&mut self, node: ast::AstNodeRef<ast::Bound<'c>>) -> Self::BoundRet {
+        let walk::Bound {
+            type_args,
+            trait_bounds,
+        } = walk::walk_bound(self, node);
+        TreeNode::branch(
+            "bound",
+            vec![
+                TreeNode::branch("vars", type_args),
+                TreeNode::branch("traits", trait_bounds),
+            ],
+        )
+    }
+
+    type EnumPatternRet = TreeNode;
+    fn visit_enum_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::EnumPattern<'c>>,
+    ) -> Self::EnumPatternRet {
+        let walk::EnumPattern { args, name } = walk::walk_enum_pattern(self, node);
+        TreeNode::branch(
+            "enum",
+            iter::once(TreeNode::leaf(labeled("name", name.label, "\"")))
+                .chain(
+                    (if args.is_empty() { None } else { Some(TreeNode::branch("args", args)) })
+                        .into_iter(),
+                )
+                .collect(),
+        )
+    }
+
+    type StructPatternRet = TreeNode;
+    fn visit_struct_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructPattern<'c>>,
+    ) -> Self::StructPatternRet {
+        let walk::StructPattern { name, entries } = walk::walk_struct_pattern(self, node);
+        TreeNode::branch(
+            "struct",
+            iter::once(TreeNode::leaf(labeled("name", name.label, "\"")))
+                .chain(
+                    (if entries.is_empty() {
+                        None
+                    } else {
+                        Some(TreeNode::branch("fields", entries))
+                    })
+                    .into_iter(),
+                )
+                .collect(),
+        )
+    }
+
+    type NamespacePatternRet = TreeNode;
+    fn visit_namespace_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::NamespacePattern<'c>>,
+    ) -> Self::NamespacePatternRet {
+        let walk::NamespacePattern { patterns } = walk::walk_namespace_pattern(self, node);
+        TreeNode::branch("namespace", vec![TreeNode::branch("members", patterns)])
+    }
+
+    type TuplePatternRet = TreeNode;
+    fn visit_tuple_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::TuplePattern<'c>>,
+    ) -> Self::TuplePatternRet {
+        let walk::TuplePattern { elements } = walk::walk_tuple_pattern(self, node);
+        TreeNode::branch("tuple", elements)
+    }
+
+    type StrLiteralPatternRet = TreeNode;
+    fn visit_str_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::StrLiteralPattern>,
+    ) -> Self::StrLiteralPatternRet {
+        TreeNode::leaf(labeled("str", STRING_LITERAL_MAP.lookup(node.0), "\""))
+    }
+
+    type CharLiteralPatternRet = TreeNode;
+    fn visit_char_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::CharLiteralPattern>,
+    ) -> Self::CharLiteralPatternRet {
+        TreeNode::leaf(labeled("char", node.0, "\'"))
+    }
+
+    type IntLiteralPatternRet = TreeNode;
+    fn visit_int_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::IntLiteralPattern>,
+    ) -> Self::IntLiteralPatternRet {
+        TreeNode::leaf(labeled("int", node.0, ""))
+    }
+
+    type FloatLiteralPatternRet = TreeNode;
+    fn visit_float_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::FloatLiteralPattern>,
+    ) -> Self::FloatLiteralPatternRet {
+        TreeNode::leaf(labeled("float", node.0, ""))
+    }
+
+    type LiteralPatternRet = TreeNode;
+    fn visit_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::LiteralPattern>,
+    ) -> Self::LiteralPatternRet {
+        walk::walk_literal_pattern_same_children(self, node)
+    }
+
+    type OrPatternRet = TreeNode;
+    fn visit_or_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::OrPattern<'c>>,
+    ) -> Self::OrPatternRet {
+        let walk::OrPattern { variants } = walk::walk_or_pattern(self, node);
+        TreeNode::branch("or", variants)
+    }
+
+    type IfPatternRet = TreeNode;
+    fn visit_if_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::IfPattern<'c>>,
+    ) -> Self::IfPatternRet {
+        let walk::IfPattern { condition, pattern } = walk::walk_if_pattern(self, node);
+        TreeNode::branch(
+            "if",
+            vec![
+                TreeNode::branch("condition", vec![condition]),
+                TreeNode::branch("pattern", vec![pattern]),
+            ],
+        )
+    }
+
+    type BindingPatternRet = TreeNode;
+    fn visit_binding_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::BindingPattern<'c>>,
+    ) -> Self::BindingPatternRet {
+        let walk::BindingPattern(name) = walk::walk_binding_pattern(self, node);
+        TreeNode::leaf(labeled("binding", name.label, "\""))
+    }
+
+    type IgnorePatternRet = TreeNode;
+    fn visit_ignore_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::IgnorePattern>,
+    ) -> Self::IgnorePatternRet {
+        TreeNode::leaf("ignore")
+    }
+
+    type DestructuringPatternRet = TreeNode;
+    fn visit_destructuring_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::DestructuringPattern<'c>>,
+    ) -> Self::DestructuringPatternRet {
+        let walk::DestructuringPattern { name, pattern } =
+            walk::walk_destructuring_pattern(self, node);
+        TreeNode::branch(labeled("binding", name.label, "\""), vec![pattern])
+    }
+
+    type ModuleRet = TreeNode;
+    fn visit_module(&mut self, node: ast::AstNodeRef<ast::Module<'c>>) -> Self::ModuleRet {
+        let walk::Module { contents } = walk::walk_module(self, node);
+        TreeNode::branch("module", contents)
+    }
+}

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -12,13 +12,6 @@ struct AstTreeGenerator;
 
 /// Easy way to format a [TreeNode] label with a main label as well as short contents, and a
 /// quoting string.
-///
-///
-/// # Examples
-///
-/// ```
-/// assert_eq(labeled("foo", "bar", "\""), "foo \"bar\"")
-/// ```
 fn labeled(label: impl ToString, contents: impl ToString, quote_str: &str) -> String {
     format!(
         "{} {}{}{}",

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -222,13 +222,13 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     type ExistentialTypeRet = TreeNode;
     fn visit_existential_type(
         &mut self,
-        node: ast::AstNodeRef<ast::ExistentialType>,
+        _: ast::AstNodeRef<ast::ExistentialType>,
     ) -> Self::ExistentialTypeRet {
         TreeNode::leaf("existential")
     }
 
     type InferTypeRet = TreeNode;
-    fn visit_infer_type(&mut self, node: ast::AstNodeRef<ast::InferType>) -> Self::InferTypeRet {
+    fn visit_infer_type(&mut self, _: ast::AstNodeRef<ast::InferType>) -> Self::InferTypeRet {
         TreeNode::leaf("infer")
     }
 
@@ -314,7 +314,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         node: ast::AstNodeRef<ast::StructLiteral<'c>>,
     ) -> Self::StructLiteralRet {
         let walk::StructLiteral {
-            name,
+            name: _,
             type_args,
             entries,
         } = walk::walk_struct_literal(self, node);
@@ -433,8 +433,8 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         if !statements.is_empty() {
             children.push(TreeNode::branch("statements", statements));
         }
-        if expr.is_some() {
-            children.push(TreeNode::branch("statements", statements));
+        if let Some(expr) = expr {
+            children.push(TreeNode::branch("expr", vec![expr]));
         }
 
         TreeNode::branch("body", children)
@@ -473,7 +473,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     type BreakStatementRet = TreeNode;
     fn visit_break_statement(
         &mut self,
-        node: ast::AstNodeRef<ast::BreakStatement>,
+        _node: ast::AstNodeRef<ast::BreakStatement>,
     ) -> Self::BreakStatementRet {
         TreeNode::leaf("break")
     }
@@ -481,7 +481,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     type ContinueStatementRet = TreeNode;
     fn visit_continue_statement(
         &mut self,
-        node: ast::AstNodeRef<ast::ContinueStatement>,
+        _node: ast::AstNodeRef<ast::ContinueStatement>,
     ) -> Self::ContinueStatementRet {
         TreeNode::leaf("continue")
     }
@@ -501,7 +501,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
             "let",
             iter::once(TreeNode::branch("pattern", vec![pattern]))
                 .chain(ty.map(|t| TreeNode::branch("type", vec![t])).into_iter())
-                .chain(bound.map(|b| b).into_iter())
+                .chain(bound.into_iter())
                 .chain(
                     value
                         .map(|v| TreeNode::branch("value", vec![v]))
@@ -547,7 +547,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         node: ast::AstNodeRef<ast::StructDef<'c>>,
     ) -> Self::StructDefRet {
         let walk::StructDef {
-            name,
+            name: _,
             entries,
             bound,
         } = walk::walk_struct_def(self, node);
@@ -591,7 +591,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     type TraitDefRet = TreeNode;
     fn visit_trait_def(&mut self, node: ast::AstNodeRef<ast::TraitDef<'c>>) -> Self::TraitDefRet {
         let walk::TraitDef {
-            name,
+            name: _,
             bound,
             trait_type,
         } = walk::walk_trait_def(self, node);
@@ -765,7 +765,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     type IgnorePatternRet = TreeNode;
     fn visit_ignore_pattern(
         &mut self,
-        node: ast::AstNodeRef<ast::IgnorePattern>,
+        _node: ast::AstNodeRef<ast::IgnorePattern>,
     ) -> Self::IgnorePatternRet {
         TreeNode::leaf("ignore")
     }

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1,8 +1,16 @@
+//! Visitor implementation for [hash::ast] nodes.
+//!
+//! All rights reserved 2021 (c) The Hash Language authors
+use crate::ast;
 use std::iter::FromIterator;
 
-use crate::ast;
-
+/// The main visitor trait for [hash::ast] nodes.
+///
+/// This contains a method for each AST structure, as well as a dedicated return type for it.
+/// These can be implemented using the functions defined in [walk] that can traverse the children
+/// of each node.
 pub trait AstVisitor<'c>: Sized {
+    /// What container to use to collect multiple children, used by [walk].
     type CollectionContainer<T>: FromIterator<T> + Sized;
 
     type ImportRet;
@@ -367,6 +375,14 @@ pub trait AstVisitor<'c>: Sized {
     fn visit_module(&mut self, node: ast::AstNodeRef<ast::Module<'c>>) -> Self::ModuleRet;
 }
 
+/// Contains helper functions and structures to traverse AST nodes using a given visitor.
+///
+/// Structures are defined which mirror the layout of the AST nodes, but instead of having AST
+/// nodes as children, they have the [AstVisitor] output type for each node.
+///
+/// For enums, there is an additional `*_same_children` function, which traverses the member of
+/// each variant and returns the inner type, given that all variants have the same declared type
+/// within the visitor.
 pub mod walk {
     use super::ast;
     use super::AstVisitor;

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -682,23 +682,23 @@ pub mod walk {
         node: ast::AstNodeRef<ast::Literal<'c>>,
     ) -> Literal<'c, V> {
         match &*node {
-            ast::Literal::Str(r) => Literal::Str(visitor.visit_str_literal(node.with_body(&r))),
-            ast::Literal::Char(r) => Literal::Char(visitor.visit_char_literal(node.with_body(&r))),
-            ast::Literal::Int(r) => Literal::Int(visitor.visit_int_literal(node.with_body(&r))),
+            ast::Literal::Str(r) => Literal::Str(visitor.visit_str_literal(node.with_body(r))),
+            ast::Literal::Char(r) => Literal::Char(visitor.visit_char_literal(node.with_body(r))),
+            ast::Literal::Int(r) => Literal::Int(visitor.visit_int_literal(node.with_body(r))),
             ast::Literal::Float(r) => {
-                Literal::Float(visitor.visit_float_literal(node.with_body(&r)))
+                Literal::Float(visitor.visit_float_literal(node.with_body(r)))
             }
-            ast::Literal::Set(r) => Literal::Set(visitor.visit_set_literal(node.with_body(&r))),
-            ast::Literal::Map(r) => Literal::Map(visitor.visit_map_literal(node.with_body(&r))),
-            ast::Literal::List(r) => Literal::List(visitor.visit_list_literal(node.with_body(&r))),
+            ast::Literal::Set(r) => Literal::Set(visitor.visit_set_literal(node.with_body(r))),
+            ast::Literal::Map(r) => Literal::Map(visitor.visit_map_literal(node.with_body(r))),
+            ast::Literal::List(r) => Literal::List(visitor.visit_list_literal(node.with_body(r))),
             ast::Literal::Tuple(r) => {
-                Literal::Tuple(visitor.visit_tuple_literal(node.with_body(&r)))
+                Literal::Tuple(visitor.visit_tuple_literal(node.with_body(r)))
             }
             ast::Literal::Struct(r) => {
-                Literal::Struct(visitor.visit_struct_literal(node.with_body(&r)))
+                Literal::Struct(visitor.visit_struct_literal(node.with_body(r)))
             }
             ast::Literal::Function(r) => {
-                Literal::Function(visitor.visit_function_def(node.with_body(&r)))
+                Literal::Function(visitor.visit_function_def(node.with_body(r)))
             }
         }
     }
@@ -812,9 +812,9 @@ pub mod walk {
         node: ast::AstNodeRef<ast::Block<'c>>,
     ) -> Block<'c, V> {
         match &*node {
-            ast::Block::Match(r) => Block::Match(visitor.visit_match_block(node.with_body(&r))),
-            ast::Block::Loop(r) => Block::Loop(visitor.visit_loop_block(node.with_body(&r))),
-            ast::Block::Body(r) => Block::Body(visitor.visit_body_block(node.with_body(&r))),
+            ast::Block::Match(r) => Block::Match(visitor.visit_match_block(node.with_body(r))),
+            ast::Block::Loop(r) => Block::Loop(visitor.visit_loop_block(node.with_body(r))),
+            ast::Block::Body(r) => Block::Body(visitor.visit_body_block(node.with_body(r))),
         }
     }
 
@@ -979,14 +979,14 @@ pub mod walk {
         node: ast::AstNodeRef<ast::Type<'c>>,
     ) -> Type<'c, V> {
         match &*node {
-            ast::Type::Named(r) => Type::Named(visitor.visit_named_type(node.with_body(&r))),
-            ast::Type::Ref(r) => Type::Ref(visitor.visit_ref_type(node.with_body(&r))),
-            ast::Type::RawRef(r) => Type::RawRef(visitor.visit_raw_ref_type(node.with_body(&r))),
-            ast::Type::TypeVar(r) => Type::TypeVar(visitor.visit_type_var(node.with_body(&r))),
+            ast::Type::Named(r) => Type::Named(visitor.visit_named_type(node.with_body(r))),
+            ast::Type::Ref(r) => Type::Ref(visitor.visit_ref_type(node.with_body(r))),
+            ast::Type::RawRef(r) => Type::RawRef(visitor.visit_raw_ref_type(node.with_body(r))),
+            ast::Type::TypeVar(r) => Type::TypeVar(visitor.visit_type_var(node.with_body(r))),
             ast::Type::Existential(r) => {
-                Type::Existential(visitor.visit_existential_type(node.with_body(&r)))
+                Type::Existential(visitor.visit_existential_type(node.with_body(r)))
             }
-            ast::Type::Infer(r) => Type::Infer(visitor.visit_infer_type(node.with_body(&r))),
+            ast::Type::Infer(r) => Type::Infer(visitor.visit_infer_type(node.with_body(r))),
         }
     }
 
@@ -1032,26 +1032,26 @@ pub mod walk {
         node: ast::AstNodeRef<ast::Pattern<'c>>,
     ) -> Pattern<'c, V> {
         match &*node {
-            ast::Pattern::Enum(r) => Pattern::Enum(visitor.visit_enum_pattern(node.with_body(&r))),
+            ast::Pattern::Enum(r) => Pattern::Enum(visitor.visit_enum_pattern(node.with_body(r))),
             ast::Pattern::Struct(r) => {
-                Pattern::Struct(visitor.visit_struct_pattern(node.with_body(&r)))
+                Pattern::Struct(visitor.visit_struct_pattern(node.with_body(r)))
             }
             ast::Pattern::Namespace(r) => {
-                Pattern::Namespace(visitor.visit_namespace_pattern(node.with_body(&r)))
+                Pattern::Namespace(visitor.visit_namespace_pattern(node.with_body(r)))
             }
             ast::Pattern::Tuple(r) => {
-                Pattern::Tuple(visitor.visit_tuple_pattern(node.with_body(&r)))
+                Pattern::Tuple(visitor.visit_tuple_pattern(node.with_body(r)))
             }
             ast::Pattern::Literal(r) => {
-                Pattern::Literal(visitor.visit_literal_pattern(node.with_body(&r)))
+                Pattern::Literal(visitor.visit_literal_pattern(node.with_body(r)))
             }
-            ast::Pattern::Or(r) => Pattern::Or(visitor.visit_or_pattern(node.with_body(&r))),
-            ast::Pattern::If(r) => Pattern::If(visitor.visit_if_pattern(node.with_body(&r))),
+            ast::Pattern::Or(r) => Pattern::Or(visitor.visit_or_pattern(node.with_body(r))),
+            ast::Pattern::If(r) => Pattern::If(visitor.visit_if_pattern(node.with_body(r))),
             ast::Pattern::Binding(r) => {
-                Pattern::Binding(visitor.visit_binding_pattern(node.with_body(&r)))
+                Pattern::Binding(visitor.visit_binding_pattern(node.with_body(r)))
             }
             ast::Pattern::Ignore(r) => {
-                Pattern::Ignore(visitor.visit_ignore_pattern(node.with_body(&r)))
+                Pattern::Ignore(visitor.visit_ignore_pattern(node.with_body(r)))
             }
         }
     }
@@ -1206,16 +1206,16 @@ pub mod walk {
     ) -> LiteralPattern<'c, V> {
         match &*node {
             ast::LiteralPattern::Str(r) => {
-                LiteralPattern::Str(visitor.visit_str_literal_pattern(node.with_body(&r)))
+                LiteralPattern::Str(visitor.visit_str_literal_pattern(node.with_body(r)))
             }
             ast::LiteralPattern::Char(r) => {
-                LiteralPattern::Char(visitor.visit_char_literal_pattern(node.with_body(&r)))
+                LiteralPattern::Char(visitor.visit_char_literal_pattern(node.with_body(r)))
             }
             ast::LiteralPattern::Int(r) => {
-                LiteralPattern::Int(visitor.visit_int_literal_pattern(node.with_body(&r)))
+                LiteralPattern::Int(visitor.visit_int_literal_pattern(node.with_body(r)))
             }
             ast::LiteralPattern::Float(r) => {
-                LiteralPattern::Float(visitor.visit_float_literal_pattern(node.with_body(&r)))
+                LiteralPattern::Float(visitor.visit_float_literal_pattern(node.with_body(r)))
             }
         }
     }
@@ -1479,34 +1479,34 @@ pub mod walk {
     ) -> Statement<'c, V> {
         match &*node {
             ast::Statement::Expr(r) => {
-                Statement::Expr(visitor.visit_expr_statement(node.with_body(&r)))
+                Statement::Expr(visitor.visit_expr_statement(node.with_body(r)))
             }
             ast::Statement::Return(r) => {
-                Statement::Return(visitor.visit_return_statement(node.with_body(&r)))
+                Statement::Return(visitor.visit_return_statement(node.with_body(r)))
             }
             ast::Statement::Block(r) => {
-                Statement::Block(visitor.visit_block_statement(node.with_body(&r)))
+                Statement::Block(visitor.visit_block_statement(node.with_body(r)))
             }
             ast::Statement::Break(r) => {
-                Statement::Break(visitor.visit_break_statement(node.with_body(&r)))
+                Statement::Break(visitor.visit_break_statement(node.with_body(r)))
             }
             ast::Statement::Continue(r) => {
-                Statement::Continue(visitor.visit_continue_statement(node.with_body(&r)))
+                Statement::Continue(visitor.visit_continue_statement(node.with_body(r)))
             }
             ast::Statement::Let(r) => {
-                Statement::Let(visitor.visit_let_statement(node.with_body(&r)))
+                Statement::Let(visitor.visit_let_statement(node.with_body(r)))
             }
             ast::Statement::Assign(r) => {
-                Statement::Assign(visitor.visit_assign_statement(node.with_body(&r)))
+                Statement::Assign(visitor.visit_assign_statement(node.with_body(r)))
             }
             ast::Statement::StructDef(r) => {
-                Statement::StructDef(visitor.visit_struct_def(node.with_body(&r)))
+                Statement::StructDef(visitor.visit_struct_def(node.with_body(r)))
             }
             ast::Statement::EnumDef(r) => {
-                Statement::EnumDef(visitor.visit_enum_def(node.with_body(&r)))
+                Statement::EnumDef(visitor.visit_enum_def(node.with_body(r)))
             }
             ast::Statement::TraitDef(r) => {
-                Statement::TraitDef(visitor.visit_trait_def(node.with_body(&r)))
+                Statement::TraitDef(visitor.visit_trait_def(node.with_body(r)))
             }
         }
     }

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1,0 +1,1563 @@
+use std::iter::FromIterator;
+
+use crate::ast;
+
+pub trait AstVisitor<'c>: Sized {
+    type CollectionContainer<T>: FromIterator<T> + Sized;
+
+    type ImportRet;
+    fn visit_import(&mut self, node: ast::AstNodeRef<ast::Import>) -> Self::ImportRet;
+
+    type NameRet;
+    fn visit_name(&mut self, node: ast::AstNodeRef<ast::Name>) -> Self::NameRet;
+
+    type AccessNameRet;
+    fn visit_access_name(
+        &mut self,
+        node: ast::AstNodeRef<ast::AccessName<'c>>,
+    ) -> Self::AccessNameRet;
+
+    type LiteralRet;
+    fn visit_literal(&mut self, node: ast::AstNodeRef<ast::Literal<'c>>) -> Self::LiteralRet;
+
+    type ExpressionRet;
+    fn visit_expression(
+        &mut self,
+        node: ast::AstNodeRef<ast::Expression<'c>>,
+    ) -> Self::ExpressionRet;
+
+    type VariableExprRet;
+    fn visit_variable_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::VariableExpr<'c>>,
+    ) -> Self::VariableExprRet;
+
+    type IntrinsicKeyRet;
+    fn visit_intrinsic_key(
+        &mut self,
+        node: ast::AstNodeRef<ast::IntrinsicKey>,
+    ) -> Self::IntrinsicKeyRet;
+
+    type FunctionCallArgsRet;
+    fn visit_function_call_args(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionCallArgs<'c>>,
+    ) -> Self::FunctionCallArgsRet;
+
+    type FunctionCallExprRet;
+    fn visit_function_call_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionCallExpr<'c>>,
+    ) -> Self::FunctionCallExprRet;
+
+    type PropertyAccessExprRet;
+    fn visit_property_access_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::PropertyAccessExpr<'c>>,
+    ) -> Self::PropertyAccessExprRet;
+
+    type RefExprRet;
+    fn visit_ref_expr(&mut self, node: ast::AstNodeRef<ast::RefExpr<'c>>) -> Self::RefExprRet;
+
+    type DerefExprRet;
+    fn visit_deref_expr(&mut self, node: ast::AstNodeRef<ast::DerefExpr<'c>>)
+        -> Self::DerefExprRet;
+
+    type LiteralExprRet;
+    fn visit_literal_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::LiteralExpr<'c>>,
+    ) -> Self::LiteralExprRet;
+
+    type TypedExprRet;
+    fn visit_typed_expr(&mut self, node: ast::AstNodeRef<ast::TypedExpr<'c>>)
+        -> Self::TypedExprRet;
+
+    type BlockExprRet;
+    fn visit_block_expr(&mut self, node: ast::AstNodeRef<ast::BlockExpr<'c>>)
+        -> Self::BlockExprRet;
+
+    type ImportExprRet;
+    fn visit_import_expr(
+        &mut self,
+        node: ast::AstNodeRef<ast::ImportExpr<'c>>,
+    ) -> Self::ImportExprRet;
+
+    type TypeRet;
+    fn visit_type(&mut self, node: ast::AstNodeRef<ast::Type<'c>>) -> Self::TypeRet;
+
+    type NamedTypeRet;
+    fn visit_named_type(&mut self, node: ast::AstNodeRef<ast::NamedType<'c>>)
+        -> Self::NamedTypeRet;
+
+    type RefTypeRet;
+    fn visit_ref_type(&mut self, node: ast::AstNodeRef<ast::RefType<'c>>) -> Self::RefTypeRet;
+
+    type RawRefTypeRet;
+    fn visit_raw_ref_type(
+        &mut self,
+        node: ast::AstNodeRef<ast::RawRefType<'c>>,
+    ) -> Self::RawRefTypeRet;
+
+    type TypeVarRet;
+    fn visit_type_var(&mut self, node: ast::AstNodeRef<ast::TypeVar<'c>>) -> Self::TypeVarRet;
+
+    type ExistentialTypeRet;
+    fn visit_existential_type(
+        &mut self,
+        node: ast::AstNodeRef<ast::ExistentialType>,
+    ) -> Self::ExistentialTypeRet;
+
+    type InferTypeRet;
+    fn visit_infer_type(&mut self, node: ast::AstNodeRef<ast::InferType>) -> Self::InferTypeRet;
+
+    type MapLiteralRet;
+    fn visit_map_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::MapLiteral<'c>>,
+    ) -> Self::MapLiteralRet;
+
+    type MapLiteralEntryRet;
+    fn visit_map_literal_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::MapLiteralEntry<'c>>,
+    ) -> Self::MapLiteralEntryRet;
+
+    type ListLiteralRet;
+    fn visit_list_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::ListLiteral<'c>>,
+    ) -> Self::ListLiteralRet;
+
+    type SetLiteralRet;
+    fn visit_set_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::SetLiteral<'c>>,
+    ) -> Self::SetLiteralRet;
+
+    type TupleLiteralRet;
+    fn visit_tuple_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::TupleLiteral<'c>>,
+    ) -> Self::TupleLiteralRet;
+
+    type StrLiteralRet;
+    fn visit_str_literal(&mut self, node: ast::AstNodeRef<ast::StrLiteral>) -> Self::StrLiteralRet;
+
+    type CharLiteralRet;
+    fn visit_char_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::CharLiteral>,
+    ) -> Self::CharLiteralRet;
+
+    type FloatLiteralRet;
+    fn visit_float_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::FloatLiteral>,
+    ) -> Self::FloatLiteralRet;
+
+    type IntLiteralRet;
+    fn visit_int_literal(&mut self, node: ast::AstNodeRef<ast::IntLiteral>) -> Self::IntLiteralRet;
+
+    type StructLiteralRet;
+    fn visit_struct_literal(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructLiteral<'c>>,
+    ) -> Self::StructLiteralRet;
+
+    type StructLiteralEntryRet;
+    fn visit_struct_literal_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructLiteralEntry<'c>>,
+    ) -> Self::StructLiteralEntryRet;
+
+    type FunctionDefRet;
+    fn visit_function_def(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionDef<'c>>,
+    ) -> Self::FunctionDefRet;
+
+    type FunctionDefArgRet;
+    fn visit_function_def_arg(
+        &mut self,
+        node: ast::AstNodeRef<ast::FunctionDefArg<'c>>,
+    ) -> Self::FunctionDefArgRet;
+
+    type BlockRet;
+    fn visit_block(&mut self, node: ast::AstNodeRef<ast::Block<'c>>) -> Self::BlockRet;
+
+    type MatchCaseRet;
+    fn visit_match_case(&mut self, node: ast::AstNodeRef<ast::MatchCase<'c>>)
+        -> Self::MatchCaseRet;
+
+    type MatchBlockRet;
+    fn visit_match_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::MatchBlock<'c>>,
+    ) -> Self::MatchBlockRet;
+
+    type LoopBlockRet;
+    fn visit_loop_block(&mut self, node: ast::AstNodeRef<ast::LoopBlock<'c>>)
+        -> Self::LoopBlockRet;
+
+    type BodyBlockRet;
+    fn visit_body_block(&mut self, node: ast::AstNodeRef<ast::BodyBlock<'c>>)
+        -> Self::BodyBlockRet;
+
+    type StatementRet;
+    fn visit_statement(&mut self, node: ast::AstNodeRef<ast::Statement<'c>>) -> Self::StatementRet;
+
+    type ExprStatementRet;
+    fn visit_expr_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ExprStatement<'c>>,
+    ) -> Self::ExprStatementRet;
+
+    type ReturnStatementRet;
+    fn visit_return_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ReturnStatement<'c>>,
+    ) -> Self::ReturnStatementRet;
+
+    type BlockStatementRet;
+    fn visit_block_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::BlockStatement<'c>>,
+    ) -> Self::BlockStatementRet;
+
+    type BreakStatementRet;
+    fn visit_break_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::BreakStatement>,
+    ) -> Self::BreakStatementRet;
+
+    type ContinueStatementRet;
+    fn visit_continue_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::ContinueStatement>,
+    ) -> Self::ContinueStatementRet;
+
+    type LetStatementRet;
+    fn visit_let_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::LetStatement<'c>>,
+    ) -> Self::LetStatementRet;
+
+    type AssignStatementRet;
+    fn visit_assign_statement(
+        &mut self,
+        node: ast::AstNodeRef<ast::AssignStatement<'c>>,
+    ) -> Self::AssignStatementRet;
+
+    type StructDefEntryRet;
+    fn visit_struct_def_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructDefEntry<'c>>,
+    ) -> Self::StructDefEntryRet;
+
+    type StructDefRet;
+    fn visit_struct_def(&mut self, node: ast::AstNodeRef<ast::StructDef<'c>>)
+        -> Self::StructDefRet;
+
+    type EnumDefEntryRet;
+    fn visit_enum_def_entry(
+        &mut self,
+        node: ast::AstNodeRef<ast::EnumDefEntry<'c>>,
+    ) -> Self::EnumDefEntryRet;
+
+    type EnumDefRet;
+    fn visit_enum_def(&mut self, node: ast::AstNodeRef<ast::EnumDef<'c>>) -> Self::EnumDefRet;
+
+    type TraitDefRet;
+    fn visit_trait_def(&mut self, node: ast::AstNodeRef<ast::TraitDef<'c>>) -> Self::TraitDefRet;
+
+    type PatternRet;
+    fn visit_pattern(&mut self, node: ast::AstNodeRef<ast::Pattern<'c>>) -> Self::PatternRet;
+
+    type TraitBoundRet;
+    fn visit_trait_bound(
+        &mut self,
+        node: ast::AstNodeRef<ast::TraitBound<'c>>,
+    ) -> Self::TraitBoundRet;
+
+    type BoundRet;
+    fn visit_bound(&mut self, node: ast::AstNodeRef<ast::Bound<'c>>) -> Self::BoundRet;
+
+    type EnumPatternRet;
+    fn visit_enum_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::EnumPattern<'c>>,
+    ) -> Self::EnumPatternRet;
+
+    type StructPatternRet;
+    fn visit_struct_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::StructPattern<'c>>,
+    ) -> Self::StructPatternRet;
+
+    type NamespacePatternRet;
+    fn visit_namespace_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::NamespacePattern<'c>>,
+    ) -> Self::NamespacePatternRet;
+
+    type TuplePatternRet;
+    fn visit_tuple_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::TuplePattern<'c>>,
+    ) -> Self::TuplePatternRet;
+
+    type StrLiteralPatternRet;
+    fn visit_str_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::StrLiteralPattern>,
+    ) -> Self::StrLiteralPatternRet;
+
+    type CharLiteralPatternRet;
+    fn visit_char_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::CharLiteralPattern>,
+    ) -> Self::CharLiteralPatternRet;
+
+    type IntLiteralPatternRet;
+    fn visit_int_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::IntLiteralPattern>,
+    ) -> Self::IntLiteralPatternRet;
+
+    type FloatLiteralPatternRet;
+    fn visit_float_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::FloatLiteralPattern>,
+    ) -> Self::FloatLiteralPatternRet;
+
+    type LiteralPatternRet;
+    fn visit_literal_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::LiteralPattern>,
+    ) -> Self::LiteralPatternRet;
+
+    type OrPatternRet;
+    fn visit_or_pattern(&mut self, node: ast::AstNodeRef<ast::OrPattern<'c>>)
+        -> Self::OrPatternRet;
+
+    type IfPatternRet;
+    fn visit_if_pattern(&mut self, node: ast::AstNodeRef<ast::IfPattern<'c>>)
+        -> Self::IfPatternRet;
+
+    type BindingPatternRet;
+    fn visit_binding_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::BindingPattern<'c>>,
+    ) -> Self::BindingPatternRet;
+
+    type IgnorePatternRet;
+    fn visit_ignore_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::IgnorePattern>,
+    ) -> Self::IgnorePatternRet;
+
+    type DestructuringPatternRet;
+    fn visit_destructuring_pattern(
+        &mut self,
+        node: ast::AstNodeRef<ast::DestructuringPattern<'c>>,
+    ) -> Self::DestructuringPatternRet;
+
+    type ModuleRet;
+    fn visit_module(&mut self, node: ast::AstNodeRef<ast::Module<'c>>) -> Self::ModuleRet;
+}
+
+pub mod walk {
+    use super::ast;
+    use super::AstVisitor;
+
+    pub struct FunctionDefArg<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub ty: Option<V::TypeRet>,
+    }
+
+    pub fn walk_function_def_arg<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::FunctionDefArg<'c>>,
+    ) -> FunctionDefArg<'c, V> {
+        FunctionDefArg {
+            name: visitor.visit_name(node.name.ast_ref()),
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(t.ast_ref())),
+        }
+    }
+
+    pub struct FunctionDef<'c, V: AstVisitor<'c>> {
+        pub args: V::CollectionContainer<V::FunctionDefArgRet>,
+        pub return_ty: Option<V::TypeRet>,
+        pub fn_body: V::ExpressionRet,
+    }
+
+    pub fn walk_function_def<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::FunctionDef<'c>>,
+    ) -> FunctionDef<'c, V> {
+        FunctionDef {
+            args: node
+                .args
+                .iter()
+                .map(|a| visitor.visit_function_def_arg(a.ast_ref()))
+                .collect(),
+            return_ty: node
+                .return_ty
+                .as_ref()
+                .map(|t| visitor.visit_type(t.ast_ref())),
+            fn_body: visitor.visit_expression(node.fn_body.ast_ref()),
+        }
+    }
+
+    pub struct StructLiteral<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub type_args: V::CollectionContainer<V::TypeRet>,
+        pub entries: V::CollectionContainer<V::StructLiteralEntryRet>,
+    }
+
+    pub fn walk_struct_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::StructLiteral<'c>>,
+    ) -> StructLiteral<'c, V> {
+        StructLiteral {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            type_args: node
+                .type_args
+                .iter()
+                .map(|a| visitor.visit_type(a.ast_ref()))
+                .collect(),
+            entries: node
+                .entries
+                .iter()
+                .map(|e| visitor.visit_struct_literal_entry(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct StructLiteralEntry<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub value: V::ExpressionRet,
+    }
+
+    pub fn walk_struct_literal_entry<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::StructLiteralEntry<'c>>,
+    ) -> StructLiteralEntry<'c, V> {
+        StructLiteralEntry {
+            name: visitor.visit_name(node.name.ast_ref()),
+            value: visitor.visit_expression(node.value.ast_ref()),
+        }
+    }
+
+    pub enum Expression<'c, V: AstVisitor<'c>> {
+        FunctionCall(V::FunctionCallExprRet),
+        Intrinsic(V::IntrinsicKeyRet),
+        Variable(V::VariableExprRet),
+        PropertyAccess(V::PropertyAccessExprRet),
+        Ref(V::RefExprRet),
+        Deref(V::DerefExprRet),
+        LiteralExpr(V::LiteralExprRet),
+        Typed(V::TypedExprRet),
+        Block(V::BlockExprRet),
+        Import(V::ImportExprRet),
+    }
+
+    pub fn walk_expression<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Expression<'c>>,
+    ) -> Expression<'c, V> {
+        match node.kind() {
+            ast::ExpressionKind::FunctionCall(inner) => {
+                Expression::FunctionCall(visitor.visit_function_call_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Intrinsic(inner) => {
+                Expression::Intrinsic(visitor.visit_intrinsic_key(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Variable(inner) => {
+                Expression::Variable(visitor.visit_variable_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::PropertyAccess(inner) => Expression::PropertyAccess({
+                visitor.visit_property_access_expr(node.with_body(inner))
+            }),
+            ast::ExpressionKind::Ref(inner) => {
+                Expression::Ref(visitor.visit_ref_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Deref(inner) => {
+                Expression::Deref(visitor.visit_deref_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::LiteralExpr(inner) => {
+                Expression::LiteralExpr(visitor.visit_literal_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Typed(inner) => {
+                Expression::Typed(visitor.visit_typed_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Block(inner) => {
+                Expression::Block(visitor.visit_block_expr(node.with_body(inner)))
+            }
+            ast::ExpressionKind::Import(inner) => {
+                Expression::Import(visitor.visit_import_expr(node.with_body(inner)))
+            }
+        }
+    }
+
+    pub fn walk_expression_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Expression<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            FunctionCallExprRet = Ret,
+            IntrinsicKeyRet = Ret,
+            VariableExprRet = Ret,
+            PropertyAccessExprRet = Ret,
+            RefExprRet = Ret,
+            DerefExprRet = Ret,
+            LiteralExprRet = Ret,
+            TypedExprRet = Ret,
+            BlockExprRet = Ret,
+            ImportExprRet = Ret,
+        >,
+    {
+        match walk_expression(visitor, node) {
+            Expression::FunctionCall(r) => r,
+            Expression::Intrinsic(r) => r,
+            Expression::Variable(r) => r,
+            Expression::PropertyAccess(r) => r,
+            Expression::Ref(r) => r,
+            Expression::Deref(r) => r,
+            Expression::LiteralExpr(r) => r,
+            Expression::Typed(r) => r,
+            Expression::Block(r) => r,
+            Expression::Import(r) => r,
+        }
+    }
+
+    pub struct VariableExpr<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub type_args: V::CollectionContainer<V::TypeRet>,
+    }
+
+    pub fn walk_variable_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::VariableExpr<'c>>,
+    ) -> VariableExpr<'c, V> {
+        VariableExpr {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            type_args: node
+                .type_args
+                .iter()
+                .map(|t| visitor.visit_type(t.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct FunctionCallArgs<'c, V: AstVisitor<'c>> {
+        pub entries: V::CollectionContainer<V::ExpressionRet>,
+    }
+
+    pub fn walk_function_call_args<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::FunctionCallArgs<'c>>,
+    ) -> FunctionCallArgs<'c, V> {
+        FunctionCallArgs {
+            entries: node
+                .entries
+                .iter()
+                .map(|e| visitor.visit_expression(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct FunctionCallExpr<'c, V: AstVisitor<'c>> {
+        pub subject: V::ExpressionRet,
+        pub args: V::FunctionCallArgsRet,
+    }
+
+    pub fn walk_function_call_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::FunctionCallExpr<'c>>,
+    ) -> FunctionCallExpr<'c, V> {
+        FunctionCallExpr {
+            subject: visitor.visit_expression(node.subject.ast_ref()),
+            args: visitor.visit_function_call_args(node.args.ast_ref()),
+        }
+    }
+
+    pub struct PropertyAccessExpr<'c, V: AstVisitor<'c>> {
+        pub subject: V::ExpressionRet,
+        pub property: V::NameRet,
+    }
+
+    pub fn walk_property_access_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::PropertyAccessExpr<'c>>,
+    ) -> PropertyAccessExpr<'c, V> {
+        PropertyAccessExpr {
+            subject: visitor.visit_expression(node.subject.ast_ref()),
+            property: visitor.visit_name(node.property.ast_ref()),
+        }
+    }
+
+    pub struct RefExpr<'c, V: AstVisitor<'c>> {
+        pub inner_expr: V::ExpressionRet,
+    }
+
+    pub fn walk_ref_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::RefExpr<'c>>,
+    ) -> RefExpr<'c, V> {
+        RefExpr {
+            inner_expr: visitor.visit_expression(node.inner_expr.ast_ref()),
+        }
+    }
+
+    pub struct DerefExpr<'c, V: AstVisitor<'c>>(pub V::ExpressionRet);
+
+    pub fn walk_deref_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::DerefExpr<'c>>,
+    ) -> DerefExpr<'c, V> {
+        DerefExpr(visitor.visit_expression(node.0.ast_ref()))
+    }
+
+    pub struct LiteralExpr<'c, V: AstVisitor<'c>>(pub V::LiteralRet);
+
+    pub fn walk_literal_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::LiteralExpr<'c>>,
+    ) -> LiteralExpr<'c, V> {
+        LiteralExpr(visitor.visit_literal(node.0.ast_ref()))
+    }
+
+    pub struct TypedExpr<'c, V: AstVisitor<'c>> {
+        pub ty: V::TypeRet,
+        pub expr: V::ExpressionRet,
+    }
+
+    pub fn walk_typed_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
+    ) -> TypedExpr<'c, V> {
+        TypedExpr {
+            ty: visitor.visit_type(node.ty.ast_ref()),
+            expr: visitor.visit_expression(node.expr.ast_ref()),
+        }
+    }
+
+    pub struct BlockExpr<'c, V: AstVisitor<'c>>(pub V::BlockRet);
+
+    pub fn walk_block_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::BlockExpr<'c>>,
+    ) -> BlockExpr<'c, V> {
+        BlockExpr(visitor.visit_block(node.0.ast_ref()))
+    }
+
+    pub struct ImportExpr<'c, V: AstVisitor<'c>>(pub V::ImportRet);
+
+    pub fn walk_import_expr<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::ImportExpr<'c>>,
+    ) -> ImportExpr<'c, V> {
+        ImportExpr(visitor.visit_import(node.0.ast_ref()))
+    }
+
+    pub enum Literal<'c, V: AstVisitor<'c>> {
+        Str(V::StrLiteralRet),
+        Char(V::CharLiteralRet),
+        Int(V::IntLiteralRet),
+        Float(V::FloatLiteralRet),
+        Set(V::SetLiteralRet),
+        Map(V::MapLiteralRet),
+        List(V::ListLiteralRet),
+        Tuple(V::TupleLiteralRet),
+        Struct(V::StructLiteralRet),
+        Function(V::FunctionDefRet),
+    }
+
+    pub fn walk_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Literal<'c>>,
+    ) -> Literal<'c, V> {
+        match &*node {
+            ast::Literal::Str(r) => Literal::Str(visitor.visit_str_literal(node.with_body(&r))),
+            ast::Literal::Char(r) => Literal::Char(visitor.visit_char_literal(node.with_body(&r))),
+            ast::Literal::Int(r) => Literal::Int(visitor.visit_int_literal(node.with_body(&r))),
+            ast::Literal::Float(r) => {
+                Literal::Float(visitor.visit_float_literal(node.with_body(&r)))
+            }
+            ast::Literal::Set(r) => Literal::Set(visitor.visit_set_literal(node.with_body(&r))),
+            ast::Literal::Map(r) => Literal::Map(visitor.visit_map_literal(node.with_body(&r))),
+            ast::Literal::List(r) => Literal::List(visitor.visit_list_literal(node.with_body(&r))),
+            ast::Literal::Tuple(r) => {
+                Literal::Tuple(visitor.visit_tuple_literal(node.with_body(&r)))
+            }
+            ast::Literal::Struct(r) => {
+                Literal::Struct(visitor.visit_struct_literal(node.with_body(&r)))
+            }
+            ast::Literal::Function(r) => {
+                Literal::Function(visitor.visit_function_def(node.with_body(&r)))
+            }
+        }
+    }
+
+    pub fn walk_literal_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Literal<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            StrLiteralRet = Ret,
+            CharLiteralRet = Ret,
+            IntLiteralRet = Ret,
+            FloatLiteralRet = Ret,
+            SetLiteralRet = Ret,
+            MapLiteralRet = Ret,
+            ListLiteralRet = Ret,
+            TupleLiteralRet = Ret,
+            StructLiteralRet = Ret,
+            FunctionDefRet = Ret,
+        >,
+    {
+        match walk_literal(visitor, node) {
+            Literal::Str(r) => r,
+            Literal::Char(r) => r,
+            Literal::Int(r) => r,
+            Literal::Float(r) => r,
+            Literal::Set(r) => r,
+            Literal::Map(r) => r,
+            Literal::List(r) => r,
+            Literal::Tuple(r) => r,
+            Literal::Struct(r) => r,
+            Literal::Function(r) => r,
+        }
+    }
+
+    pub struct MatchCase<'c, V: AstVisitor<'c>> {
+        pub pattern: V::PatternRet,
+        pub expr: V::ExpressionRet,
+    }
+
+    pub fn walk_match_case<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::MatchCase<'c>>,
+    ) -> MatchCase<'c, V> {
+        MatchCase {
+            pattern: visitor.visit_pattern(node.pattern.ast_ref()),
+            expr: visitor.visit_expression(node.expr.ast_ref()),
+        }
+    }
+
+    pub struct MatchBlock<'c, V: AstVisitor<'c>> {
+        pub subject: V::ExpressionRet,
+        pub cases: V::CollectionContainer<V::MatchCaseRet>,
+    }
+
+    pub fn walk_match_block<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::MatchBlock<'c>>,
+    ) -> MatchBlock<'c, V> {
+        MatchBlock {
+            subject: visitor.visit_expression(node.subject.ast_ref()),
+            cases: node
+                .cases
+                .iter()
+                .map(|c| visitor.visit_match_case(c.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct LoopBlock<'c, V: AstVisitor<'c>>(pub V::BlockRet);
+
+    pub fn walk_loop_block<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::LoopBlock<'c>>,
+    ) -> LoopBlock<'c, V> {
+        LoopBlock(visitor.visit_block(node.0.ast_ref()))
+    }
+
+    pub struct BodyBlock<'c, V: AstVisitor<'c>> {
+        pub statements: V::CollectionContainer<V::StatementRet>,
+        pub expr: Option<V::ExpressionRet>,
+    }
+
+    pub fn walk_body_block<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::BodyBlock<'c>>,
+    ) -> BodyBlock<'c, V> {
+        BodyBlock {
+            statements: node
+                .statements
+                .iter()
+                .map(|s| visitor.visit_statement(s.ast_ref()))
+                .collect(),
+            expr: node
+                .expr
+                .as_ref()
+                .map(|e| visitor.visit_expression(e.ast_ref())),
+        }
+    }
+
+    pub enum Block<'c, V: AstVisitor<'c>> {
+        Match(V::MatchBlockRet),
+        Loop(V::LoopBlockRet),
+        Body(V::BodyBlockRet),
+    }
+
+    pub fn walk_block<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Block<'c>>,
+    ) -> Block<'c, V> {
+        match &*node {
+            ast::Block::Match(r) => Block::Match(visitor.visit_match_block(node.with_body(&r))),
+            ast::Block::Loop(r) => Block::Loop(visitor.visit_loop_block(node.with_body(&r))),
+            ast::Block::Body(r) => Block::Body(visitor.visit_body_block(node.with_body(&r))),
+        }
+    }
+
+    pub fn walk_block_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Block<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<'c, MatchBlockRet = Ret, LoopBlockRet = Ret, BodyBlockRet = Ret>,
+    {
+        match walk_block(visitor, node) {
+            Block::Match(r) => r,
+            Block::Loop(r) => r,
+            Block::Body(r) => r,
+        }
+    }
+
+    pub struct SetLiteral<'c, V: AstVisitor<'c>> {
+        pub elements: V::CollectionContainer<V::ExpressionRet>,
+    }
+
+    pub fn walk_set_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::SetLiteral<'c>>,
+    ) -> SetLiteral<'c, V> {
+        SetLiteral {
+            elements: node
+                .elements
+                .iter()
+                .map(|e| visitor.visit_expression(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct MapLiteralEntry<'c, V: AstVisitor<'c>> {
+        pub key: V::ExpressionRet,
+        pub value: V::ExpressionRet,
+    }
+
+    pub fn walk_map_literal_entry<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::MapLiteralEntry<'c>>,
+    ) -> MapLiteralEntry<'c, V> {
+        MapLiteralEntry {
+            key: visitor.visit_expression(node.key.ast_ref()),
+            value: visitor.visit_expression(node.value.ast_ref()),
+        }
+    }
+
+    pub struct MapLiteral<'c, V: AstVisitor<'c>> {
+        pub entries: V::CollectionContainer<V::MapLiteralEntryRet>,
+    }
+
+    pub fn walk_map_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::MapLiteral<'c>>,
+    ) -> MapLiteral<'c, V> {
+        MapLiteral {
+            entries: node
+                .elements
+                .iter()
+                .map(|e| visitor.visit_map_literal_entry(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct ListLiteral<'c, V: AstVisitor<'c>> {
+        pub elements: V::CollectionContainer<V::ExpressionRet>,
+    }
+
+    pub fn walk_list_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::ListLiteral<'c>>,
+    ) -> ListLiteral<'c, V> {
+        ListLiteral {
+            elements: node
+                .elements
+                .iter()
+                .map(|e| visitor.visit_expression(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct TupleLiteral<'c, V: AstVisitor<'c>> {
+        pub elements: V::CollectionContainer<V::ExpressionRet>,
+    }
+
+    pub fn walk_tuple_literal<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TupleLiteral<'c>>,
+    ) -> TupleLiteral<'c, V> {
+        TupleLiteral {
+            elements: node
+                .elements
+                .iter()
+                .map(|e| visitor.visit_expression(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct NamedType<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub type_args: V::CollectionContainer<V::TypeRet>,
+    }
+
+    pub fn walk_named_type<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::NamedType<'c>>,
+    ) -> NamedType<'c, V> {
+        NamedType {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            type_args: node
+                .type_args
+                .iter()
+                .map(|e| visitor.visit_type(e.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct RefType<'c, V: AstVisitor<'c>>(pub V::TypeRet);
+
+    pub fn walk_ref_type<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::RefType<'c>>,
+    ) -> RefType<'c, V> {
+        RefType(visitor.visit_type(node.0.ast_ref()))
+    }
+
+    pub struct RawRefType<'c, V: AstVisitor<'c>>(pub V::TypeRet);
+
+    pub fn walk_raw_ref_type<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::RawRefType<'c>>,
+    ) -> RawRefType<'c, V> {
+        RawRefType(visitor.visit_type(node.0.ast_ref()))
+    }
+
+    pub struct TypeVar<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+    }
+
+    pub fn walk_type_var<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TypeVar<'c>>,
+    ) -> TypeVar<'c, V> {
+        TypeVar {
+            name: visitor.visit_name(node.name.ast_ref()),
+        }
+    }
+
+    pub enum Type<'c, V: AstVisitor<'c>> {
+        Named(V::NamedTypeRet),
+        Ref(V::RefTypeRet),
+        RawRef(V::RawRefTypeRet),
+        TypeVar(V::TypeVarRet),
+        Existential(V::ExistentialTypeRet),
+        Infer(V::InferTypeRet),
+    }
+
+    pub fn walk_type<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Type<'c>>,
+    ) -> Type<'c, V> {
+        match &*node {
+            ast::Type::Named(r) => Type::Named(visitor.visit_named_type(node.with_body(&r))),
+            ast::Type::Ref(r) => Type::Ref(visitor.visit_ref_type(node.with_body(&r))),
+            ast::Type::RawRef(r) => Type::RawRef(visitor.visit_raw_ref_type(node.with_body(&r))),
+            ast::Type::TypeVar(r) => Type::TypeVar(visitor.visit_type_var(node.with_body(&r))),
+            ast::Type::Existential(r) => {
+                Type::Existential(visitor.visit_existential_type(node.with_body(&r)))
+            }
+            ast::Type::Infer(r) => Type::Infer(visitor.visit_infer_type(node.with_body(&r))),
+        }
+    }
+
+    pub fn walk_type_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Type<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            NamedTypeRet = Ret,
+            RefTypeRet = Ret,
+            RawRefTypeRet = Ret,
+            TypeVarRet = Ret,
+            ExistentialTypeRet = Ret,
+            InferTypeRet = Ret,
+        >,
+    {
+        match walk_type(visitor, node) {
+            Type::Named(r) => r,
+            Type::Ref(r) => r,
+            Type::RawRef(r) => r,
+            Type::TypeVar(r) => r,
+            Type::Existential(r) => r,
+            Type::Infer(r) => r,
+        }
+    }
+
+    pub enum Pattern<'c, V: AstVisitor<'c>> {
+        Enum(V::EnumPatternRet),
+        Struct(V::StructPatternRet),
+        Namespace(V::NamespacePatternRet),
+        Tuple(V::TuplePatternRet),
+        Literal(V::LiteralPatternRet),
+        Or(V::OrPatternRet),
+        If(V::IfPatternRet),
+        Binding(V::BindingPatternRet),
+        Ignore(V::IgnorePatternRet),
+    }
+
+    pub fn walk_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Pattern<'c>>,
+    ) -> Pattern<'c, V> {
+        match &*node {
+            ast::Pattern::Enum(r) => Pattern::Enum(visitor.visit_enum_pattern(node.with_body(&r))),
+            ast::Pattern::Struct(r) => {
+                Pattern::Struct(visitor.visit_struct_pattern(node.with_body(&r)))
+            }
+            ast::Pattern::Namespace(r) => {
+                Pattern::Namespace(visitor.visit_namespace_pattern(node.with_body(&r)))
+            }
+            ast::Pattern::Tuple(r) => {
+                Pattern::Tuple(visitor.visit_tuple_pattern(node.with_body(&r)))
+            }
+            ast::Pattern::Literal(r) => {
+                Pattern::Literal(visitor.visit_literal_pattern(node.with_body(&r)))
+            }
+            ast::Pattern::Or(r) => Pattern::Or(visitor.visit_or_pattern(node.with_body(&r))),
+            ast::Pattern::If(r) => Pattern::If(visitor.visit_if_pattern(node.with_body(&r))),
+            ast::Pattern::Binding(r) => {
+                Pattern::Binding(visitor.visit_binding_pattern(node.with_body(&r)))
+            }
+            ast::Pattern::Ignore(r) => {
+                Pattern::Ignore(visitor.visit_ignore_pattern(node.with_body(&r)))
+            }
+        }
+    }
+
+    pub fn walk_pattern_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Pattern<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            EnumPatternRet = Ret,
+            StructPatternRet = Ret,
+            NamespacePatternRet = Ret,
+            TuplePatternRet = Ret,
+            LiteralPatternRet = Ret,
+            OrPatternRet = Ret,
+            IfPatternRet = Ret,
+            BindingPatternRet = Ret,
+            IgnorePatternRet = Ret,
+        >,
+    {
+        match walk_pattern(visitor, node) {
+            Pattern::Enum(r) => r,
+            Pattern::Struct(r) => r,
+            Pattern::Namespace(r) => r,
+            Pattern::Tuple(r) => r,
+            Pattern::Literal(r) => r,
+            Pattern::Or(r) => r,
+            Pattern::If(r) => r,
+            Pattern::Binding(r) => r,
+            Pattern::Ignore(r) => r,
+        }
+    }
+
+    pub struct OrPattern<'c, V: AstVisitor<'c>> {
+        pub variants: V::CollectionContainer<V::PatternRet>,
+    }
+    pub fn walk_or_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::OrPattern<'c>>,
+    ) -> OrPattern<'c, V> {
+        OrPattern {
+            variants: node
+                .variants
+                .iter()
+                .map(|v| visitor.visit_pattern(v.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct EnumPattern<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub args: V::CollectionContainer<V::PatternRet>,
+    }
+    pub fn walk_enum_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::EnumPattern<'c>>,
+    ) -> EnumPattern<'c, V> {
+        EnumPattern {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            args: node
+                .args
+                .iter()
+                .map(|a| visitor.visit_pattern(a.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct StructPattern<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub entries: V::CollectionContainer<V::DestructuringPatternRet>,
+    }
+    pub fn walk_struct_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::StructPattern<'c>>,
+    ) -> StructPattern<'c, V> {
+        StructPattern {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            entries: node
+                .entries
+                .iter()
+                .map(|a| visitor.visit_destructuring_pattern(a.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct NamespacePattern<'c, V: AstVisitor<'c>> {
+        pub patterns: V::CollectionContainer<V::DestructuringPatternRet>,
+    }
+    pub fn walk_namespace_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::NamespacePattern<'c>>,
+    ) -> NamespacePattern<'c, V> {
+        NamespacePattern {
+            patterns: node
+                .patterns
+                .iter()
+                .map(|a| visitor.visit_destructuring_pattern(a.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct TuplePattern<'c, V: AstVisitor<'c>> {
+        pub elements: V::CollectionContainer<V::PatternRet>,
+    }
+    pub fn walk_tuple_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TuplePattern<'c>>,
+    ) -> TuplePattern<'c, V> {
+        TuplePattern {
+            elements: node
+                .elements
+                .iter()
+                .map(|a| visitor.visit_pattern(a.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct IfPattern<'c, V: AstVisitor<'c>> {
+        pub pattern: V::PatternRet,
+        pub condition: V::ExpressionRet,
+    }
+    pub fn walk_if_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::IfPattern<'c>>,
+    ) -> IfPattern<'c, V> {
+        IfPattern {
+            pattern: visitor.visit_pattern(node.pattern.ast_ref()),
+            condition: visitor.visit_expression(node.condition.ast_ref()),
+        }
+    }
+
+    pub struct BindingPattern<'c, V: AstVisitor<'c>>(pub V::NameRet);
+    pub fn walk_binding_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::BindingPattern<'c>>,
+    ) -> BindingPattern<'c, V> {
+        BindingPattern(visitor.visit_name(node.0.ast_ref()))
+    }
+
+    pub enum LiteralPattern<'c, V: AstVisitor<'c>> {
+        Str(V::StrLiteralPatternRet),
+        Char(V::CharLiteralPatternRet),
+        Int(V::IntLiteralPatternRet),
+        Float(V::FloatLiteralPatternRet),
+    }
+
+    pub fn walk_literal_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::LiteralPattern>,
+    ) -> LiteralPattern<'c, V> {
+        match &*node {
+            ast::LiteralPattern::Str(r) => {
+                LiteralPattern::Str(visitor.visit_str_literal_pattern(node.with_body(&r)))
+            }
+            ast::LiteralPattern::Char(r) => {
+                LiteralPattern::Char(visitor.visit_char_literal_pattern(node.with_body(&r)))
+            }
+            ast::LiteralPattern::Int(r) => {
+                LiteralPattern::Int(visitor.visit_int_literal_pattern(node.with_body(&r)))
+            }
+            ast::LiteralPattern::Float(r) => {
+                LiteralPattern::Float(visitor.visit_float_literal_pattern(node.with_body(&r)))
+            }
+        }
+    }
+
+    pub fn walk_literal_pattern_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::LiteralPattern>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            StrLiteralPatternRet = Ret,
+            CharLiteralPatternRet = Ret,
+            IntLiteralPatternRet = Ret,
+            FloatLiteralPatternRet = Ret,
+        >,
+    {
+        match walk_literal_pattern(visitor, node) {
+            LiteralPattern::Str(r) => r,
+            LiteralPattern::Char(r) => r,
+            LiteralPattern::Int(r) => r,
+            LiteralPattern::Float(r) => r,
+        }
+    }
+
+    pub struct DestructuringPattern<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub pattern: V::PatternRet,
+    }
+    pub fn walk_destructuring_pattern<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::DestructuringPattern<'c>>,
+    ) -> DestructuringPattern<'c, V> {
+        DestructuringPattern {
+            name: visitor.visit_name(node.name.ast_ref()),
+            pattern: visitor.visit_pattern(node.pattern.ast_ref()),
+        }
+    }
+
+    pub struct ExprStatement<'c, V: AstVisitor<'c>>(pub V::ExpressionRet);
+    pub fn walk_expr_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::ExprStatement<'c>>,
+    ) -> ExprStatement<'c, V> {
+        ExprStatement(visitor.visit_expression(node.0.ast_ref()))
+    }
+
+    pub struct ReturnStatement<'c, V: AstVisitor<'c>>(pub Option<V::ExpressionRet>);
+    pub fn walk_return_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::ReturnStatement<'c>>,
+    ) -> ReturnStatement<'c, V> {
+        ReturnStatement(
+            node.0
+                .as_ref()
+                .map(|n| visitor.visit_expression(n.ast_ref())),
+        )
+    }
+
+    pub struct BlockStatement<'c, V: AstVisitor<'c>>(pub V::BlockRet);
+    pub fn walk_block_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::BlockStatement<'c>>,
+    ) -> BlockStatement<'c, V> {
+        BlockStatement(visitor.visit_block(node.0.ast_ref()))
+    }
+
+    pub struct LetStatement<'c, V: AstVisitor<'c>> {
+        pub pattern: V::PatternRet,
+        pub ty: Option<V::TypeRet>,
+        pub bound: Option<V::BoundRet>,
+        pub value: Option<V::ExpressionRet>,
+    }
+    pub fn walk_let_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::LetStatement<'c>>,
+    ) -> LetStatement<'c, V> {
+        LetStatement {
+            pattern: visitor.visit_pattern(node.pattern.ast_ref()),
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(t.ast_ref())),
+            bound: node
+                .bound
+                .as_ref()
+                .map(|t| visitor.visit_bound(t.ast_ref())),
+            value: node
+                .value
+                .as_ref()
+                .map(|t| visitor.visit_expression(t.ast_ref())),
+        }
+    }
+
+    pub struct AssignStatement<'c, V: AstVisitor<'c>> {
+        pub lhs: V::ExpressionRet,
+        pub rhs: V::ExpressionRet,
+    }
+    pub fn walk_assign_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::AssignStatement<'c>>,
+    ) -> AssignStatement<'c, V> {
+        AssignStatement {
+            lhs: visitor.visit_expression(node.lhs.ast_ref()),
+            rhs: visitor.visit_expression(node.rhs.ast_ref()),
+        }
+    }
+
+    pub struct StructDefEntry<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub ty: Option<V::TypeRet>,
+        pub default: Option<V::ExpressionRet>,
+    }
+    pub fn walk_struct_def_entry<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::StructDefEntry<'c>>,
+    ) -> StructDefEntry<'c, V> {
+        StructDefEntry {
+            name: visitor.visit_name(node.name.ast_ref()),
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(t.ast_ref())),
+            default: node
+                .default
+                .as_ref()
+                .map(|d| visitor.visit_expression(d.ast_ref())),
+        }
+    }
+
+    pub struct StructDef<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub bound: Option<V::BoundRet>,
+        pub entries: V::CollectionContainer<V::StructDefEntryRet>,
+    }
+    pub fn walk_struct_def<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::StructDef<'c>>,
+    ) -> StructDef<'c, V> {
+        StructDef {
+            name: visitor.visit_name(node.name.ast_ref()),
+            bound: node
+                .bound
+                .as_ref()
+                .map(|b| visitor.visit_bound(b.ast_ref())),
+            entries: node
+                .entries
+                .iter()
+                .map(|b| visitor.visit_struct_def_entry(b.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct EnumDefEntry<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub args: V::CollectionContainer<V::TypeRet>,
+    }
+    pub fn walk_enum_def_entry<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::EnumDefEntry<'c>>,
+    ) -> EnumDefEntry<'c, V> {
+        EnumDefEntry {
+            name: visitor.visit_name(node.name.ast_ref()),
+            args: node
+                .args
+                .iter()
+                .map(|b| visitor.visit_type(b.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct EnumDef<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub bound: Option<V::BoundRet>,
+        pub entries: V::CollectionContainer<V::EnumDefEntryRet>,
+    }
+    pub fn walk_enum_def<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::EnumDef<'c>>,
+    ) -> EnumDef<'c, V> {
+        EnumDef {
+            name: visitor.visit_name(node.name.ast_ref()),
+            bound: node
+                .bound
+                .as_ref()
+                .map(|b| visitor.visit_bound(b.ast_ref())),
+            entries: node
+                .entries
+                .iter()
+                .map(|b| visitor.visit_enum_def_entry(b.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct TraitBound<'c, V: AstVisitor<'c>> {
+        pub name: V::AccessNameRet,
+        pub type_args: V::CollectionContainer<V::TypeRet>,
+    }
+    pub fn walk_trait_bound<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TraitBound<'c>>,
+    ) -> TraitBound<'c, V> {
+        TraitBound {
+            name: visitor.visit_access_name(node.name.ast_ref()),
+            type_args: node
+                .type_args
+                .iter()
+                .map(|t| visitor.visit_type(t.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct Bound<'c, V: AstVisitor<'c>> {
+        pub type_args: V::CollectionContainer<V::TypeRet>,
+        pub trait_bounds: V::CollectionContainer<V::TraitBoundRet>,
+    }
+    pub fn walk_bound<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Bound<'c>>,
+    ) -> Bound<'c, V> {
+        Bound {
+            type_args: node
+                .type_args
+                .iter()
+                .map(|t| visitor.visit_type(t.ast_ref()))
+                .collect(),
+            trait_bounds: node
+                .trait_bounds
+                .iter()
+                .map(|t| visitor.visit_trait_bound(t.ast_ref()))
+                .collect(),
+        }
+    }
+
+    pub struct TraitDef<'c, V: AstVisitor<'c>> {
+        pub name: V::NameRet,
+        pub bound: V::BoundRet,
+        pub trait_type: V::TypeRet,
+    }
+    pub fn walk_trait_def<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::TraitDef<'c>>,
+    ) -> TraitDef<'c, V> {
+        TraitDef {
+            name: visitor.visit_name(node.name.ast_ref()),
+            bound: visitor.visit_bound(node.bound.ast_ref()),
+            trait_type: visitor.visit_type(node.trait_type.ast_ref()),
+        }
+    }
+
+    pub enum Statement<'c, V: AstVisitor<'c>> {
+        Expr(V::ExprStatementRet),
+        Return(V::ReturnStatementRet),
+        Block(V::BlockStatementRet),
+        Break(V::BreakStatementRet),
+        Continue(V::ContinueStatementRet),
+        Let(V::LetStatementRet),
+        Assign(V::AssignStatementRet),
+        StructDef(V::StructDefRet),
+        EnumDef(V::EnumDefRet),
+        TraitDef(V::TraitDefRet),
+    }
+
+    pub fn walk_statement<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Statement<'c>>,
+    ) -> Statement<'c, V> {
+        match &*node {
+            ast::Statement::Expr(r) => {
+                Statement::Expr(visitor.visit_expr_statement(node.with_body(&r)))
+            }
+            ast::Statement::Return(r) => {
+                Statement::Return(visitor.visit_return_statement(node.with_body(&r)))
+            }
+            ast::Statement::Block(r) => {
+                Statement::Block(visitor.visit_block_statement(node.with_body(&r)))
+            }
+            ast::Statement::Break(r) => {
+                Statement::Break(visitor.visit_break_statement(node.with_body(&r)))
+            }
+            ast::Statement::Continue(r) => {
+                Statement::Continue(visitor.visit_continue_statement(node.with_body(&r)))
+            }
+            ast::Statement::Let(r) => {
+                Statement::Let(visitor.visit_let_statement(node.with_body(&r)))
+            }
+            ast::Statement::Assign(r) => {
+                Statement::Assign(visitor.visit_assign_statement(node.with_body(&r)))
+            }
+            ast::Statement::StructDef(r) => {
+                Statement::StructDef(visitor.visit_struct_def(node.with_body(&r)))
+            }
+            ast::Statement::EnumDef(r) => {
+                Statement::EnumDef(visitor.visit_enum_def(node.with_body(&r)))
+            }
+            ast::Statement::TraitDef(r) => {
+                Statement::TraitDef(visitor.visit_trait_def(node.with_body(&r)))
+            }
+        }
+    }
+
+    pub fn walk_statement_same_children<'c, V, Ret>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Statement<'c>>,
+    ) -> Ret
+    where
+        V: AstVisitor<
+            'c,
+            ExprStatementRet = Ret,
+            ReturnStatementRet = Ret,
+            BlockStatementRet = Ret,
+            BreakStatementRet = Ret,
+            ContinueStatementRet = Ret,
+            LetStatementRet = Ret,
+            AssignStatementRet = Ret,
+            StructDefRet = Ret,
+            EnumDefRet = Ret,
+            TraitDefRet = Ret,
+        >,
+    {
+        match walk_statement(visitor, node) {
+            Statement::Expr(r) => r,
+            Statement::Return(r) => r,
+            Statement::Block(r) => r,
+            Statement::Break(r) => r,
+            Statement::Continue(r) => r,
+            Statement::Let(r) => r,
+            Statement::Assign(r) => r,
+            Statement::StructDef(r) => r,
+            Statement::EnumDef(r) => r,
+            Statement::TraitDef(r) => r,
+        }
+    }
+
+    pub struct Module<'c, V: AstVisitor<'c>> {
+        pub contents: V::CollectionContainer<V::StatementRet>,
+    }
+
+    pub fn walk_module<'c, V: AstVisitor<'c>>(
+        visitor: &mut V,
+        node: ast::AstNodeRef<ast::Module<'c>>,
+    ) -> Module<'c, V> {
+        Module {
+            contents: node
+                .contents
+                .iter()
+                .map(|s| visitor.visit_statement(s.ast_ref()))
+                .collect(),
+        }
+    }
+}

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1,10 +1,10 @@
-//! Visitor implementation for [hash::ast] nodes.
+//! Visitor implementation for [crate::ast] nodes.
 //!
 //! All rights reserved 2021 (c) The Hash Language authors
 use crate::ast;
 use std::iter::FromIterator;
 
-/// The main visitor trait for [hash::ast] nodes.
+/// The main visitor trait for [crate::ast] nodes.
 ///
 /// This contains a method for each AST structure, as well as a dedicated return type for it.
 /// These can be implemented using the functions defined in [walk] that can traverse the children

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -81,6 +81,7 @@ where
 
     /// Create new AST generator from a provided token stream with inherited module resolver
     /// and a provided parent span.
+    #[must_use]
     pub fn from_stream(&self, stream: &'stream [Token<'c>], parent_span: Location) -> Self {
         Self {
             stream,

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -423,19 +423,19 @@ where
                     TokenAtom::Keyword(Keyword::Struct) => {
                         Statement::StructDef(self.parse_struct_defn()?)
                     }
-                    TokenAtom::Keyword(Keyword::Continue) => Statement::Continue,
-                    TokenAtom::Keyword(Keyword::Break) => Statement::Break,
+                    TokenAtom::Keyword(Keyword::Continue) => Statement::Continue(ContinueStatement),
+                    TokenAtom::Keyword(Keyword::Break) => Statement::Break(BreakStatement),
                     TokenAtom::Keyword(Keyword::Return) => {
                         // @@Hack: check if the next token is a semi-colon, if so the return statement
                         // has no returned expression...
                         match self.peek() {
                             Some(token) if token.has_atom(TokenAtom::Semi) => {
-                                Statement::Return(None)
+                                Statement::Return(ReturnStatement(None))
                             }
-                            Some(_) => {
-                                Statement::Return(Some(self.parse_expression_with_precedence(0)?))
-                            }
-                            None => Statement::Return(None),
+                            Some(_) => Statement::Return(ReturnStatement(Some(
+                                self.parse_expression_with_precedence(0)?,
+                            ))),
+                            None => Statement::Return(ReturnStatement(None)),
                         }
                     }
                     _ => unreachable!(),
@@ -470,11 +470,11 @@ where
                     // Now we need to transform the re-assignment operator into a function call
 
                     return Ok(self.node_from_joined_location(
-                        Statement::Expr(self.transform_binary_expression(
+                        Statement::Expr(ExprStatement(self.transform_binary_expression(
                             expr,
                             rhs,
                             transformed_op,
-                        )),
+                        ))),
                         &start,
                     ));
                 }
@@ -483,7 +483,7 @@ where
                 match self.peek() {
                     Some(token) if token.has_atom(TokenAtom::Semi) => {
                         self.skip_token();
-                        Ok(self.node_from_location(Statement::Expr(expr), &start))
+                        Ok(self.node_from_location(Statement::Expr(ExprStatement(expr)), &start))
                     }
                     Some(token) if token.has_atom(TokenAtom::Eq) => {
                         self.skip_token();
@@ -500,12 +500,13 @@ where
 
                     // Special case where there is a expression at the end of the stream and therefore it
                     // is signifying that it is returning the expression value here
-                    None => Ok(self.node_from_location(Statement::Expr(expr), &start)),
+                    None => {
+                        Ok(self.node_from_location(Statement::Expr(ExprStatement(expr)), &start))
+                    }
 
                     token => match (token, expr.into_body().move_out().into_kind()) {
-                        (_, ExpressionKind::Block(block)) => {
-                            Ok(self.node_from_location(Statement::Block(block), &start))
-                        }
+                        (_, ExpressionKind::Block(BlockExpr(block))) => Ok(self
+                            .node_from_location(Statement::Block(BlockStatement(block)), &start)),
                         (Some(token), _) => self.error(
                             AstGenErrorKind::Expected,
                             Some(TokenAtomVector::begin_expression(&self.wall)),
@@ -549,7 +550,10 @@ where
         transform: bool,
     ) -> AstNode<'c, Expression<'c>> {
         match transform {
-            true => self.node(Expression::new(ExpressionKind::Ref(expr, RefKind::Normal))),
+            true => self.node(Expression::new(ExpressionKind::Ref(RefExpr {
+                inner_expr: expr,
+                kind: RefKind::Normal,
+            }))),
             false => expr,
         }
     }
@@ -608,13 +612,13 @@ where
                         args: self.node(FunctionCallArgs {
                             entries: row![&self.wall;
                                 self.transform_expr_into_ref(lhs, assigning),
-                                self.node(Expression::new(ExpressionKind::LiteralExpr(self.node(
+                                self.node(Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(self.node(
                                     Literal::Function(FunctionDef {
                                         args: row![&self.wall],
                                         return_ty: None,
                                         fn_body: rhs,
                                     }),
-                                ))))
+                                )))))
                             ],
                         }),
                     },
@@ -696,17 +700,17 @@ where
         // condition
         branches.push(
             self.node(MatchCase {
-                pattern: self.node(Pattern::Ignore),
+                pattern: self.node(Pattern::Ignore(IgnorePattern)),
                 expr: self.make_variable(self.make_boolean(false)),
             }),
             &self.wall,
         );
 
-        self.node(Expression::new(ExpressionKind::Block(self.node(
-            Block::Match(MatchBlock {
+        self.node(Expression::new(ExpressionKind::Block(BlockExpr(
+            self.node(Block::Match(MatchBlock {
                 subject: fn_call,
                 cases: branches,
-            }),
+            })),
         ))))
     }
 
@@ -1092,7 +1096,7 @@ where
         let body_location = body.location();
 
         // transpile the for loop
-        Ok(self.node_from_joined_location(Block::Loop(self.node_from_location(
+        Ok(self.node_from_joined_location(Block::Loop(LoopBlock(self.node_from_location(
             Block::Match(MatchBlock {
             subject: self.node(Expression::new(ExpressionKind::FunctionCall(
                 FunctionCallExpr {
@@ -1120,7 +1124,7 @@ where
                             },
                         ), &pattern_location
                     ),
-                    expr: self.node_from_location(Expression::new(ExpressionKind::Block(body)), &body_location),
+                    expr: self.node_from_location(Expression::new(ExpressionKind::Block(BlockExpr(body))), &body_location),
                 }, &start),
                 self.node(MatchCase {
                     pattern: self.node(
@@ -1135,15 +1139,15 @@ where
                             },
                         ),
                     ),
-                    expr: self.node(Expression::new(ExpressionKind::Block(
+                    expr: self.node(Expression::new(ExpressionKind::Block(BlockExpr(
                         self.node(Block::Body(BodyBlock {
-                            statements: row![&self.wall; self.node(Statement::Break)],
+                            statements: row![&self.wall; self.node(Statement::Break(BreakStatement))],
                             expr: None,
                         })),
-                    ))),
+                    )))),
                 }),
             ],
-        }), &start)), &start))
+        }), &start))), &start))
     }
 
     /// In general, a while loop transpilation process occurs by transferring the looping
@@ -1178,7 +1182,7 @@ where
         let body_location = body.location();
 
         Ok(self.node_from_joined_location(
-            Block::Loop(self.node_with_location(
+            Block::Loop(LoopBlock(self.node_with_location(
                 Block::Match(MatchBlock {
                     subject: condition,
                     cases: row![&self.wall; self.node(MatchCase {
@@ -1186,24 +1190,24 @@ where
                                 name: self.make_access_name_from_str("true", body_location),
                                 args: row![&self.wall],
                             })),
-                            expr: self.node(Expression::new(ExpressionKind::Block(body))),
+                            expr: self.node(Expression::new(ExpressionKind::Block(BlockExpr(body)))),
                         }),
                         self.node(MatchCase {
                             pattern: self.node(Pattern::Enum(EnumPattern {
                                 name: self.make_access_name_from_str("false", body_location),
                                 args: row![&self.wall],
                             })),
-                            expr: self.node(Expression::new(ExpressionKind::Block(
+                            expr: self.node(Expression::new(ExpressionKind::Block(BlockExpr(
                                 self.node(Block::Body(BodyBlock {
-                                    statements: row![&self.wall; self.node(Statement::Break)],
+                                    statements: row![&self.wall; self.node(Statement::Break(BreakStatement))],
                                     expr: None,
                                 })),
-                            ))),
+                            )))),
                         }),
                     ],
                 }),
                 condition_location,
-            )),
+            ))),
             &start,
         ))
     }
@@ -1315,13 +1319,16 @@ where
                     MatchCase {
                         pattern: self.node_from_location(
                             Pattern::If(IfPattern {
-                                pattern: self.node_from_location(Pattern::Ignore, &clause_loc),
+                                pattern: self.node_from_location(
+                                    Pattern::Ignore(IgnorePattern),
+                                    &clause_loc,
+                                ),
                                 condition: clause,
                             }),
                             &clause_loc,
                         ),
                         expr: self.node_from_location(
-                            Expression::new(ExpressionKind::Block(branch)),
+                            Expression::new(ExpressionKind::Block(BlockExpr(branch))),
                             &branch_loc,
                         ),
                     },
@@ -1356,9 +1363,9 @@ where
                     cases.push(
                         self.node_from_location(
                             MatchCase {
-                                pattern: self.node(Pattern::Ignore),
+                                pattern: self.node(Pattern::Ignore(IgnorePattern)),
                                 expr: self.node_from_location(
-                                    Expression::new(ExpressionKind::Block(else_branch)),
+                                    Expression::new(ExpressionKind::Block(BlockExpr(else_branch))),
                                     &loc,
                                 ),
                             },
@@ -1376,12 +1383,12 @@ where
         if !has_else_branch {
             cases.push(
                 self.node(MatchCase {
-                    pattern: self.node(Pattern::Ignore),
-                    expr: self.node(Expression::new(ExpressionKind::Block(self.node(
-                        Block::Body(BodyBlock {
+                    pattern: self.node(Pattern::Ignore(IgnorePattern)),
+                    expr: self.node(Expression::new(ExpressionKind::Block(BlockExpr(
+                        self.node(Block::Body(BodyBlock {
                             statements: row![&self.wall],
                             expr: None,
-                        }),
+                        })),
                     )))),
                 }),
                 &self.wall,
@@ -1507,7 +1514,7 @@ where
             None => {
                 let copy = self.node(Name { ..*name.body() });
                 let loc = copy.location();
-                self.node_with_location(Pattern::Binding(copy), loc)
+                self.node_with_location(Pattern::Binding(BindingPattern(copy)), loc)
             }
         };
 
@@ -1594,9 +1601,11 @@ where
                     _ => {
                         // @@Speed: Always performing a lookup?
                         if IDENTIFIER_MAP.ident_name(*k) == "_" {
-                            Pattern::Ignore
+                            Pattern::Ignore(IgnorePattern)
                         } else {
-                            Pattern::Binding(self.node_from_location(Name { ident: *k }, span))
+                            Pattern::Binding(BindingPattern(
+                                self.node_from_location(Name { ident: *k }, span),
+                            ))
                         }
                     }
                 }
@@ -1720,11 +1729,11 @@ where
 
                     block.statements.push(
                         gen.node_from_joined_location(
-                            Statement::Expr(self.transform_binary_expression(
+                            Statement::Expr(ExprStatement(self.transform_binary_expression(
                                 expr,
                                 rhs,
                                 transformed_op,
-                            )),
+                            ))),
                             &expr_loc,
                         ),
                         &self.wall,
@@ -1736,7 +1745,10 @@ where
                             gen.skip_token();
 
                             block.statements.push(
-                                gen.node_from_joined_location(Statement::Expr(expr), &expr_loc),
+                                gen.node_from_joined_location(
+                                    Statement::Expr(ExprStatement(expr)),
+                                    &expr_loc,
+                                ),
                                 &self.wall,
                             );
                         }
@@ -1757,13 +1769,15 @@ where
                         }
                         Some(token) => {
                             match expr.into_body().move_out().into_kind() {
-                                ExpressionKind::Block(inner_block) => block.statements.push(
-                                    gen.node_from_joined_location(
-                                        Statement::Block(inner_block),
-                                        &expr_loc,
-                                    ),
-                                    &self.wall,
-                                ),
+                                ExpressionKind::Block(BlockExpr(inner_block)) => {
+                                    block.statements.push(
+                                        gen.node_from_joined_location(
+                                            Statement::Block(BlockStatement(inner_block)),
+                                            &expr_loc,
+                                        ),
+                                        &self.wall,
+                                    )
+                                }
                                 _ => gen.error(
                                     AstGenErrorKind::Expected,
                                     Some(TokenAtomVector::from_row(
@@ -1824,16 +1838,17 @@ where
                 let block = match atom {
                     TokenAtom::Keyword(Keyword::For) => self.parse_for_loop()?,
                     TokenAtom::Keyword(Keyword::While) => self.parse_while_loop()?,
-                    TokenAtom::Keyword(Keyword::Loop) => {
-                        self.node_from_joined_location(Block::Loop(self.parse_block()?), &start)
-                    }
+                    TokenAtom::Keyword(Keyword::Loop) => self.node_from_joined_location(
+                        Block::Loop(LoopBlock(self.parse_block()?)),
+                        &start,
+                    ),
                     TokenAtom::Keyword(Keyword::If) => self.parse_if_statement()?,
                     TokenAtom::Keyword(Keyword::Match) => self.parse_match_block()?,
                     _ => unreachable!(),
                 };
 
                 self.node_from_joined_location(
-                    Expression::new(ExpressionKind::Block(block)),
+                    Expression::new(ExpressionKind::Block(BlockExpr(block))),
                     &start,
                 )
             }
@@ -2065,12 +2080,14 @@ where
 
         match resolved_module {
             Ok(idx) => Ok(self.node_from_joined_location(
-                Expression::new(ExpressionKind::Import(self.node_from_joined_location(
-                    Import {
-                        path: *raw,
-                        index: idx,
-                    },
-                    &start,
+                Expression::new(ExpressionKind::Import(ImportExpr(
+                    self.node_from_joined_location(
+                        Import {
+                            path: *raw,
+                            index: idx,
+                        },
+                        &start,
+                    ),
                 ))),
                 &start,
             )),
@@ -2195,13 +2212,15 @@ where
         }
 
         Ok(self.node_from_joined_location(
-            Expression::new(ExpressionKind::LiteralExpr(self.node_from_joined_location(
-                Literal::Struct(StructLiteral {
-                    name,
-                    type_args,
-                    entries,
-                }),
-                &start,
+            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                self.node_from_joined_location(
+                    Literal::Struct(StructLiteral {
+                        name,
+                        type_args,
+                        entries,
+                    }),
+                    &start,
+                ),
             ))),
             &start,
         ))
@@ -2250,15 +2269,23 @@ where
         let start = self.current_location();
 
         let expr_kind = match &token.kind {
-            TokenKind::Atom(TokenAtom::Star) => ExpressionKind::Deref(self.parse_expression()?),
+            TokenKind::Atom(TokenAtom::Star) => {
+                ExpressionKind::Deref(DerefExpr(self.parse_expression()?))
+            }
             TokenKind::Atom(TokenAtom::Amp) => {
                 // Check if this reference is raw...
                 match self.peek() {
                     Some(token) if token.has_atom(TokenAtom::Keyword(Keyword::Raw)) => {
                         self.skip_token();
-                        ExpressionKind::Ref(self.parse_expression()?, RefKind::Raw)
+                        ExpressionKind::Ref(RefExpr {
+                            inner_expr: self.parse_expression()?,
+                            kind: RefKind::Raw,
+                        })
                     }
-                    _ => ExpressionKind::Ref(self.parse_expression()?, RefKind::Normal),
+                    _ => ExpressionKind::Ref(RefExpr {
+                        inner_expr: self.parse_expression()?,
+                        kind: RefKind::Normal,
+                    }),
                 }
             }
             kind @ (TokenKind::Atom(TokenAtom::Plus) | TokenKind::Atom(TokenAtom::Minus)) => {
@@ -2649,14 +2676,14 @@ where
                 };
 
                 match self.parse_type() {
-                    Ok(ty) if is_ref => Type::RawRef(ty),
-                    Ok(ty) => Type::Ref(ty),
+                    Ok(ty) if is_ref => Type::RawRef(RawRefType(ty)),
+                    Ok(ty) => Type::Ref(RefType(ty)),
                     err => return err,
                 }
             }
             TokenKind::Atom(TokenAtom::Question) => {
                 self.skip_token();
-                Type::Existential
+                Type::Existential(ExistentialType)
             }
             TokenKind::Atom(TokenAtom::Ident(id)) => {
                 self.skip_token();
@@ -2672,7 +2699,7 @@ where
                         let ident = name.body().path.get(0).unwrap();
 
                         match IDENTIFIER_MAP.ident_name(*ident) {
-                            "_" => Type::Infer,
+                            "_" => Type::Infer(InferType),
                             // ##TypeArgsNaming: Here the rules are built-in for what the name of a type-arg is,
                             //                   a capital character of length 1...
                             ident_name => {
@@ -2844,22 +2871,26 @@ where
             match gen.peek().unwrap() {
                 token if token.has_atom(TokenAtom::Colon) => {
                     return Ok(self.node_from_location(
-                        Expression::new(ExpressionKind::LiteralExpr(self.node_from_location(
-                            Literal::Map(MapLiteral {
-                                elements: row![&self.wall],
-                            }),
-                            span,
+                        Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                            self.node_from_location(
+                                Literal::Map(MapLiteral {
+                                    elements: row![&self.wall],
+                                }),
+                                span,
+                            ),
                         ))),
                         span,
                     ))
                 }
                 token if token.has_atom(TokenAtom::Comma) => {
                     return Ok(self.node_from_location(
-                        Expression::new(ExpressionKind::LiteralExpr(self.node_from_location(
-                            Literal::Set(SetLiteral {
-                                elements: row![&self.wall],
-                            }),
-                            span,
+                        Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                            self.node_from_location(
+                                Literal::Set(SetLiteral {
+                                    elements: row![&self.wall],
+                                }),
+                                span,
+                            ),
                         ))),
                         span,
                     ))
@@ -2871,13 +2902,13 @@ where
         // Is this an empty block?
         if !gen.has_token() {
             return Ok(self.node_from_location(
-                Expression::new(ExpressionKind::Block(self.node_from_location(
+                Expression::new(ExpressionKind::Block(BlockExpr(self.node_from_location(
                     Block::Body(BodyBlock {
                         statements: row![&self.wall],
                         expr: None,
                     }),
                     span,
-                ))),
+                )))),
                 span,
             ));
         }
@@ -2895,17 +2926,21 @@ where
         let initial_statement = initial_statement.into_body().move_out();
 
         match (gen.peek(), initial_statement) {
-            (Some(token), Statement::Expr(initial_expr)) if token.has_atom(TokenAtom::Comma) => {
+            (Some(token), Statement::Expr(ExprStatement(initial_expr)))
+                if token.has_atom(TokenAtom::Comma) =>
+            {
                 gen.skip_token(); // ','
 
                 let literal = self.parse_set_literal(gen, initial_expr)?;
 
                 Ok(self.node_from_location(
-                    Expression::new(ExpressionKind::LiteralExpr(literal)),
+                    Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(literal))),
                     span,
                 ))
             }
-            (Some(token), Statement::Expr(initial_expr)) if token.has_atom(TokenAtom::Colon) => {
+            (Some(token), Statement::Expr(ExprStatement(initial_expr)))
+                if token.has_atom(TokenAtom::Colon) =>
+            {
                 gen.skip_token(); // ':'
 
                 let start_pos = initial_expr.location();
@@ -2926,16 +2961,18 @@ where
                         let literal = self.parse_map_literal(gen, entry)?;
 
                         Ok(self.node_from_location(
-                            Expression::new(ExpressionKind::LiteralExpr(literal)),
+                            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(literal))),
                             span,
                         ))
                     }
                     _ => Ok(self.node_from_location(
-                        Expression::new(ExpressionKind::LiteralExpr(self.node_from_location(
-                            Literal::Map(MapLiteral {
-                                elements: row![&self.wall; entry],
-                            }),
-                            span,
+                        Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                            self.node_from_location(
+                                Literal::Map(MapLiteral {
+                                    elements: row![&self.wall; entry],
+                                }),
+                                span,
+                            ),
                         ))),
                         span,
                     )),
@@ -2947,30 +2984,33 @@ where
                 // check here if there is a 'semi', and then convert the expression into a statement.
                 let block = self.parse_block_from_gen(&gen, *span, Some(statement))?;
 
-                Ok(self.node_from_location(Expression::new(ExpressionKind::Block(block)), span))
+                Ok(self.node_from_location(
+                    Expression::new(ExpressionKind::Block(BlockExpr(block))),
+                    span,
+                ))
             }
-            (None, Statement::Expr(initial_expr)) => {
+            (None, Statement::Expr(ExprStatement(initial_expr))) => {
                 // This block is just a block with a single expression
 
                 Ok(self.node_from_location(
-                    Expression::new(ExpressionKind::Block(self.node_from_location(
+                    Expression::new(ExpressionKind::Block(BlockExpr(self.node_from_location(
                         Block::Body(BodyBlock {
                             statements: row![&self.wall],
                             expr: Some(initial_expr),
                         }),
                         span,
-                    ))),
+                    )))),
                     span,
                 ))
             }
             (None, statement) => Ok(self.node_from_location(
-                Expression::new(ExpressionKind::Block(self.node_from_location(
+                Expression::new(ExpressionKind::Block(BlockExpr(self.node_from_location(
                     Block::Body(BodyBlock {
                         statements: row![&self.wall; self.node_with_location(statement, location)],
                         expr: None,
                     }),
                     span,
-                ))),
+                )))),
                 span,
             )),
         }
@@ -3122,13 +3162,15 @@ where
         };
 
         Ok(self.node_from_joined_location(
-            Expression::new(ExpressionKind::LiteralExpr(gen.node_from_joined_location(
-                Literal::Function(FunctionDef {
-                    args,
-                    return_ty,
-                    fn_body,
-                }),
-                &start,
+            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                gen.node_from_joined_location(
+                    Literal::Function(FunctionDef {
+                        args,
+                        return_ty,
+                        fn_body,
+                    }),
+                    &start,
+                ),
             ))),
             &start,
         ))
@@ -3161,14 +3203,14 @@ where
                     gen.skip_token();
 
                     return Ok(gen.node_from_joined_location(
-                        Expression::new(ExpressionKind::LiteralExpr(
+                        Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
                             gen.node_from_joined_location(
                                 Literal::Tuple(TupleLiteral {
                                     elements: row![&self.wall;],
                                 }),
                                 &start,
                             ),
-                        )),
+                        ))),
                         &start,
                     ));
                 }
@@ -3203,9 +3245,8 @@ where
         }
 
         Ok(gen.node_from_joined_location(
-            Expression::new(ExpressionKind::LiteralExpr(gen.node_from_joined_location(
-                Literal::Tuple(TupleLiteral { elements }),
-                &start,
+            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                gen.node_from_joined_location(Literal::Tuple(TupleLiteral { elements }), &start),
             ))),
             &start,
         ))
@@ -3244,9 +3285,8 @@ where
         }
 
         Ok(gen.node_from_joined_location(
-            Expression::new(ExpressionKind::LiteralExpr(gen.node_from_joined_location(
-                Literal::List(ListLiteral { elements }),
-                &start,
+            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                gen.node_from_joined_location(Literal::List(ListLiteral { elements }), &start),
             ))),
             &start,
         ))
@@ -3255,10 +3295,14 @@ where
     /// Convert a literal kind into a pattern literal kind.
     pub fn convert_literal_kind_into_pattern(&self, kind: &TokenKind) -> LiteralPattern {
         match kind {
-            TokenKind::Atom(TokenAtom::StrLiteral(s)) => LiteralPattern::Str(*s),
-            TokenKind::Atom(TokenAtom::CharLiteral(s)) => LiteralPattern::Char(*s),
-            TokenKind::Atom(TokenAtom::IntLiteral(s)) => LiteralPattern::Int(*s),
-            TokenKind::Atom(TokenAtom::FloatLiteral(s)) => LiteralPattern::Float(*s),
+            TokenKind::Atom(TokenAtom::StrLiteral(s)) => LiteralPattern::Str(StrLiteralPattern(*s)),
+            TokenKind::Atom(TokenAtom::CharLiteral(s)) => {
+                LiteralPattern::Char(CharLiteralPattern(*s))
+            }
+            TokenKind::Atom(TokenAtom::IntLiteral(s)) => LiteralPattern::Int(IntLiteralPattern(*s)),
+            TokenKind::Atom(TokenAtom::FloatLiteral(s)) => {
+                LiteralPattern::Float(FloatLiteralPattern(*s))
+            }
             _ => unreachable!(),
         }
     }
@@ -3269,10 +3313,10 @@ where
         let token = self.current_token();
         let literal = AstNode::new(
             match token.kind {
-                TokenKind::Atom(TokenAtom::IntLiteral(num)) => Literal::Int(num),
-                TokenKind::Atom(TokenAtom::FloatLiteral(num)) => Literal::Float(num),
-                TokenKind::Atom(TokenAtom::CharLiteral(ch)) => Literal::Char(ch),
-                TokenKind::Atom(TokenAtom::StrLiteral(str)) => Literal::Str(str),
+                TokenKind::Atom(TokenAtom::IntLiteral(num)) => Literal::Int(IntLiteral(num)),
+                TokenKind::Atom(TokenAtom::FloatLiteral(num)) => Literal::Float(FloatLiteral(num)),
+                TokenKind::Atom(TokenAtom::CharLiteral(ch)) => Literal::Char(CharLiteral(ch)),
+                TokenKind::Atom(TokenAtom::StrLiteral(str)) => Literal::Str(StrLiteral(str)),
                 _ => unreachable!(),
             },
             token.span,
@@ -3280,7 +3324,7 @@ where
         );
 
         self.node_from_location(
-            Expression::new(ExpressionKind::LiteralExpr(literal)),
+            Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(literal))),
             &token.span,
         )
     }

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -86,6 +86,7 @@ impl<'c> Token<'c> {
     }
 
     /// Copy the current token in the specified [Wall] allocator.
+    #[must_use]
     pub fn clone_in(&self, wall: &Wall<'c>) -> Self {
         Token {
             kind: self.kind.clone_in(wall),


### PR DESCRIPTION
This pull request adds an implementation of the visitor pattern for the AST node structure. This is done to avoid repetition when recursing into children, for example in typechecking and visualisation.

The `AstVisitor` trait contains methods which can be implemented for each node in the tree. This is to be used in conjunction with functions inside `visitor::walk::*`, which traverse into the children and return the visitor results.

Each node has its own "return type" within the visitor, which allows for arbitrarily complicated traversal of the tree. Furthermore, enum types within the AST have `*_same_children` helper functions within `visitor::walk`, which automatically matches on the variants and traverses the variant enum members, as long as all variants have the same return type in the visitor (this is done using a type bound for associated types).

Things still to do before the PR can be merged:
- [x] Fix compile errors relating to slight reorganisation of some AST enum types.
- [x] Add any remaining implementations in `walk::`, specifically for statement types.
- [x] Add documentation to the `visitor` module.
- [x] Finish writing `ast::tree`, which is a proof-of-concept usage of this visitor that replaces the current `visualise` module.

Things to do after the PR is merged:
- [ ] Use the visitor to make typechecking more concise.
- [ ] Use the visitor for node counting.
- [ ] Investigate if there is a way to make a generic proc-macro which can generate a visitor from a tree description. This is most likely a longer-term goal but might come in handy because we will have other sorts of trees within the compiler (in the typechecker for example).