### PR TITLE
parser: Change syntax of fn return types

### DIFF
--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -195,7 +195,7 @@ impl<'a> From<AstGenError<'a>> for ParseError {
             AstGenErrorKind::ExpectedIdentifier => "Expected an identifier ".to_string(),
             AstGenErrorKind::ExpectedArrow => "Expected an arrow '=>' ".to_string(),
             AstGenErrorKind::ExpectedFnArrow => {
-                "Expected an arrow '=>' after type arguments denoting a function type".to_string()
+                "Expected an arrow '->' after type arguments denoting a function type".to_string()
             }
             AstGenErrorKind::ExpectedFnBody => "Expected a function body".to_string(),
             AstGenErrorKind::ExpectedType => "Expected a type annotation".to_string(),

--- a/tests/parser/tests/cases/should_pass/function_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/function_defns/case.hash
@@ -2,10 +2,10 @@ let fk = () => {
     print(x)
 };
 
-let ft = (k: T): u64 => {
+let ft = (k: T) -> u64 => {
     do_something(k)
 };
 
-let ft: (T) => u64 = (k) => {
+let ft: (T) -> u64 = (k) => {
     do_something(t)
 };

--- a/tests/parser/tests/cases/should_pass/function_literals/case.hash
+++ b/tests/parser/tests/cases/should_pass/function_literals/case.hash
@@ -1,1 +1,4 @@
-let str_eq: (str, str) => str = (a, b) => a == b;
+let str_eq: (str, str) -> str = (a, b) => a == b;
+let str_eq: (str, str) -> str = (a, b) -> str => a == b;
+
+let str_eq = (a, b) -> str => a == b;

--- a/tests/parser/tests/cases/should_pass/simple_import/file.hash
+++ b/tests/parser/tests/cases/should_pass/simple_import/file.hash
@@ -1,4 +1,4 @@
 // Export this simple adding function
-let l = (a: u32, b: u32): u32 => {
+let l = (a: u32, b: u32) -> u32 => {
     a + b
 };

--- a/tests/parser/tests/cases/should_pass/traits_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/traits_defns/case.hash
@@ -1,2 +1,2 @@
-trait merge = <T> => (T, T) => T;
-trait merge = <T> where add<T>, or<T> => (T, T) => T;
+trait merge = <T> => (T, T) -> T;
+trait merge = <T> where add<T>, or<T> => (T, T) -> T;


### PR DESCRIPTION
This patch addresses the issue specified in #151. Annotated
function return types are now denoted using a `->` for both
in function literals and within function types.

Before there was a different syntax for specifying the return
type of a function within a type (using the `=>` fat-arrow) and
within function literals (`:` colon). This was inconsistent and
sometimes hard to read. This change in syntax should clear up
the ambiguity of annotating return types within functions.