### PR TITLE
Struct literal fix

### DIFF
--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -160,17 +160,22 @@ impl<'a> From<AstGenError<'a>> for ParseError {
             AstGenErrorKind::Keyword => {
                 let keyword = err.received.unwrap();
 
-                format!("Encountered an unexpected keyword '{}'", keyword)
+                format!(
+                    "Encountered an unexpected keyword {}",
+                    keyword.as_error_string()
+                )
             }
             AstGenErrorKind::Expected => match &err.received {
-                Some(atom) => format!("Unexpectedly encountered '{}'", atom),
+                Some(kind) => format!("Unexpectedly encountered {}", kind.as_error_string()),
                 None => "Unexpectedly reached the end of input".to_string(),
             },
             AstGenErrorKind::Block => {
                 let base: String = "Expected block body, which begins with a '{'".into();
 
                 match err.received {
-                    Some(atom) => format!("{}, however received '{}'.", base, atom),
+                    Some(kind) => {
+                        format!("{}, however received '{}'.", base, kind.as_error_string())
+                    }
                     None => base,
                 }
             }
@@ -207,8 +212,8 @@ impl<'a> From<AstGenError<'a>> for ParseError {
         // other error types follow a conformed order to formatting expected tokens
         if !matches!(&err.kind, AstGenErrorKind::Block) {
             if !matches!(&err.kind, AstGenErrorKind::Expected) {
-                if let Some(atom) = err.received {
-                    let atom_msg = format!(", however received a `{}`", atom);
+                if let Some(kind) = err.received {
+                    let atom_msg = format!(", however received {}", kind.as_error_string());
                     base_message.push_str(&atom_msg);
                 }
             }

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -2327,7 +2327,15 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     // now we eat the next token, checking that it is a comma
                     match gen.peek() {
                         Some(token) if token.has_kind(TokenKind::Comma) => gen.skip_token(),
-                        _ => break,
+                        Some(token) => gen.error_with_location(
+                            AstGenErrorKind::Expected,
+                            Some(TokenKindVector::from_row(
+                                row![&self.wall; TokenKind::Comma, TokenKind::Delimiter(Delimiter::Brace, false)],
+                            )),
+                            Some(token.kind),
+                            &token.span,
+                        )?,
+                        None => break,
                     };
                 }
                 Some(token) if token.has_kind(TokenKind::Comma) => {
@@ -2367,7 +2375,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 Some(token) => gen.error_with_location(
                     AstGenErrorKind::Expected,
                     Some(TokenKindVector::from_row(
-                        row![&self.wall; TokenKind::Eq, TokenKind::Comma],
+                        row![&self.wall; TokenKind::Eq, TokenKind::Comma, TokenKind::Delimiter(Delimiter::Brace, false)],
                     )),
                     Some(token.kind),
                     &token.span,

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -263,6 +263,27 @@ pub enum TokenKind {
     Unexpected(char),
 }
 
+impl TokenKind {
+    /// This function is used to create an error message representing when a token
+    /// was unexpectedly encountered or was expected in a particular context.
+    pub fn as_error_string(&self) -> String {
+        match self {
+            TokenKind::Unexpected(ch) => format!("an unknown character `{}`", ch),
+            TokenKind::IntLiteral(num) => format!("`{}`", num),
+            TokenKind::FloatLiteral(num) => format!("`{}`", num),
+            TokenKind::CharLiteral(ch) => format!("`{}`", ch),
+            TokenKind::StrLiteral(str) => {
+                format!("the string `{}`", STRING_LITERAL_MAP.lookup(*str))
+            }
+            TokenKind::Keyword(kwd) => format!("`{}`", kwd),
+            TokenKind::Ident(ident) => {
+                format!("the identifier `{}`", IDENTIFIER_MAP.get_ident(*ident))
+            }
+            kind => format!("a `{}`", kind),
+        }
+    }
+}
+
 impl fmt::Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -287,6 +308,11 @@ impl fmt::Display for TokenKind {
             TokenKind::Dollar => write!(f, "$"),
             TokenKind::Comma => write!(f, ","),
             TokenKind::Quote => write!(f, "\""),
+            TokenKind::SingleQuote => write!(f, "'"),
+            TokenKind::Unexpected(ch) => write!(f, "{}", ch),
+            TokenKind::IntLiteral(num) => write!(f, "{}", num),
+            TokenKind::FloatLiteral(num) => write!(f, "{}", num),
+            TokenKind::CharLiteral(ch) => write!(f, "'{}'", ch),
             TokenKind::Delimiter(delim, left) => {
                 if *left {
                     write!(f, "{}", delim.left())
@@ -294,12 +320,7 @@ impl fmt::Display for TokenKind {
                     write!(f, "{}", delim.right())
                 }
             }
-            TokenKind::Tree(delim, _) => write!(f, "{} tree {}", delim.left(), delim.right()),
-            TokenKind::Unexpected(ch) => write!(f, "{}", ch),
-            TokenKind::SingleQuote => write!(f, "'"),
-            TokenKind::IntLiteral(num) => write!(f, "{}", num),
-            TokenKind::FloatLiteral(num) => write!(f, "{}", num),
-            TokenKind::CharLiteral(ch) => write!(f, "'{}'", ch),
+            TokenKind::Tree(delim, _) => write!(f, "{}...{}", delim.left(), delim.right()),
             TokenKind::StrLiteral(str) => {
                 write!(f, "\"{}\"", STRING_LITERAL_MAP.lookup(*str))
             }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -812,7 +812,9 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::StructLiteral<'c>>,
     ) -> Result<Self::StructLiteralRet, Self::Error> {
         let location = self.source_location(node.location());
-        let symbol_res = self.resolve_compound_symbol(&node.name.path, location)?;
+
+        let symbol_res = self
+            .resolve_compound_symbol(&node.name.path, self.source_location(node.name.location()))?;
 
         match symbol_res {
             (_, SymbolType::TypeDef(def_id)) => {
@@ -1551,7 +1553,9 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::StructPattern<'c>>,
     ) -> Result<Self::StructPatternRet, Self::Error> {
         let location = self.source_location(node.location());
-        let symbol_res = self.resolve_compound_symbol(&node.name.path, location)?;
+
+        let symbol_res = self
+            .resolve_compound_symbol(&node.name.path, self.source_location(node.name.location()))?;
 
         match symbol_res {
             (_, SymbolType::TypeDef(def_id)) => {
@@ -1847,10 +1851,14 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
                     let entry = node.entries.get(index).unwrap();
 
                     return Err(TypecheckError::UnresolvedStructField {
-                        ty_def_location,
-                        ty_def_name: *name,
-                        field_name: entry_name,
-                        location: self.source_location(entry.location()),
+                        ty_def: Symbol::Single {
+                            symbol: *name,
+                            location: ty_def_location,
+                        },
+                        field: Symbol::Single {
+                            symbol: entry_name,
+                            location: self.some_source_location(entry.location()),
+                        },
                     });
                 }
             }
@@ -1893,10 +1901,14 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
                     let entry = node.entries.get(index).unwrap();
 
                     return Err(TypecheckError::UnresolvedStructField {
-                        ty_def_location,
-                        ty_def_name: *name,
-                        field_name: entry_name,
-                        location: self.source_location(entry.location()),
+                        ty_def: Symbol::Single {
+                            symbol: *name,
+                            location: ty_def_location,
+                        },
+                        field: Symbol::Single {
+                            symbol: entry_name,
+                            location: self.some_source_location(entry.location()),
+                        },
                     });
                 }
             }

--- a/tests/parser/tests/cases/should_fail/missing_comma_in_struct_field/case.hash
+++ b/tests/parser/tests/cases/should_fail/missing_comma_in_struct_field/case.hash
@@ -1,0 +1,7 @@
+// Create a new dog called viktor! 
+let viktor = Dog { 
+    name = "Viktor",
+    has_brother = true // <--- Error should be reported here since there is no comma....
+    age = 12, 
+    gender = false
+};


### PR DESCRIPTION
When struct literals were missing a comma somewhere in the middle of
the brace block, the parser would abort parsing any fields after it
because it considered that there cannot be anything after the
comma. However, this wasn't the correct behaviour as there might
be just a missing comma afterwards, and it will just fail to
parse everything else in the block. This patch fixes this
behaviour and reports the error.

This also improves the way token kinds are being reported in the
parser reporter logic to make more sense (in terms of English).

Also, when struct symbols (literals and patterns) weren't in scope, the incorrect span was being used to report the missing symbol. Instead of using the entire struct literal span, it should only be using the span of the name.