### PR TITLE
report: fix issue with operator locations being under reported.

### DIFF
--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -583,6 +583,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         rhs: AstNode<'c, Expression<'c>>,
         op: AstNode<'c, Operator>,
     ) -> AstNode<'c, Expression<'c>> {
+        let operator_location = op.location();
         let Operator { kind, assignable } = op.body();
 
         if kind.is_compound() {
@@ -591,7 +592,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             // 'Ord' enum variants. This also happens for operators such as '>=' which
             // essentially means that we have to check if the result of 'ord()' is either
             // 'Eq' or 'Gt'.
-            self.transform_compound_ord_fn(*kind, *assignable, lhs, rhs)
+            self.transform_compound_ord_fn(*kind, *assignable, lhs, rhs, operator_location)
         } else if kind.is_lazy() {
             // some functions have to exhibit a short-circuiting behaviour, namely
             // the logical 'and' and 'or' operators. To do this, we expect the 'and'
@@ -662,6 +663,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         assigning: bool,
         lhs: AstNode<'c, Expression<'c>>,
         rhs: AstNode<'c, Expression<'c>>,
+        operator_location: Location,
     ) -> AstNode<'c, Expression<'c>> {
         let location = lhs.location().join(rhs.location());
 
@@ -670,7 +672,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
         let fn_call = self.node(Expression::new(ExpressionKind::FunctionCall(
             FunctionCallExpr {
-                subject: self.make_ident("ord", &location),
+                subject: self.make_ident("ord", &operator_location),
                 args: self.node(FunctionCallArgs {
                     entries: ast_nodes![&self.wall; lhs, rhs],
                 }),
@@ -706,13 +708,13 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             OperatorKind::Lt => {
                 ast_nodes![&self.wall; self.node(MatchCase {
                     pattern: self.make_enum_pattern_from_str("Lt", location),
-                    expr: self.make_variable(self.make_boolean(false)),
+                    expr: self.make_variable(self.make_boolean(true)),
                 })]
             }
             OperatorKind::Gt => {
                 ast_nodes![&self.wall; self.node(MatchCase {
                     pattern: self.make_enum_pattern_from_str("Gt", location),
-                    expr: self.make_variable(self.make_boolean(false)),
+                    expr: self.make_variable(self.make_boolean(true)),
                 })]
             }
             _ => unreachable!(),

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -384,6 +384,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
     ) -> Result<Self::FunctionCallExprRet, Self::Error> {
         let given_args = self.visit_function_call_args(ctx, node.args.ast_ref())?;
         let return_ty = self.create_unknown_type();
+
         let args_ty_location = self.source_location(node.body().args.location());
         let expected_fn_ty = self.create_type(
             TypeValue::Fn(FnType {
@@ -396,7 +397,10 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         let given_ty = match node.subject.kind() {
             ast::ExpressionKind::Variable(var) => {
                 match self
-                    .resolve_compound_symbol(&var.name.path, self.source_location(node.location()))?
+                    .resolve_compound_symbol(
+                        &var.name.path,
+                        self.source_location(node.subject.location()),
+                    )?
                     .1
                 {
                     SymbolType::Trait(trait_id) => self.visit_trait_variable(


### PR DESCRIPTION
This patch fixes an issue with operator locations such as '<'
not being properly recorded due to the function `transform_compound_ord_fn`
not taking the operator location into consideration. This patch makes
the function take in the operator kind and location.

Additionally, in `hash-typecheck`, the reporting for the symbol
resolution was referencing the whole `VariableExpr` location
instead of just the location of the subject of the expression.

fixes #159