### PR TITLE
Parser: Refine type parsing

### DIFF
--- a/compiler/hash-alloc/src/collections/row.rs
+++ b/compiler/hash-alloc/src/collections/row.rs
@@ -37,7 +37,7 @@ const ROW_INITIAL_REALLOC_SIZE: usize = 4;
 const ROW_REALLOC_MULT_DIV: (usize, usize) = (2, 1);
 
 impl<'c, T> Row<'c, T> {
-    /// Create a new `Row` with zero length and capacity.
+    /// Create a new [`Row`] with zero length and capacity.
     pub fn new() -> Self {
         Self {
             data: &mut [],
@@ -181,7 +181,7 @@ impl<'c, T> Row<'c, T> {
         self.length += 1;
     }
 
-    /// Construct a `Row` from an iterator, allocating inside the given [`Wall`].
+    /// Construct a [Row] from an iterator, allocating inside the given [`Wall`].
     ///
     /// This uses `Iterator::size_hint` to predict how many elements are inside the iterator, and
     /// avoid extraneous reallocations.
@@ -199,6 +199,11 @@ impl<'c, T> Row<'c, T> {
         }
 
         row
+    }
+
+    /// Create a new [Row] from a [Vec<T>].
+    pub fn from_vec(vec: Vec<T>, wall: &Wall<'c>) -> Self {
+        Self::from_iter(vec.into_iter(), wall)
     }
 
     /// Construct a `Row` from an iterator of [`Result`]s, allocating inside the given [`Wall`].

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -315,6 +315,25 @@ pub struct TupleType<'c> {
     pub entries: AstNodes<'c, NamedFieldTypeEntry<'c>>,
 }
 
+/// The list type, , e.g. `{str}`.
+#[derive(Debug, PartialEq)]
+pub struct ListType<'c> {
+    pub inner: AstNode<'c, Type<'c>>,
+}
+
+/// The set type, , e.g. `{str}`.
+#[derive(Debug, PartialEq)]
+pub struct SetType<'c> {
+    pub key: AstNode<'c, Type<'c>>,
+}
+
+/// The map type, e.g. `{str: u32}`.
+#[derive(Debug, PartialEq)]
+pub struct MapType<'c> {
+    pub key: AstNode<'c, Type<'c>>,
+    pub value: AstNode<'c, Type<'c>>,
+}
+
 /// The function type.
 #[derive(Debug, PartialEq)]
 pub struct FnType<'c> {
@@ -326,6 +345,9 @@ pub struct FnType<'c> {
 #[derive(Debug, PartialEq)]
 pub enum Type<'c> {
     Tuple(TupleType<'c>),
+    List(ListType<'c>),
+    Set(SetType<'c>),
+    Map(MapType<'c>),
     Fn(FnType<'c>),
     Named(NamedType<'c>),
     Ref(RefType<'c>),

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -372,7 +372,6 @@ pub enum Type<'c> {
     Map(MapType<'c>),
     Fn(FnType<'c>),
     Named(NamedType<'c>),
-    Grouped(GroupedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),
     Merged(MergedType<'c>),

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -269,12 +269,6 @@ pub struct TypeVar<'c> {
     pub name: AstNode<'c, Name>,
 }
 
-/// Names for compound types that represent data structures or functions are
-/// translated into string form, and thus are represented by these names.
-pub const LIST_TYPE_NAME: &str = "List";
-pub const SET_TYPE_NAME: &str = "Set";
-pub const MAP_TYPE_NAME: &str = "Map";
-
 /// Reference kind representing either a raw reference or a normal reference.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RefKind {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -308,7 +308,9 @@ pub struct ListType<'c> {
 
 /// The set type, , e.g. `{str}`.
 #[derive(Debug, PartialEq)]
-pub struct SetType<'c>(pub AstNode<'c, Type<'c>>);
+pub struct SetType<'c> {
+    pub inner: AstNode<'c, Type<'c>>,
+}
 
 /// The grouped type (essentially a type within parenthesees), e.g. `(str)`. It
 /// differs from a tuple that it does not contain a trailing comma which signifies that

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -262,13 +262,6 @@ pub struct NamedType<'c> {
     pub name: AstNode<'c, AccessName<'c>>,
 }
 
-/// A type variable.
-#[derive(Debug, PartialEq)]
-pub struct TypeVar<'c> {
-    /// The name of the type variable.
-    pub name: AstNode<'c, Name>,
-}
-
 /// Reference kind representing either a raw reference or a normal reference.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RefKind {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -339,6 +339,11 @@ pub struct FnType<'c> {
     pub return_ty: AstNode<'c, Type<'c>>,
 }
 
+/// A merged type meaning that multiple types are considered to be
+/// specified in place of one, e.g. `Conv ~ Eq ~ Print`
+#[derive(Debug, PartialEq)]
+pub struct MergedType<'c>(pub AstNodes<'c, Type<'c>>);
+
 /// A type.
 #[derive(Debug, PartialEq)]
 pub enum Type<'c> {
@@ -350,6 +355,7 @@ pub enum Type<'c> {
     Named(NamedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),
+    Merged(MergedType<'c>),
 }
 
 /// A set literal, e.g. `{1, 2, 3}`.
@@ -618,7 +624,7 @@ pub struct TypeFunctionDefArg<'c> {
     pub name: AstNode<'c, Name>,
 
     /// The argument bounds.
-    pub bounds: AstNodes<'c, Type<'c>>,
+    pub ty: AstNode<'c, Type<'c>>,
 }
 
 /// A declaration, e.g. `x := 3;`.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -600,15 +600,6 @@ pub enum Pattern<'c> {
     Spread(SpreadPattern<'c>),
 }
 
-/// A trait bound, e.g. "where eq<T>"
-#[derive(Debug, PartialEq)]
-pub struct TraitBound<'c> {
-    /// The name of the trait.
-    pub name: AstNode<'c, AccessName<'c>>,
-    /// The type arguments of the trait.
-    pub type_args: AstNodes<'c, Type<'c>>,
-}
-
 /// A type function, e.g. `<T, U: Conv<U>> => ...`.
 ///
 /// Used in struct, enum, trait, and function definitions.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -260,8 +260,6 @@ impl AccessName<'_> {
 pub struct NamedType<'c> {
     /// The name of the type.
     pub name: AstNode<'c, AccessName<'c>>,
-    /// The type arguments of the type, if any.
-    pub type_args: AstNodes<'c, Type<'c>>,
 }
 
 /// A type variable.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -330,9 +330,6 @@ pub enum Type<'c> {
     Named(NamedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),
-    TypeVar(TypeVar<'c>),
-    Existential(ExistentialType),
-    Infer(InferType),
 }
 
 /// A set literal, e.g. `{1, 2, 3}`.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -321,9 +321,13 @@ pub struct ListType<'c> {
 
 /// The set type, , e.g. `{str}`.
 #[derive(Debug, PartialEq)]
-pub struct SetType<'c> {
-    pub key: AstNode<'c, Type<'c>>,
-}
+pub struct SetType<'c>(pub AstNode<'c, Type<'c>>);
+
+/// The grouped type (essentially a type within parenthesees), e.g. `(str)`. It
+/// differs from a tuple that it does not contain a trailing comma which signifies that
+/// this is a single element tuple.
+#[derive(Debug, PartialEq)]
+pub struct GroupedType<'c>(pub AstNode<'c, Type<'c>>);
 
 /// The map type, e.g. `{str: u32}`.
 #[derive(Debug, PartialEq)]
@@ -353,6 +357,7 @@ pub enum Type<'c> {
     Map(MapType<'c>),
     Fn(FnType<'c>),
     Named(NamedType<'c>),
+    Grouped(GroupedType<'c>),
     Ref(RefType<'c>),
     RawRef(RawRefType<'c>),
     Merged(MergedType<'c>),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -487,16 +487,6 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("type_function", children))
     }
 
-    type TypeVarRet = TreeNode;
-    fn visit_type_var(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypeVar<'c>>,
-    ) -> Result<Self::TypeVarRet, Self::Error> {
-        let walk::TypeVar { name } = walk::walk_type_var(self, ctx, node)?;
-        Ok(TreeNode::leaf(labelled("var", name.label, "\"")))
-    }
-
     type ExistentialTypeRet = TreeNode;
     fn visit_existential_type(
         &mut self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -334,7 +334,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::SetType<'c>>,
     ) -> Result<Self::TupleTypeRet, Self::Error> {
-        let walk::SetType { key } = walk::walk_set_type(self, ctx, node)?;
+        let walk::SetType { inner: key } = walk::walk_set_type(self, ctx, node)?;
 
         Ok(TreeNode::branch("set", vec![key]))
     }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -383,18 +383,8 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::NamedType<'c>>,
     ) -> Result<Self::NamedTypeRet, Self::Error> {
-        let walk::NamedType { name, type_args } = walk::walk_named_type(self, ctx, node)?;
-        let children = {
-            if type_args.is_empty() {
-                vec![]
-            } else {
-                vec![TreeNode::branch("type_args", type_args)]
-            }
-        };
-        Ok(TreeNode::branch(
-            labelled("named", name.label, "\""),
-            children,
-        ))
+        let walk::NamedType { name } = walk::walk_named_type(self, ctx, node)?;
+        Ok(TreeNode::leaf(labelled("named", name.label, "\"")))
     }
 
     type RefTypeRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -826,19 +826,6 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         walk::walk_pattern_same_children(self, ctx, node)
     }
 
-    type TraitBoundRet = TreeNode;
-    fn visit_trait_bound(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TraitBound<'c>>,
-    ) -> Result<Self::TraitBoundRet, Self::Error> {
-        let walk::TraitBound { name, type_args } = walk::walk_trait_bound(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            labelled("requires", name.label, "\""),
-            vec![TreeNode::branch("args", type_args)],
-        ))
-    }
-
     type TypeFunctionDefRet = TreeNode;
     fn visit_type_function_def(
         &mut self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -387,6 +387,16 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::leaf(labelled("named", name.label, "\"")))
     }
 
+    type GroupedTypeRet = TreeNode;
+    fn visit_grouped_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::GroupedType<'c>>,
+    ) -> Result<Self::GroupedTypeRet, Self::Error> {
+        let walk::GroupedType(inner) = walk::walk_grouped_type(self, ctx, node)?;
+        Ok(TreeNode::branch("grouped", vec![inner]))
+    }
+
     type RefTypeRet = TreeNode;
     fn visit_ref_type(
         &mut self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -407,6 +407,16 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("raw_ref", vec![inner]))
     }
 
+    type MergedTypeRet = TreeNode;
+    fn visit_merged_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::MergedType<'c>>,
+    ) -> Result<Self::RawRefTypeRet, Self::Error> {
+        let walk::MergedType(tys) = walk::walk_merged_type(self, ctx, node)?;
+        Ok(TreeNode::branch("merged", tys))
+    }
+
     type TypeVarRet = TreeNode;
     fn visit_type_var(
         &mut self,
@@ -846,13 +856,10 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionDefArg<'c>>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
-        let walk::TypeFunctionDefArg { name, bounds } =
+        let walk::TypeFunctionDefArg { name, ty } =
             walk::walk_type_function_def_arg(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            "arg",
-            vec![name, TreeNode::branch("bounds", bounds)],
-        ))
+        Ok(TreeNode::branch("arg", vec![name, ty]))
     }
 
     type ConstructorPatternRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -317,6 +317,45 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(TreeNode::branch("tuple", entries))
     }
 
+    type ListTypeRet = TreeNode;
+    fn visit_list_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::ListType<'c>>,
+    ) -> Result<Self::TupleTypeRet, Self::Error> {
+        let walk::ListType { inner } = walk::walk_list_type(self, ctx, node)?;
+
+        Ok(TreeNode::branch("list", vec![inner]))
+    }
+
+    type SetTypeRet = TreeNode;
+    fn visit_set_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::SetType<'c>>,
+    ) -> Result<Self::TupleTypeRet, Self::Error> {
+        let walk::SetType { key } = walk::walk_set_type(self, ctx, node)?;
+
+        Ok(TreeNode::branch("set", vec![key]))
+    }
+
+    type MapTypeRet = TreeNode;
+    fn visit_map_type(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::MapType<'c>>,
+    ) -> Result<Self::TupleTypeRet, Self::Error> {
+        let walk::MapType { key, value } = walk::walk_map_type(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            "map",
+            vec![
+                TreeNode::branch("key", vec![key]),
+                TreeNode::branch("key", vec![value]),
+            ],
+        ))
+    }
+
     type FnTypeRet = TreeNode;
     fn visit_function_type(
         &mut self,

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1411,9 +1411,6 @@ pub mod walk {
         Named(V::NamedTypeRet),
         Ref(V::RefTypeRet),
         RawRef(V::RawRefTypeRet),
-        TypeVar(V::TypeVarRet),
-        Existential(V::ExistentialTypeRet),
-        Infer(V::InferTypeRet),
     }
 
     pub fn walk_type<'c, V: AstVisitor<'c>>(
@@ -1429,11 +1426,6 @@ pub mod walk {
             ast::Type::RawRef(r) => {
                 Type::RawRef(visitor.visit_raw_ref_type(ctx, node.with_body(r))?)
             }
-            ast::Type::TypeVar(r) => Type::TypeVar(visitor.visit_type_var(ctx, node.with_body(r))?),
-            ast::Type::Existential(r) => {
-                Type::Existential(visitor.visit_existential_type(ctx, node.with_body(r))?)
-            }
-            ast::Type::Infer(r) => Type::Infer(visitor.visit_infer_type(ctx, node.with_body(r))?),
         })
     }
 
@@ -1450,9 +1442,6 @@ pub mod walk {
             NamedTypeRet = Ret,
             RefTypeRet = Ret,
             RawRefTypeRet = Ret,
-            TypeVarRet = Ret,
-            ExistentialTypeRet = Ret,
-            InferTypeRet = Ret,
         >,
     {
         Ok(match walk_type(visitor, ctx, node)? {
@@ -1461,9 +1450,6 @@ pub mod walk {
             Type::Named(r) => r,
             Type::Ref(r) => r,
             Type::RawRef(r) => r,
-            Type::TypeVar(r) => r,
-            Type::Existential(r) => r,
-            Type::Infer(r) => r,
         })
     }
 

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -236,13 +236,6 @@ pub trait AstVisitor<'c>: Sized {
         node: ast::AstNodeRef<ast::MergedType<'c>>,
     ) -> Result<Self::MergedTypeRet, Self::Error>;
 
-    type TypeVarRet: 'c;
-    fn visit_type_var(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypeVar<'c>>,
-    ) -> Result<Self::TypeVarRet, Self::Error>;
-
     type ExistentialTypeRet: 'c;
     fn visit_existential_type(
         &mut self,
@@ -1565,20 +1558,6 @@ pub mod walk {
                     .map(|a| visitor.visit_type_function_param(ctx, a.ast_ref())),
             )?,
             return_ty: visitor.visit_type(ctx, node.return_ty.ast_ref())?,
-        })
-    }
-
-    pub struct TypeVar<'c, V: AstVisitor<'c>> {
-        pub name: V::NameRet,
-    }
-
-    pub fn walk_type_var<'c, V: AstVisitor<'c>>(
-        visitor: &mut V,
-        ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::TypeVar<'c>>,
-    ) -> Result<TypeVar<'c, V>, V::Error> {
-        Ok(TypeVar {
-            name: visitor.visit_name(ctx, node.name.ast_ref())?,
         })
     }
 

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -439,13 +439,6 @@ pub trait AstVisitor<'c>: Sized {
         node: ast::AstNodeRef<ast::Pattern<'c>>,
     ) -> Result<Self::PatternRet, Self::Error>;
 
-    type TraitBoundRet: 'c;
-    fn visit_trait_bound(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TraitBound<'c>>,
-    ) -> Result<Self::TraitBoundRet, Self::Error>;
-
     type TypeFunctionDefRet: 'c;
     fn visit_type_function_def(
         &mut self,
@@ -2012,26 +2005,6 @@ pub mod walk {
                 node.entries
                     .iter()
                     .map(|b| visitor.visit_enum_def_entry(ctx, b.ast_ref())),
-            )?,
-        })
-    }
-
-    pub struct TraitBound<'c, V: AstVisitor<'c>> {
-        pub name: V::AccessNameRet,
-        pub type_args: V::CollectionContainer<V::TypeRet>,
-    }
-    pub fn walk_trait_bound<'c, V: AstVisitor<'c>>(
-        visitor: &mut V,
-        ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::TraitBound<'c>>,
-    ) -> Result<TraitBound<'c, V>, V::Error> {
-        Ok(TraitBound {
-            name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
-            type_args: V::try_collect_items(
-                ctx,
-                node.type_args
-                    .iter()
-                    .map(|t| visitor.visit_type(ctx, t.ast_ref())),
             )?,
         })
     }

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -208,13 +208,6 @@ pub trait AstVisitor<'c>: Sized {
         node: ast::AstNodeRef<ast::NamedType<'c>>,
     ) -> Result<Self::NamedTypeRet, Self::Error>;
 
-    type GroupedTypeRet: 'c;
-    fn visit_grouped_type(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::GroupedType<'c>>,
-    ) -> Result<Self::GroupedTypeRet, Self::Error>;
-
     type RefTypeRet: 'c;
     fn visit_ref_type(
         &mut self,
@@ -1450,16 +1443,6 @@ pub mod walk {
         })
     }
 
-    pub struct GroupedType<'c, V: AstVisitor<'c>>(pub V::TypeRet);
-
-    pub fn walk_grouped_type<'c, V: AstVisitor<'c>>(
-        visitor: &mut V,
-        ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::GroupedType<'c>>,
-    ) -> Result<GroupedType<'c, V>, V::Error> {
-        Ok(GroupedType(visitor.visit_type(ctx, node.0.ast_ref())?))
-    }
-
     pub struct RefType<'c, V: AstVisitor<'c>>(pub V::TypeRet);
 
     pub fn walk_ref_type<'c, V: AstVisitor<'c>>(
@@ -1568,7 +1551,6 @@ pub mod walk {
         Set(V::SetTypeRet),
         Map(V::MapTypeRet),
         Named(V::NamedTypeRet),
-        Grouped(V::GroupedTypeRet),
         Ref(V::RefTypeRet),
         RawRef(V::RawRefTypeRet),
         Merged(V::MergedTypeRet),
@@ -1588,9 +1570,6 @@ pub mod walk {
             ast::Type::Set(r) => Type::Set(visitor.visit_set_type(ctx, node.with_body(r))?),
             ast::Type::Map(r) => Type::Map(visitor.visit_map_type(ctx, node.with_body(r))?),
             ast::Type::Named(r) => Type::Named(visitor.visit_named_type(ctx, node.with_body(r))?),
-            ast::Type::Grouped(r) => {
-                Type::Grouped(visitor.visit_grouped_type(ctx, node.with_body(r))?)
-            }
             ast::Type::Ref(r) => Type::Ref(visitor.visit_ref_type(ctx, node.with_body(r))?),
             ast::Type::RawRef(r) => {
                 Type::RawRef(visitor.visit_raw_ref_type(ctx, node.with_body(r))?)
@@ -1621,7 +1600,6 @@ pub mod walk {
             SetTypeRet = Ret,
             MapTypeRet = Ret,
             NamedTypeRet = Ret,
-            GroupedTypeRet = Ret,
             RefTypeRet = Ret,
             RawRefTypeRet = Ret,
             MergedTypeRet = Ret,
@@ -1636,7 +1614,6 @@ pub mod walk {
             Type::Set(r) => r,
             Type::Map(r) => r,
             Type::Named(r) => r,
-            Type::Grouped(r) => r,
             Type::Ref(r) => r,
             Type::RawRef(r) => r,
             Type::Merged(r) => r,

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1417,7 +1417,6 @@ pub mod walk {
 
     pub struct NamedType<'c, V: AstVisitor<'c>> {
         pub name: V::AccessNameRet,
-        pub type_args: V::CollectionContainer<V::TypeRet>,
     }
 
     pub fn walk_named_type<'c, V: AstVisitor<'c>>(
@@ -1427,12 +1426,6 @@ pub mod walk {
     ) -> Result<NamedType<'c, V>, V::Error> {
         Ok(NamedType {
             name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
-            type_args: V::try_collect_items(
-                ctx,
-                node.type_args
-                    .iter()
-                    .map(|e| visitor.visit_type(ctx, e.ast_ref())),
-            )?,
         })
     }
 

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1407,7 +1407,7 @@ pub mod walk {
     }
 
     pub struct SetType<'c, V: AstVisitor<'c>> {
-        pub key: V::TypeRet,
+        pub inner: V::TypeRet,
     }
 
     pub fn walk_set_type<'c, V: AstVisitor<'c>>(
@@ -1416,7 +1416,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::SetType<'c>>,
     ) -> Result<SetType<'c, V>, V::Error> {
         Ok(SetType {
-            key: visitor.visit_type(ctx, node.0.ast_ref())?,
+            inner: visitor.visit_type(ctx, node.inner.ast_ref())?,
         })
     }
 

--- a/compiler/hash-parser/src/parser/block.rs
+++ b/compiler/hash-parser/src/parser/block.rs
@@ -90,7 +90,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         // now we parse the singular pattern that begins at the for-loop
         let pattern = self.parse_singular_pattern()?;
 
-        self.parse_token_atom(TokenKind::Keyword(Keyword::In))?;
+        self.parse_token(TokenKind::Keyword(Keyword::In))?;
 
         let iterator = self.parse_expression_with_precedence(0)?;
 
@@ -269,7 +269,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 while gen.has_token() {
                     cases.nodes.push(gen.parse_match_case()?, &self.wall);
 
-                    gen.parse_token_atom(TokenKind::Semi)?;
+                    gen.parse_token(TokenKind::Semi)?;
                 }
             }
             Some(token) => {

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -196,31 +196,13 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         // Now it's followed by a colon
         self.parse_token_atom(TokenKind::Colon)?;
 
-        // Parse any bounds present
-        let mut bounds = AstNodes::empty();
-
-        loop {
-            match self.peek_resultant_fn(|| self.parse_type()) {
-                Some(ty) => {
-                    bounds.nodes.push(ty, &self.wall);
-
-                    match self.peek() {
-                        Some(token) if token.has_kind(TokenKind::Tilde) => {
-                            self.skip_token();
-                        }
-                        _ => break,
-                    }
-                }
-                None => self.error_with_location(
-                    AstGenErrorKind::ExpectedType,
-                    None,
-                    None,
-                    self.next_location(),
-                )?,
-            }
-        }
-
-        Ok(self.node_with_joined_span(TypeFunctionDefArg { name, bounds }, &start))
+        Ok(self.node_with_joined_span(
+            TypeFunctionDefArg {
+                name,
+                ty: self.parse_type()?,
+            },
+            &start,
+        ))
     }
 
     /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with `trait` that contains

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -30,7 +30,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
                 gen.parse_separated_fn(
                     || gen.parse_struct_def_entry(),
-                    || gen.parse_token_atom(TokenKind::Comma),
+                    || gen.parse_token(TokenKind::Comma),
                 )?
             }
             token => self.error_with_location(
@@ -87,7 +87,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
                 gen.parse_separated_fn(
                     || gen.parse_enum_def_entry(),
-                    || gen.parse_token_atom(TokenKind::Comma),
+                    || gen.parse_token(TokenKind::Comma),
                 )?
             }
             token => self.error_with_location(
@@ -123,7 +123,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 args.nodes.push(ty, &self.wall);
 
                 if gen.has_token() {
-                    gen.parse_token_atom(TokenKind::Comma)?;
+                    gen.parse_token(TokenKind::Comma)?;
                 }
             }
         }
@@ -194,7 +194,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         let name = self.parse_name()?;
 
         // Now it's followed by a colon
-        self.parse_token_atom(TokenKind::Colon)?;
+        self.parse_token(TokenKind::Colon)?;
 
         Ok(self.node_with_joined_span(
             TypeFunctionDefArg {

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -88,7 +88,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         // Depending on whether it's expected of the expression to have a semi-colon, we
         // try and parse one anyway, if so
         let has_semi = if semi_required {
-            self.parse_token_atom(TokenKind::Semi)?;
+            self.parse_token(TokenKind::Semi)?;
             true
         } else {
             self.parse_token_fast(TokenKind::Semi).is_some()
@@ -736,7 +736,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         &self,
         pattern: AstNode<'c, Pattern<'c>>,
     ) -> AstGenResult<'c, Declaration<'c>> {
-        self.parse_token_atom(TokenKind::Colon)?;
+        self.parse_token(TokenKind::Colon)?;
 
         // Attempt to parse an optional type...
         let ty = match self.peek() {
@@ -1344,7 +1344,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         &self,
     ) -> AstGenResult<'c, AstNode<'c, FunctionDefArg<'c>>> {
         let name = self.parse_name()?;
-        let start = name.location();
+        let name_span = name.location();
 
         let ty = match self.peek() {
             Some(token) if token.has_kind(TokenKind::Colon) => {
@@ -1362,7 +1362,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             _ => None,
         };
 
-        Ok(self.node_with_joined_span(FunctionDefArg { name, ty, default }, &start))
+        Ok(self.node_with_joined_span(FunctionDefArg { name, ty, default }, &name_span))
     }
 
     /// Parse a function literal. Function literals are essentially definitions of lambdas
@@ -1376,7 +1376,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         // parse function definition arguments.
         let args = gen.parse_separated_fn(
             || gen.parse_function_def_arg(),
-            || gen.parse_token_atom(TokenKind::Comma),
+            || gen.parse_token(TokenKind::Comma),
         )?;
 
         // check if there is a return type

--- a/compiler/hash-parser/src/parser/literal.rs
+++ b/compiler/hash-parser/src/parser/literal.rs
@@ -39,7 +39,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         let start = self.current_location();
 
         let key = self.parse_expression_with_precedence(0)?;
-        self.parse_token_atom(TokenKind::Colon)?;
+        self.parse_token(TokenKind::Colon)?;
         let value = self.parse_expression_with_precedence(0)?;
 
         Ok(self.node_with_joined_span(MapLiteralEntry { key, value }, &start))
@@ -55,7 +55,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         let start = gen.current_location();
         let mut elements = gen.parse_separated_fn(
             || gen.parse_map_entry(),
-            || gen.parse_token_atom(TokenKind::Comma),
+            || gen.parse_token(TokenKind::Comma),
         )?;
 
         elements.nodes.insert(0, initial_entry, &self.wall);
@@ -74,7 +74,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
         let mut elements = gen.parse_separated_fn(
             || gen.parse_expression_with_precedence(0),
-            || gen.parse_token_atom(TokenKind::Comma),
+            || gen.parse_token(TokenKind::Comma),
         )?;
 
         // insert the first item into elements
@@ -116,7 +116,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     _ => None,
                 };
 
-                self.parse_token_atom(TokenKind::Eq)?;
+                self.parse_token(TokenKind::Eq)?;
 
                 // Now we try and parse an expression that allows re-assignment operators...
                 Some(self.node_with_joined_span(

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -198,10 +198,19 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         value
     }
 
-    /// Get the current token in the stream.
+    /// Get the current [Token] in the stream. Panics if the current offset has passed the
+    /// size of the stream, e.g tring to get the current token after reaching the end of the
+    /// stream.
     pub(crate) fn current_token(&self) -> &Token {
         let offset = if self.offset.get() > 0 { self.offset.get() - 1 } else { 0 };
 
+        self.stream.get(offset).unwrap()
+    }
+
+    /// Get a [Token] at a specified location in the stream. Panics if the given
+    /// stream  position is out of bounds.
+    #[inline(always)]
+    pub(crate) fn token_at(&self, offset: usize) -> &Token {
         self.stream.get(offset).unwrap()
     }
 

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -441,7 +441,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
     /// Function to parse a token atom optionally. If the appropriate token atom is
     /// present we advance the token count, if not then just return None
-    pub(crate) fn parse_token_atom_fast(&self, atom: TokenKind) -> Option<()> {
+    pub(crate) fn parse_token_fast(&self, atom: TokenKind) -> Option<()> {
         match self.peek() {
             Some(token) if token.has_kind(atom) => {
                 self.skip_token();

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -109,11 +109,11 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
     pub(crate) fn parse_arrow(&self) -> AstGenResult<'c, ()> {
         // Essentially, we want to re-map the error into a more concise one given
         // the parsing context.
-        if self.parse_token_atom_fast(TokenKind::Eq).is_none() {
+        if self.parse_token_fast(TokenKind::Eq).is_none() {
             return self.error(AstGenErrorKind::ExpectedArrow, None, None)?;
         }
 
-        if self.parse_token_atom_fast(TokenKind::Gt).is_none() {
+        if self.parse_token_fast(TokenKind::Gt).is_none() {
             return self.error(AstGenErrorKind::ExpectedArrow, None, None)?;
         }
 
@@ -124,11 +124,11 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
     pub(crate) fn parse_thin_arrow(&self) -> AstGenResult<'c, ()> {
         // Essentially, we want to re-map the error into a more concise one given
         // the parsing context.
-        if self.parse_token_atom_fast(TokenKind::Minus).is_none() {
+        if self.parse_token_fast(TokenKind::Minus).is_none() {
             return self.error(AstGenErrorKind::ExpectedFnArrow, None, None)?;
         }
 
-        if self.parse_token_atom_fast(TokenKind::Gt).is_none() {
+        if self.parse_token_fast(TokenKind::Gt).is_none() {
             return self.error(AstGenErrorKind::ExpectedFnArrow, None, None)?;
         }
 

--- a/compiler/hash-parser/src/parser/pattern.rs
+++ b/compiler/hash-parser/src/parser/pattern.rs
@@ -104,7 +104,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                         disable_flag!(gen; spread_patterns_allowed;
                             let fields = gen.parse_separated_fn(
                                 || gen.parse_tuple_pattern_entry(),
-                                || gen.parse_token_atom(TokenKind::Comma),
+                                || gen.parse_token(TokenKind::Comma),
                             )?
                         );
 
@@ -181,7 +181,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
     pub fn parse_pattern_collection(&self) -> AstGenResult<'c, AstNodes<'c, Pattern<'c>>> {
         self.parse_separated_fn(
             || self.parse_pattern(),
-            || self.parse_token_atom(TokenKind::Comma),
+            || self.parse_token(TokenKind::Comma),
         )
     }
 
@@ -198,7 +198,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         // if the next token is the correct assigning operator, attempt to parse a
         // pattern here, if not then we copy the parsed ident and make a binding
         // pattern.
-        let pattern = match self.peek_resultant_fn(|| self.parse_token_atom(TokenKind::Eq)) {
+        let pattern = match self.peek_resultant_fn(|| self.parse_token(TokenKind::Eq)) {
             Some(_) => self.parse_pattern()?,
             None => {
                 let span = name.location();
@@ -228,7 +228,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             }
 
             if gen.has_token() {
-                gen.parse_token_atom(TokenKind::Comma)?;
+                gen.parse_token(TokenKind::Comma)?;
             }
         }
 
@@ -294,7 +294,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             //            mean that this is still a singular pattern or if it is now treated as a tuple pattern?
             let mut elements = gen.parse_separated_fn(
                 || gen.parse_tuple_pattern_entry(),
-                || gen.parse_token_atom(TokenKind::Comma),
+                || gen.parse_token(TokenKind::Comma),
             )?
         );
 
@@ -363,7 +363,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
     ///
     pub(crate) fn parse_spread_pattern(&self) -> AstGenResult<'c, SpreadPattern<'c>> {
         for _ in 0..3 {
-            self.parse_token_atom(TokenKind::Dot)?;
+            self.parse_token(TokenKind::Dot)?;
         }
 
         // Try and see if there is a identifier that is followed by the spread to try and

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -4,11 +4,7 @@
 //! All rights reserved 2022 (c) The Hash Language authors
 
 use hash_alloc::row;
-use hash_ast::{
-    ast::*,
-    ast_nodes,
-    ident::{Identifier, IDENTIFIER_MAP},
-};
+use hash_ast::{ast::*, ident::Identifier};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
 
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
@@ -49,13 +45,12 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             TokenKind::Ident(id) => {
                 self.skip_token();
 
-                let (name, args) =
+                let (name, _args) =
                     self.parse_name_with_type_args(self.node_with_span(*id, start))?;
 
-                Type::Named(NamedType {
-                    name,
-                    type_args: args.unwrap_or_else(AstNodes::empty),
-                })
+                // @@TODO: return a type function call here... if it has arguments
+
+                Type::Named(NamedType { name })
             }
 
             // Map or set type
@@ -95,13 +90,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 let inner_type = gen.parse_type()?;
                 gen.verify_is_empty()?;
 
-                // @@Incomplete: inline type names into ident map...
-                let name = IDENTIFIER_MAP.create_ident(LIST_TYPE_NAME);
-
-                Type::Named(NamedType {
-                    name: self.make_access_name_from_identifier(name, token.span),
-                    type_args: ast_nodes![&self.wall; inner_type],
-                })
+                Type::List(ListType { inner: inner_type })
             }
 
             // Tuple or function type

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -281,7 +281,8 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
 
                 // Here we check that the token tree has a comma at the end to later determine if
                 // this is a `GroupedType` or a `TupleType`...
-                gen_has_comma = gen.current_token().has_kind(TokenKind::Comma);
+                gen_has_comma = !gen.stream.is_empty()
+                    && gen.token_at(gen.offset() - 1).has_kind(TokenKind::Comma);
             }
             Some(token) => self.error(
                 AstGenErrorKind::Expected,

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -98,7 +98,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                             value: value_ty,
                         })
                     }
-                    None => Type::Set(SetType(key_ty)),
+                    None => Type::Set(SetType { inner: key_ty }),
                     Some(_) => gen.expected_eof()?,
                 }
             }

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -65,34 +65,23 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 let tree = self.token_trees.get(*tree_index).unwrap();
                 let gen = self.from_stream(tree, token.span);
 
-                let lhs_type = gen.parse_type()?;
+                let key_ty = gen.parse_type()?;
 
                 match gen.peek() {
                     // This must be a map
                     Some(token) if token.has_kind(TokenKind::Colon) => {
                         gen.skip_token();
 
-                        let rhs_type = gen.parse_type()?;
+                        let value_ty = gen.parse_type()?;
                         gen.verify_is_empty()?;
 
-                        // @@Incomplete: inline type names into ident map...
-                        let name = IDENTIFIER_MAP.create_ident(MAP_TYPE_NAME);
-
-                        Type::Named(NamedType {
-                            name: self.make_access_name_from_identifier(name, token.span),
-                            type_args: ast_nodes![&self.wall; lhs_type, rhs_type],
+                        Type::Map(MapType {
+                            key: key_ty,
+                            value: value_ty,
                         })
                     }
+                    None => Type::Set(SetType { key: key_ty }),
                     Some(_) => gen.expected_eof()?,
-                    None => {
-                        // @@Incomplete: inline type names into ident map...
-                        let name = IDENTIFIER_MAP.create_ident(SET_TYPE_NAME);
-
-                        Type::Named(NamedType {
-                            name: self.make_access_name_from_identifier(name, token.span),
-                            type_args: ast_nodes![&self.wall; lhs_type],
-                        })
-                    }
                 }
             }
 

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -36,9 +36,11 @@ impl Location {
     /// lhs span is returned.
     ///
     /// In essence, if this was the source stream:
-    /// > --------------------------------------------------------------
-    /// >  ( <- lhs-start    lhs-end -> )   ( <- rhs-start rhs-end -> )
-    /// > --------------------------------------------------------------
+    /// ```text
+    /// --------------------------------------------------------------
+    ///  ( <- lhs-start    lhs-end -> )   ( <- rhs-start rhs-end -> )
+    /// --------------------------------------------------------------
+    /// ```
     ///
     /// Then the two locations are joined into one, otherwise the lhs is returned
     #[must_use]

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1271,29 +1271,29 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         walk::walk_pattern_same_children(self, ctx, node)
     }
 
-    type TraitBoundRet = (TraitId, Vec<TypeId>);
-    fn visit_trait_bound(
-        &mut self,
-        ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TraitBound<'c>>,
-    ) -> Result<Self::TraitBoundRet, Self::Error> {
-        let name_loc = self.source_location(node.name.location());
+    // type TraitBoundRet = (TraitId, Vec<TypeId>);
+    // fn visit_trait_bound(
+    //     &mut self,
+    //     ctx: &Self::Ctx,
+    //     node: ast::AstNodeRef<ast::TraitBound<'c>>,
+    // ) -> Result<Self::TraitBoundRet, Self::Error> {
+    // let name_loc = self.source_location(node.name.location());
 
-        match self.resolve_compound_symbol(&node.name)? {
-            (_, SymbolType::Trait(trait_id)) => {
-                let type_args: Vec<_> = node
-                    .type_args
-                    .iter()
-                    .map(|arg| self.visit_type(ctx, arg.ast_ref()))
-                    .collect::<Result<_, _>>()?;
-                Ok((trait_id, type_args))
-            }
-            _ => Err(TypecheckError::SymbolIsNotATrait(Symbol::Compound {
-                path: node.name.path(),
-                location: Some(name_loc),
-            })),
-        }
-    }
+    // match self.resolve_compound_symbol(&node.name)? {
+    //     (_, SymbolType::Trait(trait_id)) => {
+    //         let type_args: Vec<_> = node
+    //             .type_args
+    //             .iter()
+    //             .map(|arg| self.visit_type(ctx, arg.ast_ref()))
+    //             .collect::<Result<_, _>>()?;
+    //         Ok((trait_id, type_args))
+    //     }
+    //     _ => Err(TypecheckError::SymbolIsNotATrait(Symbol::Compound {
+    //         path: node.name.path(),
+    //         location: Some(name_loc),
+    //     })),
+    // }
+    // }
 
     type TypeFunctionDefRet = TypeId;
     fn visit_type_function_def(

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -669,6 +669,15 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         }
     }
 
+    type GroupedTypeRet = TypeId;
+    fn visit_grouped_type(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::GroupedType<'c>>,
+    ) -> Result<Self::GroupedTypeRet, Self::Error> {
+        todo!()
+    }
+
     type RefTypeRet = TypeId;
     fn visit_ref_type(
         &mut self,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1,7 +1,7 @@
 //! All rights reserved 2022 (c) The Hash Language authors
 use crate::types::{
     CoreTypeDefs, EnumDef, FnType, NamespaceType, PrimType, RawRefType, RefType, StructDef,
-    TupleType, TypeDefStorage, TypeId, TypeStorage, TypeValue, TypeVarMode, TypeVars,
+    TupleType, TypeDefStorage, TypeId, TypeStorage, TypeValue, TypeVars,
 };
 use crate::types::{TypeDefId, TypeVar, UserType};
 use crate::unify::{Substitution, Unifier, UnifyStrategy};
@@ -737,34 +737,34 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         todo!()
     }
 
-    type TypeVarRet = TypeId;
-    fn visit_type_var(
-        &mut self,
-        _ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypeVar<'c>>,
-    ) -> Result<Self::TypeVarRet, Self::Error> {
-        let ty_location = self.some_source_location(node.location());
-        let var = TypeVar {
-            name: node.name.ident,
-        };
-        if self.tc_state().in_bound_def {
-            Ok(self.create_type(TypeValue::Var(var), ty_location))
-        } else {
-            match self.source_storage.type_vars.find_type_var(var) {
-                Some((_, TypeVarMode::Bound)) => {
-                    Ok(self.create_type(TypeValue::Var(var), ty_location))
-                }
-                Some((_, TypeVarMode::Substitution(other_id))) => Ok(other_id),
-                None => Err(TypecheckError::UnresolvedSymbol {
-                    symbol: Symbol::Single {
-                        symbol: var.name,
-                        location: ty_location,
-                    },
-                    ancestor: None,
-                }),
-            }
-        }
-    }
+    // type TypeVarRet = TypeId;
+    // fn visit_type_var(
+    //     &mut self,
+    //     _ctx: &Self::Ctx,
+    //     node: ast::AstNodeRef<ast::TypeVar<'c>>,
+    // ) -> Result<Self::TypeVarRet, Self::Error> {
+    //     let ty_location = self.some_source_location(node.location());
+    //     let var = TypeVar {
+    //         name: node.name.ident,
+    //     };
+    //     if self.tc_state().in_bound_def {
+    //         Ok(self.create_type(TypeValue::Var(var), ty_location))
+    //     } else {
+    //         match self.source_storage.type_vars.find_type_var(var) {
+    //             Some((_, TypeVarMode::Bound)) => {
+    //                 Ok(self.create_type(TypeValue::Var(var), ty_location))
+    //             }
+    //             Some((_, TypeVarMode::Substitution(other_id))) => Ok(other_id),
+    //             None => Err(TypecheckError::UnresolvedSymbol {
+    //                 symbol: Symbol::Single {
+    //                     symbol: var.name,
+    //                     location: ty_location,
+    //                 },
+    //                 ancestor: None,
+    //             }),
+    //         }
+    //     }
+    // }
 
     type ExistentialTypeRet = TypeId;
     fn visit_existential_type(

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -633,33 +633,34 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
 
         match self.resolve_compound_symbol(&node.name)? {
             (_, SymbolType::Type(ty_id)) => Ok(self.types_mut().duplicate(ty_id, Some(location))),
-            (_, SymbolType::TypeDef(def_id)) => {
-                let walk::NamedType { type_args, .. } = walk::walk_named_type(self, ctx, node)?;
-                let def = self.type_defs().get(def_id);
+            (_, SymbolType::TypeDef(_)) => {
+                let walk::NamedType { .. } = walk::walk_named_type(self, ctx, node)?;
+                // let def = self.type_defs().get(def_id);
 
-                // @@Todo bounds
-                match &def.kind {
-                    TypeDefValueKind::Enum(EnumDef { generics, .. })
-                    | TypeDefValueKind::Struct(StructDef { generics, .. }) => {
-                        let args_sub = self.unifier().instantiate_vars_list(&generics.params)?;
-                        let instantiated_args = self
-                            .unifier()
-                            .apply_sub_to_list_make_vec(&args_sub, &generics.params)?;
+                todo!()
+                // // @@Todo bounds
+                // match &def.kind {
+                //     TypeDefValueKind::Enum(EnumDef { generics, .. })
+                //     | TypeDefValueKind::Struct(StructDef { generics, .. }) => {
+                //         let args_sub = self.unifier().instantiate_vars_list(&generics.params)?;
+                //         let instantiated_args = self
+                //             .unifier()
+                //             .apply_sub_to_list_make_vec(&args_sub, &generics.params)?;
 
-                        self.unifier().unify_pairs(
-                            type_args.iter().zip(instantiated_args.iter()),
-                            UnifyStrategy::ModifyTarget,
-                        )?;
-                        let ty = self.create_type(
-                            TypeValue::User(UserType {
-                                def_id,
-                                args: type_args,
-                            }),
-                            Some(location),
-                        );
-                        Ok(ty)
-                    }
-                }
+                //         self.unifier().unify_pairs(
+                //             type_args.iter().zip(instantiated_args.iter()),
+                //             UnifyStrategy::ModifyTarget,
+                //         )?;
+                //         let ty = self.create_type(
+                //             TypeValue::User(UserType {
+                //                 def_id,
+                //                 args: type_args,
+                //             }),
+                //             Some(location),
+                //         );
+                //         Ok(ty)
+                //     }
+                // }
             }
             _ => Err(TypecheckError::SymbolIsNotAType(Symbol::Compound {
                 path: node.name.path(),

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -692,6 +692,15 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(self.create_type(TypeValue::RawRef(RawRefType { inner }), Some(ty_location)))
     }
 
+    type MergedTypeRet = TypeId;
+    fn visit_merged_type(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::MergedType<'c>>,
+    ) -> Result<Self::RawRefTypeRet, Self::Error> {
+        todo!()
+    }
+
     type TypeVarRet = TypeId;
     fn visit_type_var(
         &mut self,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -559,6 +559,33 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
             .create(TypeValue::Tuple(TupleType { types: entries }), ty_location))
     }
 
+    type ListTypeRet = TypeId;
+    fn visit_list_type(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::ListType<'c>>,
+    ) -> Result<Self::ListTypeRet, Self::Error> {
+        todo!()
+    }
+
+    type SetTypeRet = TypeId;
+    fn visit_set_type(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::SetType<'c>>,
+    ) -> Result<Self::SetTypeRet, Self::Error> {
+        todo!()
+    }
+
+    type MapTypeRet = TypeId;
+    fn visit_map_type(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::MapType<'c>>,
+    ) -> Result<Self::MapTypeRet, Self::Error> {
+        todo!()
+    }
+
     type FnTypeRet = TypeId;
     fn visit_function_type(
         &mut self,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -669,6 +669,33 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         }
     }
 
+    type TypeFunctionParamRet = TypeId;
+    fn visit_type_function_param(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::TypeFunctionParam<'c>>,
+    ) -> Result<Self::TypeFunctionParamRet, Self::Error> {
+        todo!()
+    }
+
+    type TypeFunctionRet = TypeId;
+    fn visit_type_function(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::TypeFunction<'c>>,
+    ) -> Result<Self::TypeFunctionRet, Self::Error> {
+        todo!()
+    }
+
+    type TypeFunctionCallRet = TypeId;
+    fn visit_type_function_call(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::TypeFunctionCall<'c>>,
+    ) -> Result<Self::TypeFunctionCallRet, Self::Error> {
+        todo!()
+    }
+
     type GroupedTypeRet = TypeId;
     fn visit_grouped_type(
         &mut self,
@@ -2022,7 +2049,7 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
         let args: Vec<_> = node
             .type_args
             .iter()
-            .map(|a| self.visit_type(ctx, a.ast_ref()))
+            .map(|a| self.visit_named_field_type(ctx, a.ast_ref()))
             .collect::<Result<_, _>>()?;
         let trt_name_location = self.some_source_location(node.name.location());
         let trt_symbol = || Symbol::Compound {
@@ -2034,7 +2061,7 @@ impl<'c, 'w, 'g, 'src> SourceTypechecker<'c, 'w, 'g, 'src> {
             sub_from_trait_def, ..
         } = self.trait_helper().find_trait_impl(
             trt,
-            &args,
+            &args.iter().map(|ty| ty.1).collect::<Vec<_>>(),
             fn_type,
             trt_symbol,
             type_args_location,

--- a/tests/parser/tests/cases/should_pass/existential_type/case.hash
+++ b/tests/parser/tests/cases/should_pass/existential_type/case.hash
@@ -1,1 +1,0 @@
-k := <T: s<?>> => b; // the question mark should be parsed an an existential.


### PR DESCRIPTION
This patch implements the slightly amended type parsing and adds support for the new specified type [grammar](https://hash-org.github.io/lang/features/types.html).

 In summary, this patch changes/adds the following:
- Remove `TypeVar`, `Infer` and `Existential` variants from`Type`
- `Set`, `Map` and `List` are now variants of `Type`
- `NamedType` no longer holds `type_args` as that is structured as a `TypeFunctionCall`
- Added `MergedType` which allows you to specify the intersection of types  (primarily used in type bounds).
- Added support for parenthesising a `Type` which makes it a `GroupedType`. The difference between a `TupleType` and `GroupedType` is that `TupleType`s must have multiple members or single element `TupleType`s should have a trailing comma at the end of the parentheses.
- Added support for `TypeFunction` and `TypeFunctionCall` variants which allows to specify the `type` of a `TypeFunction`.
- Use a `Vector` instead of re-allocating `row` each time for `AstNodes`. Only create a row in the end when the whole `Vector` has been constructed.
- rename `parse_token_atom` to`parse_token`
- rename `parse_token_atom_fast` to`parse_token_fast`