### PR TITLE
Wrap `ast::Module` nodes inside `ast::AstNode` in `Modules`

### DIFF
--- a/compiler/hash-ast/src/module.rs
+++ b/compiler/hash-ast/src/module.rs
@@ -24,7 +24,7 @@ pub struct ModuleBuilder<'c> {
     indexes: DashMap<ModuleIdx, ()>,
     path_to_index: DashMap<PathBuf, ModuleIdx>,
     filenames_by_index: DashMap<ModuleIdx, PathBuf>,
-    modules_by_index: DashMap<ModuleIdx, ast::Module<'c>>,
+    modules_by_index: DashMap<ModuleIdx, ast::AstNode<'c, ast::Module<'c>>>,
     contents_by_index: DashMap<ModuleIdx, String>,
     deps_by_index: DashMap<ModuleIdx, DashMap<ModuleIdx, ()>>,
     entry_point: RwLock<Option<ModuleIdx>>,
@@ -35,7 +35,7 @@ impl<'c> ModuleBuilder<'c> {
         Self::default()
     }
 
-    pub fn add_module_at(&self, index: ModuleIdx, node: ast::Module<'c>) {
+    pub fn add_module_at(&self, index: ModuleIdx, node: ast::AstNode<'c, ast::Module<'c>>) {
         self.modules_by_index.insert(index, node);
     }
 
@@ -86,7 +86,7 @@ pub struct Modules<'c> {
     indexes: ReadOnlyView<ModuleIdx, ()>,
     path_to_index: ReadOnlyView<PathBuf, ModuleIdx>,
     filenames_by_index: ReadOnlyView<ModuleIdx, PathBuf>,
-    modules_by_index: ReadOnlyView<ModuleIdx, ast::Module<'c>>,
+    modules_by_index: ReadOnlyView<ModuleIdx, ast::AstNode<'c, ast::Module<'c>>>,
     contents_by_index: ReadOnlyView<ModuleIdx, String>,
     deps_by_index: HashMap<ModuleIdx, ReadOnlyView<ModuleIdx, ()>>,
     entry_point: Option<ModuleIdx>,
@@ -157,11 +157,14 @@ impl<'c, 'm> Module<'c, 'm> {
         self.modules.entry_point == Some(self.index)
     }
 
-    pub fn ast_checked(&self) -> Option<&ast::Module<'c>> {
-        self.modules.modules_by_index.get(&self.index)
+    pub fn ast_checked(&self) -> Option<ast::AstNodeRef<ast::Module<'c>>> {
+        self.modules
+            .modules_by_index
+            .get(&self.index)
+            .map(|a| a.ast_ref())
     }
 
-    pub fn ast(&self) -> &ast::Module<'c> {
+    pub fn ast(&self) -> ast::AstNodeRef<ast::Module<'c>> {
         self.ast_checked().unwrap()
     }
 

--- a/compiler/hash-ast/src/parse.rs
+++ b/compiler/hash-ast/src/parse.rs
@@ -272,7 +272,7 @@ where
                     Level::Debug,
                     "file \"{}\":\n{}",
                     module.filename().display(),
-                    module.ast()
+                    module.ast().body()
                 );
             }
         }
@@ -308,11 +308,11 @@ pub trait ParserBackend<'c>: Sync + Sized {
         resolver: impl ModuleResolver,
         path: &Path,
         contents: &str,
-    ) -> ParseResult<ast::Module<'c>>;
+    ) -> ParseResult<ast::AstNode<'c, ast::Module<'c>>>;
 
     fn parse_interactive(
         &self,
         resolver: impl ModuleResolver,
         contents: &str,
-    ) -> ParseResult<AstNode<'c, ast::BodyBlock<'c>>>;
+    ) -> ParseResult<ast::AstNode<'c, ast::BodyBlock<'c>>>;
 }

--- a/compiler/hash-parser/src/backend.rs
+++ b/compiler/hash-parser/src/backend.rs
@@ -32,7 +32,7 @@ impl<'c> ParserBackend<'c> for HashParser<'c> {
         resolver: impl ModuleResolver,
         _path: &Path,
         contents: &str,
-    ) -> ParseResult<ast::Module<'c>> {
+    ) -> ParseResult<ast::AstNode<'c, ast::Module<'c>>> {
         let wall = self.castle.wall();
 
         let index = resolver.module_index().unwrap_or(ModuleIdx(0));

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -393,14 +393,15 @@ where
     }
 
     /// Parse a [Module] which is simply made of a list of statements
-    pub fn parse_module(&self) -> AstGenResult<'c, Module<'c>> {
+    pub fn parse_module(&self) -> AstGenResult<'c, AstNode<'c, Module<'c>>> {
+        let start = self.current_location();
         let mut contents = row![&self.wall];
 
         while self.has_token() {
             contents.push(self.parse_statement()?, &self.wall);
         }
 
-        Ok(Module { contents })
+        Ok(self.node_from_joined_location(Module { contents }, &start))
     }
 
     /// Parse a statement.

--- a/compiler/hash-reporting/src/reporting.rs
+++ b/compiler/hash-reporting/src/reporting.rs
@@ -467,9 +467,13 @@ mod tests {
         builder.add_contents(test_idx, path, contents);
         builder.add_module_at(
             test_idx,
-            ast::Module {
-                contents: row![&wall],
-            },
+            ast::AstNode::new(
+                ast::Module {
+                    contents: row![&wall],
+                },
+                Location::pos(0),
+                &wall,
+            ),
         );
 
         let modules = builder.build();


### PR DESCRIPTION
This is done for the sake of consistency with `parse_interactive`, and provides more information about a module (i.e. the span of the file that contains it, as well as the filename of the file).

This is also needed to be able to pass a module into an `ast::visitor::AstVisitor`.