### PR TITLE
Typechecker: Implement tuple types

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -670,6 +670,15 @@ pub struct MatchCase<'c> {
     pub expr: AstNode<'c, Expression<'c>>,
 }
 
+/// The origin of a match block
+#[derive(Debug, PartialEq)]
+pub enum MatchOrigin {
+    If,
+    Match,
+    For,
+    While,
+}
+
 /// A `match` block.
 #[derive(Debug, PartialEq)]
 pub struct MatchBlock<'c> {
@@ -677,6 +686,8 @@ pub struct MatchBlock<'c> {
     pub subject: AstNode<'c, Expression<'c>>,
     /// The match cases to execute.
     pub cases: AstNodes<'c, MatchCase<'c>>,
+    /// Whether the match block represents a for, while, if or match statement
+    pub origin: MatchOrigin,
 }
 
 /// A body block.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -287,9 +287,16 @@ pub struct ExistentialType;
 #[derive(Debug, PartialEq)]
 pub struct InferType;
 
+/// The type infer operator.
+#[derive(Debug, PartialEq)]
+pub struct TupleType<'c> {
+    pub entries: AstNodes<'c, Type<'c>>,
+}
+
 /// A type.
 #[derive(Debug, PartialEq)]
 pub enum Type<'c> {
+    Tuple(TupleType<'c>),
     Named(NamedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -67,13 +67,15 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         _: &Self::Ctx,
         node: ast::AstNodeRef<ast::AccessName<'c>>,
     ) -> Result<Self::AccessNameRet, Self::Error> {
-        Ok(TreeNode::leaf(
+        Ok(TreeNode::leaf(labelled(
+            "name",
             node.path
                 .iter()
                 .map(|p| IDENTIFIER_MAP.get_ident(*p))
                 .intersperse("::")
                 .collect::<String>(),
-        ))
+            "\"",
+        )))
     }
 
     type LiteralRet = TreeNode;

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -10,7 +10,7 @@ use hash_pipeline::{sources::InteractiveBlock, Checker, Compiler, CompilerState,
 use hash_reporting::errors::{CompilerError, InteractiveCommandError};
 use hash_reporting::reporting::ReportWriter;
 use hash_source::SourceId;
-use hash_utils::tree_writing::{TreeWriter, TreeWriterConfig};
+use hash_utils::tree_writing::TreeWriter;
 use rustyline::{error::ReadlineError, Editor};
 use std::env;
 use std::process::exit;
@@ -134,13 +134,7 @@ where
                         .visit_body_block(&(), block.node())
                         .unwrap();
 
-                    // Don't use any spaces between the label and child...
-                    let config = TreeWriterConfig {
-                        child_prefix: "─".into(),
-                        ..TreeWriterConfig::unicode()
-                    };
-
-                    println!("{}", TreeWriter::new_with_config(&tree, config));
+                    println!("{}", TreeWriter::new(&tree));
                 }
                 Err(err) => {
                     println!("{}", ReportWriter::new(err, &compiler_state.sources));

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -10,7 +10,7 @@ use hash_pipeline::{sources::InteractiveBlock, Checker, Compiler, CompilerState,
 use hash_reporting::errors::{CompilerError, InteractiveCommandError};
 use hash_reporting::reporting::ReportWriter;
 use hash_source::SourceId;
-use hash_utils::tree_writing::TreeWriter;
+use hash_utils::tree_writing::{TreeWriter, TreeWriterConfig};
 use rustyline::{error::ReadlineError, Editor};
 use std::env;
 use std::process::exit;
@@ -134,7 +134,13 @@ where
                         .visit_body_block(&(), block.node())
                         .unwrap();
 
-                    println!("{}", TreeWriter::new(&tree));
+                    // Don't use any spaces between the label and child...
+                    let config = TreeWriterConfig {
+                        child_prefix: "─".into(),
+                        ..TreeWriterConfig::unicode()
+                    };
+
+                    println!("{}", TreeWriter::new_with_config(&tree, config));
                 }
                 Err(err) => {
                     println!("{}", ReportWriter::new(err, &compiler_state.sources));

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -732,6 +732,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             self.node(Block::Match(MatchBlock {
                 subject: fn_call,
                 cases: branches,
+                origin: MatchOrigin::Match,
             })),
         ))))
     }
@@ -1181,6 +1182,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     )))),
                 }),
             ],
+            origin: MatchOrigin::For
         }), &start))), &start))
     }
 
@@ -1239,6 +1241,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                             )))),
                         }),
                     ],
+                    origin: MatchOrigin::While
                 }),
                 condition_location,
             ))),
@@ -1300,7 +1303,14 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             _ => self.unexpected_eof()?,
         };
 
-        Ok(self.node_from_joined_location(Block::Match(MatchBlock { subject, cases }), &start))
+        Ok(self.node_from_joined_location(
+            Block::Match(MatchBlock {
+                subject,
+                cases,
+                origin: MatchOrigin::Match,
+            }),
+            &start,
+        ))
     }
 
     /// we transpile if-else blocks into match blocks in order to simplify
@@ -1436,6 +1446,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             Block::Match(MatchBlock {
                 subject: self.make_ident("true", &self.current_location()),
                 cases,
+                origin: MatchOrigin::If,
             }),
             &start,
         ))

--- a/compiler/hash-reporting/src/reporting.rs
+++ b/compiler/hash-reporting/src/reporting.rs
@@ -69,8 +69,9 @@ impl ReportNote {
     fn render(&self, f: &mut fmt::Formatter<'_>, longest_indent_width: usize) -> fmt::Result {
         writeln!(
             f,
-            "{} = {}: {}",
+            "{} {} {}: {}",
             " ".repeat(longest_indent_width),
+            highlight(Colour::Blue, "="),
             highlight(Modifier::Bold, &self.label),
             self.message
         )?;
@@ -217,8 +218,9 @@ impl ReportCodeBlock {
         // Print the filename of the code block...
         writeln!(
             f,
-            "{}--> {}",
+            "{}{} {}",
             " ".repeat(longest_indent_width),
+            highlight(Colour::Blue, "-->"),
             highlight(
                 Modifier::Underline,
                 format!(
@@ -239,12 +241,13 @@ impl ReportCodeBlock {
             );
             writeln!(
                 f,
-                "{} |   {}",
+                "{} {}   {}",
                 if (start_row..=end_row).contains(&index) {
                     highlight(report_kind.as_colour(), &index_str)
                 } else {
                     index_str
                 },
+                highlight(Colour::Blue, "|"),
                 line
             )?;
 
@@ -272,8 +275,9 @@ impl ReportCodeBlock {
 
                 writeln!(
                     f,
-                    "{} |   {}",
+                    "{} {}   {}",
                     " ".repeat(longest_indent_width),
+                    highlight(Colour::Blue, "|"),
                     highlight(report_kind.as_colour(), &code_note)
                 )?;
             }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -574,6 +574,20 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(walk::walk_import_expr(self, ctx, node)?.0)
     }
 
+    type TupleTypeRet = TypeId;
+    fn visit_tuple_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::TupleType<'c>>,
+    ) -> Result<Self::TupleTypeRet, Self::Error> {
+        let walk::TupleType { entries } = walk::walk_tuple_type(self, ctx, node)?;
+        let ty_location = self.some_source_location(node.location());
+
+        Ok(self
+            .types_mut()
+            .create(TypeValue::Tuple(TupleType { types: entries }), ty_location))
+    }
+
     type TypeRet = TypeId;
     fn visit_type(
         &mut self,
@@ -1013,7 +1027,6 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         _ctx: &Self::Ctx,
         _node: ast::AstNodeRef<ast::MatchBlock<'c>>,
     ) -> Result<Self::MatchBlockRet, Self::Error> {
-        // @@Cowbunga
         todo!()
     }
 

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1013,6 +1013,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         _ctx: &Self::Ctx,
         _node: ast::AstNodeRef<ast::MatchBlock<'c>>,
     ) -> Result<Self::MatchBlockRet, Self::Error> {
+        // @@Cowbunga
         todo!()
     }
 

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -266,15 +266,15 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
                 self.unify_pairs(fn_target.args.iter().zip(fn_source.args.iter()), strategy)?;
                 // Maybe this should be flipped (see variance comment above)
                 self.unify(fn_target.ret, fn_source.ret, strategy)?;
-
-                // let merged_sub = args_sub.merge(self, &ret_sub);
-
-                // let unified_ty = Fn(FnType {
-                //     args: unified_args,
-                //     ret: Box::new(unified_ret),
-                // });
-
                 Ok(())
+            }
+            (Tuple(tuple_target), Tuple(tuple_source))
+                if tuple_target.types.len() == tuple_source.types.len() =>
+            {
+                self.unify_pairs(
+                    tuple_target.types.iter().zip(tuple_source.types.iter()),
+                    strategy,
+                )
             }
             (Unknown(_), Unknown(_)) => {
                 // @@TODO: Ensure that trait bounds are compatible

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -50,14 +50,14 @@ impl TreeWriterConfig {
             vertical_line: '│',
             middle_intersect: '├',
             end_intersect: '└',
-            child_prefix: "─ ".into(),
+            child_prefix: "─".into(),
         }
     }
 
     /// Draw trees using Unicode box drawing characters and longer child prefixes.
     pub fn unicode_long() -> Self {
         Self {
-            child_prefix: "── ".into(),
+            child_prefix: "──".into(),
             ..Self::unicode()
         }
     }
@@ -69,7 +69,7 @@ impl TreeWriterConfig {
             vertical_line: '|',
             middle_intersect: '|',
             end_intersect: '`',
-            child_prefix: "- ".into(),
+            child_prefix: "-".into(),
         }
     }
 
@@ -80,7 +80,7 @@ impl TreeWriterConfig {
             vertical_line: ' ',
             middle_intersect: ' ',
             end_intersect: ' ',
-            child_prefix: "- ".into(),
+            child_prefix: "-".into(),
         }
     }
 }


### PR DESCRIPTION
This patch implements tuple types in the typechecker by modifying the way they are represented in the AST. 

Additionally:
- This also adds some minor improvements to AST visualisation. 
- Reporting boundary between line numbers and code is highlighted in blue to give a clear boundary between both elements.