### PR TITLE
parser: Empty tuple syntax `()`

### DIFF
--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -38,6 +38,9 @@ pub enum TokenErrorKind {
     /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
     #[error("Malformed numerical literal")]
     MalformedNumericalLiteral,
+    /// Occurs when a float literal exponent has no proceeding digits.
+    #[error("Expected float exponent to have at least one digit")]
+    MissingExponentDigits,
     /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
     #[error("Unclosed string literal")]
     UnclosedStringLiteral,

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -22,8 +22,8 @@ impl Location {
 
     /// Create a 'Span' variant by providing a start and end byte position.
     pub fn span(start: usize, end: usize) -> Self {
-        assert!(
-            end > start,
+        debug_assert!(
+            end >= start,
             "Got invalid span for Location::span. Start needs to be smaller than end."
         );
 

--- a/tests/parser/tests/cases/should_pass/tuple_literals/case.hash
+++ b/tests/parser/tests/cases/should_pass/tuple_literals/case.hash
@@ -1,4 +1,8 @@
+// This should be the same
+let tup = ();
 let tup = (,);
+
+// Different sizes
 let tup = (a,);
 let tup = (a,c);
 let tup = (a,c,b);

--- a/tests/parser/tests/cases/should_pass/tuple_types/case.hash
+++ b/tests/parser/tests/cases/should_pass/tuple_types/case.hash
@@ -1,4 +1,8 @@
+// This should be the same
+let k: () = b;
 let k: (,) = b;
+
+// Different sizes
 let k: (int) = b;
 let k: (int, float) = b;
 let k: (int, float,) = b;


### PR DESCRIPTION
- This patch adds support within the parser to treat `()` as an empty tuple whilst allowing for the old `(,)` syntax to also persist. (Fixes #147)

- This also fixes a parser bug involving invalid float literal exponents which causes the compiler to crash when reporting the issue (fixes #153).