### PR TITLE
Typecheck namespace patterns

### DIFF
--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -27,4 +27,5 @@ error_codes! {
     TypeArgumentLengthMismatch = 23,
     NoMatchingTraitImplementations = 24,
     FunctionArgumentLengthMismatch = 25,
+    UnresolvedType = 26,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -28,4 +28,5 @@ error_codes! {
     NoMatchingTraitImplementations = 24,
     FunctionArgumentLengthMismatch = 25,
     UnresolvedType = 26,
+    DisallowedPatternNonVariable = 27,
 }

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -159,6 +159,7 @@ pub enum TypecheckError {
         mismatch: ArgumentLengthMismatch,
     },
     UnresolvedType(TypeId),
+    DisallowedPatternNonVariable(Symbol, SourceLocation),
 }
 
 pub type TypecheckResult<T> = Result<T, TypecheckError>;
@@ -690,6 +691,19 @@ impl TypecheckError {
                 builder.add_element(ReportElement::Note(ReportNote::new(
                     ReportNoteKind::Help,
                     "Try adding more type annotations.",
+                )));
+            }
+            TypecheckError::DisallowedPatternNonVariable(symbol, location) => {
+                builder.with_error_code(HashErrorCode::DisallowedPatternNonVariable);
+
+                builder.with_message(format!(
+                    "This destructuring pattern is not allowed because {} is not a variable.",
+                    IDENTIFIER_MAP.get_path(symbol.get_ident().into_iter())
+                ));
+
+                builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                    location,
+                    "Destructuring pattern not allowed here.",
                 )));
             }
         }

--- a/compiler/hash-typecheck/src/state.rs
+++ b/compiler/hash-typecheck/src/state.rs
@@ -10,6 +10,7 @@ pub struct TypecheckState {
     pub ret_once: bool,
     pub func_ret_type: Option<TypeId>,
     pub current_module: SourceId,
+    pub pattern_hint: Option<TypeId>,
 }
 
 impl TypecheckState {
@@ -20,6 +21,7 @@ impl TypecheckState {
             ret_once: false,
             func_ret_type: None,
             current_module,
+            pattern_hint: None,
         }
     }
 }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1165,10 +1165,10 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             }
         } else {
             let walk::LetStatement {
-                pattern: pattern_ty,
-                ty: annot_maybe_ty,
+                pattern: _pattern_ty,
+                ty: _annot_maybe_ty,
                 bound: _,
-                value: value_maybe_ty,
+                value: _value_maybe_ty,
             } = walk::walk_let_statement(self, ctx, node)?;
 
             // Ensure that the given pattern for let statements is irrefutable
@@ -1648,14 +1648,14 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             .pattern_hint
             .unwrap_or_else(|| self.create_unknown_type());
         self.unifier()
-            .unify(pattern_ty, subject_ty, UnifyStrategy::ModifyTarget);
+            .unify(pattern_ty, subject_ty, UnifyStrategy::ModifyTarget)?;
 
         match self.types().get(pattern_ty) {
             TypeValue::Namespace(NamespaceType { members }) => {
                 let symbols: Vec<_> = patterns
                     .iter()
                     .map(
-                        |&(ident, ty, location)| match members.resolve_symbol(ident) {
+                        |&(ident, _ty, location)| match members.resolve_symbol(ident) {
                             Some(symbol) => Ok((ident, symbol)),
                             None => Err(TypecheckError::UnresolvedSymbol(Symbol::Single {
                                 symbol: ident,

--- a/compiler/hash-typecheck/src/types.rs
+++ b/compiler/hash-typecheck/src/types.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use hash_alloc::{collections::row::Row, row, Wall};
 use hash_ast::ident::{Identifier, IDENTIFIER_MAP};
-use hash_source::location::SourceLocation;
+use hash_source::{location::SourceLocation, ModuleId};
 use hash_utils::counter;
 use slotmap::{new_key_type, Key, SlotMap};
 use std::hash::Hash;
@@ -181,6 +181,7 @@ pub struct FnType<'c> {
 
 #[derive(Debug)]
 pub struct NamespaceType {
+    pub module_id: ModuleId,
     pub members: ScopeStack,
 }
 
@@ -261,6 +262,7 @@ impl<'c> TypeValue<'c> {
             TypeValue::Unknown(unknown) => TypeValue::Unknown(*unknown),
             TypeValue::Namespace(ns) => TypeValue::Namespace(NamespaceType {
                 members: ns.members.clone(),
+                ..*ns
             }),
         })
     }
@@ -291,6 +293,7 @@ impl<'c> TypeValue<'c> {
             TypeValue::Unknown(unknown) => TypeValue::Unknown(*unknown),
             TypeValue::Namespace(ns) => TypeValue::Namespace(NamespaceType {
                 members: ns.members.clone(),
+                ..*ns
             }),
         }
     }

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -335,11 +335,11 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
                 Ok(())
             }
             (Prim(prim_target), Prim(prim_source)) if prim_target == prim_source => Ok(()),
-            // (Namespace(ns_target), Namespace(ns_source))
-            //     if ns_target.module_idx == ns_source.module_idx =>
-            // {
-            //     Ok(())
-            // }
+            (Namespace(ns_target), Namespace(ns_source))
+                if ns_target.module_id == ns_source.module_id =>
+            {
+                Ok(())
+            }
             _ => Err(TypecheckError::TypeMismatch {
                 given: target,
                 wanted: source,

--- a/compiler/hash-typecheck/src/unify.rs
+++ b/compiler/hash-typecheck/src/unify.rs
@@ -305,11 +305,17 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
             (Var(var_a), Var(var_b)) if var_a == var_b => Ok(()),
             (Var(var), _) => match self.module_storage.type_vars.potentially_resolve(*var) {
                 Some(var_res) => self.unify(var_res, source, strategy),
-                None => Err(TypecheckError::TypeMismatch(target, source)),
+                None => Err(TypecheckError::TypeMismatch {
+                    given: target,
+                    wanted: source,
+                }),
             },
             (_, Var(var)) => match self.module_storage.type_vars.potentially_resolve(*var) {
                 Some(var_res) => self.unify(target, var_res, strategy),
-                None => Err(TypecheckError::TypeMismatch(target, source)),
+                None => Err(TypecheckError::TypeMismatch {
+                    given: target,
+                    wanted: source,
+                }),
             },
             (User(user_target), User(user_source)) if user_target.def_id == user_source.def_id => {
                 // Make sure we got same number of type arguments
@@ -334,7 +340,10 @@ impl<'c, 'w, 'ms, 'gs> Unifier<'c, 'w, 'ms, 'gs> {
             // {
             //     Ok(())
             // }
-            _ => Err(TypecheckError::TypeMismatch(target, source)),
+            _ => Err(TypecheckError::TypeMismatch {
+                given: target,
+                wanted: source,
+            }),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for namespace patterns, which can be used to extract contents from modules.