### PR TITLE
Parser: Added declaration visibility

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -559,7 +559,12 @@ pub enum LiteralPattern {
 
 /// A pattern name binding.
 #[derive(Debug, PartialEq)]
-pub struct BindingPattern<'c>(pub AstNode<'c, Name>);
+pub struct BindingPattern<'c> {
+    /// The identifier that the name bind is using
+    pub name: AstNode<'c, Name>,
+    /// Visibility of the declaration (`priv` by default)
+    pub visibility: Option<AstNode<'c, Visibility>>,
+}
 
 /// A pattern spread
 #[derive(Debug, PartialEq)]
@@ -607,6 +612,14 @@ pub struct TypeFunctionDefArg<'c> {
 
     /// The argument bounds.
     pub ty: AstNode<'c, Type<'c>>,
+}
+
+/// Enum representing whether a declaration is public or private
+/// within module scope.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Visibility {
+    Private,
+    Public,
 }
 
 /// A declaration, e.g. `x := 3;`.

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -293,6 +293,8 @@ impl<'w, 'c, 'a> Lexer<'w, 'c, 'a> {
             "import" => TokenKind::Keyword(Keyword::Import),
             "raw" => TokenKind::Keyword(Keyword::Raw),
             "unsafe" => TokenKind::Keyword(Keyword::Unsafe),
+            "priv" => TokenKind::Keyword(Keyword::Priv),
+            "pub" => TokenKind::Keyword(Keyword::Pub),
             "_" => TokenKind::Ident(CORE_IDENTIFIERS.underscore),
             _ => {
                 // create the identifier here from the created map

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -23,8 +23,8 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         &self,
         semi_required: bool,
     ) -> AstGenResult<'c, (bool, AstNode<'c, Expression<'c>>)> {
-        let start = self.current_location();
         let offset = self.offset();
+        let start = self.current_location();
 
         let decl =
             if let Some(pat) = self.peek_resultant_fn(|| self.parse_singular_pattern()) {

--- a/compiler/hash-token/src/keyword.rs
+++ b/compiler/hash-token/src/keyword.rs
@@ -27,6 +27,8 @@ pub enum Keyword {
     False,
     True,
     Unsafe,
+    Pub,
+    Priv,
 }
 
 /// Enum Variants for keywords

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -306,6 +306,14 @@ impl<'c> TokenKindVector<'c> {
         Self(row![wall; atom])
     }
 
+    #[inline(always)]
+    pub fn begin_visibility(wall: &Wall<'c>) -> Self {
+        Self(row![wall;
+            TokenKind::Keyword(Keyword::Pub),
+            TokenKind::Keyword(Keyword::Priv),
+        ])
+    }
+
     /// Tokens expected when the parser expects a collection of patterns to be present.
     pub fn begin_pattern_collection(wall: &Wall<'c>) -> Self {
         Self(row![wall;

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1138,6 +1138,15 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         }
     }
 
+    type VisibilityRet = TypeId;
+    fn visit_visibility_modifier(
+        &mut self,
+        _: &Self::Ctx,
+        _: ast::AstNodeRef<ast::Visibility>,
+    ) -> Result<Self::VisibilityRet, Self::Error> {
+        todo!()
+    }
+
     type DeclarationRet = TypeId;
     fn visit_declaration(
         &mut self,
@@ -1518,8 +1527,8 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
                         }
                         // Everything else better be just a binding
                         Some(symbol_type) => match field.pattern.body() {
-                            ast::Pattern::Binding(BindingPattern(binding)) => {
-                                self.scopes().add_symbol(binding.ident, symbol_type);
+                            ast::Pattern::Binding(BindingPattern { name, .. }) => {
+                                self.scopes().add_symbol(name.ident, symbol_type);
                             }
                             _ => {
                                 return Err(TypecheckError::DisallowedPatternNonVariable(
@@ -1708,7 +1717,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
 
         // we need to resolve the symbol in the current scope and firstly check if it's
         // an enum...
-        let ident = node.0.ident;
+        let ident = node.name.ident;
 
         match self.scopes().resolve_symbol(ident) {
             Some(SymbolType::EnumVariant(ty_def_id)) => {
@@ -1733,7 +1742,7 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
 
                 // @@Correctness, should we add the node into scope if the variable ident is equal to '_' ignore?
                 self.scopes()
-                    .add_symbol(node.0.ident, SymbolType::Variable(variable_ty));
+                    .add_symbol(node.name.ident, SymbolType::Variable(variable_ty));
                 Ok(variable_ty)
             }
         }

--- a/tests/parser/tests/cases/should_pass/visibility/case.hash
+++ b/tests/parser/tests/cases/should_pass/visibility/case.hash
@@ -1,0 +1,14 @@
+// Visible from outside:
+pub foo := 3;
+
+// Not visible from outside:
+bar := 4;
+
+
+Foo := trait {
+    // Visible from outside
+    foo: (Self) -> str;
+
+    // Not visible from outside
+    priv bar: (Self) -> str;
+};


### PR DESCRIPTION
This patch adds declaration visibility modifier support within the `Lexer`, `Parser`, and `AST` crates.