### PR TITLE
refactor: use `From` utility traits for `StringLiteral` and `Identifier` instead of directly accessing maps

### DIFF
--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -5,7 +5,6 @@
 //!
 //! All rights reserved 2022 (c) The Hash Language authors
 #![feature(generic_associated_types)]
-// #![allow(unreachable_code, unused, clippy::diverging_sub_expression)] // @@Temporary
 
 use hash_ast::{
     ast::{
@@ -19,7 +18,7 @@ use hash_ast::{
     visitor::{walk_mut, AstVisitorMut},
 };
 use hash_pipeline::sources::Sources;
-use hash_source::{identifier::IDENTIFIER_MAP, location::Span};
+use hash_source::location::Span;
 use std::convert::Infallible;
 
 pub struct AstLowering;
@@ -109,11 +108,9 @@ fn lower_for_loop_block(node: Block, parent_span: Span) -> Block {
 
     let make_access_name = |label: &str| -> AstNode<AccessName> {
         // Create the identifier within the map...
-        let ident = IDENTIFIER_MAP.create_ident(label);
-
         AstNode::new(
             AccessName {
-                path: ast_nodes![AstNode::new(ident, iter_span)],
+                path: ast_nodes![AstNode::new(label.into(), iter_span)],
             },
             iter_span,
         )

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -4,7 +4,6 @@
 use std::convert::Infallible;
 use std::iter;
 
-use hash_source::{identifier::IDENTIFIER_MAP, string::STRING_LITERAL_MAP};
 use hash_utils::tree_writing::TreeNode;
 
 use crate::{ast, visitor::walk, visitor::AstVisitor};
@@ -44,11 +43,7 @@ impl AstVisitor for AstTreeGenerator {
         _: &Self::Ctx,
         node: ast::AstNodeRef<ast::Import>,
     ) -> Result<Self::ImportRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled(
-            "import",
-            STRING_LITERAL_MAP.lookup(node.path),
-            "\"",
-        )))
+        Ok(TreeNode::leaf(labelled("import", node.path, "\"")))
     }
 
     type NameRet = TreeNode;
@@ -57,7 +52,7 @@ impl AstVisitor for AstTreeGenerator {
         _: &Self::Ctx,
         node: ast::AstNodeRef<ast::Name>,
     ) -> Result<Self::NameRet, Self::Error> {
-        Ok(TreeNode::leaf(IDENTIFIER_MAP.get_ident(node.ident)))
+        Ok(TreeNode::leaf(node.ident))
     }
 
     type AccessNameRet = TreeNode;
@@ -69,7 +64,7 @@ impl AstVisitor for AstTreeGenerator {
         Ok(TreeNode::leaf(
             node.path
                 .iter()
-                .map(|p| IDENTIFIER_MAP.get_ident(*p.body()))
+                .map(|p| (*p.body()).into())
                 .intersperse("::")
                 .collect::<String>(),
         ))
@@ -119,7 +114,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::DirectiveExpr { subject, .. } = walk::walk_directive_expr(self, ctx, node)?;
 
         Ok(TreeNode::branch(
-            labelled("directive", IDENTIFIER_MAP.get_ident(node.name.ident), "\""),
+            labelled("directive", node.name.ident, "\""),
             vec![subject],
         ))
     }
@@ -135,11 +130,7 @@ impl AstVisitor for AstTreeGenerator {
             Ok(TreeNode::branch(
                 "arg",
                 vec![
-                    TreeNode::leaf(labelled(
-                        "named",
-                        IDENTIFIER_MAP.get_ident(name.ident),
-                        "\"",
-                    )),
+                    TreeNode::leaf(labelled("named", name.ident, "\"")),
                     TreeNode::branch(
                         "value",
                         vec![self.visit_expression(ctx, node.value.ast_ref())?],
@@ -584,11 +575,7 @@ impl AstVisitor for AstTreeGenerator {
         _: &Self::Ctx,
         node: ast::AstNodeRef<ast::StrLiteral>,
     ) -> Result<Self::StrLiteralRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled(
-            "str",
-            STRING_LITERAL_MAP.lookup(node.0),
-            "\"",
-        )))
+        Ok(TreeNode::leaf(labelled("str", node.0, "\"")))
     }
 
     type CharLiteralRet = TreeNode;
@@ -1217,11 +1204,7 @@ impl AstVisitor for AstTreeGenerator {
         _: &Self::Ctx,
         node: ast::AstNodeRef<ast::StrLiteralPattern>,
     ) -> Result<Self::StrLiteralPatternRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled(
-            "str",
-            STRING_LITERAL_MAP.lookup(node.0),
-            "\"",
-        )))
+        Ok(TreeNode::leaf(labelled("str", node.0, "\"")))
     }
 
     type CharLiteralPatternRet = TreeNode;

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -4,12 +4,7 @@
 #![feature(cell_update)]
 
 use error::{LexerError, LexerErrorKind, LexerErrorWrapper, LexerResult};
-use hash_source::{
-    identifier::{CORE_IDENTIFIERS, IDENTIFIER_MAP},
-    location::Span,
-    string::STRING_LITERAL_MAP,
-    SourceId,
-};
+use hash_source::{identifier::CORE_IDENTIFIERS, location::Span, SourceId};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind};
 use std::{cell::Cell, iter};
 use utils::is_id_start;
@@ -300,13 +295,7 @@ impl<'a> Lexer<'a> {
             "impl" => TokenKind::Keyword(Keyword::Impl),
             "type" => TokenKind::Keyword(Keyword::Type),
             "_" => TokenKind::Ident(CORE_IDENTIFIERS.underscore),
-            _ => {
-                // create the identifier here from the created map
-                let ident = IDENTIFIER_MAP.create_ident(name);
-
-                // check if this is an actual keyword instead of an ident, and if it is convert the token type...
-                TokenKind::Ident(ident)
-            }
+            _ => TokenKind::Ident(name.into()),
         }
     }
 
@@ -656,8 +645,7 @@ impl<'a> Lexer<'a> {
 
         // Essentially we put the string into the literal map and get an id out which we use for the
         // actual representation in the token
-        let id = STRING_LITERAL_MAP.create_string(&value);
-        Ok(TokenKind::StrLiteral(id))
+        Ok(TokenKind::StrLiteral(value.into()))
     }
 
     /// Consume a line comment after the first following slash, essentially eating

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -6,7 +6,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use hash_ast::{ast::*, ast_nodes};
-use hash_source::{identifier::Identifier, location::Span, string::STRING_LITERAL_MAP};
+use hash_source::{identifier::Identifier, location::Span};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
 
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
@@ -520,7 +520,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             Some(Token {
                 kind: TokenKind::StrLiteral(str),
                 span,
-            }) => (str, STRING_LITERAL_MAP.lookup(*str), span),
+            }) => (str, *str, span),
             _ => gen.error(AstGenErrorKind::ImportPath, None, None)?,
         };
 
@@ -528,7 +528,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         gen.verify_is_empty()?;
 
         // Attempt to add the module via the resolver
-        let import_path = PathBuf::from_str(path).unwrap_or_else(|err| match err {});
+        let import_path = PathBuf::from_str(path.into()).unwrap_or_else(|err| match err {});
         let resolved_import_path = self
             .resolver
             .parse_import(&import_path, self.source_location(span));

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -21,35 +21,32 @@ counter! {
 }
 
 impl Display for Identifier {
-    /// Render the identifier when displaying it
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", IDENTIFIER_MAP.get_ident(*self))
     }
 }
 
+// Utility methods for converting from a String to an Identifier and vice versa.
+
 impl From<&str> for Identifier {
-    /// Create an identifier from a string.
     fn from(name: &str) -> Self {
         IDENTIFIER_MAP.create_ident(name)
     }
 }
 
 impl From<Identifier> for &str {
-    /// Convert an identifier into a string, panics if the identifier doesn't exist.
     fn from(ident: Identifier) -> Self {
         IDENTIFIER_MAP.get_ident(ident)
     }
 }
 
 impl From<Identifier> for String {
-    /// Convert an identifier into a string, panics if the identifier doesn't exist.
     fn from(ident: Identifier) -> Self {
         String::from(IDENTIFIER_MAP.get_ident(ident))
     }
 }
 
 impl From<Identifier> for Cow<'static, str> {
-    /// Convert an identifier into a string, panics if the identifier doesn't exist.
     fn from(ident: Identifier) -> Self {
         Cow::from(IDENTIFIER_MAP.get_ident(ident))
     }
@@ -104,7 +101,11 @@ impl<'c> IdentifierMap<'c> {
         } else {
             IDENTIFIER_STORAGE_WALL.with(|wall| {
                 let ident = Identifier::new();
+
+                // We need to copy over the string so that it can be inserted into
+                // the table
                 let ident_str_alloc = BrickString::new(ident_str, wall).into_str();
+
                 self.identifiers.insert(ident_str_alloc, ident);
                 self.reverse_lookup.insert(ident, ident_str_alloc);
                 ident

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -7,7 +7,11 @@ use fnv::FnvBuildHasher;
 use hash_alloc::{collections::string::BrickString, Castle, Wall};
 use hash_utils::counter;
 use lazy_static::lazy_static;
-use std::{borrow::Borrow, fmt::Display, thread_local};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt::Display,
+    thread_local,
+};
 
 counter! {
     name: Identifier,
@@ -16,17 +20,38 @@ counter! {
     method_visibility:,
 }
 
-/// Render the identifier when displaying it
 impl Display for Identifier {
+    /// Render the identifier when displaying it
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", IDENTIFIER_MAP.get_ident(*self))
     }
 }
 
-/// Create an identifier from a string.
 impl From<&str> for Identifier {
+    /// Create an identifier from a string.
     fn from(name: &str) -> Self {
         IDENTIFIER_MAP.create_ident(name)
+    }
+}
+
+impl From<Identifier> for &str {
+    /// Convert an identifier into a string, panics if the identifier doesn't exist.
+    fn from(ident: Identifier) -> Self {
+        IDENTIFIER_MAP.get_ident(ident)
+    }
+}
+
+impl From<Identifier> for String {
+    /// Convert an identifier into a string, panics if the identifier doesn't exist.
+    fn from(ident: Identifier) -> Self {
+        String::from(IDENTIFIER_MAP.get_ident(ident))
+    }
+}
+
+impl From<Identifier> for Cow<'static, str> {
+    /// Convert an identifier into a string, panics if the identifier doesn't exist.
+    fn from(ident: Identifier) -> Self {
+        Cow::from(IDENTIFIER_MAP.get_ident(ident))
     }
 }
 

--- a/compiler/hash-source/src/string.rs
+++ b/compiler/hash-source/src/string.rs
@@ -26,35 +26,32 @@ counter! {
 }
 
 impl Display for StringLiteral {
-    /// Render the identifier when displaying it
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", STRING_LITERAL_MAP.lookup(*self))
     }
 }
 
+// Utility methods for converting from a String to an StringLiteral and vice versa.
+
 impl From<&str> for StringLiteral {
-    /// Create an identifier from a string.
     fn from(string: &str) -> Self {
         STRING_LITERAL_MAP.create_string(string)
     }
 }
 
 impl From<String> for StringLiteral {
-    /// Create an identifier from a string.
     fn from(string: String) -> Self {
         STRING_LITERAL_MAP.create_string(&string)
     }
 }
 
 impl From<StringLiteral> for &str {
-    /// Convert an identifier into a string, panics if the identifier doesn't exist.
     fn from(string: StringLiteral) -> Self {
         STRING_LITERAL_MAP.lookup(string)
     }
 }
 
 impl From<StringLiteral> for String {
-    /// Convert an identifier into a string, panics if the identifier doesn't exist.
     fn from(string: StringLiteral) -> Self {
         String::from(STRING_LITERAL_MAP.lookup(string))
     }
@@ -74,8 +71,6 @@ impl StringLiteralMap {
             let ident = StringLiteral::new();
 
             // copy over the string so that we can insert it into the reverse lookup table
-            // let wall = STATIC_CASTLE.wall();
-            // let value_copy = BrickString::new(value, &wall);
             let value_copy = Box::leak(value.to_owned().into_boxed_str());
 
             self.reverse_table.insert(value_copy, ident);

--- a/compiler/hash-source/src/string.rs
+++ b/compiler/hash-source/src/string.rs
@@ -1,6 +1,8 @@
 //! Hash AST string literal storage utilities and wrappers.
 //!
 //! All rights reserved 2022 (c) The Hash Language authors
+use std::fmt::Display;
+
 use fnv::FnvBuildHasher;
 use hash_utils::counter;
 use lazy_static::lazy_static;
@@ -21,6 +23,41 @@ counter! {
     counter_name: STRING_LITERAL_COUNTER,
     visibility: pub,
     method_visibility:,
+}
+
+impl Display for StringLiteral {
+    /// Render the identifier when displaying it
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", STRING_LITERAL_MAP.lookup(*self))
+    }
+}
+
+impl From<&str> for StringLiteral {
+    /// Create an identifier from a string.
+    fn from(string: &str) -> Self {
+        STRING_LITERAL_MAP.create_string(string)
+    }
+}
+
+impl From<String> for StringLiteral {
+    /// Create an identifier from a string.
+    fn from(string: String) -> Self {
+        STRING_LITERAL_MAP.create_string(&string)
+    }
+}
+
+impl From<StringLiteral> for &str {
+    /// Convert an identifier into a string, panics if the identifier doesn't exist.
+    fn from(string: StringLiteral) -> Self {
+        STRING_LITERAL_MAP.lookup(string)
+    }
+}
+
+impl From<StringLiteral> for String {
+    /// Convert an identifier into a string, panics if the identifier doesn't exist.
+    fn from(string: StringLiteral) -> Self {
+        String::from(STRING_LITERAL_MAP.lookup(string))
+    }
 }
 
 lazy_static! {

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -7,11 +7,7 @@ pub mod delimiter;
 pub mod keyword;
 
 use delimiter::Delimiter;
-use hash_source::{
-    identifier::{Identifier, IDENTIFIER_MAP},
-    location::Span,
-    string::{StringLiteral, STRING_LITERAL_MAP},
-};
+use hash_source::{identifier::Identifier, location::Span, string::StringLiteral};
 use keyword::Keyword;
 
 /// A Lexeme token that represents the smallest code unit of a hash source file. The
@@ -54,14 +50,10 @@ impl std::fmt::Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
             TokenKind::Ident(ident) => {
-                write!(f, "Ident ({})", IDENTIFIER_MAP.get_ident(*ident))
+                write!(f, "Ident ({})", String::from(*ident))
             }
             TokenKind::StrLiteral(literal) => {
-                write!(
-                    f,
-                    "StringLiteral (\"{}\")",
-                    STRING_LITERAL_MAP.lookup(*literal)
-                )
+                write!(f, "StringLiteral (\"{}\")", String::from(*literal))
             }
             // We want to print the actual character, instead of a potential escape code
             TokenKind::CharLiteral(ch) => {
@@ -205,11 +197,11 @@ impl TokenKind {
             TokenKind::FloatLiteral(num) => format!("`{}`", num),
             TokenKind::CharLiteral(ch) => format!("`{}`", ch),
             TokenKind::StrLiteral(str) => {
-                format!("the string `{}`", STRING_LITERAL_MAP.lookup(*str))
+                format!("the string `{}`", *str)
             }
             TokenKind::Keyword(kwd) => format!("`{}`", kwd),
             TokenKind::Ident(ident) => {
-                format!("the identifier `{}`", IDENTIFIER_MAP.get_ident(*ident))
+                format!("the identifier `{}`", *ident)
             }
             kind => format!("a `{}`", kind),
         }
@@ -254,11 +246,11 @@ impl std::fmt::Display for TokenKind {
             }
             TokenKind::Tree(delim, _) => write!(f, "{}...{}", delim.left(), delim.right()),
             TokenKind::StrLiteral(str) => {
-                write!(f, "\"{}\"", STRING_LITERAL_MAP.lookup(*str))
+                write!(f, "\"{}\"", *str)
             }
             TokenKind::Keyword(kwd) => kwd.fmt(f),
             TokenKind::Ident(ident) => {
-                write!(f, "{}", IDENTIFIER_MAP.get_ident(*ident))
+                write!(f, "{}", String::from(*ident))
             }
         }
     }


### PR DESCRIPTION
closes #234 