### PR TITLE
Parser: use '=' instead of ':' for namespace destructuring

### DIFF
--- a/tests/parser/tests/cases/should_pass/pattern_matching_let/case.hash
+++ b/tests/parser/tests/cases/should_pass/pattern_matching_let/case.hash
@@ -3,4 +3,5 @@ let Dog { name } = dog;
 let Dog { name = better_name } = dog;
 
 // namespace destructuring
-let { name: even_better_name} = dog;
+let { name } = dog;
+let { name = even_better_name} = dog;


### PR DESCRIPTION
This patch closes #88.