### PR TITLE
fix: Don't display UNC paths on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "hash-alloc",
  "hash-error-codes",
  "hash-source",
+ "hash-utils",
  "thiserror",
 ]
 

--- a/compiler/hash-reporting/Cargo.toml
+++ b/compiler/hash-reporting/Cargo.toml
@@ -9,3 +9,4 @@ thiserror = "1.0"
 hash-source = {path = "../hash-source" }
 hash-alloc = {path = "../hash-alloc" }
 hash-error-codes = {path = "../hash-error-codes" }
+hash-utils = {path = "../hash-utils" }

--- a/compiler/hash-reporting/src/reporting.rs
+++ b/compiler/hash-reporting/src/reporting.rs
@@ -5,6 +5,7 @@ use crate::highlight::{highlight, Colour, Modifier};
 use core::fmt;
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_source::{location::SourceLocation, SourceMap};
+use hash_utils::path::adjust_canonicalization;
 use std::{
     cell::Cell,
     iter::{once, repeat},
@@ -239,7 +240,7 @@ impl ReportCodeBlock {
                 Modifier::Underline,
                 format!(
                     "{}:{}:{}",
-                    modules.path_by_id(source_id).to_string_lossy(),
+                    adjust_canonicalization(modules.path_by_id(source_id)),
                     start_row + 1,
                     start_col + 1,
                 )

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -1,6 +1,7 @@
 //! Hash compiler timing and profiling utilities.
 //!
 //! All rights reserved 2022 (c) The Hash Language authors
+pub mod path;
 pub mod printing;
 pub mod testing;
 pub mod tree_writing;

--- a/compiler/hash-utils/src/path.rs
+++ b/compiler/hash-utils/src/path.rs
@@ -1,0 +1,20 @@
+//! Hash compiler path utilities.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors
+use std::path::Path;
+
+#[cfg(not(target_os = "windows"))]
+pub fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    p.as_ref().display().to_string()
+}
+
+#[cfg(target_os = "windows")]
+pub fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
+    const VERBATIM_PREFIX: &str = r#"\\?\"#;
+    let p = p.as_ref().display().to_string();
+    if p.starts_with(VERBATIM_PREFIX) {
+        p[VERBATIM_PREFIX.len()..].to_string()
+    } else {
+        p
+    }
+}


### PR DESCRIPTION
On Windows, paths are defaulted to using the `UNC` format which enables paths to be considerably longer than the default value of 260. However, we don't want to show the paths as this, we want to display them with the drive beginning.

Before on Windows, it prints:
```
 error[0006]: Symbol `T` is not defined in the current scope.
   --> \\?\C:\Users\Alex\Desktop\hash-org\lang\examples\ignored\variety.hash:299:31
298 |
299 |   let next<Enumerate<$I>, (i32, T)> where next<$I, $T> = (iterator) => {
    |                                 ^ not found in this scope
300 |       match next(iterator.item) {
```

Now it prints:
```
error[0006]: Symbol `T` is not defined in the current scope.
   --> C:\Users\Alex\Desktop\hash-org\lang\examples\ignored\variety.hash:299:31
298 |
299 |   let next<Enumerate<$I>, (i32, T)> where next<$I, $T> = (iterator) => {
    |                                 ^ not found in this scope
300 |       match next(iterator.item) {
```