### PR TITLE
Add `PrimitiveReader` to simplify accessing terms and other data

### DIFF
--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -5,3 +5,4 @@
 pub mod building;
 pub mod scope;
 pub mod unify;
+pub mod reader;

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -3,6 +3,6 @@
 //! Code from this module is to be used while traversing and typing the AST, in order to unify
 //! types and ensure correctness.
 pub mod building;
+pub mod reader;
 pub mod scope;
 pub mod unify;
-pub mod reader;

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -1,0 +1,56 @@
+//! Contains helpers to read various things stored in [crate::storage] with ease.
+use hash_source::SourceId;
+
+use crate::storage::{
+    primitives::{
+        ModDef, ModDefId, NominalDef, NominalDefId, Scope, ScopeId, Term, TermId, TrtDef, TrtDefId,
+    },
+    GlobalStorage,
+};
+
+/// Helper to read various primitive constructions (from [crate::storage::primitives]).
+pub struct PrimitiveReader<'gs> {
+    gs: &'gs GlobalStorage,
+}
+
+impl<'gs> PrimitiveReader<'gs> {
+    /// Create a new [PrimitiveReader] with a given scope.
+    pub fn new(gs: &'gs GlobalStorage) -> Self {
+        Self { gs }
+    }
+
+    /// Get an immutable reference to the inner global storage.
+    pub fn global_storage(&self) -> &GlobalStorage {
+        self.gs
+    }
+
+    /// Get the term with the given [TermId].
+    pub fn get_term(&self, term_id: TermId) -> &Term {
+        self.gs.term_store.get(term_id)
+    }
+
+    /// Get the module definition with the given [ModDefId].
+    pub fn get_mod_def(&self, mod_def_id: ModDefId) -> &ModDef {
+        self.gs.mod_def_store.get(mod_def_id)
+    }
+
+    /// Get the nominal definition with the given [NominalDefId].
+    pub fn get_nominal_def(&self, nominal_def_id: NominalDefId) -> &NominalDef {
+        self.gs.nominal_def_store.get(nominal_def_id)
+    }
+
+    /// Get the scope with the given [ScopeId].
+    pub fn get_scope(&self, scope_id: ScopeId) -> &Scope {
+        self.gs.scope_store.get(scope_id)
+    }
+
+    /// Get the trait definition with the given [TrtDefId].
+    pub fn get_trt_def(&self, trt_def_id: TrtDefId) -> &TrtDef {
+        self.gs.trt_def_store.get(trt_def_id)
+    }
+
+    /// Get the module definition ID of the given source, if it has already been checked.
+    pub fn get_source_term(&self, source_id: SourceId) -> Option<ModDefId> {
+        self.gs.checked_sources.source_type_id(source_id)
+    }
+}

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -73,11 +73,6 @@ pub enum TermsAreEqual {
     Unsure,
 }
 
-/// Performs type unification and other related operations.
-pub struct Unifier<'gs, 'ls, 'cd> {
-    storage: StorageRefMut<'gs, 'ls, 'cd>,
-}
-
 /// Options that are received by the unifier when unifying types.
 pub struct UnifyTysOpts {}
 
@@ -88,13 +83,26 @@ pub enum SubSubject {
     Unresolved(UnresolvedTerm),
 }
 
+/// Performs type unification and other related operations.
+pub struct Unifier<'gs, 'ls, 'cd> {
+    storage: StorageRefMut<'gs, 'ls, 'cd>,
+}
+
+impl<'gs, 'ls, 'cd> AccessToStorage for Unifier<'gs, 'ls, 'cd> {
+    fn storages(&self) -> crate::storage::StorageRef {
+        self.storage.storages()
+    }
+}
+
+impl<'gs, 'ls, 'cd> AccessToStorageMut for Unifier<'gs, 'ls, 'cd> {
+    fn storages_mut(&mut self) -> StorageRefMut {
+        self.storage.storages_mut()
+    }
+}
+
 impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
     pub fn new(storage: StorageRefMut<'gs, 'ls, 'cd>) -> Self {
         Self { storage }
-    }
-
-    fn primitive_builder(&mut self) -> PrimitiveBuilder {
-        PrimitiveBuilder::new(self.storage.global_storage_mut())
     }
 
     /// Pair the given parameters with the given arguments.
@@ -241,7 +249,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                     .collect::<Result<Vec<_>, _>>()?;
                 if inner_tys.iter().any(|x| x.is_some()) {
                     Ok(Some(
-                        self.primitive_builder().create_merge_term(
+                        self.builder().create_merge_term(
                             inner_tys
                                 .iter()
                                 .zip(inner)

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -9,6 +9,8 @@
 
 use hash_source::SourceId;
 
+use crate::ops::{building::PrimitiveBuilder, reader::PrimitiveReader};
+
 use self::{
     core::CoreDefs,
     mods::ModDefStore,
@@ -117,6 +119,11 @@ pub struct StorageRefMut<'gs, 'ls, 'cd> {
 pub trait AccessToStorage {
     fn storages(&self) -> StorageRef;
 
+    /// Create an instance of [PrimitiveReader] from the global storage.
+    fn reader(&self) -> PrimitiveReader {
+        PrimitiveReader::new(self.global_storage())
+    }
+
     fn global_storage(&self) -> &GlobalStorage {
         self.storages().global_storage
     }
@@ -170,6 +177,18 @@ pub trait AccessToStorage {
 /// path to a [StorageRefMut] object.
 pub trait AccessToStorageMut: AccessToStorage {
     fn storages_mut(&mut self) -> StorageRefMut;
+
+    /// Create an instance of [PrimitiveBuilder] from the global storage.
+    fn builder(&mut self) -> PrimitiveBuilder {
+        PrimitiveBuilder::new(self.global_storage_mut())
+    }
+
+    /// Create an instance of [PrimitiveBuilder] from the global storage, with the given scope.
+    ///
+    /// See [PrimitiveBuilder] docs for more information.
+    fn builder_with_scope(&mut self, scope: ScopeId) -> PrimitiveBuilder {
+        PrimitiveBuilder::new_with_scope(self.global_storage_mut(), scope)
+    }
 
     fn global_storage_mut(&mut self) -> &mut GlobalStorage {
         self.storages_mut().global_storage

--- a/compiler/hash-typecheck/src/storage/sources.rs
+++ b/compiler/hash-typecheck/src/storage/sources.rs
@@ -20,7 +20,7 @@ impl CheckedSources {
     }
 
     /// Get the module type of the given source if it has already been checked.
-    pub fn source_type_id(&mut self, source_id: SourceId) -> Option<ModDefId> {
+    pub fn source_type_id(&self, source_id: SourceId) -> Option<ModDefId> {
         self.data.get(&source_id).copied()
     }
 }


### PR DESCRIPTION
This provides accessors methods to most things stored in the `storage`
module. Closes #258, #259.