### PR TITLE
Language: support trait implementation definition constructs

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -921,7 +921,7 @@ pub struct ImportExpr<'c>(pub AstNode<'c, Import>);
 #[derive(Debug, PartialEq)]
 pub struct TraitImpl<'c> {
     /// The referenced name to the trait
-    pub name: AstNode<'c, Name>,
+    pub name: AstNode<'c, VariableExpr<'c>>,
     /// The implementation of the trait.
     pub implementation: AstNodes<'c, Expression<'c>>,
 }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -652,6 +652,17 @@ pub struct Declaration<'c> {
     pub value: Option<AstNode<'c, Expression<'c>>>,
 }
 
+/// A merge declaration (adding implementations to traits/structs), e.g. `x ~= impl { ... };`.
+#[derive(Debug, PartialEq)]
+pub struct MergeDeclaration<'c> {
+    /// The pattern to bind the right-hand side to.
+    pub pattern: AstNode<'c, Pattern<'c>>,
+
+    /// Any value that is assigned to the binding, simply
+    /// an expression.
+    pub value: AstNode<'c, Expression<'c>>,
+}
+
 /// An assign expression, e.g. `x = 4;`.
 #[derive(Debug, PartialEq)]
 pub struct AssignExpression<'c> {
@@ -930,6 +941,7 @@ pub enum ExpressionKind<'c> {
     Break(BreakStatement),
     Continue(ContinueStatement),
     Assign(AssignExpression<'c>),
+    MergeDeclaration(MergeDeclaration<'c>)
 }
 
 /// An expression.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -767,6 +767,9 @@ pub struct LoopBlock<'c>(pub AstNode<'c, Block<'c>>);
 #[derive(Debug, PartialEq)]
 pub struct ModBlock<'c>(pub AstNode<'c, Block<'c>>);
 
+#[derive(Debug, PartialEq)]
+pub struct ImplBlock<'c>(pub AstNode<'c, Block<'c>>);
+
 /// A block.
 #[derive(Debug, PartialEq)]
 pub enum Block<'c> {
@@ -778,6 +781,8 @@ pub enum Block<'c> {
     Mod(ModBlock<'c>),
     /// A body block.
     Body(BodyBlock<'c>),
+    /// An implementation block
+    Impl(ImplBlock<'c>),
 }
 
 /// A function definition argument.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -941,7 +941,7 @@ pub enum ExpressionKind<'c> {
     Break(BreakStatement),
     Continue(ContinueStatement),
     Assign(AssignExpression<'c>),
-    MergeDeclaration(MergeDeclaration<'c>)
+    MergeDeclaration(MergeDeclaration<'c>),
 }
 
 /// An expression.

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -917,6 +917,15 @@ pub struct BlockExpr<'c>(pub AstNode<'c, Block<'c>>);
 #[derive(Debug, PartialEq)]
 pub struct ImportExpr<'c>(pub AstNode<'c, Import>);
 
+/// A trait implementation.
+#[derive(Debug, PartialEq)]
+pub struct TraitImpl<'c> {
+    /// The referenced name to the trait
+    pub name: AstNode<'c, Name>,
+    /// The implementation of the trait.
+    pub implementation: AstNodes<'c, Expression<'c>>,
+}
+
 /// The kind of an expression.
 #[derive(Debug, PartialEq)]
 pub enum ExpressionKind<'c> {
@@ -942,6 +951,7 @@ pub enum ExpressionKind<'c> {
     Continue(ContinueStatement),
     Assign(AssignExpression<'c>),
     MergeDeclaration(MergeDeclaration<'c>),
+    TraitImpl(TraitImpl<'c>),
 }
 
 /// An expression.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -822,12 +822,10 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::MergeDeclaration<'c>>,
     ) -> Result<Self::MergeDeclarationRet, Self::Error> {
-        let walk::MergeDeclaration { pattern, value } = walk::walk_merge_declaration(self, ctx, node)?;
+        let walk::MergeDeclaration { pattern, value } =
+            walk::walk_merge_declaration(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            "merge_declaration",
-            vec![pattern, value]
-        ))
+        Ok(TreeNode::branch("merge_declaration", vec![pattern, value]))
     }
 
     type AssignExpressionRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -914,6 +914,24 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ))
     }
 
+    type TraitImplRet = TreeNode;
+
+    fn visit_trait_impl(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::TraitImpl<'c>>,
+    ) -> Result<Self::TraitImplRet, Self::Error> {
+        let walk::TraitImpl {
+            implementation,
+            name,
+        } = walk::walk_trait_impl(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            "trait_impl",
+            vec![name, TreeNode::branch("implementation", implementation)],
+        ))
+    }
+
     type PatternRet = TreeNode;
     fn visit_pattern(
         &mut self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -816,6 +816,20 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ))
     }
 
+    type MergeDeclarationRet = TreeNode;
+    fn visit_merge_declaration(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::MergeDeclaration<'c>>,
+    ) -> Result<Self::MergeDeclarationRet, Self::Error> {
+        let walk::MergeDeclaration { pattern, value } = walk::walk_merge_declaration(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            "merge_declaration",
+            vec![pattern, value]
+        ))
+    }
+
     type AssignExpressionRet = TreeNode;
     fn visit_assign_expression(
         &mut self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -923,7 +923,7 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     ) -> Result<Self::TraitImplRet, Self::Error> {
         let walk::TraitImpl {
             implementation,
-            name,
+            trait_name: name,
         } = walk::walk_trait_impl(self, ctx, node)?;
 
         Ok(TreeNode::branch(

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -709,7 +709,6 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     }
 
     type ModBlockRet = TreeNode;
-
     fn visit_mod_block(
         &mut self,
         ctx: &Self::Ctx,
@@ -717,6 +716,16 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
     ) -> Result<Self::ModBlockRet, Self::Error> {
         let walk::ModBlock(inner) = walk::walk_mod_block(self, ctx, node)?;
         Ok(TreeNode::branch("module", inner.children))
+    }
+
+    type ImplBlockRet = TreeNode;
+    fn visit_impl_block(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::ImplBlock<'c>>,
+    ) -> Result<Self::ImplBlockRet, Self::Error> {
+        let walk::ImplBlock(inner) = walk::walk_impl_block(self, ctx, node)?;
+        Ok(TreeNode::branch("impl", inner.children))
     }
 
     type BodyBlockRet = TreeNode;

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -2251,7 +2251,7 @@ pub mod walk {
     }
 
     pub struct TraitImpl<'c, V: AstVisitor<'c>> {
-        pub name: V::NameRet,
+        pub trait_name: V::VariableExprRet,
         pub implementation: V::CollectionContainer<V::ExpressionRet>,
     }
 
@@ -2261,7 +2261,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::TraitImpl<'c>>,
     ) -> Result<TraitImpl<'c, V>, V::Error> {
         Ok(TraitImpl {
-            name: visitor.visit_name(ctx, node.name.ast_ref())?,
+            trait_name: visitor.visit_variable_expr(ctx, node.name.ast_ref())?,
             implementation: V::try_collect_items(
                 ctx,
                 node.implementation

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -297,6 +297,7 @@ impl<'w, 'c, 'a> Lexer<'w, 'c, 'a> {
             "pub" => TokenKind::Keyword(Keyword::Pub),
             "mut" => TokenKind::Keyword(Keyword::Mut),
             "mod" => TokenKind::Keyword(Keyword::Mod),
+            "impl" => TokenKind::Keyword(Keyword::Impl),
             "_" => TokenKind::Ident(CORE_IDENTIFIERS.underscore),
             _ => {
                 // create the identifier here from the created map

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -212,40 +212,8 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             .current_token()
             .has_kind(TokenKind::Keyword(Keyword::Trait)));
 
-        let members = match self.peek() {
-            Some(Token {
-                kind: TokenKind::Tree(Delimiter::Brace, tree_index),
-                span,
-            }) => {
-                self.skip_token();
-                let tree = self.token_trees.get(*tree_index).unwrap();
-                let gen = self.from_stream(tree, *span);
-
-                let mut expressions = AstNodes::empty();
-
-                while gen.has_token() {
-                    let (_, expr) = gen.parse_top_level_expression(true)?;
-                    expressions.nodes.push(expr, &self.wall);
-                }
-
-                // Verify that generator is empty
-                if gen.has_token() {
-                    gen.error(AstGenErrorKind::EOF, None, None)?
-                }
-
-                expressions
-            }
-            token => self.error_with_location(
-                AstGenErrorKind::Expected,
-                Some(TokenKindVector::singleton(
-                    &self.wall,
-                    TokenKind::Delimiter(Delimiter::Brace, true),
-                )),
-                token.map(|t| t.kind),
-                token.map_or_else(|| self.next_location(), |t| t.span),
-            )?,
-        };
-
-        Ok(TraitDef { members })
+        Ok(TraitDef {
+            members: self.parse_expressions_from_braces()?,
+        })
     }
 }

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -157,8 +157,6 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
             kind if kind.begins_block() => {
                 let start = self.current_location();
 
-                println!("{kind}");
-
                 let block = match kind {
                     TokenKind::Keyword(Keyword::For) => self.parse_for_loop()?,
                     TokenKind::Keyword(Keyword::While) => self.parse_while_loop()?,
@@ -168,6 +166,8 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     TokenKind::Keyword(Keyword::Match) => self.parse_match_block()?,
                     TokenKind::Keyword(Keyword::Mod) => self
                         .node_with_joined_span(Block::Mod(ModBlock(self.parse_block()?)), &start),
+                    TokenKind::Keyword(Keyword::Impl) => self
+                        .node_with_joined_span(Block::Impl(ImplBlock(self.parse_block()?)), &start),
                     _ => unreachable!(),
                 };
 

--- a/compiler/hash-token/src/keyword.rs
+++ b/compiler/hash-token/src/keyword.rs
@@ -31,6 +31,7 @@ pub enum Keyword {
     Priv,
     Mut,
     Mod,
+    Impl,
 }
 
 /// Enum Variants for keywords

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -104,6 +104,7 @@ impl TokenKind {
                 | TokenKind::Keyword(Keyword::Mod)
                 | TokenKind::Keyword(Keyword::If)
                 | TokenKind::Keyword(Keyword::Match)
+                | TokenKind::Keyword(Keyword::Impl)
         )
     }
 

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1224,6 +1224,16 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(self.create_void_type())
     }
 
+    type MergeDeclarationRet = TypeId;
+
+    fn visit_merge_declaration(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::MergeDeclaration<'c>>,
+    ) -> Result<Self::MergeDeclarationRet, Self::Error> {
+        todo!()
+    }
+
     type AssignExpressionRet = TypeId;
 
     fn visit_assign_expression(

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1327,6 +1327,16 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         Ok(self.types_mut().create_void_type())
     }
 
+    type TraitImplRet = TypeId;
+
+    fn visit_trait_impl(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::TraitImpl<'c>>,
+    ) -> Result<Self::TraitImplRet, Self::Error> {
+        todo!()
+    }
+
     type PatternRet = TypeId;
     fn visit_pattern(
         &mut self,

--- a/compiler/hash-typecheck/src/traverse.rs
+++ b/compiler/hash-typecheck/src/traverse.rs
@@ -1080,6 +1080,15 @@ impl<'c, 'w, 'g, 'src> visitor::AstVisitor<'c> for SourceTypechecker<'c, 'w, 'g,
         todo!()
     }
 
+    type ImplBlockRet = TypeId;
+    fn visit_impl_block(
+        &mut self,
+        _ctx: &Self::Ctx,
+        _node: ast::AstNodeRef<ast::ImplBlock<'c>>,
+    ) -> Result<Self::ImplBlockRet, Self::Error> {
+        todo!()
+    }
+
     type BodyBlockRet = TypeId;
     fn visit_body_block(
         &mut self,

--- a/tests/parser/tests/cases/should_pass/impl_blocks/case.hash
+++ b/tests/parser/tests/cases/should_pass/impl_blocks/case.hash
@@ -1,0 +1,14 @@
+Vector3 := <T: Eq> => struct(x: T, y: T, z: T);
+
+Vector3 ~= <T: Mul ~ Sub> => impl {
+  // Cross is an associated function on `Vector3<T>` for any `T: Mul ~ Sub`.
+  cross := (self, other: Self) -> Self => {
+      Vector3(
+        self.y * other.z - self.z * other.y,
+        self.z * other.x - self.x * other.z,
+        self.x * other.y - self.y * other.x,
+      )
+  };
+};
+
+print(Vector3(1, 2, 3).cross(Vector3(4, 5, 6)));


### PR DESCRIPTION
This patch adds support for the following:

- `impl` blocks which are now part of the `Block` enum and are attachable to declarations via the `~=` operator.