### PR TITLE
docs: Update documentation and use GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Create a bug report for Hash.
+labels: C-bug
+---
+<!--
+Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,
+along with any information you feel relevant to replicating the bug.
+-->
+
+The following snippet:
+
+```rust
+<code>
+```
+
+Should produce this behaviour: *explanation*
+
+Instead, this happened: *explanation*
+
+```
+<behaviour>
+```
+
+### Meta
+
+<!--
+Include a backtrace in the code block (if applicable)
+-->
+<details><summary>Backtrace</summary>
+<p>
+
+```
+<backtrace>
+```
+
+</p>
+</details>

--- a/compiler/hash-parser/src/error.rs
+++ b/compiler/hash-parser/src/error.rs
@@ -195,7 +195,7 @@ impl<'a> From<AstGenError<'a>> for ParseError {
             AstGenErrorKind::ExpectedIdentifier => "Expected an identifier ".to_string(),
             AstGenErrorKind::ExpectedArrow => "Expected an arrow '=>' ".to_string(),
             AstGenErrorKind::ExpectedFnArrow => {
-                "Expected an arrow '=>' after type arguments denoting a function type".to_string()
+                "Expected an arrow '->' after type arguments denoting a function type".to_string()
             }
             AstGenErrorKind::ExpectedFnBody => "Expected a function body".to_string(),
             AstGenErrorKind::ExpectedType => "Expected a type annotation".to_string(),

--- a/compiler/hash/src/crash_handler.rs
+++ b/compiler/hash/src/crash_handler.rs
@@ -7,6 +7,10 @@ use std::panic::PanicInfo;
 use std::process::exit;
 use std::{io::Write, sync::atomic, thread};
 
+const BUG_REPORT_MSG: &str = "This is an compiler bug, please file a bug report at";
+const BUG_REPORT_URI: &str =
+    "https://github.com/hash-org/lang/issues?labels=bug&template=bug_report";
+
 pub(crate) fn panic_handler(info: &PanicInfo) {
     // keep track to ensure that we only panic once and multiple threads can exit gracefully!
     static PANIC_ONCE: atomic::AtomicBool = atomic::AtomicBool::new(false);
@@ -49,10 +53,13 @@ pub(crate) fn panic_handler(info: &PanicInfo) {
             let _ = writeln!(&mut stdout, "Backtrace:\n{:?}", backtrace);
         }
 
-        let msg = "This is an compiler bug, please file a bug report at";
-        let uri = "https://github.com/hash-org/lang/issues";
-
-        let _ = writeln!(&mut stdout, "{}\n\n{:^len$}\n", msg, uri, len = msg.len());
+        let _ = writeln!(
+            &mut stdout,
+            "{}\n\n{:^len$}\n",
+            BUG_REPORT_MSG,
+            BUG_REPORT_URI,
+            len = BUG_REPORT_MSG.len()
+        );
     }
 
     // Now call exit after we have printed all the relevant info

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
     - [Pattern matching](./basics/pattern-matching.md)
     - [Loops](./basics/loops.md)
     - [Functions](./basics/functions.md)
+    - [Directives](./basics/directives.md)
     - [Prelude & Built-in functionality](./basics/prelude.md)
     - [Modules](./basics/modules.md)
 - [Standard library](./standard-library/intro.md)

--- a/docs/src/basics/directives.md
+++ b/docs/src/basics/directives.md
@@ -1,0 +1,71 @@
+# Directives
+
+## Overview
+
+`Hash` has the ability to specify directives onto general expressions. Directives 
+are essentially built-in compiler functionality. Directives are similar to annotations 
+in Python decorators and Java annotations. They serve the purpose of providing a 
+facet for meta-programming. Currently, directives are primarily being used when 
+debugging or experimenting with compile-time evaluation and are not yet intended for full 
+usage until the language has matured enough beyond a first (or a few) syntactic 
+revisions.
+
+## General syntax and notes
+
+Directives are attached labels to expression that follow the syntax `#<identifier>`. 
+This means that directives can be placed onto any expression whether it is a block
+or a simple expression. 
+
+The general syntax for directives is:
+
+```
+#<identifier> <expr>
+```
+
+This also means that multiple directives can be specified onto a single expression like so:
+
+```
+#directive_0 #directive_1 expr()
+```
+This means that the syntax tree for the directive is then:
+```
+body
+└─expr
+  └─directive "directive_0"
+    └─directive "directive_1"
+      └─function_call
+        └─subject
+          └─variable
+            └─named "expr"
+```
+
+
+## Example
+
+An Example of a directive in use is the `#dump` directive.
+
+```rust
+let fib = #dump (n: u32) -> u32 => 
+   if n == 1 || n == 2 {
+       n
+   } else {
+       fib(n - 1) + fib(n - 2)
+   };
+}
+```
+
+The `dump` directive is used to dump the generated instructions that the compiler produces for 
+the `fib` function at compile time. This is useful when debugging code generation. However, 
+this is only a very brief example of what directives can be used when using them for 
+meta-programming.
+
+
+
+
+## Other notes 🚧
+
+- In the future, directives will be able to be defined by the user using a specific format. 
+See discussion [here](https://github.com/hash-org/lang/discussions/149#discussioncomment-2603749).
+
+- Many directives such as `#dump` and `#memoise` are built in compile time functions that 
+may invoke specific behaviour within the compiler when being invoked.

--- a/docs/src/basics/functions.md
+++ b/docs/src/basics/functions.md
@@ -1,8 +1,40 @@
 # Functions
 
+## Overview
+
 `Hash` places a lot of emphasis on functions, which are first class citizens.
 Functions can be assigned to variables in the same way that any other value is stored, similar to languages like Python, JavaScript, etc.
-In fact, the way to define a function is to assign it to a variable.
+
+## General syntax and notes
+
+Functions are defined by being assigned to variables as literals:
+
+```rust
+let var = (...args) => { ...body... };
+
+// With a return type
+let var = (...args) -> return_ty => { ...body... };
+```
+
+Function arguments are comma separated:
+
+```rust
+let var = (arg0, arg1) => { ...body... };
+
+// and you can optionally specify types:
+let var = (arg0: str, arg1: char) -> u32 => { ...body... };
+```
+
+Function literal definitions can also leave annotations to
+the variable definition:
+
+```rust
+let var: (str, char) -> u32 = (arg0, arg1) => { ...body... };
+```
+
+## Examples
+
+Define a function is to assign it to a variable:
 
 ```rust
 let fib = (n: u32) => 
@@ -11,6 +43,7 @@ let fib = (n: u32) =>
    } else {
        fib(n - 1) + fib(n - 2)
    };
+}
 
 print(fib) // <function at ____>
 print(fib(3)) // 3
@@ -25,5 +58,5 @@ let str_eq = (a: str, b: str) => a == b;
 The type of a function can be specified in a similar way:
 
 ```rust
-let str_eq: (str, str) => str = (a, b) => a == b;
+let str_eq: (str, str) -> str = (a, b) => a == b;
 ```

--- a/docs/src/basics/generics-polymorphism.md
+++ b/docs/src/basics/generics-polymorphism.md
@@ -13,7 +13,7 @@ The following code defines a function trait `merge` which, for some type `T`, ta
 Generic type names are denoted by single capital letters.
 
 ```rust
-trait merge = <T> => (T, T) => T;
+trait merge = <T> => (T, T) -> T;
 ```
 
 Angular brackets (`<`, `>`) define a *type argument list*, containing one or more generic type names.

--- a/docs/src/basics/operators.md
+++ b/docs/src/basics/operators.md
@@ -10,13 +10,11 @@ a specific group of operations or are used to convey meaning within the language
 
 | Operator             | Example              | Description                   | Overloadable trait |
 |----------------------|----------------------|-------------------------------|--------------------|
-| `->`                 | N/A                  | `Reserved`                    | N/A                |
-| `=>`                 | `(a) => a + 2`       | Function notation             | N/A                |
 | `==`, `!=`           | `a == 2`, `b != 'a'` | Equality                      | `eq`               |
 | `=`                  | `a = 2`              | Assignment                    | N/A                |
 | `!`                  | `!a`                 | Logical not                   | `not`              |
 | `&&`                 | `a && b`            | Logical and                   | `and`              |
-| <code>&#124;&#124;</code>               | <code>a  &#124;&#124; b</code>           | Logical or                    | `or`               |
+| <code>&#124;&#124;</code>               | <code>a  &#124;&#124; b</code>           | Logical or    | `or`               |
 | `+`                  | `2 + 2`, `3 + b`     | Addition                      | `add`              |
 | `-`                  | `3 - a`        | Subtraction | `sub`       |
 | `-`                  | `-2`        | Negation | `neg`       |
@@ -43,7 +41,7 @@ a specific group of operations or are used to convey meaning within the language
 | `&=`                 | `a &= b`             | Bitwise and with assignment   | `andb`             |
 | <code>&#124;=</code>                | <code>b  &#124;= SOME_CONST</code>   | Bitwise or with assignment    | `orb`              |
 | `^=`                 | `a ^= 1`             | Bitwise xor with assignment   | `xorb`             |
-| `.`  	| `a.foo`, `item.id` 	| Struct/Tuple enum property accessor 	| N/A 	|
+| `.`  	| `a.foo`   	| Struct/Tuple enum property accessor 	| N/A 	|
 | `:`  	| `{2: 'a'}`         	| Map key-value separator             	| N/A 	|
 | `::` 	| `io::open()`       	| Namespace symbol access             	| N/A 	|
 | `as` 	| `t as str`         	| Type assertion                      	| N/A 	|
@@ -51,6 +49,8 @@ a specific group of operations or are used to convey meaning within the language
 | `...` 	| N/A                	| Spread operator (Not-implemented)   	| `range`? 	|
 | `;` 	| `expression;`              	| statement terminator   	| N/A 	|
 | `?` 	| `let k<T> where s<T, ?> = ...`              	| Type argument wildcard   	| N/A 	|
+| `->`                 | `(str) -> usize`     | Function return type notation | N/A                |
+| `=>`                 | `(a) => a + 2`       | Function Body definition      | N/A                |
 
 ## Comments 🚧
 

--- a/docs/src/basics/primitive-types.md
+++ b/docs/src/basics/primitive-types.md
@@ -58,7 +58,7 @@ let some_list: [u64] = [];
 Tuples have a familiar syntax with many other languages, but exhibit two distinct
 differences between the common syntax. These differences are:
 
-- Empty tuples: `(,)`
+- Empty tuples: `(,)` or `()`
 - Singleton tuple : `(A,)`
 - Many membered tuple: `(A, B, C)` or `(A, B, C,)` 
 
@@ -66,6 +66,7 @@ To explicitly declare a variable is of a `tuple` type, you do so:
 
 ```rs
 let empty_tuple: (,) = (,);
+let empty_tuple: () = ();
 //               ^^^
 //               type
 

--- a/docs/src/basics/types-assertions.md
+++ b/docs/src/basics/types-assertions.md
@@ -5,7 +5,7 @@
 As in many other languages, the programmer can specify the type of a variable or
 a literal by using some special syntax. For example, in languages such as typescript,
 you can say that: 
-```ts 
+```rust
 some_value as str
 ```
 which implies that you are asserting that `some_value` is a string, this is essentially a way to avoid explicitly stating that type of a variable every
@@ -43,12 +43,15 @@ For example, if you were to specify the expression:
 The compiler will report this error as:
 
 ```
-error[0052]: Failed to typecheck: Mismatching types
---> 1:1 - 1:3
-  |
-1 | "2" as char
-  | ^^^  Cannot match type 'char' with 'str'.
-  |
+error[0001]: Types mismatch, got a `str`, but wanted a `char`.
+ --> <interactive>:1:8
+1 |   "A" as char
+  |          ^^^^ This specifies that the expression should be of type `char`
+
+ --> <interactive>:1:1
+1 |   "A" as char
+  |   ^^^ Found this to be of type `str`
+
 ```
 
 ## Usefulness

--- a/tests/parser/tests/cases/should_pass/function_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/function_defns/case.hash
@@ -2,10 +2,10 @@ let fk = () => {
     print(x)
 };
 
-let ft = (k: T): u64 => {
+let ft = (k: T) -> u64 => {
     do_something(k)
 };
 
-let ft: (T) => u64 = (k) => {
+let ft: (T) -> u64 = (k) => {
     do_something(t)
 };

--- a/tests/parser/tests/cases/should_pass/function_literals/case.hash
+++ b/tests/parser/tests/cases/should_pass/function_literals/case.hash
@@ -1,1 +1,4 @@
-let str_eq: (str, str) => str = (a, b) => a == b;
+let str_eq: (str, str) -> str = (a, b) => a == b;
+let str_eq: (str, str) -> str = (a, b) -> str => a == b;
+
+let str_eq = (a, b) -> str => a == b;

--- a/tests/parser/tests/cases/should_pass/simple_import/file.hash
+++ b/tests/parser/tests/cases/should_pass/simple_import/file.hash
@@ -1,4 +1,4 @@
 // Export this simple adding function
-let l = (a: u32, b: u32): u32 => {
+let l = (a: u32, b: u32) -> u32 => {
     a + b
 };

--- a/tests/parser/tests/cases/should_pass/traits_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/traits_defns/case.hash
@@ -1,2 +1,2 @@
-trait merge = <T> => (T, T) => T;
-trait merge = <T> where add<T>, or<T> => (T, T) => T;
+trait merge = <T> => (T, T) -> T;
+trait merge = <T> where add<T>, or<T> => (T, T) -> T;


### PR DESCRIPTION
This patch updates the documentation book and updates the CI to include a new bug report template

- Add basic documentation on directives
- Update some snippets in the documentation to reflect syntax changes.
- adds an issue template for creating a bug report.
- updates the compiler panic URL to default to using the "bug report" template.