### PR TITLE
Parser: Improve and refactor `Identifier` handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,6 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "parking_lot",
  "rayon",
  "strum",
  "strum_macros",
@@ -433,15 +432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,15 +442,6 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -544,31 +525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
 ]
 
 [[package]]

--- a/compiler/hash-ast/Cargo.toml
+++ b/compiler/hash-ast/Cargo.toml
@@ -16,6 +16,5 @@ fnv = "1.0.7"
 strum = "0.21"
 strum_macros = "0.21"
 derive_more = "0.99"
-parking_lot = "0.11"
 hash-utils = { path = "../hash-utils" } 
 hash-alloc = { path = "../hash-alloc" }

--- a/compiler/hash-ast/src/ident.rs
+++ b/compiler/hash-ast/src/ident.rs
@@ -4,7 +4,7 @@ use fnv::FnvBuildHasher;
 use hash_alloc::{collections::string::BrickString, Castle, Wall};
 use hash_utils::counter;
 use lazy_static::lazy_static;
-use parking_lot::Mutex;
+use std::thread_local;
 
 counter! {
     name: Identifier,
@@ -13,75 +13,68 @@ counter! {
     method_visibility:,
 }
 
+lazy_static! {
+    static ref IDENTIFIER_STORAGE_CASTLE: Castle = Castle::new();
+}
+
+thread_local! {
+    static IDENTIFIER_STORAGE_WALL: Wall<'static> = IDENTIFIER_STORAGE_CASTLE.wall();
+}
+
+lazy_static! {
+    pub static ref IDENTIFIER_MAP: IdentifierMap<'static> = IdentifierMap::new();
+    pub static ref CORE_IDENTIFIERS: CoreIdentifiers =
+        CoreIdentifiers::from_ident_map(&IDENTIFIER_MAP);
+}
+
 /// Struct representing a globally accessible identifier map. The struct contains a identifier
 /// map and another map for reverse lookups.
 #[derive(Debug, Default)]
-pub struct IdentifierMap {
-    identifiers: DashMap<&'static str, Identifier, FnvBuildHasher>,
-    reverse_lookup: DashMap<Identifier, &'static str, FnvBuildHasher>,
+pub struct IdentifierMap<'c> {
+    identifiers: DashMap<&'c str, Identifier, FnvBuildHasher>,
+    reverse_lookup: DashMap<Identifier, &'c str, FnvBuildHasher>,
 }
 
-lazy_static! {
-    static ref IDENTIFIER_STORAGE_CASTLE: Castle = Castle::new();
-    static ref IDENTIFIER_STORAGE_WALL: Mutex<Wall<'static>> =
-        Mutex::new(IDENTIFIER_STORAGE_CASTLE.wall());
+/// Holds some default identifiers in order to avoid map lookups when e.g. generating the AST.
+pub struct CoreIdentifiers {
+    pub underscore: Identifier,
 }
 
-lazy_static! {
-    pub static ref IDENTIFIER_MAP: IdentifierMap = IdentifierMap::new();
-}
-
-impl IdentifierMap {
-    /// Function to create a new identifier map instance.
-    pub fn new() -> Self {
-        let map = IdentifierMap {
-            identifiers: DashMap::default(),
-            reverse_lookup: DashMap::default(),
-        };
-
-        // TODO: temporary: insert the '_' identifier as the default one with identifier
-        // value of zero for default reasons
-        map.create_ident("_");
-        map
-    }
-
-    /// Create an identifier in the identifier map but check if the it exists before trying
-    /// to insert the value into the map and just return it otherwise.
-    pub fn create_ident_existing(&self, ident_str: &'static str) -> Identifier {
-        if let Some(key) = self.identifiers.get(ident_str) {
-            *key
-        } else {
-            let ident = Identifier::new();
-
-            self.identifiers.insert(ident_str, ident);
-            self.reverse_lookup.insert(ident, ident_str);
-            ident
+impl CoreIdentifiers {
+    /// Create the core identifiers inside the given [IdentifierMap].
+    pub fn from_ident_map(ident_map: &IdentifierMap) -> Self {
+        Self {
+            underscore: ident_map.create_ident("_"),
         }
     }
+}
 
-    /// Create the identifier in the identifiers map but also allocate the static string in a provided
-    /// [Wall].
-    fn create_ident_in(&self, ident_str: &str, wall: &Wall<'static>) -> Identifier {
-        if let Some(key) = self.identifiers.get(ident_str) {
-            *key
-        } else {
-            let ident = Identifier::new();
-            let ident_str_alloc = BrickString::new(ident_str, wall).into_str();
-
-            self.identifiers.insert(ident_str_alloc, ident);
-            self.reverse_lookup.insert(ident, ident_str_alloc);
-            ident
+impl<'c> IdentifierMap<'c> {
+    /// Function to create a new identifier map instance.
+    pub fn new() -> Self {
+        IdentifierMap {
+            identifiers: DashMap::default(),
+            reverse_lookup: DashMap::default(),
         }
     }
 
     /// Function to create an identifier in the identifier map.
     pub fn create_ident(&self, ident_str: &str) -> Identifier {
-        let wall = IDENTIFIER_STORAGE_WALL.lock();
-        self.create_ident_in(ident_str, &wall)
+        if let Some(ident) = self.identifiers.get(ident_str) {
+            *ident
+        } else {
+            IDENTIFIER_STORAGE_WALL.with(|wall| {
+                let ident = Identifier::new();
+                let ident_str_alloc = BrickString::new(ident_str, wall).into_str();
+                self.identifiers.insert(ident_str_alloc, ident);
+                self.reverse_lookup.insert(ident, ident_str_alloc);
+                ident
+            })
+        }
     }
 
     /// Function to lookup an identifier by an [Identifier] value in the identifier map.
-    pub fn ident_name(&self, ident: Identifier) -> &'static str {
+    pub fn get_ident(&self, ident: Identifier) -> &'c str {
         self.reverse_lookup.get(&ident).unwrap().value()
     }
 }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -36,7 +36,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
 
     type NameRet = TreeNode;
     fn visit_name(&mut self, node: ast::AstNodeRef<ast::Name>) -> Self::NameRet {
-        TreeNode::leaf(IDENTIFIER_MAP.ident_name(node.ident))
+        TreeNode::leaf(IDENTIFIER_MAP.get_ident(node.ident))
     }
 
     type AccessNameRet = TreeNode;
@@ -47,7 +47,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         TreeNode::leaf(
             node.path
                 .iter()
-                .map(|p| IDENTIFIER_MAP.ident_name(*p))
+                .map(|p| IDENTIFIER_MAP.get_ident(*p))
                 .intersperse("::")
                 .collect::<String>(),
         )
@@ -85,7 +85,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     ) -> Self::IntrinsicKeyRet {
         TreeNode::leaf(labeled(
             "intrinsic",
-            IDENTIFIER_MAP.ident_name(node.name),
+            IDENTIFIER_MAP.get_ident(node.name),
             "\"",
         ))
     }

--- a/compiler/hash-ast/src/visualise.rs
+++ b/compiler/hash-ast/src/visualise.rs
@@ -364,7 +364,7 @@ impl NodeDisplay for AccessName<'_> {
             (self
                 .path
                 .iter()
-                .map(|x| IDENTIFIER_MAP.ident_name(*x).to_owned())
+                .map(|x| IDENTIFIER_MAP.get_ident(*x).to_owned())
                 .collect::<Vec<String>>()
                 .join("::"))
         )]
@@ -373,7 +373,7 @@ impl NodeDisplay for AccessName<'_> {
 
 impl NodeDisplay for Name {
     fn node_display(&self) -> Vec<String> {
-        vec![format!("\"{}\"", IDENTIFIER_MAP.ident_name(self.ident))]
+        vec![format!("\"{}\"", IDENTIFIER_MAP.get_ident(self.ident))]
     }
 }
 
@@ -634,7 +634,7 @@ impl NodeDisplay for Expression<'_> {
             ExpressionKind::Intrinsic(intrinsic) => {
                 vec![format!(
                     "intrinsic \"{}\"",
-                    IDENTIFIER_MAP.ident_name(intrinsic.name)
+                    IDENTIFIER_MAP.get_ident(intrinsic.name)
                 )]
             }
             ExpressionKind::Variable(var) => {
@@ -665,7 +665,7 @@ impl NodeDisplay for Expression<'_> {
                 // now deal with the field
                 let field_lines = vec![format!(
                     "field \"{}\"",
-                    IDENTIFIER_MAP.ident_name(expr.property.body().ident)
+                    IDENTIFIER_MAP.get_ident(expr.property.body().ident)
                 )];
 
                 iter::once("property_access".to_string())

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -8,6 +8,7 @@ use std::cell::Cell;
 use hash_alloc::Wall;
 use hash_alloc::{collections::row::Row, row};
 
+use hash_ast::ident::CORE_IDENTIFIERS;
 use hash_ast::{
     ast::*,
     ident::{Identifier, IDENTIFIER_MAP},
@@ -2840,7 +2841,7 @@ where
                         let ident = name.body().path.get(0).unwrap();
 
                         match *ident {
-                            Identifier(0) => Type::Infer(InferType),
+                            i if i == CORE_IDENTIFIERS.underscore => Type::Infer(InferType),
                             _ => Type::Named(NamedType {
                                 name,
                                 type_args: row![&self.wall],

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -58,7 +58,7 @@ impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
             TokenKind::Ident(ident) => {
-                write!(f, "Ident ({})", IDENTIFIER_MAP.ident_name(*ident))
+                write!(f, "Ident ({})", IDENTIFIER_MAP.get_ident(*ident))
             }
             TokenKind::StrLiteral(literal) => {
                 write!(
@@ -305,7 +305,7 @@ impl fmt::Display for TokenKind {
             }
             TokenKind::Keyword(kwd) => kwd.fmt(f),
             TokenKind::Ident(ident) => {
-                write!(f, "{}", IDENTIFIER_MAP.ident_name(*ident))
+                write!(f, "{}", IDENTIFIER_MAP.get_ident(*ident))
             }
         }
     }

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -24,12 +24,20 @@ macro_rules! counter {
                 Self($counter_name.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
             }
 
-            $method_visibility fn from(id: u32) -> Self {
-                $name(id)
-            }
-
             $method_visibility fn total() -> u32 {
                 $counter_name.load(std::sync::atomic::Ordering::SeqCst)
+            }
+        }
+
+        impl From<u32> for $name {
+            fn from(id: u32) -> Self {
+                $name(id)
+            }
+        }
+
+        impl From<$name> for u32 {
+            fn from(counter: $name) -> u32 {
+                counter.0
             }
         }
     };


### PR DESCRIPTION
This PR improves the handling of identifiers in the parser and removes a bunch of redundant behaviour in the `IdentifierMap` type. The changes can be summarised by the following points:
- Use `ThreadLocal` to keep a wall on each thread in order for faster allocations when creating identifiers and inserting them into the identifier map.
- Don't even try to allocate before looking up if an identifier exists in the map.
- Better naming convention in the `IdentifierMap` type:
  - `get_ident` gets an identifier 
  - `create_ident` creates an identifier :))
- Introduced a concept of `CORE_IDENTIFIERS` which is a wrapper around `IDENTIFIER_MAP` that contains inserted core identifiers like the primitives and the `_` identifier.
- Removed dependency on `parking_lot` as we no longer need to lock the wall per each thread.
- Implementation for `From<u32> for Identifier` and `From<Identifier> for u32`