### PR TITLE
Reporting: More accurate error locations for unresolved symbols

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -236,7 +236,23 @@ pub struct Name {
 #[derive(Debug, PartialEq)]
 pub struct AccessName<'c> {
     /// The list of names that make up the access name.
-    pub path: Row<'c, Identifier>,
+    pub path: AstNodes<'c, Identifier>,
+}
+
+impl AccessName<'_> {
+    pub fn path(&self) -> Vec<Identifier> {
+        self.path
+            .iter()
+            .map(|part| *part.body())
+            .collect::<Vec<_>>()
+    }
+
+    pub fn path_with_locations(&self) -> Vec<(Identifier, Location)> {
+        self.path
+            .iter()
+            .map(|part| (*part.body(), part.location()))
+            .collect::<Vec<_>>()
+    }
 }
 
 /// A concrete/"named" type.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -70,7 +70,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::leaf(
             node.path
                 .iter()
-                .map(|p| IDENTIFIER_MAP.get_ident(*p))
+                .map(|p| IDENTIFIER_MAP.get_ident(*p.body()))
                 .intersperse("::")
                 .collect::<String>(),
         ))

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -251,7 +251,10 @@ impl TypecheckError {
                 builder.with_error_code(HashErrorCode::UnresolvedSymbol);
 
                 let ident_path = symbol.get_ident();
+                println!("{:?}", ident_path);
+
                 let formatted_symbol = IDENTIFIER_MAP.get_path(ident_path.into_iter());
+                println!("{formatted_symbol}");
 
                 if let Some(location) = symbol.location() {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -103,9 +103,18 @@ pub enum TypecheckError {
     UsingContinueOutsideLoop(SourceLocation),
     UsingReturnOutsideFunction(SourceLocation),
     RequiresIrrefutablePattern(SourceLocation),
-    UnresolvedSymbol(Symbol),
-    TryingToNamespaceType(Symbol),
-    TryingToNamespaceVariable(Symbol),
+    UnresolvedSymbol {
+        symbol: Symbol,
+        ancestor: Option<Symbol>,
+    },
+    TryingToNamespaceType {
+        symbol: Symbol,
+        ancestor: Option<Symbol>,
+    },
+    TryingToNamespaceVariable {
+        symbol: Symbol,
+        ancestor: Option<Symbol>,
+    },
     SymbolIsNotAType(Symbol),
     SymbolIsNotAVariable(Symbol),
     SymbolIsNotATrait(Symbol),
@@ -247,41 +256,69 @@ impl TypecheckError {
                         "Destructuring patterns in `let` statements must use an irrefutable.",
                     )));
             }
-            TypecheckError::UnresolvedSymbol(symbol) => {
+            TypecheckError::UnresolvedSymbol { symbol, ancestor } => {
                 builder.with_error_code(HashErrorCode::UnresolvedSymbol);
 
                 let ident_path = symbol.get_ident();
-                println!("{:?}", ident_path);
+                let symbol_name = IDENTIFIER_MAP.get_path(ident_path.into_iter());
 
-                let formatted_symbol = IDENTIFIER_MAP.get_path(ident_path.into_iter());
-                println!("{formatted_symbol}");
+                if let Some(ancestor_symbol) = ancestor {
+                    let ancestor_name =
+                        IDENTIFIER_MAP.get_path(ancestor_symbol.get_ident().into_iter());
 
-                if let Some(location) = symbol.location() {
-                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        location,
-                        "not found in this scope",
-                    )));
+                    if let Some(location) = symbol.location() {
+                        builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                            location,
+                            format!("not found in `{}`", ancestor_name),
+                        )));
+                    }
+
+                    // At-least we can print the symbol that wasn't found...
+                    builder.with_message(format!(
+                        "Symbol `{}` is not defined in `{}`",
+                        symbol_name, ancestor_name
+                    ));
+                } else {
+                    if let Some(location) = symbol.location() {
+                        builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                            location,
+                            "not found in this scope",
+                        )));
+                    }
+
+                    // At-least we can print the symbol that wasn't found...
+                    builder.with_message(format!(
+                        "Symbol `{}` is not defined in the current scope.",
+                        symbol_name
+                    ));
                 }
-
-                // At-least we can print the symbol that wasn't found...
-                builder.with_message(format!(
-                    "Symbol `{}` is not defined in the current scope.",
-                    formatted_symbol
-                ));
             }
-            TypecheckError::TryingToNamespaceType(symbol) => {
+            TypecheckError::TryingToNamespaceType { symbol, ancestor } => {
                 builder.with_error_code(HashErrorCode::TryingToNamespaceType);
 
                 let symbol_name = IDENTIFIER_MAP.get_path(symbol.get_ident().into_iter());
 
                 if let Some(location) = symbol.location() {
-                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        location,
-                        format!(
-                            "This symbol `{}` is defined as a type in the current scope.",
-                            symbol_name
-                        ),
-                    )));
+                    if let Some(ancestor_symbol) = ancestor {
+                        let ancestor_name =
+                            IDENTIFIER_MAP.get_path(ancestor_symbol.get_ident().into_iter());
+
+                        builder.add_element(ReportElement::Note(ReportNote::new(
+                            ReportNoteKind::Note,
+                            format!(
+                                "Symbol `{}` is defined as a type in `{}`.",
+                                symbol_name, ancestor_name
+                            ),
+                        )));
+                    } else {
+                        builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                            location,
+                            format!(
+                                "Symbol `{}` is defined as a type in the current scope.",
+                                symbol_name
+                            ),
+                        )));
+                    }
                 }
 
                 builder.add_element(ReportElement::Note(ReportNote::new(
@@ -289,7 +326,7 @@ impl TypecheckError {
                     "You cannot namespace a symbol that's a type.",
                 )));
             }
-            TypecheckError::TryingToNamespaceVariable(symbol) => {
+            TypecheckError::TryingToNamespaceVariable { symbol, ancestor } => {
                 builder.with_error_code(HashErrorCode::TryingToNamespaceVariable);
 
                 let symbol_name = IDENTIFIER_MAP.get_path(symbol.get_ident().into_iter());
@@ -301,10 +338,23 @@ impl TypecheckError {
                     )));
                 }
 
-                builder.add_element(ReportElement::Note(ReportNote::new(
-                    ReportNoteKind::Note,
-                    format!("`{}` is a variable. You cannot namespace a variable defined in the current scope.", symbol_name),
-                )));
+                if let Some(ancestor_symbol) = ancestor {
+                    let ancestor_name =
+                        IDENTIFIER_MAP.get_path(ancestor_symbol.get_ident().into_iter());
+
+                    builder.add_element(ReportElement::Note(ReportNote::new(
+                        ReportNoteKind::Note,
+                        format!(
+                            "`{}` is a variable. You cannot namespace a variable defined in `{}`.",
+                            symbol_name, ancestor_name
+                        ),
+                    )));
+                } else {
+                    builder.add_element(ReportElement::Note(ReportNote::new(
+                        ReportNoteKind::Note,
+                        format!("`{}` is a variable. You cannot namespace a variable defined in the current scope.", symbol_name),
+                    )));
+                }
             }
             TypecheckError::SymbolIsNotAType(symbol) => {
                 builder.with_error_code(HashErrorCode::SymbolIsNotAType);

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -659,10 +659,13 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                     Ok(self.create_type(TypeValue::Var(var), ty_location))
                 }
                 Some((_, TypeVarMode::Substitution(other_id))) => Ok(other_id),
-                None => Err(TypecheckError::UnresolvedSymbol(Symbol::Single {
-                    symbol: var.name,
-                    location: ty_location,
-                })),
+                None => Err(TypecheckError::UnresolvedSymbol {
+                    symbol: Symbol::Single {
+                        symbol: var.name,
+                        location: ty_location,
+                    },
+                    ancestor: None,
+                }),
             }
         }
     }
@@ -1681,10 +1684,13 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                             }
                         },
                         None => {
-                            return Err(TypecheckError::UnresolvedSymbol(Symbol::Single {
-                                symbol: field.name.ident,
-                                location: Some(location),
-                            }))
+                            return Err(TypecheckError::UnresolvedSymbol {
+                                symbol: Symbol::Single {
+                                    symbol: field.name.ident,
+                                    location: Some(location),
+                                },
+                                ancestor: None,
+                            })
                         }
                     }
                 }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -30,7 +30,7 @@ use crate::{state::TypecheckState, types::EnumVariant};
 use core::panic;
 use hash_alloc::row;
 use hash_alloc::{collections::row::Row, Wall};
-use hash_ast::ast::{self, BindingPattern};
+use hash_ast::ast::{self, AccessName, BindingPattern};
 use hash_ast::ident::{Identifier, IDENTIFIER_MAP};
 use hash_ast::visitor::AstVisitor;
 use hash_ast::{visitor, visitor::walk};
@@ -239,14 +239,13 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
 
     fn resolve_compound_symbol(
         &mut self,
-        symbols: &[Identifier],
-        location: SourceLocation,
+        symbols: &AccessName<'_>,
     ) -> TypecheckResult<(Identifier, SymbolType)> {
         resolve_compound_symbol(
             &self.source_storage.scopes,
             &self.global_storage.types,
             symbols,
-            location,
+            self.source_id,
         )
     }
 }
@@ -328,7 +327,8 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::VariableExpr<'c>>,
     ) -> Result<Self::VariableExprRet, Self::Error> {
         let loc = self.source_location(node.location());
-        match self.resolve_compound_symbol(&node.name.path, loc)? {
+
+        match self.resolve_compound_symbol(&node.name)? {
             (_, SymbolType::Variable(var_ty_id)) => {
                 if !node.type_args.is_empty() {
                     Err(TypecheckError::TypeArgumentLengthMismatch {
@@ -347,7 +347,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 .query_type_of_enum_variant(ty_def_id, ident, loc)
                 .map(|(id, _)| id),
             _ => Err(TypecheckError::SymbolIsNotAVariable(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(loc),
             })),
         }
@@ -395,23 +395,15 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         );
 
         let given_ty = match node.subject.kind() {
-            ast::ExpressionKind::Variable(var) => {
-                match self
-                    .resolve_compound_symbol(
-                        &var.name.path,
-                        self.source_location(node.subject.location()),
-                    )?
-                    .1
-                {
-                    SymbolType::Trait(trait_id) => self.visit_trait_variable(
-                        ctx,
-                        trait_id,
-                        node.with_body(var),
-                        Some(expected_fn_ty),
-                    )?,
-                    _ => walk::walk_function_call_expr(self, ctx, node)?.subject,
-                }
-            }
+            ast::ExpressionKind::Variable(var) => match self.resolve_compound_symbol(&var.name)? {
+                (_, SymbolType::Trait(trait_id)) => self.visit_trait_variable(
+                    ctx,
+                    trait_id,
+                    node.with_body(var),
+                    Some(expected_fn_ty),
+                )?,
+                _ => walk::walk_function_call_expr(self, ctx, node)?.subject,
+            },
             _ => walk::walk_function_call_expr(self, ctx, node)?.subject,
         };
 
@@ -589,7 +581,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
     ) -> Result<Self::NamedTypeRet, Self::Error> {
         let location = self.source_location(node.location());
 
-        match self.resolve_compound_symbol(&node.name.path, location)? {
+        match self.resolve_compound_symbol(&node.name)? {
             (_, SymbolType::Type(ty_id)) => Ok(self.types_mut().duplicate(ty_id, Some(location))),
             (_, SymbolType::TypeDef(def_id)) => {
                 let walk::NamedType { type_args, .. } = walk::walk_named_type(self, ctx, node)?;
@@ -620,7 +612,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 }
             }
             _ => Err(TypecheckError::SymbolIsNotAType(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(location),
             })),
         }
@@ -827,8 +819,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
     ) -> Result<Self::StructLiteralRet, Self::Error> {
         let location = self.source_location(node.location());
 
-        let symbol_res = self
-            .resolve_compound_symbol(&node.name.path, self.source_location(node.name.location()))?;
+        let symbol_res = self.resolve_compound_symbol(&node.name)?;
 
         match symbol_res {
             (_, SymbolType::TypeDef(def_id)) => {
@@ -879,7 +870,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 }
             }
             _ => Err(TypecheckError::SymbolIsNotAType(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(location),
             })),
         }
@@ -1467,7 +1458,8 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::TraitBound<'c>>,
     ) -> Result<Self::TraitBoundRet, Self::Error> {
         let name_loc = self.source_location(node.name.location());
-        match self.resolve_compound_symbol(&node.name.path, name_loc)? {
+
+        match self.resolve_compound_symbol(&node.name)? {
             (_, SymbolType::Trait(trait_id)) => {
                 let type_args: Vec<_> = node
                     .type_args
@@ -1477,7 +1469,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 Ok((trait_id, type_args))
             }
             _ => Err(TypecheckError::SymbolIsNotATrait(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(name_loc),
             })),
         }
@@ -1520,7 +1512,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             })
         };
 
-        match self.resolve_compound_symbol(&node.name.path, location)? {
+        match self.resolve_compound_symbol(&node.name)? {
             (ident, SymbolType::EnumVariant(ty_def_id)) => {
                 let (variant_id, variant_location) =
                     self.query_type_of_enum_variant(ty_def_id, ident, location)?;
@@ -1565,7 +1557,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 }
             }
             _ => Err(TypecheckError::SymbolIsNotAEnum(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(location),
             })),
         }
@@ -1579,8 +1571,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
     ) -> Result<Self::StructPatternRet, Self::Error> {
         let location = self.source_location(node.location());
 
-        let symbol_res = self
-            .resolve_compound_symbol(&node.name.path, self.source_location(node.name.location()))?;
+        let symbol_res = self.resolve_compound_symbol(&node.name)?;
 
         match symbol_res {
             (_, SymbolType::TypeDef(def_id)) => {
@@ -1633,7 +1624,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                 }
             }
             _ => Err(TypecheckError::SymbolIsNotAType(Symbol::Compound {
-                path: node.name.path.to_owned(),
+                path: node.name.path(),
                 location: Some(location),
             })),
         }
@@ -1832,8 +1823,10 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
 
         // we need to resolve the symbol in the current scope and firstly check if it's
         // an enum...
-        match self.resolve_compound_symbol(&[node.0.ident], location) {
-            Ok((ident, SymbolType::EnumVariant(ty_def_id))) => {
+        let ident = node.0.ident;
+
+        match self.scopes().resolve_symbol(ident) {
+            Some(SymbolType::EnumVariant(ty_def_id)) => {
                 let (variant_id, variant_location) =
                     self.query_type_of_enum_variant(ty_def_id, ident, location)?;
 
@@ -2142,7 +2135,7 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
         let trt_name_location = self.some_source_location(node.name.location());
         let trt_symbol = || Symbol::Compound {
             location: trt_name_location,
-            path: node.name.path.to_owned(),
+            path: node.name.path(),
         };
         let type_args_location = node.type_args.location().map(|l| self.source_location(l));
         let MatchTraitImplResult {


### PR DESCRIPTION
This patch adds source location data to components of an `AccessName`. This means that when symbols are being resolved in the typechecking stage, more accurate errors can be provided when certain variables are not in the file scope, or in the scope of a namespace.

fixes #160