### PR TITLE
Typechecking: Minimum traits

### DIFF
--- a/compiler/hash-typecheck/src/traits.rs
+++ b/compiler/hash-typecheck/src/traits.rs
@@ -3,8 +3,8 @@ use crate::{
     error::{Symbol, TypecheckError, TypecheckResult},
     storage::{GlobalStorage, SourceStorage},
     types::{TypeId, TypeList, TypeStorage},
-    unify::{Substitution, SubstitutionWithStorage, Unifier, UnifyStrategy},
-    writer::{print_type, print_type_list, TypeWithStorage},
+    unify::{Substitution, Unifier, UnifyStrategy},
+    writer::TypeWithStorage,
 };
 use hash_alloc::{collections::row::Row, row, Wall};
 use hash_source::location::SourceLocation;

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -4,7 +4,7 @@ use crate::traits::{TraitBounds, TraitHelper, TraitId, TraitImpl, TraitImplStora
 use crate::types::{
     CoreTypeDefs, EnumDef, FnType, Generics, NamespaceType, PrimType, RawRefType, RefType,
     StructDef, StructFields, TupleType, TypeDefStorage, TypeId, TypeStorage, TypeValue,
-    TypeVarMode, TypeVars, UnknownType,
+    TypeVarMode, TypeVars,
 };
 use crate::types::{TypeDefId, TypeVar, UserType};
 use crate::unify::{Substitution, Unifier, UnifyStrategy};
@@ -523,7 +523,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
 
         let ref_location = self.source_location(node.location());
 
-        let created_inner_ty = self.create_type(TypeValue::Unknown(UnknownType::unbounded()), None);
+        let created_inner_ty = self.create_unknown_type();
         let created_ref_ty = self.create_type(
             TypeValue::Ref(RefType {
                 inner: created_inner_ty,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -11,7 +11,7 @@ use crate::types::{
 };
 use crate::types::{TypeDefId, TypeVar, UserType};
 use crate::unify::{Substitution, Unifier, UnifyStrategy};
-use crate::writer::print_type;
+
 use crate::{
     error::{Symbol, TypecheckError, TypecheckResult},
     types::TypeDefValueKind,
@@ -1761,6 +1761,6 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
             type_args_location,
         )?;
 
-        Ok(self.unifier().apply_sub(&sub_from_trait_def, trt.fn_type)?)
+        self.unifier().apply_sub(&sub_from_trait_def, trt.fn_type)
     }
 }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1,6 +1,9 @@
 //! All rights reserved 2022 (c) The Hash Language authors
 use crate::storage::{GlobalStorage, SourceStorage};
-use crate::traits::{TraitBounds, TraitHelper, TraitId, TraitImpl, TraitImplStorage, TraitStorage, MatchTraitImplResult};
+use crate::traits::{
+    MatchTraitImplResult, TraitBounds, TraitHelper, TraitId, TraitImpl, TraitImplStorage,
+    TraitStorage,
+};
 use crate::types::{
     CoreTypeDefs, EnumDef, FnType, Generics, NamespaceType, PrimType, RawRefType, RefType,
     StructDef, StructFields, TupleType, TypeDefStorage, TypeId, TypeStorage, TypeValue,
@@ -258,7 +261,6 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         _ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::Import>,
     ) -> Result<Self::ImportRet, Self::Error> {
-
         let import_module_id = self
             .sources
             .get_module_id_by_path(&node.resolved_path)
@@ -331,27 +333,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 }
             }
             (_, SymbolType::Trait(var_trait_id)) => {
-                let trt = self.traits().get(var_trait_id);
-                let args: Vec<_> = node
-                    .type_args
-                    .iter()
-                    .map(|a| self.visit_type(ctx, a.ast_ref()))
-                    .collect::<Result<_, _>>()?;
-                let trt_name_location = self.some_source_location(node.name.location());
-                let trt_symbol = || Symbol::Compound {
-                    location: trt_name_location,
-                    path: node.name.path.to_owned(),
-                };
-                let type_args_location = node.type_args.location().map(|l| self.source_location(l));
-                let MatchTraitImplResult { sub_from_trait_def, .. } = self.trait_helper().find_trait_impl(
-                    trt,
-                    &args,
-                    None,
-                    trt_symbol,
-                    type_args_location,
-                )?;
-
-                Ok(self.unifier().apply_sub(&sub_from_trait_def, trt.fn_type)?)
+                self.visit_trait_variable(ctx, var_trait_id, node, None)
             }
             (ident, SymbolType::EnumVariant(ty_def_id)) => {
                 let ty_def = self.type_defs().get(ty_def_id);
@@ -429,16 +411,9 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::FunctionCallExpr<'c>>,
     ) -> Result<Self::FunctionCallExprRet, Self::Error> {
-        let walk::FunctionCallExpr {
-            args: given_args,
-            subject: given_ty,
-        } = walk::walk_function_call_expr(self, ctx, node)?;
-
-        let args_ty_location = self.source_location(node.body().args.location());
-
-        // Todo: here specialise trait resolution in order to be able to do more inference (from
-        // args)
+        let given_args = self.visit_function_call_args(ctx, node.args.ast_ref())?;
         let ret_ty = self.create_unknown_type();
+        let args_ty_location = self.source_location(node.body().args.location());
         let expected_fn_ty = self.create_type(
             TypeValue::Fn(FnType {
                 args: given_args,
@@ -446,6 +421,24 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             }),
             Some(args_ty_location),
         );
+
+        let given_ty = match node.subject.kind() {
+            ast::ExpressionKind::Variable(var) => {
+                match self
+                    .resolve_compound_symbol(&var.name.path, self.source_location(node.location()))?
+                    .1
+                {
+                    SymbolType::Trait(trait_id) => self.visit_trait_variable(
+                        ctx,
+                        trait_id,
+                        node.with_body(var),
+                        Some(expected_fn_ty),
+                    )?,
+                    _ => walk::walk_function_call_expr(self, ctx, node)?.subject,
+                }
+            }
+            _ => walk::walk_function_call_expr(self, ctx, node)?.subject,
+        };
 
         self.unifier()
             .unify(expected_fn_ty, given_ty, UnifyStrategy::ModifyBoth)?;
@@ -1737,5 +1730,37 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
                 )),
             })
             .collect()
+    }
+
+    fn visit_trait_variable(
+        &mut self,
+        ctx: &<Self as AstVisitor<'c>>::Ctx,
+        trait_id: TraitId,
+        node: ast::AstNodeRef<ast::VariableExpr<'c>>,
+        fn_type: Option<TypeId>,
+    ) -> TypecheckResult<TypeId> {
+        let trt = self.traits().get(trait_id);
+        let args: Vec<_> = node
+            .type_args
+            .iter()
+            .map(|a| self.visit_type(ctx, a.ast_ref()))
+            .collect::<Result<_, _>>()?;
+        let trt_name_location = self.some_source_location(node.name.location());
+        let trt_symbol = || Symbol::Compound {
+            location: trt_name_location,
+            path: node.name.path.to_owned(),
+        };
+        let type_args_location = node.type_args.location().map(|l| self.source_location(l));
+        let MatchTraitImplResult {
+            sub_from_trait_def, ..
+        } = self.trait_helper().find_trait_impl(
+            trt,
+            &args,
+            fn_type,
+            trt_symbol,
+            type_args_location,
+        )?;
+
+        Ok(self.unifier().apply_sub(&sub_from_trait_def, trt.fn_type)?)
     }
 }

--- a/compiler/hash-typecheck/src/types.rs
+++ b/compiler/hash-typecheck/src/types.rs
@@ -480,7 +480,6 @@ impl<'c, 'w> TypeStorage<'c, 'w> {
     }
 
     pub fn get(&self, ty: TypeId) -> &'c TypeValue<'c> {
-        // @@Todo: resolve type variables bro!
         match self.data.get(ty).unwrap().get() {
             val @ TypeValue::Unknown(UnknownType { unknown_id }) => {
                 if let Some(mapping) = self.unknown_data.get(*unknown_id).unwrap().get() {

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{TypecheckError, TypecheckResult},
     storage::{GlobalStorage, SourceStorage},
     types::{TypeId, TypeStorage, TypeValue, UnknownType},
-    writer::{print_type, TypeWithStorage},
+    writer::TypeWithStorage,
 };
 use core::fmt;
 use hash_alloc::collections::row::Row;

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{TypecheckError, TypecheckResult},
     storage::{GlobalStorage, SourceStorage},
     types::{TypeId, TypeStorage, TypeValue},
-    writer::TypeWithStorage,
+    writer::{TypeWithStorage, print_type},
 };
 use core::fmt;
 use hash_alloc::collections::row::Row;
@@ -213,11 +213,8 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
             .types
             .get(curr_ty)
             .try_map_type_ids(|ty_id| self.apply_sub(sub, ty_id), wall)?;
-        // @@Broken: here new unknown types will get created, will lose identity. We need a
-        // different way to keep track of unknown types, basically a mapping like GenTypeVar in haskell. OR, we prevent loss of identity somehow
 
         let created = self.global_storage.types.create(new_ty_value, None);
-        self.unify(created, curr_ty, UnifyStrategy::ModifyTarget)?;
         Ok(created)
     }
 

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -54,16 +54,16 @@ impl<'c> Substitution {
         self
     }
 
+    pub fn add(&mut self, from: TypeId, to: TypeId) {
+        self.subs.push((from, to));
+    }
+
     pub fn from_pairs(
         pairs: impl Iterator<Item = (impl Borrow<TypeId>, impl Borrow<TypeId>)>,
     ) -> Self {
         Self {
             subs: pairs.map(|(x, y)| (*x.borrow(), *y.borrow())).collect(),
         }
-    }
-
-    pub fn add(&mut self, from: TypeId, to: TypeId) {
-        self.subs.push((from, to));
     }
 }
 
@@ -216,9 +216,9 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
         // @@Broken: here new unknown types will get created, will lose identity. We need a
         // different way to keep track of unknown types, basically a mapping like GenTypeVar in haskell. OR, we prevent loss of identity somehow
 
-        let _created = self.global_storage.types.create(new_ty_value, None);
-        // self.unify(created, curr_ty, UnifyStrategy::ModifyTarget)?;
-        Ok(curr_ty)
+        let created = self.global_storage.types.create(new_ty_value, None);
+        self.unify(created, curr_ty, UnifyStrategy::ModifyTarget)?;
+        Ok(created)
     }
 
     pub fn unify(

--- a/compiler/hash-typecheck/src/writer.rs
+++ b/compiler/hash-typecheck/src/writer.rs
@@ -9,10 +9,6 @@ use core::fmt;
 use hash_ast::ident::IDENTIFIER_MAP;
 use hash_utils::tree_writing::TreeNode;
 
-pub fn print_type(ty: TypeId, storage: &GlobalStorage) {
-    println!("{}", TypeWithStorage::new(ty, storage));
-}
-
 pub fn print_type_list(types: &[TypeId], storage: &GlobalStorage) {
     print!("[");
     for (i, ty) in types.iter().enumerate() {
@@ -26,17 +22,6 @@ pub fn print_type_list(types: &[TypeId], storage: &GlobalStorage) {
 
 pub fn print_type(ty: TypeId, storage: &GlobalStorage) {
     println!("{}", TypeWithStorage::new(ty, storage));
-}
-
-pub fn print_type_list(types: &[TypeId], storage: &GlobalStorage) {
-    print!("[");
-    for (i, ty) in types.iter().enumerate() {
-        print!("{}", TypeWithStorage::new(*ty, storage));
-        if i != types.len() - 1 {
-            print!(", ");
-        }
-    }
-    println!("]");
 }
 
 // pub fn print_type_list(type_list: )

--- a/compiler/hash-typecheck/src/writer.rs
+++ b/compiler/hash-typecheck/src/writer.rs
@@ -24,8 +24,6 @@ pub fn print_type(ty: TypeId, storage: &GlobalStorage) {
     println!("{}", TypeWithStorage::new(ty, storage));
 }
 
-// pub fn print_type_list(type_list: )
-
 pub struct TypeWithStorage<'g, 'c, 'w> {
     ty: TypeId,
     storage: &'g GlobalStorage<'c, 'w>,

--- a/compiler/hash-typecheck/src/writer.rs
+++ b/compiler/hash-typecheck/src/writer.rs
@@ -24,6 +24,23 @@ pub fn print_type_list(types: &[TypeId], storage: &GlobalStorage) {
     println!("]");
 }
 
+pub fn print_type(ty: TypeId, storage: &GlobalStorage) {
+    println!("{}", TypeWithStorage::new(ty, storage));
+}
+
+pub fn print_type_list(types: &[TypeId], storage: &GlobalStorage) {
+    print!("[");
+    for (i, ty) in types.iter().enumerate() {
+        print!("{}", TypeWithStorage::new(*ty, storage));
+        if i != types.len() - 1 {
+            print!(", ");
+        }
+    }
+    println!("]");
+}
+
+// pub fn print_type_list(type_list: )
+
 pub struct TypeWithStorage<'g, 'c, 'w> {
     ty: TypeId,
     storage: &'g GlobalStorage<'c, 'w>,


### PR DESCRIPTION
This PR implements an MVP version of trait resolution and inference, including inferring trait implementations from function call arguments and surrounding context.

In order to achieve this feat, the nature of unknown types has changed. Each unknown type carries an ID (`UnknownTypeId`, which points to a slot with an optional "resolved" type). It is no longer the case that `TypeId`s themselves can have their type swapped; this is only true for unknown types now. This allows types to be entirely deep-copied without losing the identity of each unknown type within them. This theoretically improves type inference across the board, not just for traits.

There are a few more things to tackle after this PR regarding traits and generic resolution:
- Implement support for trait bounds.
- Find a way to not have super deep nested unknown types, which happens with many unifications.
- Perhaps rename "unknown types" to something a bit more fitting.