### PR TITLE
Parser: Speed improvement of parsing declarations

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -652,7 +652,7 @@ pub struct Declaration<'c> {
 #[derive(Debug, PartialEq)]
 pub struct MergeDeclaration<'c> {
     /// The pattern to bind the right-hand side to.
-    pub pattern: AstNode<'c, Pattern<'c>>,
+    pub decl: AstNode<'c, Expression<'c>>,
 
     /// Any value that is assigned to the binding, simply
     /// an expression.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -847,8 +847,10 @@ impl<'c> AstVisitor<'c> for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::MergeDeclaration<'c>>,
     ) -> Result<Self::MergeDeclarationRet, Self::Error> {
-        let walk::MergeDeclaration { pattern, value } =
-            walk::walk_merge_declaration(self, ctx, node)?;
+        let walk::MergeDeclaration {
+            decl: pattern,
+            value,
+        } = walk::walk_merge_declaration(self, ctx, node)?;
 
         Ok(TreeNode::branch("merge_declaration", vec![pattern, value]))
     }

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -2093,7 +2093,7 @@ pub mod walk {
     }
 
     pub struct MergeDeclaration<'c, V: AstVisitor<'c>> {
-        pub pattern: V::PatternRet,
+        pub decl: V::ExpressionRet,
         pub value: V::ExpressionRet,
     }
 
@@ -2103,7 +2103,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::MergeDeclaration<'c>>,
     ) -> Result<MergeDeclaration<'c, V>, V::Error> {
         Ok(MergeDeclaration {
-            pattern: visitor.visit_pattern(ctx, node.pattern.ast_ref())?,
+            decl: visitor.visit_expression(ctx, node.decl.ast_ref())?,
             value: visitor.visit_expression(ctx, node.value.ast_ref())?,
         })
     }

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -302,7 +302,10 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 Some(Token {
                     kind: TokenKind::Ident(ident),
                     span,
-                }) => self.parse_access_name(self.node_with_span(*ident, *span))?,
+                }) => {
+                    self.skip_token();
+                    self.parse_access_name(self.node_with_span(*ident, *span))?
+                }
                 token => self.error_with_location(
                     AstGenErrorKind::AccessName,
                     None,

--- a/compiler/hash-parser/src/parser/literal.rs
+++ b/compiler/hash-parser/src/parser/literal.rs
@@ -123,7 +123,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                     TupleLiteralEntry {
                         name: Some(name),
                         ty,
-                        value: self.try_parse_expression_with_re_assignment()?.0,
+                        value: self.parse_expression_with_re_assignment()?.0,
                     },
                     &start,
                 ))
@@ -138,7 +138,7 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 TupleLiteralEntry {
                     name: None,
                     ty: None,
-                    value: self.try_parse_expression_with_re_assignment()?.0,
+                    value: self.parse_expression_with_re_assignment()?.0,
                 },
                 &start,
             )),

--- a/compiler/hash-parser/src/parser/pattern.rs
+++ b/compiler/hash-parser/src/parser/pattern.rs
@@ -83,11 +83,11 @@ impl<'c, 'stream, 'resolver> AstGen<'c, 'stream, 'resolver> {
                 kind: TokenKind::Keyword(Keyword::Pub | Keyword::Priv | Keyword::Mut),
                 ..
             } => self.parse_binding_pattern()?,
+            // this could be either just a binding pattern, enum, or a struct pattern
             Token {
                 kind: TokenKind::Ident(ident),
                 span,
             } => {
-                // this could be either just a binding pattern, enum, or a struct pattern
                 self.skip_token();
 
                 // So here we try to parse an access name, if it is only made of a single binding

--- a/stdlib/io.hash
+++ b/stdlib/io.hash
@@ -10,7 +10,7 @@
 
 
 // Error type for all I/O operations.
-enum IoErrorType = {
+IoErrorType := enum(
    FileNotFound,
    PermissionDenied,
    AlreadyExists,
@@ -19,20 +19,20 @@ enum IoErrorType = {
    EOF, // Failed due to end of file being reached
    IllegalOperation,
    Other,
-};
+);
 
 // @@Safety: The order of these fields must be preserved since the compiler internally assumes
 // this order. Yes it is somewhat dangerous, and the 'IoError' struct will likely get moved into 
 // Primitives, but for now: DO NOT TOUCH THE ORDER OF THE FIELDS!
-struct IoError = {
+IoError = struct(
     error: IoErrorType,
     message: str,
-};
+);
 
 // These mapping is the same as the internal one, so it should be ok to convert.
 // the primitive int code into an one of the IoErrorType variants.
-let _conv_ioerr_code: (int) => IoErrorType = (code: int) => {
-    let ret = match code {
+_conv_ioerr_code := (code: int) -> IoErrorType => {
+    match code {
         0 => FileNotFound;
         1 => PermissionDenied;
         2 => AlreadyExists;
@@ -41,53 +41,55 @@ let _conv_ioerr_code: (int) => IoErrorType = (code: int) => {
         5 => EOF;
         6 => IllegalOperation;
         _ => Other;
-    };
-
-    ret
-};
-
-let _conv_ioerr_prim: ((int, str)) => IoError = (e: (int, str)) => {
-    IoError {
-        error   = _conv_ioerr_code(e.first),
-        message = e.second,
     }
 };
 
-trait _wrap_io = <T> => (Result<T, (int, str)>) => Result<T, IoError>;
-let _wrap_io<T> = (res: Result<T, (int, str)>): Result<T, IoError> => match res {
-    Err(e) => Err(_conv_ioerr_prim(e));
-    Ok(t) => Ok(t);
+_conv_ioerr_prim: = (e: (i32, str)) -> IoError => {
+    IoError(
+        error   = _conv_ioerr_code(e.first),
+        message = e.second,
+    )
+};
+
+
+_wrap_io := <T> => trait {
+    wrap: (Result<T, (int, str)>) -> Result<T, IoError>;
+};
+
+_wrap_io ~= impl {
+    wrap := (res: Result<T, (int, str)>) -> Result<T, IoError> => match res {
+        Err(e) => Err(_conv_ioerr_prim(e));
+        Ok(t) => Ok(t);
+    };
 };
 
 // Send a character to stdout.
-let set = (data: char): Result<void, IoError> => {
-    let ret = match (#intrinsic_char_set(data) as Result<void, (int, str)>) {
+set := (data: char) -> Result<void, IoError> => {
+    match (intrinsic_char_set(data) as Result<void, (int, str)>) {
         Err(e) => Err(_conv_ioerr_prim(e));
         Ok(r) => Ok(r);
-    };
-
-    ret
+    }
 };
 
 
 // Read a character from stdin.
-let get: () => Result<char, IoError> = () => _wrap_io<char>(Ok(#intrinsic_char_get()) as Result<char, (int, str)>);
+get := () => _wrap_io<char>(Ok(#intrinsic_char_get()) as Result<char, (int, str)>);
 
 // File opening mode
-enum OpenMode = {
+OpenMode = enum(
    Read, // r
    ReadWrite, // r+ | w+
    Write, // w
    Append, // a
-};
+);
 
-enum SeekMode = {
+SeekMode = enum(
     SeekSet, // begin file offset
     SeekCur, // current handle offset
     SeekEnd, // end of file offset
-};
+);
 
-let _mode_to_int = (mode: OpenMode): int => match mode {
+_mode_to_int := (mode: OpenMode) -> u32 => match mode {
     Read => 0;
     Write => 1;
     Append => 2;
@@ -95,7 +97,7 @@ let _mode_to_int = (mode: OpenMode): int => match mode {
 };
 
 // Convert a string representation of a mode into a mode enum
-let str_to_mode = (mode: str): OpenMode => match mode {
+str_to_mode := (mode: str) -> OpenMode => match mode {
     "r" => Read;
     "w" => Write;
     "a" => Append;
@@ -104,36 +106,36 @@ let str_to_mode = (mode: str): OpenMode => match mode {
 };
 
 // A data structure representing a file.
-struct File = { 
+File = struct( 
     handle: Native,
-};
+);
 
 // Standard In/Out file handles
-let stdin: File = #intrinsic_get_stdin();
-let stdout: File = #intrinsic_get_stdout();
-let stderr: File = #intrinsic_get_stderr();
+stdin: File = intrinsic_get_stdin();
+stdout: File = intrinsic_get_stdout();
+stderr: File = intrinsic_get_stderr();
 
 // Open a file
-let open = (filename: str, mode: OpenMode): Result<File, IoError> => _wrap_io<File>(#intrinsic_open(filename, _mode_to_int(mode)));
+open := (filename: str, mode: OpenMode) -> Result<File, IoError> => _wrap_io<File>(#intrinsic_open(filename, _mode_to_int(mode)));
    
 // Close a file
-let close = (handle: File): Result<void, IoError> => _wrap_io<void>(#intrinsic_close(handle));
+close := (handle: File) -> Result<void, IoError> => _wrap_io<void>(#intrinsic_close(handle));
 
 // Send a character to a file.
-let fset = (handle: File, ch: char): Result<void, IoError> => _wrap_io<void>(#intrinsic_fset(handle, ch));
+fset := (handle: File, ch: char) -> Result<void, IoError> => _wrap_io<void>(#intrinsic_fset(handle, ch));
 
 // Read a character from a file.
-let fget = (handle: File): Result<char, IoError> => _wrap_io<char>(#intrinsic_fget(handle));
+fget := (handle: File) -> Result<char, IoError> => _wrap_io<char>(#intrinsic_fget(handle));
 
 // Send a string to a file, \n terminated.
-let fprint = (handle: File, line: str): Result<void, IoError> => _wrap_io<void>(#intrinsic_fprint(handle, line));
+fprint := (handle: File, line: str) -> Result<void, IoError> => _wrap_io<void>(#intrinsic_fprint(handle, line));
 
 // Read a line from a file.
-let finput = (handle: File): Result<str, IoError> => _wrap_io<str>(#intrinsic_finput(handle));
+finput := (handle: File) -> Result<str, IoError> => _wrap_io<str>(#intrinsic_finput(handle));
 
 // Seek a file.
-let fseek = (file: File, position: int, whence: SeekMode): Result<void, IoError> => {
-    let whence_mode = match whence {
+fseek := (file: File, position: u64, whence: SeekMode) -> Result<void, IoError> => {
+    whence_mode = match whence {
         SeekSet => 0;
         SeekCur => 1;
         SeekEnd => 2;
@@ -144,10 +146,10 @@ let fseek = (file: File, position: int, whence: SeekMode): Result<void, IoError>
 
 
 // Lines iterator
-struct LinesIterator = {
-   index: int,
+LinesIterator := struct(
+   index: u64,
    lines: [str],
-};
+);
 
 //let next<LinesIterator, Result<str, IoError>>;
 //let flines = (file: File) => LinesIterator;

--- a/stdlib/iter.hash
+++ b/stdlib/iter.hash
@@ -8,331 +8,399 @@
 //
 
 // Collect into some type C
-trait collect = <I, C> => (I) => C;
+Collect := <I, C> => trait {
+    collect: (I) -> C;
+};
 
 // Get the next item of an iterator.
 // I is the iterator type.
 // T is the element type.
 // When next returns None, the iterator has ended iteration.
-trait next = <I, T> => (I) => Option<T>;
+Next := <I, T> => trait { 
+    next: (I) -> Option<T>;
+};
 
 // Collect iterator of values into a list
-let collect<I, [A]> where next<I, A>;
+// let collect<I, [A]> where next<I, A>;
 
-struct RangeIterator = <I> => {
+RangeIterator := <I> => struct(
     current: I,
     final: I,
     step: I,
-};
+);
 
 // Ranges, take some initial bound, max bound and then finally a step
-trait range = <I> => (I, I, I) => RangeIterator<I>;
+Range := <I> => trait {
+    range: (I, I, I) -> RangeIterator<I>;
+};
 
-// create a range iterator for a range of integers
-let range<int> = (min: int, max: int, step: int) => {
-    if (max <= min || ((min + step) >= max)) {         
-        return RangeIterator<int>{current=min, final=min, step=0}; // essentially no iterations occur
-    }
 
-    // check here if the step is negative and the max isn't, we also
-    // return a iterator that has 'zero' iterations
-    if ((step < 0) && (max > 0)) {
-        return RangeIterator<int>{current=min, final=min, step=0}; // essentially no iterations occur
-    }
+Range ~= impl {
+    range := (min: int, max: int, step: int) => {
+        if (max <= min || ((min + step) >= max)) {         
+            return RangeIterator<int>(current=min, final=min, step=0); // essentially no iterations occur
+        };
 
-    RangeIterator<int> {
-        current=min,
-        final=max,
-        step=step,
-    }
+        // check here if the step is negative and the max isn't, we also
+        // return a iterator that has 'zero' iterations
+        if ((step < 0) && (max > 0)) {
+            return RangeIterator<int>(current=min, final=min, step=0); // essentially no iterations occur
+        };
+
+        RangeIterator<int>(   
+            current=min,
+            final=max,
+            step=step,
+        )
+    };
 };
 
 // Turn a container of type C into an iterator of type I
-trait iter = <C, I> => (C) => I;
-
-// Turn a list into an iterator
-struct ListIterator = <A> => { list: [A], idx: int, };
-let iter<[A], ListIterator<A>> = (list) => {
-    ListIterator<A> {
-        list=list,
-        idx=0,
-    }
+Iter := <C, I> => trait {
+    iter: (C) -> I;
 };
 
-let next<ListIterator<A>, A> = (iterator: ListIterator<A>) => {
-    if (iterator.idx == iterator.list.size() - 1) {
-        None
-    } else {
-        let idx = iterator.idx;
-        iterator.idx += 1;
+// Turn a list into an iterator
+ListIterator = <A> => struct(
+    list: [A], 
+    idx: int,
+);
 
-        Some(iterator.list[idx])
-    }
+Iter ~= impl ListIterator<A> {
+    iter :=  (list) => {
+        ListIterator<A>(
+            list,
+            idx=0,
+        )
+    };
+};
+
+Next ~= impl ListIterator<A> {
+    next := (iter) => {
+        if (iterator.idx == iterator.list.size() - 1) {
+            None
+        } else {
+            idx := iterator.idx;
+            iterator.idx += 1;
+
+            Some(iterator.list[idx])
+        }
+    };
 };
 
 // Turn a string into a character iterator
-struct CharIterator = {
+CharIterator := struct(
     idx: int,
     string: str,
+);
+
+
+Next ~= impl CharIterator {
+    next := (iterator) => {
+        if (iterator.idx == iterator.string.size() - 1) {
+            None
+        };
+
+        idx := iterator.idx;
+        iterator.idx += 1;
+
+        Some(iterator.string[idx])
+    };
 };
 
-
-// The character iterator.
-let next<CharIterator, char> = (iterator: CharIterator) => {
-    if (iterator.idx == iterator.string.size() - 1) {
-        None
-    }
-
-    let idx = iterator.idx;
-    iterator.idx += 1;
-
-    Some(iterator.string[idx])
-};
-
-let iter<str, CharIterator> = (string) => {
-    CharIterator {
-        string=string,
-        idx=0,
-    }
+Iter ~= impl CharIterator {
+    iter := (string) => {
+        CharIterator(
+            string=string,
+            idx=0,
+        ) 
+    };
 };
 
 // Turn a map into a tuple iterator
-struct MapIterator = <A, B> => { 
+MapIterator := <A, B> => struct( 
     keys: [A],
     original: {A: B},
-    idx: int,
-};
+    idx: usize,
+);
 
 // Implementation for the map iterator 
-let next<MapIterator<A, B>, (A, B)> = (iterator) => {
-    if (iterator.idx == iterator.keys.size() - 1) {
-        None
-    }
+Next ~= impl MapIterator<A, B> {
+    iter := (iterator) => {
+        if (iterator.idx == iterator.keys.size() - 1) {
+            return None;
+        };
 
-    let idx = iterator.idx;
-    iterator.idx += 1;
+        idx := iterator.idx;
+        iterator.idx += 1;
 
-    Some(map[iterator.map[idx]]);
+        Some(map[iterator.map[idx]])
+    };
 };
 
-let iter<{A:B}, MapIterator<A, B>> = (map) => {
-    // essentially iterate over the keys of a map and just convert into a list of keys
-
-    MapIterator<A, B> {
-        keys=#intrinsic_get_keys(map),
-        map=map,
-        idx=0,
-    }
+Iter ~= impl MapIterator<A, B> {
+    iter := (map) => {
+        // essentially iterate over the keys of a map and just convert into a list of keys
+        MapIterator<A, B>(   
+            keys = intrinsic_get_keys(map),
+            map,
+            idx = 0,
+        )
+    };
 };
 
 // Turn a set into a list iterator
-struct SetIterator = <A, B> => { set: [A], idx: int, };
+SetIterator := <A> => struct( 
+    set: [A], 
+    idx: usize,
+);
 
 // Implementation for the map iterator 
-let next<SetIterator<A>, A> = (iterator) => {
-    if (iterator.idx == iterator.map.size() - 1) {
-        None
-    }
+Next ~= impl SetIterator<A> { 
+    next := (iterator) => {
+        if (iterator.idx == iterator.map.size() - 1) {
+            return None;
+        };
 
-    let idx = iterator.idx;
-    iterator.idx += 1;
+        idx := iterator.idx;
+        iterator.idx += 1;
 
-    Some(set[idx]);
+        Some(set[idx])
+    };
 };
 
 // Create a set iterator from an iterator
-let iter<{A}, SetIterator<A>> = (set) => {
-    // essentially iterate over the keys of a set and just convert into a list of keys
-    Setterator<A> {
-        map=#intrinsic_get_keys(set),
-        idx=0,
-    }
+Iter ~= impl SetIterator<A> {
+    iter := (set) => {
+        // essentially iterate over the keys of a set and just convert into a list of keys
+        SetIterator<A>(   
+            map = intrinsic_get_keys(set),
+            idx = 0,
+        )
+    };
 };
-
 
 // Skip n elements.
-struct Skip = <I> => { inner: I, skip: int, current: int, };
-trait skip = <I> => (I, int) => Skip<I>;
+Skip := <I: Next> => trait {
+    Self := struct( 
+        inner: I, 
+        skip: usize, 
+        current: usize
+    );
 
-let skip<I> where next<I, ?> = (skipper, skips) => {
-    // check if the number of skips that are performed will exceed the iterator
-    // in this case we can just return None
-    Skip {
-        inner=skipper,
-        skip=skips,
-        current=0,
-    }
+    skip := (inner: I, skips: usize) -> Self => {
+        // check if the number of skips that are performed will exceed the iterator
+        // in this case we can just return None
+        Self(
+            inner = i,
+            skip = skips,
+            current = 0,
+        )
+    };
 };
 
-let next<Skip<I>, T> where next<I, T> = (skipper) => {
-    let {inner, current, skip} = skipper;
+Next ~= impl Skip<I> {
+    next := (iterator) => {
+        Self(inner, current, skip) := iterator;
 
-    if (skip > current) {
-        // increment the count within the inner iterator and set the 'current' value
-        // within the skipper
-        inner.idx += skip - current;
-    }
+        if (skip > current) {
+            // increment the count within the inner iterator and set the 'current' value
+            // within the skipper
+            inner.idx += skip - current;
+        };
 
-    next(inner)
+        next(inner)
+    };
 };
 
 // First n elements.
-struct First = <I> => {
-    elements: I,
-    current: int,
-    end: int,
+First ~= <I: Next> => trait {
+    Self := struct(
+        elements: I,
+        current: usize,
+        end: usize,
+    );
+
+    first : (I, usize) -> Self<I>;
 };
 
-trait first = <I> => (I, int) => First<I>;
+First ~= impl {
+    first := (iterator, count) => {
+        // call next 'count' many times and collect the items into the first few items
+        elements := [];
 
-let first<I> where next<I, ?> = (iterator, count) => {
-    // call next 'count' many times and collect the items into the first few items
-    let elements = [];
-
-    while (count > 0) {
-        match next(iterator) {
-            Some(k) => {elements.append(k);};
-            None => {break;};
-        }
-         
-        count-= 1;
-    }
+        while (count > 0) {
+            match next(iterator) {
+                Some(k) => { elements.append(k); };
+                None => break;
+            };
+            
+            count-= 1;
+        };
 
 
-    First {
-        elements=elements,
-        current=0,
-        end=0,
-    }
-}; 
-
-let next<First<I>, T> where next<I, T> = (iterator) => {
-    if (iterator.current == iterator.end) {
-        None
-    } else {
-        let idx = iterator.current;
-        iterator.current+=1;
-        Some(iterator.elements[idx])
-    }
+        First(
+            elements,
+            current = 0,
+            end = 0,
+        )
+    };
 };
 
-trait last = <I, T> => (I, int) => ListIterator<T>;
-let last<I, T> where next<I, T> = (iterator, count) => {
-    let elements = [];
+Next ~= <I> => impl First<I> {
+    next := (iterator) => {
+        if (iterator.current == iterator.end) {
+            None
+        } else {
+            idx := iterator.current;
+            iterator.current += 1;
 
-    // loop through the whole iterator up until the end and the collect the terms
-    for i in iterator {
-        elements.push(i);
-    }
-
-    let to_keep = [];
-    for x in range(0, elements.size()) {
-        if (elements.size() - x <= count) {
-            to_keep.push(elements[x]);
-        }
-    }
-    return to_keep.iter();
+            Some(iterator.elements[idx])
+        }    
+    };
 };
 
-let last<ListIterator<T>, T> = (iterator, count) => {
-    let to_keep = [];
-    for x in range(iterator.idx, iterator.list.size()) {
-        if (literator.list.size() - x <= count) {
-            to_keep.push(iterator.list[x]);
-        }
-    }
-    return to_keep.iter();
+Last := <I, T> => trait {
+    last := (iterator: I, index: usize) -> ListIterator<T> => {
+        elements := [];
+
+        // loop through the whole iterator up until the end and the collect the terms
+        for i in iterator {
+            elements.push(i);
+        };
+
+        to_keep := [];
+
+        for x in range(0, elements.size()) {
+            if (elements.size() - x <= count) {
+                to_keep.push(elements[x]);
+            };
+        };
+
+        return to_keep.iter();
+    };
+};
+
+
+Last ~= impl Last<ListIterator<T>, T> {
+    last := (iterator, count) => {
+        to_keep := [];
+
+        for x in range(iterator.idx, iterator.list.size()) {
+            if (literator.list.size() - x <= count) {
+                to_keep.push(iterator.list[x]);
+            };
+        };
+
+        return to_keep.iter();
+    };
 };
 
 // Get the nth element.
-trait nth = <I, T> => (I, int) => Option<T>;
-let nth<I, T> where next<I, T> = (iterator, idx) => {
-    let count = 0;
-    let result;
-
-    while (count < idx) {
-        result = next(iterator);
-
-        match result {
-            Some(k) => {continue;};
-            None => {return None;};
-        }
-        count+=1;
-    }
-
-    result
+Nth := <I, T> => trait {
+    nth : (I, usize) -> Option<T>;
 };
 
+Nth ~= impl {
+    nth := (iterator, index) => {
+        count := 0;
+        result: Option<T>;
 
-trait reverse = <I, T> => (I) => ListIterator<T>;
-let reverse<I, T> where next<I, T> = (iterator) => {
-    let elements = [];
+        while (count < idx) {
+            result = next(iterator);
 
-    for item in iterator {
-        elements.push_front(item);
-    }
+            match result {
+                Some(k) => {
+                    continue 
+                };
+                None => { 
+                    return None 
+                };
+            };
 
-    elements.iter()
+            count += 1;
+        };
+
+        result
+    };
+};
+
+Reverse := <I, T: Next<I, T>> => trait {    
+    reverse: (I) -> ListIterator<T> = (iterator) => {
+        elements := [];
+
+        for item in iterator {
+            elements.push_front(item);
+        };
+
+        elements.iter()
+    };
 };
 
 // Enumerate the iterator.
-struct Enumerate = <I> => {
-    idx: int,
-    item: I,
+Enumerate := <I: Next> => trait {
+    Self := struct(
+        idx: usize,
+        item: I,
+    );
+
+    enumerate := (iterator) -> Self => {
+        Self(
+            idx = 0,
+            item = iterator
+        )
+    };
 };
 
-trait enumerate = <I> => (I) => Enumerate<I>;
-let enumerate<I> where next<I, ?> = (iterator) => {
-    Enumerate {
-        idx=0,
-        item=iterator,
-    }
-}; 
+Enumerate ~= <I> => impl Next<I> {
+    next := (iter: Enumerate<I>) -> Option<(T, usize)> => {
+        match next(iterator.item) {
+            Some(k) => { 
+                idx := iterator.idx;
+                iterator.idx += 1;
 
-let next<Enumerate<I>, (int, T)> where next<I, T> = (iterator) => {
-    match next(iterator.item) {
-        Some(k) => { 
-            let idx = iterator.idx;
-            iterator.idx += 1;
-            Some(idx, k)
-        };
-        None => {None;};
-    }
+                Some(idx, k)
+            };
+            None => None;
+        }    
+    };
 };
+
 
 // Zip two iterators.
-struct Zip = <A, B> => {
-    first: A,
-    second: B,
+Zip := <A: Next, B: Next> => trait {
+    Self := <A: Next, B: Next> => struct(
+        first: A,
+        second: B,
+    );
+
+    zip := (a: A, b: B) -> Self<A, B> => {
+        Self(a, b)  
+    };
 };
 
-trait zip = <A, B> => (A, B) => Zip<A, B>;
+Zip ~= <A: Next<X>, B: Next<Y>> => impl Next<(X, Y)> {
+    next := (zipper) => {
+        left_result  := next(zipper.first);
+        right_result := next(zipper.first);
 
-let zip<A, B> where next<A, ?>, next<B, ?> = (left_iter, right_iter) => {
-    Zip {
-        a=left_iter,
-        b=right_iter,
-    }
+
+        match (left_result, right_result) {
+           (Some(k), Some(t)) => Some((k, t));
+           _ => None;
+        }
+    };
 };
 
-// Get the next element from the zip iterator
-let next<Zip<A, B>, (X, Y)> where next<A, X>, next<B, Y> = (zipper) => {
-    let left_result = next(zipper.first);
-    let right_result = next(zipper.right);
+// {A: B}
+Collect ~= <I, S: Eq ~ Hash ~ Next<I, (A, B)>> => impl {
+    collect := (iterator) => {
+        new_map: {A:B} = {};
 
-    match (left_result, right_result) {
-        (Some(k), Some(t)) => Some((k, t));
-        _ => None;
-    }
-};
+        for (a, b) in iterator {
+            new_map[a] = b;
+        }
 
-// Collect iterator of tuples into a map
-let collect<I, {A:B}> where eq<A>, hash<A>, next<I, (A, B)> = (iterator) => {
-    let new_map: {A:B} = {};
-
-    for (a, b) in iterator {
-        new_map[a] = b;
-    }
-
-    new_map
+        new_map
+    };
 };

--- a/stdlib/list.hash
+++ b/stdlib/list.hash
@@ -7,38 +7,36 @@
 // All rights reserved 2021 (c) The Hash Language authors
 //
 
+// swap two elements within an array
+swap := <A> => (arr: [A], a: usize, b: usize) -> void => {
+    temp := arr[a];
+    arr[a] = arr[b];
+    arr[b] = temp;
+};
+
 /* This function takes last element as pivot, places the pivot element at its 
  * correct position in sorted list, and places all smaller (smaller than pivot)
  * to left of pivot and all greater elements to right of pivot */
-trait partition = <A> where ord<A> => ([A]) => [A];
-let partition<A> where ord<A> = (arr: [A], low: int, high: int) => {
-    // swap two elements within an array
-    trait swap = <A> => ([A], int, int) => void;
-    let swap<A, int, int> = (arr, a, b) => {
-        let temp = arr[a];
-        arr[a] = arr[b];
-        arr[b] = temp;
-    };
-    
-    let pivot = arr[high]; // pivot
-    let i = low - 1; // Index of smaller element and indicates the right position of pivot found so far
-    let j = low;
+partition := <A: Ord> => (arr: [A], low: usize, high: usize) => {    
+    pivot := arr[high]; // pivot
+    i := low - 1; // Index of smaller element and indicates the right position of pivot found so far
+    j := low;
 
     while (low <= high - 1) {
         if (arr[j] < pivot) {
             i+=1;
             swap(arr, i, j);
         }
-    }
+    };
     
     swap(arr, i + 1, high);
     i + 1
 };
 
-let quick_sort<A> where ord<A> = (arr: [A], low: int, end: int) => {
+quick_sort := <A: Ord> => (arr: [A], low: int, end: int) => {
     /* part is partitioning index, arr[pi] is now at right place */
-    if {low < high} {
-        let part = partition(arr, low, high);
+    if low < high {
+        part := partition(arr, low, high);
     
         quick_sort(arr, low, pi - 1);
         quick_sort(arr, part, high)
@@ -48,64 +46,60 @@ let quick_sort<A> where ord<A> = (arr: [A], low: int, end: int) => {
 };
 
 
-// Unstable sorting
-trait unstable_sort = <A> => ([A]) => [A];
-let unstable_sort<[A]> where ord<A> = (arr) => {
-    quick_sort(arr, 0, arr.size);
-};
 
-
-let merge<A> = (arr: [A], l: int, m: int, r: int) => {
-    let n1 = m - l + 1;
-    let n2 = r - m;
+merge := <A: ORD> => (arr: [A], l: int, m: int, r: int) => {
+    n1 := m - l + 1;
+    n2 := r - m;
  
     /* create temp arrays */
-    let temp_right = [];
-    let temp_left = [];
+    temp_right := [];
+    temp_left := [];
  
     /* Copy data to temp arrays temp_left and temp_right */
     for i in range(0, n1).iter() {
         temp_left[i] = arr[l + i];
-    }
+    };
+
     for j in range(0, n2).iter() {
         temp_right[j] = arr[m + 1 + j];
-    }
+    };
 
     /* Merge the temp arrays back into arr[l..r]*/
-    let i = 0; // Initial index of first subarray
-    let j = 0; // Initial index of second subarray
-    let k = l; // Initial index of merged subarray
+    i := 0; // Initial index of first subarray
+    j := 0; // Initial index of second subarray
+    k := l; // Initial index of merged subarray
     while (i < n1 && j < n2) {
         if (temp_left[i] <= temp_right[j]) {
             arr[k] = temp_left[i];
-            i+=1;
+            i += 1;
         } else {
             arr[k] = temp_right[j];
-            j+=1;
-        }
-        k+=1;
-    }
+            j += 1;
+        };
+
+        k += 1;
+    };
     
     // copy the remaining left handside 
     while (i < n1) {
         arr[k] = left_temp[i];
         i+=1; k+=1;
-    }
+    };
     
     // copy the remaining right handside 
     while (j < n2) {
         arr[k] = right_temp[j];
         j+=1; k+=1;
-    } 
+    };
 
     arr
 };
  
 /* l is for left index and r is right index of the
 sub-array of arr to be sorted */
-let merge_sort<A> where ord<A> = (arr: [A], l: int, r: int) => {
-    if (l < r) {
-        let m = (l+r)/2;
+merge_sort := <A: Ord> => (arr: [A], l: usize, r: usize) => {
+    if l < r {
+        m := (l + r) / 2;
  
         // Sort first and second halves
         merge_sort(arr, l, m);
@@ -116,8 +110,3 @@ let merge_sort<A> where ord<A> = (arr: [A], l: int, r: int) => {
         arr
     }
 };
-
-
-// Stable sort
-trait sort = <A> => ([A]) => [A];
-let sort<A> where ord<A> = (arr) => merge_sort(arr);

--- a/stdlib/num.hash
+++ b/stdlib/num.hash
@@ -8,59 +8,55 @@
 //
 
 // PI
-let pi: float = 3.141592653589793;
+pub pi: float = 3.141592653589793;
 
 // Euler's Number
-let exp = 2.718281828459045;
+pub exp = 2.718281828459045;
 
 // Exponentiation
-trait pow = <T> => (T, T) => T;
-let pow<int>   = (base, exponent) => #intrinsic_pow(base, exponent);
-let pow<float> = (base, exponent) => #intrinsic_pow(base, exponent);
+Pow := <T> => trait {
+    pow : (base: T, exponent: T) -> T;
+}
+
+Pow ~= impl float {
+    pow := (base, exponent) => intrinsic_pow(base, exponent);
+};
+
+Pow ~= impl int {
+    pow := (base, exponent) => intrinsic_pow(base, exponent);
+};
+
 
 // Trigonometry
-trait sin = <T> => (T) => T;
-trait cos = <T> => (T) => T;
-trait tan = <T> => (T) => T;
-trait asin = <T> => (T) => T;
-trait acos = <T> => (T) => T;
-trait atan = <T> => (T) => T;
-trait sinh = <T> => (T) => T;
-trait cosh = <T> => (T) => T;
-trait tanh = <T> => (T) => T;
-trait asinh = <T> => (T) => T;
-trait acosh = <T> => (T) => T;
-trait atanh = <T> => (T) => T;
-
-let sin<float>   = (num) => #intrinsic_sin(num);
-let cos<float>   = (num) => #intrinsic_cos(num);
-let tan<float>   = (num) => #intrinsic_tan(num);
-let asin<float>  = (num) => #intrinsic_asin(num);
-let acos<float>  = (num) => #intrinsic_acos(num);
-let atan<float>  = (num) => #intrinsic_atan(num);
-let sinh<float>  = (num) => #intrinsic_sinh(num);
-let cosh<float>  = (num) => #intrinsic_cosh(num);
-let tanh<float>  = (num) => #intrinsic_tanh(num);
-let asinh<float> = (num) => #intrinsic_asinh(num);
-let acosh<float> = (num) => #intrinsic_acosh(num);
-let atanh<float> = (num) => #intrinsic_atanh(num);
+sin   = <T> => (value: T) -> T => intrinsic_sin(value);
+cos   = <T> => (value: T) -> T => intrinsic_cos(value);
+tan   = <T> => (value: T) -> T => intrinsic_tan(value);
+asin  = <T> => (value: T) -> T => intrinsic_asin(value);
+acos  = <T> => (value: T) -> T => intrinsic_acos(value);
+atan  = <T> => (value: T) -> T => intrinsic_atan(value);
+sinh  = <T> => (value: T) -> T => intrinsic_sinh(value);
+cosh  = <T> => (value: T) -> T => intrinsic_cosh(value);
+tanh  = <T> => (value: T) -> T => intrinsic_tanh(value);
+asinh = <T> => (value: T) -> T => intrinsic_asinh(value);
+acosh = <T> => (value: T) -> T => intrinsic_acosh(value);
+atanh = <T> => (value: T) -> T => intrinsic_atanh(value);
 
 // Logarithm (value, base)
-trait log = <T> => (T, T) => T;
-let log<float> = (num) => #intrinsic_log(num);
+log := <T> => (num: T, base: T) -> T => intrinsic_log(num, base);
 
 // Square root (may be faster than pow(conv(x), 0.5))
-trait sqrt = <T> => (T) => T;
-let sqrt<float> = (num) => #intrinsic_sqrt(num);
+sqrt := (num: f64) => intrinsic_sqrt(num);
 
 // Convert degrees to radians
-let to_rad: (float) => float = (deg) => (pi/180.0)*deg;
+to_rad: (f64) -> f64 = (deg) => (pi/180.0)*deg;
+to_rad: (f32) -> f32 = (deg) => (pi/180.0)*deg;
 
 // Convert radians to degrees
-let to_deg: (float) => float = (rad) => (180.0/pi)*rad;
+to_deg: (f64) => f64 = (rad) => (180.0/pi)*rad;
+to_deg: (f32) => f32 = (rad) => (180.0/pi)*rad;
 
 // complex numbers
-struct Complex = <I> where add<I>, sub<I>, mul<I>, sub<I> => {
+Complex = <I: Add ~ Sub ~ Mul> => struct(
     a: I,
-    b: I,
-};
+    b: I,   
+);

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -10,248 +10,346 @@
 //
 
 // Output a line to standard output
-let print = (msg: str): void => #intrinsic_print(msg);
+print := (msg: str) -> void => intrinsic_print(msg);
 
 // Read a line from standard input
-let input: () => str = () => #intrinsic_input();
+input := () -> str => intrinsic_input();
 
 // Panic
 // Kill the process and exit with a message.
-let panic = (msg: str): never => #intrinsic_panic(msg);
+panic := (msg: str) -> never => #intrinsic_panic(msg);
 
 // Unreachable case filling
 // For when you do a match case and need to provide a '_' case
 // you should use the 'unreachable' function
-let unreachable = (): never => panic("Reached unreachable case!");
+unreachable := () -> never => panic("Reached unreachable case!");
 
 // Convert type A to type B
-trait conv = <A, B> => (A) => B;
+Conv := <A, B> => trait {
+    conv : (item: A) -> B;
+};
 
 // we provide a number of implementations for converting types
 
 // Blanket to string
-let conv<T, str> = (x) => "<unknown>";
+Conv ~= <T> => impl Conv<T, str> {
+    conv := (_) => "<unknown>";
+};
 
-let conv<int,float>    = (num) => #intrinsic_conv_to_float(num);
-let conv<float, float> = (num) => num; // @@Cleanup: maybe a better way to do this rather than explicitly providing an implementation
-let conv<str, Result<float, str>> = (s) => #intrinsic_conv_to_float(s);
+Conv ~= impl Conv<u64, f64> {
+    conv := (item) => intrinsic_conv_to_float(num);
+};
 
-let conv<int, Result<char, str>> = (num) => #intrinsic_conv_to_char(num);
-let conv<char, char> = (ch) => ch;
+// Fallible conversion methods for float, int, char from a `str`
+Conv ~= impl Conv<str, Result<float, str>> {
+    conv := (s) => #intrinsic_conv_to_float(s);
+};
 
-let conv<char, int>  = (ch) => #intrinsic_conv_to_int(ch);
-let conv<float, int> = (num) => #intrinsic_conv_to_int(num);
-let conv<int, int>   = (num) => num; // @@Cleanup: maybe a better way to do this rather than explicitly providing an implementation
-let conv<str, Result<int, str>> = (s) => #intrinsic_conv_to_int(s);
+Conv ~= impl Conv<str, Result<int, str>> {
+    conv := (s) => intrinsic_conv_to_int(s);
+};
 
-let conv<bool, str> = (x: bool) => match x {
+Conv ~= impl Conv<int, Result<char, str>> {
+    conv := (s) => intrinsic_conv_to_char(s);
+};
+
+Conv ~= impl Conv<char, int> {  
+    conv := (ch) => intrinsic_conv_to_int(ch); 
+};
+
+Conv ~= impl Conv<float, int> { 
+    conv := (num) => intrinsic_conv_to_int(num); 
+};
+
+Conv ~= impl Conv<str, Result<int, str>> {
+    conv := (s) => intrinsic_conv_to_int(s);
+};
+
+Conv ~= impl Conv<bool, str> {
+    conv := (x) => match x {
     true => "true";
     false => "false";
+    };
 };
-let conv<int, str>   = (num) => #intrinsic_conv_to_str(num);
-let conv<float, str> = (num) => #intrinsic_conv_to_str(num);
-let conv<char, str>  = (ch) => #intrinsic_conv_to_str(ch);
-let conv<void, str>  = (v) => ""; // @@Cleanup: Is this really needed?
-let conv<str, str> = (s) => s;
-//let conv<() => T,  str> = (val) => #intrinsic_conv_to_str(val);
 
-let conv<{A:B}, str> where hash<A>, eq<A>, conv<A, str>, conv<B, str> = (map) => #intrinsic_conv_map_to_str(map, (a) => conv<A, str>(a), (a) => conv<B, str>(a));
-let conv<{A}, str> where hash<A>, eq<A>, conv<A, str>  = (set) => #intrinsic_conv_bracketted_to_str(set, (a) => conv<A, str>(a)); 
-let conv<[A], str> where conv<A, str>   = (arr) => #intrinsic_conv_bracketted_to_str(arr, (a) => conv<A, str>(a)); //@@Cleanup: variables should support generic args 
+Conv ~= impl Conv<int, str> { conv := (num) => intrinsic_conv_to_str(num); };
+Conv ~= impl Conv<float, str> { conv := (num) => intrinsic_conv_to_str(num); };
+Conv ~= impl Conv<char, str> { conv := (ch) => intrinsic_conv_to_str(ch); };
+Conv ~= impl Conv<void, str> { conv := (v) => ""; };
+
+Conv ~= impl Conv<{A:B}, str> { 
+    conv := (map) => intrinsic_conv_map_to_str(
+        map, 
+        (a) => conv<A, str>(a), 
+        (b) => conv<B, str>(b)
+    ); 
+};
+
+Conv ~= impl Conv<{A}, str> {
+    conv := (set) => intrinsic_conv_bracketted_to_str(set, (a) => conv<A, str>(a));
+};
+
+Conv ~= impl Conv<[A], str> {
+    conv := (arr) => intrinsic_conv_bracketted_to_str(arr, (a) => conv<A, str>(a)); 
+}; 
 
 // Tuples conv: @@TODO
 
 // Trait to get the size of an item, such as a bracktted type or a string
-trait size = <A> => (A) => int;
+Size := <A> => trait {
+    size : (item: A) -> usize;
+};
 
-let size<[T]> = (arr) => #intrinsic_size(arr);
-let size<str> = (str) => #intrinsic_size(str);
-let size<{T}> where eq<T>, hash<T> = (set) => #intrinsic_size(set);
-let size<{K:V}> where eq<K>, hash<K> = (map) => #intrinsic_size(map);
+Size ~= impl Size<[T]>    { size := (item) => intrinsic_size(item); };
+Size ~= impl Size<str>    { size := (item) => intrinsic_size(item); };
+Size ~= impl Size<{T}>    { size := (item) => intrinsic_size(item); };
+Size ~= impl Size<{K: V}> { size := (item) => intrinsic_size(item); };
 
-// Primitives that are injected even before the prelude is injected 
-//enum bool = {
-//   true,
-//   false,
-//};
 
-// Represents an optional value.
-// enum Option = <T> => {
-//   Some(T),
-//   None,
-// };
+// Convert some type `T` into a `u64`. Hashing trait.
+Hash := <T> => trait {
+    hash : (item: T) -> u64;
+};
 
-// Represents the result of a fallible operation.
-// enum Result = <T, E> => {
-//   Ok(T),
-//   Err(E),
-// };
+Hash ~= impl Hash<int> { 
+    hash := (num) => #intrinsic_hash(num); 
+};
 
-// Hash a value into a 64-bit integer
-// trait hash = <A> => (A) => int;
+Hash ~= impl Hash<float> { 
+    hash := (num) => #intrinsic_hash(num); 
+};
 
-let hash<int>   = (num) => #intrinsic_hash(num);
-let hash<float> = (num) => #intrinsic_hash(num);
-let hash<char>  = (ch) => #intrinsic_hash(ch);
-let hash<str>   = (string) => #intrinsic_hash(string);
+Hash ~= impl Hash<char> { 
+    hash := (ch) => #intrinsic_hash(ch); 
+};
+
+Hash ~= impl Hash<str> { 
+    hash := (string) => #intrinsic_hash(string); 
+};
 
 // Add operator (+)
 // Implemented for all numeric primitives, strings, lists.
-trait add = <T> => (T, T) => T;
-let add<int>   = (left, right) => #intrinsic_add(left, right);
-let add<float> = (left, right) => #intrinsic_add(left, right);
-let add<str>   = (left, right) => #intrinsic_add(left, right); 
-let add<[A]>   = (left, right) => #intrinsic_add(left, right);
+Add := <T> => trait {
+    add: (T, T) -> T;
+};
+
+Add ~= impl Add<int>   { add := (left, right) => intrinsic_add(left, right); };
+Add ~= impl Add<float> { add := (left, right) => intrinsic_add(left, right); };
+Add ~= impl Add<str>   { add := (left, right) => intrinsic_add(left, right);  };
 
 // adding sets and maps together
-// let add<{A:B}> where eq<A>, hash<A> = (left, right) => #intrinsic_map_add(left, right, (a) => hash<A>(a));
-// let add<{A}> where eq<A>, hash<A>  = (left, right) => #intrinsic_set_add(left, right, (a) => hash<A>(a));
+// Add ~= impl Add<[A]>   { add := (left, right) => intrinsic_add(left, right); };
+// Add ~= impl Add<{A}>   { add := (left, right) => intrinsic_set_add(left, right); };
+// Add ~= impl Add<{A: B}>   { add := (left, right) => intrinsic_map_add(left, right); };
 
 // The following are implemented for all numeric primitives:
 
 // Subtract operator (-)
-trait sub = <T> => (T, T) => T;
-let sub<int>   = (left, right) => #intrinsic_sub(left, right);
-let sub<float> = (left, right) => #intrinsic_sub(left, right);
+Sub := <T> => trait {
+    sub: (T, T) -> T;
+};
+
+Sub ~= impl Sub<int>   { sub := (left, right) => intrinsic_sub(left, right); };
+Sub ~= impl Sub<float> { sub := (left, right) => intrinsic_sub(left, right); };
 
 // Multiply operator (*)
-trait mul = <T> => (T, T) => T;
-let mul<int>   = (left, right) => #intrinsic_mul(left, right);
-let mul<float> = (left, right) => #intrinsic_mul(left, right);
+Mul := <T> => trait {
+    mul: (T, T) -> T;
+};
+
+Mul ~= impl Mul<int>   { mul := (left, right) => intrinsic_mul(left, right); };
+Mul ~= impl Mul<float> { mul := (left, right) => intrinsic_mul(left, right); };
 
 // Divide operator (/)
-trait div = <T> => (T, T) => T;
-let div<int>   = (left, right) => #intrinsic_div(left, right);
-let div<float> = (left, right) => #intrinsic_div(left, right);
+Div := <T> => trait {
+    div: (T, T) -> T;
+};
+
+Div ~= impl Div<int>   { div := (left, right) => intrinsic_div(left, right); };
+Div ~= impl Div<float> { div := (left, right) => intrinsic_div(left, right); };
 
 // Modulus operator (%)
-trait mod = <T> => (T, T) => T;
-let mod<int>   = (left, right) => #intrinsic_mod(left, right);
-let mod<float> = (left, right) => #intrinsic_mod(left, right);
+Mod := <T> => trait {
+    modulo: (T, T) -> T;
+};
+
+Mod ~= impl Mod<int>   { modulo := (left, right) => intrinsic_mod(left, right); };
+Mod ~= impl Mod<float> { modulo := (left, right) => intrinsic_mod(left, right); };
 
 // Negation
-trait neg = <T> => (T) => T;
-let neg<int>   = (x) => #intrinsic_neg(x);
-let neg<float> = (x) => #intrinsic_neg(x);
+Neg := <T> => trait {
+    neg: (T) -> T;
+};
+
+Neg ~= impl Neg<int>   { neg := (item) => intrinsic_neg(item); };
+Neg ~= impl Neg<float> { neg := (item) => intrinsic_neg(item); };
 
 // Bitwise operations
-trait bit_shr = <T> => (T, T) => T;
-trait bit_shl = <T> => (T, T) => T;
-trait bit_not = <T> => (T) => T;
-trait bit_and = <T> => (T, T) => T;
-trait bit_or  = <T> => (T, T) => T;
-trait bit_xor = <T> => (T, T) => T;
+BitShr := <T> => trait {bit_shr : (T, T) -> T;};
+BitShl := <T> => trait {bit_shl : (T, T) -> T;};
+BitOr  := <T> => trait {bit_or  : (T, T) -> T;};
+BitXor := <T> => trait {bit_xor : (T, T) -> T;};
 
-let bit_shr<int> = (a, b) => #intrinsic_bit_shr(a, b);
-let bit_shl<int> = (a, b) => #intrinsic_bit_shl(a, b);
-let bit_not<int> = (b) => #intrinsic_bit_not(b);
-let bit_and<int> = (a, b) => #intrinsic_bit_and(b);
-let bit_or<int>  = (b, b) => #intrinsic_bit_or(b);
-let bit_xor<int> = (b, b) => #intrinsic_bit_xor(b);
+BitNot := <T> => trait {bit_not : (T) -> T;};
+BitAnd := <T> => trait {bit_and : (T, T) -> T;};
+
+BitShr := impl BitShr<int> {bit_shr := (a, b) => #intrinsic_bit_shr(a, b); };
+BitShl := impl BitShl<int> {bit_shl := (a, b) => #intrinsic_bit_shl(a, b); };
+BitOr  := impl BitOr <int> {bit_or  := (a, b)=> #intrinsic_bit_or(b); };
+BitXor := impl BitXor<int> {bit_xor := (a, b)=> #intrinsic_bit_xor(b); };
+
+BitNot := impl BitNot<int> {bit_not := (a) => #intrinsic_bit_not(a); };
+BitAnd := impl BitAnd<int> {bit_and := (a) => #intrinsic_bit_and(a); };
+
 
 // Equality
-// trait eq = <T> => (T, T) => bool;
-let eq<int> = (a, b) => #intrinsic_eq(a, b);
-let eq<char> = (a, b) => #intrinsic_eq(a, b);
-let eq<float> = (a, b) => #intrinsic_eq(a, b);
-let eq<str> = (a, b) => #intrinsic_eq(a, b);
-let eq<[A]> where eq<A> = (a, b) => #intrinsic_eq_bracketted(a, b, (x, y) => eq<A>(x, y));
+Eq := <T> => trait {
+    eq: (T, T) -> bool;
+};
+
+
+Eq ~= impl Eq<int> {
+    eq := (a, b) => intrinsic_eq(a, b);
+};
+
+Eq ~= impl Eq<char> {
+    eq := (a, b) => intrinsic_eq(a, b);
+};
+
+Eq ~= impl Eq<float> {
+    eq := (a, b) => intrinsic_eq(a, b);
+};
+
+Eq ~= impl Eq<str> {
+    eq := (a, b) => intrinsic_eq(a, b);
+};
+
+Eq ~= <A: Eq> => impl Eq<[A]> {
+    eq := (a, b) => intrinsic_eq_bracketted(a, b, (x, y) => eq<A>(x, y));
+};
 
 // @@TODO: I think these are still flaky
-let eq<{A}> where eq<A>, hash<A> = (a, b) => #intrinsic_eq_bracketted(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-let eq<{A:B}> where eq<A>, hash<A>, eq<B> = (a, b) => #intrinsic_eq_map(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y), (x, y) => eq<B>(x, y));
+// let eq<{A}> where eq<A>, hash<A> = (a, b) => #intrinsic_eq_bracketted(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
+// let eq<{A:B}> where eq<A>, hash<A>, eq<B> = (a, b) => #intrinsic_eq_map(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y), (x, y) => eq<B>(x, y));
 
 
 // Ordering
 // Implemented for numeric primitives and strings.
-enum Ordering = { Lt, Eq, Gt, };
-let eq<Ordering> = (a: Ordering, b: Ordering) => match (a, b) {
-    (Eq, Eq) => true;
-    (Lt, Lt) => true;
-    (Gt, Gt) => true;
-    _ => false;
+Ordering := enum( Lt, Eq, Gt, );
+
+Eq ~= impl Eq<Ordering> {
+    eq := (a, b) => match (a, b) {
+        (Eq, Eq) => true;
+        (Lt, Lt) => true;
+        (Gt, Gt) => true;
+        _ => false;
+    };
 };
-let _int_to_ord: (int) => Ordering = (i: int) => match i {
+
+pub _int_to_ord := (i: int) -> Ordering => match i {
     0 => Eq;
     1 => Lt; 
-    x if (x == -1) => Gt;
+    x if x == -1 => Gt;
+    _ => unreachable();
 };
-trait ord = <T> => (T, T) => Ordering;
-let ord<int> = (a, b) => _int_to_ord(#intrinsic_ord(a, b));
-let ord<char> = (a, b) => _int_to_ord(#intrinsic_ord(a, b));
-let ord<float> = (a, b) => _int_to_ord(#intrinsic_ord(a, b));
-let ord<str> = (a, b) => _int_to_ord(#intrinsic_ord(a, b));
 
 
-// Reference equality
-// Automatically implemented for all types.
-trait ref_eq = <T> => (T, T) => bool;
-let ref_eq<A> = (a, b) => #intrinsic_ref_eq(a, b);
+Ord := <T> => trait {
+    ord: (a: T, b: T) -> Ordering;
+};
+
+
+Ord ~= impl Ord<int> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+Ord ~= impl Ord<char> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+Ord ~= impl Ord<float> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+Ord ~= impl Ord<str> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
 
 // Indexing
 // Implemented for maps and lists.
-trait index = <T, I, O> => (T, I) => O;
-trait index_mut = <T, I, O> => (T, I, O) => void;
 
-let index<[T], int, T> = (arr: [T], index: int): T => #intrinsic_index_get(arr, index); 
-let index<{A:B}, A, B> where hash<A>, eq<A> = (map, index): B => #intrinsic_index_map_get(map, index); 
+Index := <T, I, O> => trait {
+    index : (T, I) -> O;
+};
 
-let index_mut<[A], int, A> = (arr, index, val): void => #intrinsic_index_mut(arr, index, val); 
-let index_mut<{A:B}, A, B> where hash<A>, eq<A> = (map, index, val): void => #intrinsic_index_map_mut(map, index, val); 
+IndexMut := <T, I> => trait {
+    index_mut : (T, I, O) -> void;
+};
+
+
+Index ~= impl Index<[T], usize, T> { index := (arr, index) => intrinsic_index_get(arr, index); }; 
+Index ~= impl Index<{A:B}, A, B> { index := (map, index) => intrinsic_index_map_get(map, index); }; 
+
+IndexMut ~= impl IndexMut<[T], usize, T> { index := (arr, index, value) => intrinsic_index_mut(arr, index, value); }; 
+IndexMut ~= impl IndexMut<{A:B}, A, B> { index := (map, index, value) => intrinsic_index_map_mut(map, index, value); }; 
+
+// Index a string, returning a character
+Index ~= impl Index<str, int, char> { 
+    index := (string, idx) => intrinsic_index_get(string, idx); 
+};
+
 
 // append an item to a list
-trait push = <A> => ([A], A) => void;
-let push<A> where eq<A> = (arr, item) => #intrinsic_list_push(arr, item);
-trait push_front = <A> => ([A], A) => void;
-let push_front<A> where eq<A> = (arr, item) => #intrinsic_list_push_front(arr, item);
+Sequence := <A: Eq> => trait { 
+    inner := type A;
 
-// pop an item from a list
-trait pop = <A> => ([A]) => A;
-let pop<A> where eq<A> = (arr) => #intrinsic_list_pop(arr);
+    try_get : (Self, usize) -> Option<A>;
+    push: (Self, A) -> void;
+    push_front: (Self, A) -> void;
+    pop: (Self) -> A;
+    contains: (Self, A) -> bool;
+    insert: (Self, A, usize) -> void;
+    remove: (Self, usize) -> void;
+};
 
-// insert an into a list at a given index
-trait list_insert = <A> => ([A], A, int) => void;
-let list_insert<A> = (arr, item, idx) => #intrinsic_list_insert(arr, item, idx);
-
-// Operations on the bracketted types like insertion/removal
-trait index_remove = <T, I> => (T, I) => void;
-let index_remove<[A], int>   = (arr, index) => #intrinsic_list_remove(arr, index);
+Sequence ~= impl Sequence<[A]> {
+    try_get := (list, item) => intrinsic_list_try_get(list, item);
+    push := (list, item) => intrinsic_list_push(list, item);
+    push_front := (list, item) => intrinsic_list_push_front(list, item);
+    pop := (list) => intrinsic_list_pop(list);
+    contains := (list, item) => intrinsic_contains(list, item);
+    insert := (list, item, index) => intrinsic_list_insert(list, item, index);
+    remove := (list, index) => intrinsic_list_remove(list, index);
+};
 
 // checking if items exist within a bracketted type
-trait contains = <B, A> => (B, A) => bool;
+// trait contains = <B, A> => (B, A) => bool;
 
-let contains<[A], A> where eq<A> = (arr, item) => #intrinsic_contains(arr, item);
+// let contains<[A], A> where eq<A> = (arr, item) => #intrinsic_contains(arr, item);
 
-let contains<{A}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
+// let contains<{A}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
 
-let contains<{A:B}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
+// let contains<{A:B}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
 
-// Delete a key from a map, and return its value.
-trait remove = <C, A, B> => (C, A) => B;
+// // Delete a key from a map, and return its value.
+// trait remove = <C, A, B> => (C, A) => B;
 
-let remove<[A], A, A> where eq<A> = (arr, key) => #intrinsic_list_remove(arr, key, (x, y) => eq<A>(x, y));
+// let remove<[A], A, A> where eq<A> = (arr, key) => #intrinsic_list_remove(arr, key, (x, y) => eq<A>(x, y));
 
-let remove<{A:B}, A, B> where eq<A>, hash<A> = (map, key) => #intrinsic_bracketted_remove(map, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
+// let remove<{A:B}, A, B> where eq<A>, hash<A> = (map, key) => #intrinsic_bracketted_remove(map, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
 
-let remove<{A}, A, A> where eq<A>, hash<A> = (set, key) => #intrinsic_bracketted_remove(set, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
+// let remove<{A}, A, A> where eq<A>, hash<A> = (set, key) => #intrinsic_bracketted_remove(set, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
 
 // Index a map a key, returning a value if the key exists
-trait try_get = <A, B> where eq<A>, hash<A> => ({A:B}, A) => Option<B>; //@@TODO: should we add this?
-let try_get<A, B> where eq<A>, hash<A>;
+// trait try_get = <A, B> where eq<A>, hash<A> => ({A:B}, A) => Option<B>; //@@TODO: should we add this?
+// let try_get<A, B> where eq<A>, hash<A>;
 
 
 // Enum primitive conv
-let conv<Result<A, B>, str> where conv<A, str>, conv<B, str> = (res: Result<A, B>) => { match res { Ok(a) => "Ok(" + conv<A, str>(a) + ")"; Err(b) => "Err(" + conv<B, str>(b) + ")"; } };
-// 
-// let conv<Option<A>, str> where conv<A, str> = (opt: Option<A>) => {
-//     match opt {
-//         Some(a) => "Some(" + conv<A, str>(a) + ")";
-//         None => "None";
-//     }
-// };
+Conv ~= <A: Conv<str>, B: Conv<str>> => impl Conv<Result<A, B>, str> {
+    conv := (res: Result<A, B>) => match res { 
+        Ok(a) => "Ok(" + conv(a) + ")"; 
+        Err(b) => "Err(" + conv(b) + ")"; 
+    };
+};
 
-// Index a string, returning a character
-let index<str, int, char> = (string, idx) => #intrinsic_index_get(string, idx);
+Conv ~= <A: Conv<str>> => impl Conv<Option<A>, str> {
+    conv := (res) => match res { 
+        Some(a) => "Somw(" + conv(a) + ")"; 
+        None => "None"; 
+    };
+};
 
+
+// @@TODO: Potentially move this to `string.hash`?
 // Slice a string at [begin, end)
-let slice: (str, int, int) => str = (string, start, end) => #intrinsic_slice(string, start, end);
+slice := (string: str, start: usize, end: usize) -> str => intrinsic_slice(string, start, end);


### PR DESCRIPTION
This patch adds/fixes the following:

-  Improve(speed) parsing of decls/expressions to determine if the parser should try to parse a declaration or an expression.
- `MergeDeclaration` lhs should be an `Expression` and not a `Pattern`.