### PR TITLE
Compiler modes: Re-integrate modes with `hash-pipeline`

### DIFF
--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -1,0 +1,33 @@
+//! Hash Compiler pipeline implementation. This file contains various structures and
+//! utilities representing settings and configurations that can be applied to the
+//! Compiler pipeline.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors
+
+/// Various settings that are present on the compiler pipeline when initially launching.
+#[derive(Debug, Clone, Copy)]
+pub struct CompilerSettings {
+    pub mode: CompilerMode,
+}
+
+/// Enum representing what mode the compiler should run in. Specifically, if the
+/// compiler should only run up to a particular stage within the pipeline.
+#[derive(Debug, Clone, Copy)]
+pub enum CompilerMode {
+    AstGen,
+    Full,
+}
+
+impl CompilerSettings {
+    pub fn new(mode: CompilerMode) -> Self {
+        Self { mode }
+    }
+}
+
+impl Default for CompilerSettings {
+    fn default() -> Self {
+        Self {
+            mode: CompilerMode::Full,
+        }
+    }
+}

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -4,7 +4,7 @@
 //! All rights reserved 2022 (c) The Hash Language authors
 use hash_ast::ast;
 use hash_source::{InteractiveId, ModuleId, SourceId, SourceMap};
-use slotmap::SlotMap;
+use slotmap::{basic::Iter, SlotMap};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -155,6 +155,12 @@ impl<'c> Sources<'c> {
 
     pub fn get_module_by_path(&self, path: &Path) -> Option<&Module<'c>> {
         Some(self.get_module(self.get_module_id_by_path(path)?))
+    }
+
+    /// Function to iterate over the modules that are currently
+    /// present within the sources.
+    pub fn iter_modules(&self) -> Iter<'_, ModuleId, Module<'c>> {
+        self.modules.iter()
     }
 
     pub fn get_source(&self, source_id: SourceId) -> SourceRef<'_, 'c> {

--- a/compiler/hash-typecheck/src/types.rs
+++ b/compiler/hash-typecheck/src/types.rs
@@ -1,5 +1,4 @@
 //! All rights reserved 2022 (c) The Hash Language authors
-#![allow(dead_code)] // @@Temporary until enums are implemented.
 
 use crate::{
     scope::ScopeStack,

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -62,7 +62,7 @@ struct CompilerOptions {
 #[derive(ClapParser)]
 enum SubCmd {
     AstGen(AstGen),
-    IrGen(IrGen), 
+    IrGen(IrGen),
 }
 
 /// Generate AST from given input file
@@ -179,7 +179,7 @@ fn main() {
                 // @@Organisation: This should be moved out of this file into a potential 'modes' structure
                 //                 so that we can differentiate between different modes and have a sane
                 //                 structure when performing these kind of operations. We could also
-                //                 look into using some kind of 'hook' system that u can register into the
+                //                 look into using some kind of 'hook' system that you can register into the
                 //                 pipeline when this runs instead of performing this operation here.
 
                 // If the mode is ast-gen, and the `--debug` flag is specified, then we should


### PR DESCRIPTION
This patch expands the `hash-pipeline` to have modes that are
derived from the provided command-line arguments. By doing this,
the compiler now supports `ast-gen` mode again which will only
run the pipeline up to the typechecking stage.

With `ast-gen` mode, this also means that when the compiler runs
with the `--debug` flag, it will print the generated AST for
each module source that has been parsed.