### PR TITLE
AST: use special variant for function types.

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -256,8 +256,6 @@ pub struct TypeVar<'c> {
 
 /// Names for compound types that represent data structures or functions are
 /// translated into string form, and thus are represented by these names.
-pub const FUNCTION_TYPE_NAME: &str = "Function";
-pub const TUPLE_TYPE_NAME: &str = "Tuple";
 pub const LIST_TYPE_NAME: &str = "List";
 pub const SET_TYPE_NAME: &str = "Set";
 pub const MAP_TYPE_NAME: &str = "Map";
@@ -287,16 +285,24 @@ pub struct ExistentialType;
 #[derive(Debug, PartialEq)]
 pub struct InferType;
 
-/// The type infer operator.
+/// The tuple type.
 #[derive(Debug, PartialEq)]
 pub struct TupleType<'c> {
     pub entries: AstNodes<'c, Type<'c>>,
+}
+
+/// The function type.
+#[derive(Debug, PartialEq)]
+pub struct FnType<'c> {
+    pub args: AstNodes<'c, Type<'c>>,
+    pub return_ty: AstNode<'c, Type<'c>>,
 }
 
 /// A type.
 #[derive(Debug, PartialEq)]
 pub enum Type<'c> {
     Tuple(TupleType<'c>),
+    Fn(FnType<'c>),
     Named(NamedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -255,6 +255,27 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("tuple", entries))
     }
 
+    type FnTypeRet = TreeNode;
+    fn visit_function_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::FnType<'c>>,
+    ) -> Result<Self::FnTypeRet, Self::Error> {
+        let walk::FnType { args, return_ty } = walk::walk_function_type(self, ctx, node)?;
+
+        let return_child = TreeNode::branch("return", vec![return_ty]);
+
+        let children = {
+            if args.is_empty() {
+                vec![return_child]
+            } else {
+                vec![TreeNode::branch("arguments", args), return_child]
+            }
+        };
+
+        Ok(TreeNode::branch("function", children))
+    }
+
     type NamedTypeRet = TreeNode;
     fn visit_named_type(
         &mut self,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -23,8 +23,8 @@ use crate::{
 use crate::{state::TypecheckState, types::EnumVariant};
 use hash_alloc::row;
 use hash_alloc::{collections::row::Row, Wall};
-use hash_ast::ast::{self, FUNCTION_TYPE_NAME};
-use hash_ast::ident::{Identifier, IDENTIFIER_MAP};
+use hash_ast::ast;
+use hash_ast::ident::Identifier;
 use hash_ast::visitor::AstVisitor;
 use hash_ast::{visitor, visitor::walk};
 use hash_pipeline::sources::{SourceRef, Sources};
@@ -369,7 +369,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                         let enum_variant_fn_ty = self.types_mut().create(
                             TypeValue::Fn(FnType {
                                 args,
-                                ret: enum_ty_id,
+                                return_ty: enum_ty_id,
                             }),
                             Some(loc),
                         );
@@ -412,12 +412,12 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::FunctionCallExpr<'c>>,
     ) -> Result<Self::FunctionCallExprRet, Self::Error> {
         let given_args = self.visit_function_call_args(ctx, node.args.ast_ref())?;
-        let ret_ty = self.create_unknown_type();
+        let return_ty = self.create_unknown_type();
         let args_ty_location = self.source_location(node.body().args.location());
         let expected_fn_ty = self.create_type(
             TypeValue::Fn(FnType {
                 args: given_args,
-                ret: ret_ty,
+                return_ty,
             }),
             Some(args_ty_location),
         );
@@ -443,7 +443,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         self.unifier()
             .unify(expected_fn_ty, given_ty, UnifyStrategy::ModifyBoth)?;
 
-        Ok(ret_ty)
+        Ok(return_ty)
     }
 
     type PropertyAccessExprRet = TypeId;
@@ -581,6 +581,20 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             .create(TypeValue::Tuple(TupleType { types: entries }), ty_location))
     }
 
+    type FnTypeRet = TypeId;
+    fn visit_function_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::FnType<'c>>,
+    ) -> Result<Self::TupleTypeRet, Self::Error> {
+        let walk::FnType { args, return_ty } = walk::walk_function_type(self, ctx, node)?;
+
+        Ok(self.create_type(
+            TypeValue::Fn(FnType { args, return_ty }),
+            self.some_source_location(node.location()),
+        ))
+    }
+
     type TypeRet = TypeId;
     fn visit_type(
         &mut self,
@@ -598,27 +612,8 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::NamedType<'c>>,
     ) -> Result<Self::NamedTypeRet, Self::Error> {
-        // @@Hack: ast names functions as Function, which is not ideal
-        match &node.name.path[..] {
-            [x] if *x == IDENTIFIER_MAP.create_ident(FUNCTION_TYPE_NAME) => {
-                let walk::NamedType { type_args, .. } = walk::walk_named_type(self, ctx, node)?;
-                if let [args @ .., ret] = &type_args[..] {
-                    return Ok(self.create_type(
-                        TypeValue::Fn(FnType {
-                            args: Row::from_iter(args.iter().copied(), self.wall()),
-                            ret: *ret,
-                        }),
-                        self.some_source_location(node.location()),
-                    ));
-                } else {
-                    // Will always have at least one arg.
-                    unreachable!()
-                }
-            }
-            _ => {}
-        }
-
         let location = self.source_location(node.location());
+
         match self.resolve_compound_symbol(&node.name.path, location)? {
             (_, SymbolType::Type(ty_id)) => Ok(self.types_mut().duplicate(ty_id, Some(location))),
             (_, SymbolType::TypeDef(def_id)) => {
@@ -973,7 +968,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         let fn_ty = self.create_type(
             TypeValue::Fn(FnType {
                 args: args_ty,
-                ret: return_ty,
+                return_ty,
             }),
             Some(location),
         ); // @@Correctness: this isn't the correct location

--- a/compiler/hash-typecheck/src/types.rs
+++ b/compiler/hash-typecheck/src/types.rs
@@ -175,7 +175,7 @@ pub struct UserType<'c> {
 #[derive(Debug)]
 pub struct FnType<'c> {
     pub args: TypeList<'c>,
-    pub ret: TypeId,
+    pub return_ty: TypeId,
 }
 
 #[derive(Debug)]
@@ -218,9 +218,9 @@ impl<'c> TypeValue<'c> {
         match self {
             TypeValue::Ref(RefType { inner }) => f(initial, *inner),
             TypeValue::RawRef(RawRefType { inner }) => f(initial, *inner),
-            TypeValue::Fn(FnType { args, ret }) => {
+            TypeValue::Fn(FnType { args, return_ty }) => {
                 let args_res = args.iter().fold(initial, |acc, x| f(acc, *x));
-                f(args_res, *ret)
+                f(args_res, *return_ty)
             }
             TypeValue::User(UserType { args, def_id: _ }) => {
                 args.iter().fold(initial, |acc, x| f(acc, *x))
@@ -244,9 +244,9 @@ impl<'c> TypeValue<'c> {
             TypeValue::RawRef(RawRefType { inner }) => {
                 TypeValue::RawRef(RawRefType { inner: f(*inner)? })
             }
-            TypeValue::Fn(FnType { args, ret }) => TypeValue::Fn(FnType {
+            TypeValue::Fn(FnType { args, return_ty }) => TypeValue::Fn(FnType {
                 args: Row::try_from_iter(args.iter().map(|&arg| f(arg)), wall)?,
-                ret: f(*ret)?,
+                return_ty: f(*return_ty)?,
             }),
             TypeValue::User(UserType { args, def_id }) => TypeValue::User(UserType {
                 args: Row::try_from_iter(args.iter().map(|&arg| f(arg)), wall)?,
@@ -274,9 +274,9 @@ impl<'c> TypeValue<'c> {
             TypeValue::RawRef(RawRefType { inner }) => {
                 TypeValue::RawRef(RawRefType { inner: f(*inner) })
             }
-            TypeValue::Fn(FnType { args, ret }) => TypeValue::Fn(FnType {
+            TypeValue::Fn(FnType { args, return_ty }) => TypeValue::Fn(FnType {
                 args: Row::from_iter(args.iter().map(|&arg| f(arg)), wall),
-                ret: f(*ret),
+                return_ty: f(*return_ty),
             }),
             TypeValue::User(UserType { args, def_id }) => TypeValue::User(UserType {
                 args: Row::from_iter(args.iter().map(|&arg| f(arg)), wall),

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -262,7 +262,7 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
 
                 self.unify_pairs(fn_target.args.iter().zip(fn_source.args.iter()), strategy)?;
                 // Maybe this should be flipped (see variance comment above)
-                self.unify(fn_target.ret, fn_source.ret, strategy)?;
+                self.unify(fn_target.return_ty, fn_source.return_ty, strategy)?;
                 Ok(())
             }
             (Tuple(tuple_target), Tuple(tuple_source))

--- a/compiler/hash-typecheck/src/writer.rs
+++ b/compiler/hash-typecheck/src/writer.rs
@@ -47,7 +47,7 @@ impl<'g, 'c, 'w> TypeWithStorage<'g, 'c, 'w> {
             crate::types::TypeValue::RawRef(RawRefType { inner }) => {
                 TreeNode::branch("raw_ref", vec![self.for_type(*inner).to_tree_node()])
             }
-            crate::types::TypeValue::Fn(FnType { args, ret }) => TreeNode::branch(
+            crate::types::TypeValue::Fn(FnType { args, return_ty }) => TreeNode::branch(
                 "function",
                 vec![
                     TreeNode::branch(
@@ -56,7 +56,7 @@ impl<'g, 'c, 'w> TypeWithStorage<'g, 'c, 'w> {
                             .map(|a| self.for_type(*a).to_tree_node())
                             .collect(),
                     ),
-                    TreeNode::branch("return", vec![self.for_type(*ret).to_tree_node()]),
+                    TreeNode::branch("return", vec![self.for_type(*return_ty).to_tree_node()]),
                 ],
             ),
             crate::types::TypeValue::Var(TypeVar { name }) => {
@@ -128,7 +128,7 @@ impl<'g, 'c, 'w> fmt::Display for TypeWithStorage<'g, 'c, 'w> {
             crate::types::TypeValue::RawRef(RawRefType { inner }) => {
                 write!(f, "&raw {}", self.for_type(*inner))?;
             }
-            crate::types::TypeValue::Fn(FnType { args, ret }) => {
+            crate::types::TypeValue::Fn(FnType { args, return_ty }) => {
                 write!(f, "(")?;
                 for (i, arg) in args.iter().enumerate() {
                     write!(f, "{}", self.for_type(*arg))?;
@@ -136,7 +136,7 @@ impl<'g, 'c, 'w> fmt::Display for TypeWithStorage<'g, 'c, 'w> {
                         write!(f, ", ")?;
                     }
                 }
-                write!(f, ") => {}", self.for_type(*ret))?;
+                write!(f, ") => {}", self.for_type(*return_ty))?;
             }
             crate::types::TypeValue::Var(TypeVar { name }) => {
                 write!(f, "{}", IDENTIFIER_MAP.get_ident(*name))?;


### PR DESCRIPTION
Similarly to tuple types, the current way of handling function types
was to check if an identifier was being used to denote the function
as 'Function' which was very hacky. This patch removes this behaviour
and adds a new variant to the `Type` variant called `Fn`.

This makes it considerably easier to work within the typechecker
and the visualiser.

closes #119