### PR TITLE
Language: add support for `type` expressions

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -852,7 +852,7 @@ pub struct PropertyAccessExpr<'c> {
 
 /// A typed expression, e.g. `foo as int`.
 #[derive(Debug, PartialEq)]
-pub struct TypedExpr<'c> {
+pub struct AsExpr<'c> {
     /// The annotated type of the expression.
     pub ty: AstNode<'c, Type<'c>>,
     /// The expression being typed.
@@ -913,7 +913,7 @@ pub enum ExpressionKind<'c> {
     Deref(DerefExpr<'c>),
     Unsafe(UnsafeExpr<'c>),
     LiteralExpr(LiteralExpr<'c>),
-    Typed(TypedExpr<'c>),
+    As(AsExpr<'c>),
     Block(BlockExpr<'c>),
     Import(ImportExpr<'c>),
     StructDef(StructDef<'c>),

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -635,7 +635,7 @@ pub struct TypeFunctionDefArg<'c> {
     pub name: AstNode<'c, Name>,
 
     /// The argument bounds.
-    pub ty: AstNode<'c, Type<'c>>,
+    pub ty: Option<AstNode<'c, Type<'c>>>,
 }
 
 /// A declaration, e.g. `x := 3;`.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -881,6 +881,11 @@ pub struct RefExpr<'c> {
     pub inner_expr: AstNode<'c, Expression<'c>>,
     pub kind: RefKind,
 }
+
+/// A dereference expression.
+#[derive(Debug, PartialEq)]
+pub struct TypeExpr<'c>(pub AstNode<'c, Type<'c>>);
+
 /// A dereference expression.
 #[derive(Debug, PartialEq)]
 pub struct DerefExpr<'c>(pub AstNode<'c, Expression<'c>>);
@@ -921,6 +926,7 @@ pub enum ExpressionKind<'c> {
     TypeFunctionDef(TypeFunctionDef<'c>),
     TraitDef(TraitDef<'c>),
     FunctionDef(FunctionDef<'c>),
+    Type(TypeExpr<'c>),
     Return(ReturnStatement<'c>),
     Break(BreakStatement),
     Continue(ContinueStatement),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -943,7 +943,10 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         let walk::TypeFunctionDefArg { name, ty } =
             walk::walk_type_function_def_arg(self, ctx, node)?;
 
-        Ok(TreeNode::branch("arg", iter::once(name).chain(ty).collect()))
+        Ok(TreeNode::branch(
+            "arg",
+            iter::once(name).chain(ty).collect(),
+        ))
     }
 
     type ConstructorPatternRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -943,7 +943,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         let walk::TypeFunctionDefArg { name, ty } =
             walk::walk_type_function_def_arg(self, ctx, node)?;
 
-        Ok(TreeNode::branch("arg", vec![name, ty]))
+        Ok(TreeNode::branch("arg", iter::once(name).chain(ty).collect()))
     }
 
     type ConstructorPatternRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -242,13 +242,13 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         Ok(literal)
     }
 
-    type TypedExprRet = TreeNode;
-    fn visit_typed_expr(
+    type AsExprRet = TreeNode;
+    fn visit_as_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
-    ) -> Result<Self::TypedExprRet, Self::Error> {
-        let walk::TypedExpr { ty, expr } = walk::walk_typed_expr(self, ctx, node)?;
+        node: ast::AstNodeRef<ast::AsExpr<'c>>,
+    ) -> Result<Self::AsExprRet, Self::Error> {
+        let walk::AsExpr { ty, expr } = walk::walk_as_expr(self, ctx, node)?;
         Ok(TreeNode::branch(
             "typed_expr",
             vec![

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -258,6 +258,17 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ))
     }
 
+    type TypeExprRet = TreeNode;
+    fn visit_type_expr(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::TypeExpr<'c>>,
+    ) -> Result<Self::TypeExprRet, Self::Error> {
+        let walk::TypeExpr(ty) = walk::walk_type_expr(self, ctx, node)?;
+
+        Ok(TreeNode::branch("type", vec![ty]))
+    }
+
     type BlockExprRet = TreeNode;
     fn visit_block_expr(
         &mut self,

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -2177,7 +2177,7 @@ pub mod walk {
 
     pub struct TypeFunctionDefArg<'c, V: AstVisitor<'c>> {
         pub name: V::NameRet,
-        pub ty: V::TypeRet,
+        pub ty: Option<V::TypeRet>,
     }
 
     pub fn walk_type_function_def_arg<'c, V: AstVisitor<'c>>(
@@ -2187,7 +2187,11 @@ pub mod walk {
     ) -> Result<TypeFunctionDefArg<'c, V>, V::Error> {
         Ok(TypeFunctionDefArg {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
-            ty: visitor.visit_type(ctx, node.ty.ast_ref())?,
+            ty: node
+                .ty
+                .as_ref()
+                .map(|inner| visitor.visit_type(ctx, inner.ast_ref()))
+                .transpose()?,
         })
     }
 

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -138,12 +138,12 @@ pub trait AstVisitor<'c>: Sized {
         node: ast::AstNodeRef<ast::LiteralExpr<'c>>,
     ) -> Result<Self::LiteralExprRet, Self::Error>;
 
-    type TypedExprRet: 'c;
-    fn visit_typed_expr(
+    type AsExprRet: 'c;
+    fn visit_as_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
-    ) -> Result<Self::TypedExprRet, Self::Error>;
+        node: ast::AstNodeRef<ast::AsExpr<'c>>,
+    ) -> Result<Self::AsExprRet, Self::Error>;
 
     type BlockExprRet: 'c;
     fn visit_block_expr(
@@ -711,7 +711,7 @@ pub mod walk {
         Deref(V::DerefExprRet),
         Unsafe(V::UnsafeExprRet),
         LiteralExpr(V::LiteralExprRet),
-        Typed(V::TypedExprRet),
+        Typed(V::AsExprRet),
         Block(V::BlockExprRet),
         Import(V::ImportExprRet),
         StructDef(V::StructDefRet),
@@ -758,8 +758,8 @@ pub mod walk {
             ast::ExpressionKind::LiteralExpr(inner) => {
                 Expression::LiteralExpr(visitor.visit_literal_expr(ctx, node.with_body(inner))?)
             }
-            ast::ExpressionKind::Typed(inner) => {
-                Expression::Typed(visitor.visit_typed_expr(ctx, node.with_body(inner))?)
+            ast::ExpressionKind::As(inner) => {
+                Expression::Typed(visitor.visit_as_expr(ctx, node.with_body(inner))?)
             }
             ast::ExpressionKind::Block(inner) => {
                 Expression::Block(visitor.visit_block_expr(ctx, node.with_body(inner))?)
@@ -814,7 +814,7 @@ pub mod walk {
             DerefExprRet = Ret,
             UnsafeExprRet = Ret,
             LiteralExprRet = Ret,
-            TypedExprRet = Ret,
+            AsExprRet = Ret,
             BlockExprRet = Ret,
             ImportExprRet = Ret,
             StructDefRet = Ret,
@@ -1005,17 +1005,17 @@ pub mod walk {
         Ok(LiteralExpr(visitor.visit_literal(ctx, node.0.ast_ref())?))
     }
 
-    pub struct TypedExpr<'c, V: AstVisitor<'c>> {
+    pub struct AsExpr<'c, V: AstVisitor<'c>> {
         pub ty: V::TypeRet,
         pub expr: V::ExpressionRet,
     }
 
-    pub fn walk_typed_expr<'c, V: AstVisitor<'c>>(
+    pub fn walk_as_expr<'c, V: AstVisitor<'c>>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
-    ) -> Result<TypedExpr<'c, V>, V::Error> {
-        Ok(TypedExpr {
+        node: ast::AstNodeRef<ast::AsExpr<'c>>,
+    ) -> Result<AsExpr<'c, V>, V::Error> {
+        Ok(AsExpr {
             ty: visitor.visit_type(ctx, node.ty.ast_ref())?,
             expr: visitor.visit_expression(ctx, node.expr.ast_ref())?,
         })

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -297,6 +297,7 @@ impl<'w, 'c, 'a> Lexer<'w, 'c, 'a> {
             "pub" => TokenKind::Keyword(Keyword::Pub),
             "mut" => TokenKind::Keyword(Keyword::Mut),
             "mod" => TokenKind::Keyword(Keyword::Mod),
+            "type" => TokenKind::Keyword(Keyword::Type),
             "_" => TokenKind::Ident(CORE_IDENTIFIERS.underscore),
             _ => {
                 // create the identifier here from the created map

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -194,15 +194,12 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
         let name = self.parse_name()?;
 
         // Now it's followed by a colon
-        self.parse_token(TokenKind::Colon)?;
+        let ty = self
+            .parse_token_fast(TokenKind::Colon)
+            .map(|_| self.parse_type())
+            .transpose()?;
 
-        Ok(self.node_with_joined_span(
-            TypeFunctionDefArg {
-                name,
-                ty: self.parse_type()?,
-            },
-            &start,
-        ))
+        Ok(self.node_with_joined_span(TypeFunctionDefArg { name, ty }, &start))
     }
 
     /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with `trait` that contains

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -153,6 +153,10 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 Expression::new(ExpressionKind::TraitDef(self.parse_trait_def()?)),
                 &token.span,
             ),
+            TokenKind::Keyword(Keyword::Type) => self.node_with_joined_span(
+                Expression::new(ExpressionKind::Type(TypeExpr(self.parse_type()?))),
+                &token.span,
+            ),
             // @@Note: This doesn't cover '{' case.
             kind if kind.begins_block() => {
                 let start = self.current_location();
@@ -732,9 +736,9 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
     /// A destructuring pattern, potential for-all statement, optional
     /// type definition and a potential definition of the right hand side. For example:
     /// ```text
-    /// some_var...<int>: float = ...;
-    /// ^^^^^^^^   ^^^^^  ^^^^^   ^^^─────┐
-    ///   pattern  bound   type    the right hand-side expr
+    /// some_var: float = ...;
+    /// ^^^^^^^^  ^^^^^   ^^^─────┐
+    /// pattern    type    the right hand-side expr
     /// ```
     pub(crate) fn parse_declaration(
         &self,

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -313,7 +313,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     // where we transform the AstNode into a different
                     if matches!(op.kind, OperatorKind::As) {
                         lhs = self.node_with_joined_span(
-                            Expression::new(ExpressionKind::Typed(TypedExpr {
+                            Expression::new(ExpressionKind::As(AsExpr {
                                 expr: lhs,
                                 ty: self.parse_type()?,
                             })),

--- a/compiler/hash-token/src/keyword.rs
+++ b/compiler/hash-token/src/keyword.rs
@@ -31,6 +31,7 @@ pub enum Keyword {
     Priv,
     Mut,
     Mod,
+    Type,
 }
 
 /// Enum Variants for keywords

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -516,13 +516,13 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(walk::walk_literal_expr(self, ctx, node)?.0)
     }
 
-    type TypedExprRet = TypeId;
-    fn visit_typed_expr(
+    type AsExprRet = TypeId;
+    fn visit_as_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypedExpr<'c>>,
-    ) -> Result<Self::TypedExprRet, Self::Error> {
-        let walk::TypedExpr { expr, ty } = walk::walk_typed_expr(self, ctx, node)?;
+        node: ast::AstNodeRef<ast::AsExpr<'c>>,
+    ) -> Result<Self::AsExprRet, Self::Error> {
+        let walk::AsExpr { expr, ty } = walk::walk_as_expr(self, ctx, node)?;
         self.unifier().unify(expr, ty, UnifyStrategy::ModifyBoth)?;
         Ok(expr)
     }

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -527,6 +527,18 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(expr)
     }
 
+    type TypeExprRet = TypeId;
+
+    fn visit_type_expr(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::TypeExpr<'c>>,
+    ) -> Result<Self::TypeExprRet, Self::Error> {
+        let walk::TypeExpr(inner) = walk::walk_type_expr(self, ctx, node)?;
+
+        Ok(inner)
+    }
+
     type BlockExprRet = TypeId;
     fn visit_block_expr(
         &mut self,

--- a/tests/parser/tests/cases/should_pass/traits_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/traits_defns/case.hash
@@ -4,4 +4,4 @@ Merge := <T: Add ~ Or> => trait {
 
 /// Type function def with no specified bounds on the parameter
 Merge := <R> => trait {
-}
+};

--- a/tests/parser/tests/cases/should_pass/traits_defns/case.hash
+++ b/tests/parser/tests/cases/should_pass/traits_defns/case.hash
@@ -1,3 +1,7 @@
 Merge := <T: Add ~ Or> => trait {
     merge: (T, T) -> T = () => {};
 };
+
+/// Type function def with no specified bounds on the parameter
+Merge := <R> => trait {
+}

--- a/tests/parser/tests/cases/should_pass/type_exprs/case.hash
+++ b/tests/parser/tests/cases/should_pass/type_exprs/case.hash
@@ -1,0 +1,5 @@
+ty := <R> => type Vec<R>;
+
+my := <R: Clone ~ Eq> => type (Vec<R>, u32);
+sy := type (Vec<R>, u32);
+


### PR DESCRIPTION
This patch adds a new variant to expressions which allows for explicitly writing types by specifying the `type` keyword at the 
beginning of the expression.

In regards to renaming the `TypedExpr` to `AsExpr`, this is the reasoning:

A new type of expression is planned to be added which provides a
method of putting a type within an expression by prefixing the
expression with the `type` keyword.

This naming shift from `TypedExpr` to `AsExpr` is to avoid the confusion
between `TypeExpr` and `TypedExpr`.
