### PR TITLE
Parser: Boolean literals

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -423,6 +423,10 @@ pub struct IntLiteral(pub u64);
 #[derive(Debug, PartialEq)]
 pub struct FloatLiteral(pub f64);
 
+/// A boolean literal.
+#[derive(Debug, PartialEq)]
+pub struct BoolLiteral(pub bool);
+
 /// A literal.
 #[derive(Debug, PartialEq)]
 pub enum Literal<'c> {
@@ -430,6 +434,7 @@ pub enum Literal<'c> {
     Char(CharLiteral),
     Int(IntLiteral),
     Float(FloatLiteral),
+    Bool(BoolLiteral),
     Set(SetLiteral<'c>),
     Map(MapLiteral<'c>),
     List(ListLiteral<'c>),

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -118,6 +118,7 @@ impl NodeCount for Literal<'_> {
             Literal::Char(CharLiteral(_)) => 0,
             Literal::Int(IntLiteral(_)) => 0,
             Literal::Float(FloatLiteral(_)) => 0,
+            Literal::Bool(BoolLiteral(_)) => 0,
             Literal::Set(l) => l.elements.iter().map(|e| e.node_count()).sum(),
             Literal::Map(l) => l
                 .elements

--- a/compiler/hash-ast/src/keyword.rs
+++ b/compiler/hash-ast/src/keyword.rs
@@ -25,6 +25,8 @@ pub enum Keyword {
     Return,
     Import,
     Raw,
+    False,
+    True,
 }
 
 /// Enum Variants for keywords

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -434,6 +434,15 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::leaf(labelled("float", node.0, "")))
     }
 
+    type BoolLiteralRet = TreeNode;
+    fn visit_bool_literal(
+        &mut self,
+        _: &Self::Ctx,
+        node: ast::AstNodeRef<ast::BoolLiteral>,
+    ) -> Result<Self::BoolLiteralRet, Self::Error> {
+        Ok(TreeNode::leaf(labelled("bool", node.0, "")))
+    }
+
     type IntLiteralRet = TreeNode;
     fn visit_int_literal(
         &mut self,

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -257,6 +257,13 @@ pub trait AstVisitor<'c>: Sized {
         node: ast::AstNodeRef<ast::FloatLiteral>,
     ) -> Result<Self::FloatLiteralRet, Self::Error>;
 
+    type BoolLiteralRet: 'c;
+    fn visit_bool_literal(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::BoolLiteral>,
+    ) -> Result<Self::BoolLiteralRet, Self::Error>;
+
     type IntLiteralRet: 'c;
     fn visit_int_literal(
         &mut self,
@@ -910,6 +917,7 @@ pub mod walk {
         Char(V::CharLiteralRet),
         Int(V::IntLiteralRet),
         Float(V::FloatLiteralRet),
+        Bool(V::BoolLiteralRet),
         Set(V::SetLiteralRet),
         Map(V::MapLiteralRet),
         List(V::ListLiteralRet),
@@ -935,6 +943,9 @@ pub mod walk {
             }
             ast::Literal::Float(r) => {
                 Literal::Float(visitor.visit_float_literal(ctx, node.with_body(r))?)
+            }
+            ast::Literal::Bool(r) => {
+                Literal::Bool(visitor.visit_bool_literal(ctx, node.with_body(r))?)
             }
             ast::Literal::Set(r) => {
                 Literal::Set(visitor.visit_set_literal(ctx, node.with_body(r))?)
@@ -969,6 +980,7 @@ pub mod walk {
             CharLiteralRet = Ret,
             IntLiteralRet = Ret,
             FloatLiteralRet = Ret,
+            BoolLiteralRet = Ret,
             SetLiteralRet = Ret,
             MapLiteralRet = Ret,
             ListLiteralRet = Ret,
@@ -982,6 +994,7 @@ pub mod walk {
             Literal::Char(r) => r,
             Literal::Int(r) => r,
             Literal::Float(r) => r,
+            Literal::Bool(r) => r,
             Literal::Set(r) => r,
             Literal::Map(r) => r,
             Literal::List(r) => r,

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -3732,6 +3732,8 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 TokenKind::FloatLiteral(num) => Literal::Float(FloatLiteral(num)),
                 TokenKind::CharLiteral(ch) => Literal::Char(CharLiteral(ch)),
                 TokenKind::StrLiteral(str) => Literal::Str(StrLiteral(str)),
+                TokenKind::Keyword(Keyword::False) => Literal::Bool(BoolLiteral(false)),
+                TokenKind::Keyword(Keyword::True) => Literal::Bool(BoolLiteral(true)),
                 _ => unreachable!(),
             },
             token.span,

--- a/compiler/hash-parser/src/lexer.rs
+++ b/compiler/hash-parser/src/lexer.rs
@@ -261,6 +261,8 @@ impl<'w, 'c, 'a> Lexer<'w, 'c, 'a> {
         let name = &self.contents[start..self.offset.get()];
 
         match name {
+            "true" => TokenKind::Keyword(Keyword::True),
+            "false" => TokenKind::Keyword(Keyword::False),
             "for" => TokenKind::Keyword(Keyword::For),
             "while" => TokenKind::Keyword(Keyword::While),
             "loop" => TokenKind::Keyword(Keyword::Loop),

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -125,7 +125,9 @@ impl TokenKind {
     pub(crate) fn is_literal(&self) -> bool {
         matches!(
             self,
-            TokenKind::IntLiteral(_)
+            TokenKind::Keyword(Keyword::False)
+                | TokenKind::Keyword(Keyword::True)
+                | TokenKind::IntLiteral(_)
                 | TokenKind::FloatLiteral(_)
                 | TokenKind::CharLiteral(_)
                 | TokenKind::StrLiteral(_)

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -31,7 +31,7 @@ use core::panic;
 use hash_alloc::row;
 use hash_alloc::{collections::row::Row, Wall};
 use hash_ast::ast::{self, AccessName, BindingPattern};
-use hash_ast::ident::{Identifier, IDENTIFIER_MAP};
+use hash_ast::ident::Identifier;
 use hash_ast::visitor::AstVisitor;
 use hash_ast::{visitor, visitor::walk};
 use hash_pipeline::sources::{SourceRef, Sources};
@@ -805,6 +805,17 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         let ty_location = self.source_location(node.location());
 
         Ok(self.create_type(TypeValue::Prim(PrimType::F32), Some(ty_location)))
+    }
+
+    type BoolLiteralRet = TypeId;
+    fn visit_bool_literal(
+        &mut self,
+        _ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::BoolLiteral>,
+    ) -> Result<Self::FloatLiteralRet, Self::Error> {
+        let ty_location = self.source_location(node.location());
+
+        Ok(self.create_type(TypeValue::Prim(PrimType::Bool), Some(ty_location)))
     }
 
     type IntLiteralRet = TypeId;
@@ -1820,11 +1831,6 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         node: ast::AstNodeRef<ast::BindingPattern<'c>>,
     ) -> Result<Self::BindingPatternRet, Self::Error> {
         let location = self.source_location(node.location());
-
-        // @@Hack: check if this is true or false. Eventually we want these to be enums.
-        if ["true", "false"].contains(&IDENTIFIER_MAP.get_ident(node.0.ident)) {
-            return Ok(self.create_type(TypeValue::Prim(PrimType::Bool), Some(location)));
-        }
 
         // we need to resolve the symbol in the current scope and firstly check if it's
         // an enum...


### PR DESCRIPTION
This patch makes boolean literals more distinct at the parsing level to avoid confusion at later stages.

Should be checked out after #170