### PR TITLE
Docs: Remove unnecessary ":=" variant in type function arguments

### DIFF
--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -34,9 +34,7 @@ function_type = "(" ( function_type_param "," )* function_type_param? ")" "->" t
 type_function_call_arg = type | ( ident "=" type )
 type_function_call = ( grouped_type | named_type ) "<" ( type_function_call_arg "," )* type_function_call_arg? ">"
 
-type_function_param =
-  | ( ident ":=" type )  // Declaration and assignment, infer type
-  | ( ident ( ":" type )? ( "=" type )?  ) // Declaration or assignment
+type_function_param = ident ( ":" type )? ( "=" type )?
 
 type_function = "<" ( type_function_param "," )* type_function_param? ">" "->" type
 

--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -15,7 +15,7 @@ type =
   | type_function
   | merged_types
 
-tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )* type ")" )
+tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )+ type ")" )
 
 list_type = "[" type "]"
 


### PR DESCRIPTION
It is not clear how to infer the type of a type, because it can be any
level of refinement.
For example, if `T` implements `Copy` and `Eq`, the following are true:
```
T: T
T: Copy
T: Eq
T: Copy ~ Eq
T: Type
```

Given this, which bound should be inferred? The answer is that we
shouldn't try to infer a bound, and it should be `Type` by default
unless someone specifies otherwise (with an explicit `: MyBound`).