### PR TITLE
Unsafe expressions

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -818,6 +818,10 @@ pub struct RefExpr<'c> {
 #[derive(Debug, PartialEq)]
 pub struct DerefExpr<'c>(pub AstNode<'c, Expression<'c>>);
 
+/// An unsafe expression.
+#[derive(Debug, PartialEq)]
+pub struct UnsafeExpr<'c>(pub AstNode<'c, Expression<'c>>);
+
 /// A literal.
 #[derive(Debug, PartialEq)]
 pub struct LiteralExpr<'c>(pub AstNode<'c, Literal<'c>>);
@@ -840,6 +844,7 @@ pub enum ExpressionKind<'c> {
     PropertyAccess(PropertyAccessExpr<'c>),
     Ref(RefExpr<'c>),
     Deref(DerefExpr<'c>),
+    Unsafe(UnsafeExpr<'c>),
     LiteralExpr(LiteralExpr<'c>),
     Typed(TypedExpr<'c>),
     Block(BlockExpr<'c>),

--- a/compiler/hash-ast/src/count.rs
+++ b/compiler/hash-ast/src/count.rs
@@ -100,6 +100,7 @@ impl NodeCount for Expression<'_> {
             ExpressionKind::Typed(e) => e.ty.node_count() + e.expr.node_count(),
             ExpressionKind::Block(BlockExpr(e)) => e.node_count(),
             ExpressionKind::Deref(DerefExpr(e)) => e.node_count(),
+            ExpressionKind::Unsafe(UnsafeExpr(e)) => e.node_count(),
             ExpressionKind::Ref(RefExpr {
                 inner_expr: e,
                 kind: _,

--- a/compiler/hash-ast/src/keyword.rs
+++ b/compiler/hash-ast/src/keyword.rs
@@ -27,6 +27,7 @@ pub enum Keyword {
     Raw,
     False,
     True,
+    Unsafe,
 }
 
 /// Enum Variants for keywords

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -192,6 +192,16 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("deref", vec![inner_expr]))
     }
 
+    type UnsafeExprRet = TreeNode;
+    fn visit_unsafe_expr(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::UnsafeExpr<'c>>,
+    ) -> Result<Self::DerefExprRet, Self::Error> {
+        let walk::UnsafeExpr(inner_expr) = walk::walk_unsafe_expr(self, ctx, node)?;
+        Ok(TreeNode::branch("unsafe", vec![inner_expr]))
+    }
+
     type LiteralExprRet = TreeNode;
     fn visit_literal_expr(
         &mut self,

--- a/compiler/hash-parser/src/gen.rs
+++ b/compiler/hash-parser/src/gen.rs
@@ -2476,9 +2476,9 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         ))
     }
 
-    /// Parses a unary operator followed by a singular expression. Once the unary operator
-    /// is picked up, the expression is transformed into a function call to the corresponding
-    /// trait that implements the unary operator operation.
+    /// Parses a unary operator or expression modifier followed by a singular expression.
+    /// Once the unary operator is picked up, the expression is parsed given the specific
+    /// rules of the operator or expression modifier.
     pub fn parse_unary_expression(&self) -> AstGenResult<'c, AstNode<'c, Expression<'c>>> {
         let token = self.current_token();
         let start = self.current_location();
@@ -2560,6 +2560,10 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                         span,
                     ),
                 })
+            }
+            TokenKind::Keyword(Keyword::Unsafe) => {
+                let arg = self.parse_expression()?;
+                ExpressionKind::Unsafe(UnsafeExpr(arg))
             }
             kind => panic!("Expected token to be a unary operator, but got '{}'", kind),
         };

--- a/compiler/hash-parser/src/lexer.rs
+++ b/compiler/hash-parser/src/lexer.rs
@@ -280,6 +280,7 @@ impl<'w, 'c, 'a> Lexer<'w, 'c, 'a> {
             "return" => TokenKind::Keyword(Keyword::Return),
             "import" => TokenKind::Keyword(Keyword::Import),
             "raw" => TokenKind::Keyword(Keyword::Raw),
+            "unsafe" => TokenKind::Keyword(Keyword::Unsafe),
             "_" => TokenKind::Ident(CORE_IDENTIFIERS.underscore),
             _ => {
                 // create the identifier here from the created map

--- a/compiler/hash-parser/src/token.rs
+++ b/compiler/hash-parser/src/token.rs
@@ -85,10 +85,11 @@ impl TokenKind {
                     | TokenKind::Minus
                     | TokenKind::Star
                     | TokenKind::Slash
-                    | TokenKind::Hash // intrinsics
+                    | TokenKind::Hash // directives
                     | TokenKind::Amp
                     | TokenKind::Tilde
                     | TokenKind::Exclamation
+                    | TokenKind::Keyword(Keyword::Unsafe)
         )
     }
 

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -500,6 +500,20 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(created_inner_ty)
     }
 
+    type UnsafeExprRet = TypeId;
+    fn visit_unsafe_expr(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::UnsafeExpr<'c>>,
+    ) -> Result<Self::DerefExprRet, Self::Error> {
+        let walk::UnsafeExpr(inner_ty) = walk::walk_unsafe_expr(self, ctx, node)?;
+
+        // @@Incomplete: For now this does nothing but serve as a modifier on expressions. Later
+        //               we will be able to define rules about what is and what isn't allowed in
+        //               safe/unsafe blocks.
+        Ok(inner_ty)
+    }
+
     type LiteralExprRet = TypeId;
     fn visit_literal_expr(
         &mut self,

--- a/tests/parser/tests/cases/should_pass/unsafe_blocks/case.hash
+++ b/tests/parser/tests/cases/should_pass/unsafe_blocks/case.hash
@@ -1,0 +1,6 @@
+a := unsafe { 2 };
+a := unsafe { unsafe { 2 } };
+
+a := unsafe match k {
+    _ => print("beep!");
+};


### PR DESCRIPTION
This patch adds support for specifying that some expressions are unsafe. This is required for the planned changes that are to occur in the core of the language.