### PR TITLE
lang: Implementation for directives

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -225,13 +225,6 @@ impl<T> DerefMut for AstNode<'_, T> {
     }
 }
 
-/// An intrinsic identifier.
-#[derive(Hash, PartialEq, Debug)]
-pub struct IntrinsicKey {
-    /// The name of the intrinsic (without the "#").
-    pub name: Identifier,
-}
-
 /// A single name/symbol.
 #[derive(Hash, PartialEq, Debug)]
 pub struct Name {
@@ -752,6 +745,15 @@ pub struct FunctionCallExpr<'c> {
     pub args: AstNode<'c, FunctionCallArgs<'c>>,
 }
 
+/// An directive expression.
+#[derive(PartialEq, Debug)]
+pub struct DirectiveExpr<'c> {
+    /// The name of the directive (without the "#").
+    pub name: AstNode<'c, Name>,
+    /// An expression which is referenced in the directive
+    pub subject: AstNode<'c, Expression<'c>>,
+}
+
 /// A property access expression.
 #[derive(Debug, PartialEq)]
 pub struct PropertyAccessExpr<'c> {
@@ -812,7 +814,7 @@ pub struct ImportExpr<'c>(pub AstNode<'c, Import>);
 #[derive(Debug, PartialEq)]
 pub enum ExpressionKind<'c> {
     FunctionCall(FunctionCallExpr<'c>),
-    Intrinsic(IntrinsicKey),
+    Directive(DirectiveExpr<'c>),
     Variable(VariableExpr<'c>),
     PropertyAccess(PropertyAccessExpr<'c>),
     Ref(RefExpr<'c>),

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -89,7 +89,7 @@ impl NodeCount for Expression<'_> {
                 let fn_args: usize = e.args.entries.iter().map(|a| a.node_count()).sum();
                 e.subject.node_count() + fn_args
             }
-            ExpressionKind::Intrinsic(_) => 0,
+            ExpressionKind::Directive(_) => 0,
             ExpressionKind::Variable(e) => {
                 let ty_args: usize = e.type_args.iter().map(|t| t.node_count()).sum();
 

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -111,17 +111,18 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("variable", children))
     }
 
-    type IntrinsicKeyRet = TreeNode;
-    fn visit_intrinsic_key(
+    type DirectiveExprRet = TreeNode;
+    fn visit_directive_expr(
         &mut self,
-        _: &Self::Ctx,
-        node: ast::AstNodeRef<ast::IntrinsicKey>,
-    ) -> Result<Self::IntrinsicKeyRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled(
-            "intrinsic",
-            IDENTIFIER_MAP.get_ident(node.name),
-            "\"",
-        )))
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::DirectiveExpr>,
+    ) -> Result<Self::DirectiveExprRet, Self::Error> {
+        let walk::DirectiveExpr { subject, .. } = walk::walk_directive_expr(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            labelled("directive", IDENTIFIER_MAP.get_ident(node.name.ident), "\""),
+            vec![subject],
+        ))
     }
 
     type FunctionCallArgsRet = TreeNode;

--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -38,6 +38,9 @@ pub enum TokenErrorKind {
     /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
     #[error("Malformed numerical literal")]
     MalformedNumericalLiteral,
+    /// Occurs when a float literal exponent has no proceeding digits.
+    #[error("Expected float exponent to have at least one digit")]
+    MissingExponentDigits,
     /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
     #[error("Unclosed string literal")]
     UnclosedStringLiteral,

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -2493,18 +2493,16 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 })
             }
             TokenKind::Hash => {
-                // First get the intrinsic subject, and expect a possible singular expression
-                // followed by the intrinsic.
-                let subject = self.parse_ident()?;
-                let name = subject.ident;
+                // First get the directive subject, and expect a possible singular expression
+                // followed by the directive.
+                let name = self.parse_ident()?;
+                let subject = self.parse_expression()?;
 
                 // create the subject node
-                let subject_node = self.node_from_joined_location(
-                    Expression::new(ExpressionKind::Intrinsic(IntrinsicKey { name })),
+                return Ok(self.node_from_joined_location(
+                    Expression::new(ExpressionKind::Directive(DirectiveExpr { name, subject })),
                     &start,
-                );
-
-                return self.parse_singular_expression(subject_node);
+                ));
             }
             TokenKind::Exclamation => {
                 let arg = self.parse_expression()?;

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -185,7 +185,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         match self.peek() {
             Some(token) => token.span,
             None => {
-                let Token { span, kind: _ } = self.current_token();
+                let span = self.current_location();
                 Location::span(span.end(), span.end() + 1)
             }
         }
@@ -3392,24 +3392,30 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         let gen = self.from_stream(tree, *span);
         let start = self.current_location();
 
+        // Handle the case if it is an empty stream, this means that if it failed to
+        // parse a function in the form of `() => ...` for whatever reason, then it
+        // is trying to parse either a tuple or an expression.
         // Handle the empty tuple case
-        if gen.stream.len() == 1 {
-            match gen.peek().unwrap() {
-                token if token.has_kind(TokenKind::Comma) => {
+        if gen.stream.len() < 2 {
+            let tuple = gen.node_from_joined_location(
+                Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
+                    gen.node_from_joined_location(
+                        Literal::Tuple(TupleLiteral {
+                            elements: ast_nodes![&self.wall;],
+                        }),
+                        &start,
+                    ),
+                ))),
+                &start,
+            );
+
+            match gen.peek() {
+                Some(token) if token.has_kind(TokenKind::Comma) => {
                     gen.skip_token();
 
-                    return Ok(gen.node_from_joined_location(
-                        Expression::new(ExpressionKind::LiteralExpr(LiteralExpr(
-                            gen.node_from_joined_location(
-                                Literal::Tuple(TupleLiteral {
-                                    elements: ast_nodes![&self.wall;],
-                                }),
-                                &start,
-                            ),
-                        ))),
-                        &start,
-                    ));
+                    return Ok(tuple);
                 }
+                None => return Ok(tuple),
                 _ => (),
             };
         }

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -22,8 +22,8 @@ impl Location {
 
     /// Create a 'Span' variant by providing a start and end byte position.
     pub fn span(start: usize, end: usize) -> Self {
-        assert!(
-            end > start,
+        debug_assert!(
+            end >= start,
             "Got invalid span for Location::span. Start needs to be smaller than end."
         );
 

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -353,14 +353,18 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         }
     }
 
-    type IntrinsicKeyRet = TypeId;
-    fn visit_intrinsic_key(
+    type DirectiveExprRet = TypeId;
+    fn visit_directive_expr(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: ast::AstNodeRef<ast::IntrinsicKey>,
-    ) -> Result<Self::IntrinsicKeyRet, Self::Error> {
-        // @@Todo: maybe we want to store intrinsic types somewhere
-        Ok(self.create_unknown_type())
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::DirectiveExpr<'c>>,
+    ) -> Result<Self::DirectiveExprRet, Self::Error> {
+        // @@Future: At the moment, we're completely passing the 'directive' within the
+        //          typechecking stage. This will change when we solidify how we want
+        //          to type directives and then they become essentially indistinguishable
+        //          from normal functions that perform operations on code.
+        let walk::DirectiveExpr { subject, .. } = walk::walk_directive_expr(self, ctx, node)?;
+        Ok(subject)
     }
 
     type FunctionCallArgsRet = Row<'c, TypeId>;

--- a/tests/parser/tests/cases/should_fail/expresionless_directive/case.hash
+++ b/tests/parser/tests/cases/should_fail/expresionless_directive/case.hash
@@ -1,0 +1,2 @@
+// This directive does not have an expression
+let k = #dump;

--- a/tests/parser/tests/cases/should_pass/basic_directives/case.hash
+++ b/tests/parser/tests/cases/should_pass/basic_directives/case.hash
@@ -1,0 +1,6 @@
+// Here we specify that the function `fact` should be memoised using the 
+// directive `memoised`.
+
+// Directives discussion: https://github.com/hash-org/lang/discussions/149
+
+let fact = #memoised (n: bigint): bigint => if n < 2 { 1 } else { n * fact(n - 1) };

--- a/tests/parser/tests/cases/should_pass/block_directive/case.hash
+++ b/tests/parser/tests/cases/should_pass/block_directive/case.hash
@@ -1,0 +1,10 @@
+let t = #dump match t {
+    "one" => 1;
+    "two" => 2;
+    "three" => 3;
+    "four" | "five" if var => 4.5;
+    alpha if var == 2 => {
+        print(alpha)
+    };
+    _ => -1;
+};

--- a/tests/parser/tests/cases/should_pass/compound_pattern_matching/case.hash
+++ b/tests/parser/tests/cases/should_pass/compound_pattern_matching/case.hash
@@ -2,5 +2,5 @@ let data = match some_struct {
     1 | 2 => do_something_with_name();
     1 | 2 | 3 => do_something_with_name();
     4 | 5 if x > 17 => do_something_with_name();
-    _ => #unreachable();
+    _ => unreachable();
 };

--- a/tests/parser/tests/cases/should_pass/compount_pattern_matching_with_structs/case.hash
+++ b/tests/parser/tests/cases/should_pass/compount_pattern_matching_with_structs/case.hash
@@ -2,5 +2,5 @@ let data = match some_struct {
     Dog { name, age = 6 } | Dog { name, age = 5 }  => do_something_with_name();
     Dog { name, age = 13 } | Dog { name, age } if age % 2 == 0  => do_something_with_name();
     Dog { name, age } => do_something_with_name();
-    _ => #unreachable();
+    _ => unreachable();
 };

--- a/tests/parser/tests/cases/should_pass/multiple_directives/case.hash
+++ b/tests/parser/tests/cases/should_pass/multiple_directives/case.hash
@@ -1,0 +1,2 @@
+ // Here we apply two directives in order
+ let a = #dump #memoise () => 3;

--- a/tests/parser/tests/cases/should_pass/nested_match/case.hash
+++ b/tests/parser/tests/cases/should_pass/nested_match/case.hash
@@ -6,5 +6,5 @@ let data = match some_struct {
         name => print(name + " is 6");
     };
     Dog { name, age } => do_something_with_name();
-    _ => #unreachable();
+    _ => unreachable();
 };

--- a/tests/parser/tests/cases/should_pass/parenthesised_match_statement/case.hash
+++ b/tests/parser/tests/cases/should_pass/parenthesised_match_statement/case.hash
@@ -6,5 +6,5 @@ let b = ((match some_struct {
         name => print(name + " is 6");
     };
     Dog { name, age } => do_something_with_name();
-    _ => #unreachable();
+    _ => unreachable();
 }));

--- a/tests/parser/tests/cases/should_pass/struct_pattern_matching/case.hash
+++ b/tests/parser/tests/cases/should_pass/struct_pattern_matching/case.hash
@@ -1,5 +1,5 @@
 let data = match some_struct {
     Dog { name, age = 6 } => do_something_with_name();
     Dog { name, age } => do_something_with_name();
-    _ => #unreachable();
+    _ => unreachable();
 };

--- a/tests/parser/tests/cases/should_pass/tuple_literals/case.hash
+++ b/tests/parser/tests/cases/should_pass/tuple_literals/case.hash
@@ -1,4 +1,8 @@
+// This should be the same
+let tup = ();
 let tup = (,);
+
+// Different sizes
 let tup = (a,);
 let tup = (a,c);
 let tup = (a,c,b);

--- a/tests/parser/tests/cases/should_pass/tuple_types/case.hash
+++ b/tests/parser/tests/cases/should_pass/tuple_types/case.hash
@@ -1,4 +1,8 @@
+// This should be the same
+let k: () = b;
 let k: (,) = b;
+
+// Different sizes
 let k: (int) = b;
 let k: (int, float) = b;
 let k: (int, float,) = b;


### PR DESCRIPTION
This patch implements a basic form of directives within the parser and parser tooling.


https://github.com/hash-org/lang/pull/154 should be merged before this.