### PR TITLE
Docs: Add initial grammar for types

### DIFF
--- a/docs/src/features/functions.md
+++ b/docs/src/features/functions.md
@@ -79,13 +79,13 @@ function_param =
   | ( ident ( ":" type )? "=" expr  ) // Assignment
   | ( ident ( ":" type )  ) // Declaration
 
-function_def = "(" function_param* ")" ( "->" type )? ("=>" expr)
-function_type = "(" function_param* ")" "->" type
+function_def = "(" ( function_param "," )* ")" ( "->" type )? ("=>" expr)
+function_type = "(" ( function_param "," )* ")" "->" type
 ```
 
 The grammar for function calls is as follows:
 
 ```
 function_call_arg = expr | ( ident "=" expr )
-function_call = expr "(" function_call_arg* ")"
+function_call = expr "(" ( function_call_arg "," )* ")"
 ```

--- a/docs/src/features/functions.md
+++ b/docs/src/features/functions.md
@@ -79,13 +79,13 @@ function_param =
   | ( ident ( ":" type )? "=" expr  ) // Assignment
   | ( ident ( ":" type )  ) // Declaration
 
-function_def = "(" ( function_param "," )* ")" ( "->" type )? ("=>" expr)
-function_type = "(" ( function_param "," )* ")" "->" type
+function_def = "(" ( function_param "," )* function_param? ")" ( "->" type )? ("=>" expr)
+function_type = "(" ( function_param "," )* function_param? ")" "->" type
 ```
 
 The grammar for function calls is as follows:
 
 ```
 function_call_arg = expr | ( ident "=" expr )
-function_call = expr "(" ( function_call_arg "," )* ")"
+function_call = expr "(" ( function_call_arg "," )* function_call_arg? ")"
 ```

--- a/docs/src/features/primitives.md
+++ b/docs/src/features/primitives.md
@@ -98,7 +98,6 @@ Grammar for tuples:
 
 ```
 tuple_literal = ( "(" ( expr "," )* ")" ) | ( "(" ( expr "," )* expr ")" )
-tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )* type ")" )
 ```
 
 ### Named tuples
@@ -158,7 +157,6 @@ The syntax for sets is as follows:
 
 ```
 set_literal = ( "{" "," "}" ) | ( "{" ( expr "," )+ "}" ) | ( "{" ( expr "," )* expr "}" )
-set_type = "{" type "}"
 ```
 
 ### Map
@@ -174,5 +172,6 @@ The syntax for maps is as follows:
 
 ```
 map_literal = ( "{" ":" "}" ) | ( "{" ( expr ":" expr "," )* ( expr ":" expr )? "}" )
-map_type = "{" type ":" type "}"
 ```
+
+**Note**: the grammar for literal types can be found in the [Types](./types.md) section.

--- a/docs/src/features/primitives.md
+++ b/docs/src/features/primitives.md
@@ -173,6 +173,6 @@ The syntax for maps is as follows:
 - Map type: `{K:V}`, for example `names: {str:str} = {"thom":"yorke", "jonny":"greenwood"}`.
 
 ```
-set_literal = ( "{" ":" "}" ) | ( "{" ( expr ":" expr "," )* ( expr ":" expr )? "}" )
-set_type = "{" type ":" type "}"
+map_literal = ( "{" ":" "}" ) | ( "{" ( expr ":" expr "," )* ( expr ":" expr )? "}" )
+map_type = "{" type ":" type "}"
 ```

--- a/docs/src/features/type-functions.md
+++ b/docs/src/features/type-functions.md
@@ -107,24 +107,4 @@ y := make_vec_with_alloc<str, _>(slab_allocator); // `Allocator = SlabAllocator`
 
 ## Grammar
 
-The grammar for type function definitions and type function types is as follows:
-
-```
-type_function_param =
-  | ( ident ":=" type )  // Declaration and assignment, infer type
-  | ( ident ( ":" type )? ( "=" type )?  ) // Declaration or assignment
-
-// The below is an expression:
-type_function_def = "<" type_function_param+ ">" ( "->" type )? "=>" expr
-
-// The below is a type:
-type_function_type = "<" type_function_param+ ">" "->" type
-```
-
-The grammar for type function calls is as follows:
-
-```
-// These should be supported both at the type level and the expression level
-type_function_call_arg = type | ( ident "=" type )
-type_function_call = ident "<" type_function_call_arg* ">"
-```
+The grammar for type function definitions and type function types can be found in the [Types](./types.md) section.

--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -27,13 +27,13 @@ grouped_type = "(" type ")"
 named_type = access_name
 
 type_function_call_arg = type | ( ident "=" type )
-type_function_call = ( grouped_type | named_type ) "<" ( type_function_call_arg "," )* ">"
+type_function_call = ( grouped_type | named_type ) "<" ( type_function_call_arg "," )* type_function_call_arg? ">"
 
 type_function_param =
   | ( ident ":=" type )  // Declaration and assignment, infer type
   | ( ident ( ":" type )? ( "=" type )?  ) // Declaration or assignment
 
-type_function = "<" ( type_function_param "," )+ ">" "->" type
+type_function = "<" ( type_function_param "," )* type_function_param? ">" "->" type
 
 merged_types = ( type "~" )+ type
 ```

--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -8,7 +8,10 @@ type =
   | list_type
   | set_type
   | map_type
-  | named_type_or_type_function
+  | grouped_type
+  | named_type
+  | type_function_call
+  | type_function
   | merged_types
 
 tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )* type ")" )
@@ -19,8 +22,18 @@ map_type = "{" type ":" type "}"
 
 set_type = "{" type "}"
 
+grouped_type = "(" type ")"
+
+named_type = access_name
+
 type_function_call_arg = type | ( ident "=" type )
-named_type_or_type_function = ident ( "<" type_function_call_arg+ ">" )?
+type_function_call = ( grouped_type | named_type ) "<" ( type_function_call_arg "," )* ">"
+
+type_function_param =
+  | ( ident ":=" type )  // Declaration and assignment, infer type
+  | ( ident ( ":" type )? ( "=" type )?  ) // Declaration or assignment
+
+type_function = "<" ( type_function_param "," )+ ">" "->" type
 
 merged_types = ( type "~" )+ type
 ```

--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -1,0 +1,26 @@
+# Types
+
+## Grammar
+
+```
+type =
+  | tuple_type
+  | list_type
+  | set_type
+  | map_type
+  | named_type_or_type_function
+  | merged_types
+
+tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )* type ")" )
+
+list_type = "[" type "]"
+
+map_type = "{" type ":" type "}"
+
+set_type = "{" type "}"
+
+type_function_call_arg = type | ( ident "=" type )
+named_type_or_type_function = ident ( "<" type_function_call_arg+ ">" )?
+
+merged_types = ( type "~" )+ type
+```


### PR DESCRIPTION
This is the first in a couple of PRs that add documentation about general type-related things in Hash.