### PR TITLE
TC: Implement term substitutions in `Substitutor`

### DIFF
--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -1,9 +1,9 @@
 //! Contains utilities to format types for displaying in error messages and debug output.
 use crate::storage::{
     primitives::{
-        AppSub, Args, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, ModDefId,
-        ModDefOrigin, NominalDef, NominalDefId, Params, StructDef, SubSubject, Term, TermId,
-        TrtDefId, UnresolvedTerm,
+        Args, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, ModDefId, ModDefOrigin,
+        NominalDef, NominalDefId, Params, StructDef, SubSubject, Term, TermId, TrtDefId,
+        UnresolvedTerm,
     },
     GlobalStorage,
 };

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -1,8 +1,9 @@
 //! Contains utilities to format types for displaying in error messages and debug output.
 use crate::storage::{
     primitives::{
-        Args, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, ModDefId, ModDefOrigin,
-        NominalDef, NominalDefId, Params, StructDef, Term, TermId, TrtDefId, UnresolvedTerm,
+        AppSub, Args, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, ModDefId,
+        ModDefOrigin, NominalDef, NominalDefId, Params, StructDef, SubSubject, Term, TermId,
+        TrtDefId, UnresolvedTerm,
     },
     GlobalStorage,
 };
@@ -177,6 +178,22 @@ impl<'gs> TcFormatter<'gs> {
         }
     }
 
+    pub fn fmt_term_as_single(&self, f: &mut fmt::Formatter, term_id: TermId) -> fmt::Result {
+        let term_is_atomic = Cell::new(false);
+        let term_fmt = format!(
+            "{}",
+            term_id.for_formatting_with_atomic_flag(self.global_storage, &term_is_atomic)
+        );
+        if !term_is_atomic.get() {
+            write!(f, "(")?;
+        }
+        write!(f, "{}", term_fmt)?;
+        if !term_is_atomic.get() {
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+
     /// Format the [Term] indexed by the given [TermId] with the given formatter.
     pub fn fmt_term(
         &self,
@@ -187,20 +204,7 @@ impl<'gs> TcFormatter<'gs> {
         match self.global_storage.term_store.get(term_id) {
             Term::Access(access_term) => {
                 is_atomic.set(true);
-                let subject_is_atomic = Cell::new(false);
-                let subject_fmt = format!(
-                    "{}",
-                    access_term
-                        .subject_id
-                        .for_formatting_with_atomic_flag(self.global_storage, &subject_is_atomic)
-                );
-                if !subject_is_atomic.get() {
-                    write!(f, "(")?;
-                }
-                write!(f, "{}", subject_fmt)?;
-                if !subject_is_atomic.get() {
-                    write!(f, ")")?;
-                }
+                self.fmt_term_as_single(f, access_term.subject_id)?;
                 write!(f, "::{}", access_term.name)?;
                 Ok(())
             }
@@ -209,21 +213,8 @@ impl<'gs> TcFormatter<'gs> {
             }
             Term::Merge(terms) => {
                 is_atomic.set(false);
-                for (i, term) in terms.iter().enumerate() {
-                    let term_is_atomic = Cell::new(false);
-                    let term_fmt = format!(
-                        "{}",
-                        term.for_formatting_with_atomic_flag(self.global_storage, &term_is_atomic)
-                    );
-
-                    if !term_is_atomic.get() {
-                        write!(f, "(")?;
-                    }
-                    write!(f, "{}", term_fmt)?;
-                    if !term_is_atomic.get() {
-                        write!(f, ")")?;
-                    }
-
+                for (i, term_id) in terms.iter().enumerate() {
+                    self.fmt_term_as_single(f, *term_id)?;
                     if i != terms.len() - 1 {
                         write!(f, " ~ ")?;
                     }
@@ -265,30 +256,33 @@ impl<'gs> TcFormatter<'gs> {
                 Ok(())
             }
             Term::AppTyFn(app_ty_fn) => {
-                let subject_is_atomic = Cell::new(false);
-                let subject_fmt = format!(
-                    "{}",
-                    app_ty_fn
-                        .subject
-                        .for_formatting_with_atomic_flag(self.global_storage, &subject_is_atomic)
-                );
-
-                if !subject_is_atomic.get() {
-                    write!(f, "(")?;
-                }
-                write!(f, "{}", subject_fmt)?;
-                if !subject_is_atomic.get() {
-                    write!(f, ")")?;
-                }
+                self.fmt_term_as_single(f, app_ty_fn.subject)?;
                 write!(f, "<")?;
-
                 self.fmt_args(f, &app_ty_fn.args)?;
                 write!(f, ">")?;
-
                 Ok(())
             }
             Term::Unresolved(unresolved_term) => {
                 write!(f, "{{unresolved({:?})}}", unresolved_term.resolution_id)
+            }
+            Term::AppSub(app_sub) => {
+                write!(f, "[");
+                let pairs = app_sub.sub.pairs().collect::<Vec<_>>();
+                for (i, (from, to)) in pairs.iter().enumerate() {
+                    self.fmt_term_as_single(f, *to)?;
+                    write!(f, "/")?;
+                    match from {
+                        SubSubject::Var(var) => write!(f, "{}", var.name)?,
+                        SubSubject::Unresolved(unresolved) => self.fmt_unresolved(f, unresolved)?,
+                    }
+
+                    if i != pairs.len() - 1 {
+                        write!(f, ", ")?;
+                    }
+                }
+                write!(f, "[");
+                self.fmt_term_as_single(f, app_sub.term);
+                Ok(())
             }
             Term::Level3(term) => self.fmt_level3_term(f, term, is_atomic),
             Term::Level2(term) => self.fmt_level2_term(f, term, is_atomic),
@@ -303,7 +297,7 @@ impl<'gs> TcFormatter<'gs> {
         f: &mut fmt::Formatter,
         UnresolvedTerm { resolution_id }: &UnresolvedTerm,
     ) -> fmt::Result {
-        write!(f, "{{unresolved({:?})}}", resolution_id,)
+        write!(f, "U_{}", resolution_id)
     }
 
     /// Format a [NominalDef] indexed by the given [NominalDefId].

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -266,7 +266,7 @@ impl<'gs> TcFormatter<'gs> {
                 write!(f, "{{unresolved({:?})}}", unresolved_term.resolution_id)
             }
             Term::AppSub(app_sub) => {
-                write!(f, "[");
+                write!(f, "[")?;
                 let pairs = app_sub.sub.pairs().collect::<Vec<_>>();
                 for (i, (from, to)) in pairs.iter().enumerate() {
                     self.fmt_term_as_single(f, *to)?;
@@ -280,8 +280,8 @@ impl<'gs> TcFormatter<'gs> {
                         write!(f, ", ")?;
                     }
                 }
-                write!(f, "[");
-                self.fmt_term_as_single(f, app_sub.term);
+                write!(f, "]")?;
+                self.fmt_term_as_single(f, app_sub.term)?;
                 Ok(())
             }
             Term::Level3(term) => self.fmt_level3_term(f, term, is_atomic),

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -269,7 +269,7 @@ impl<'gs> TcFormatter<'gs> {
                 let subject_fmt = format!(
                     "{}",
                     app_ty_fn
-                        .ty_fn_value
+                        .subject
                         .for_formatting_with_atomic_flag(self.global_storage, &subject_is_atomic)
                 );
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -10,10 +10,7 @@ use crate::storage::{
     GlobalStorage,
 };
 use hash_source::identifier::Identifier;
-use std::{
-    cell::{Cell, RefCell},
-    ops::Deref,
-};
+use std::cell::{Cell, RefCell};
 
 /// Helper to create various primitive constructions (from [crate::storage::primitives]).
 ///

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -2,9 +2,9 @@
 //! the corresponding stores.
 use crate::storage::{
     primitives::{
-        AccessTerm, AppTyFn, Arg, Args, EnumDef, EnumVariant, FnTy, Level0Term, Level1Term,
-        Level2Term, Level3Term, Member, ModDefId, Mutability, NominalDef, NominalDefId, Param,
-        ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Term, TermId, TrtDef,
+        AccessTerm, AppTyFn, Arg, Args, EnumDef, EnumVariant, FnTy, GetNameOpt, Level0Term,
+        Level1Term, Level2Term, Level3Term, Member, ModDefId, Mutability, NominalDef, NominalDefId,
+        Param, ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Term, TermId, TrtDef,
         TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, Var, Visibility,
     },
     GlobalStorage,
@@ -236,6 +236,14 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Level0(Level0Term::Rt(ty_term_id)))
     }
 
+    /// Create a [ParamList<T>] from the given set of items.
+    pub fn create_param_list<T: GetNameOpt + Clone>(
+        &self,
+        items: impl IntoIterator<Item = T>,
+    ) -> ParamList<T> {
+        ParamList::new(items.into_iter().collect())
+    }
+
     /// Create a parameter with the given name and type.
     pub fn create_param(&self, name: impl Into<Identifier>, ty: TermId) -> Param {
         Param {
@@ -359,7 +367,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     ) -> AppTyFn {
         AppTyFn {
             args: Args::new(args.into_iter().collect()),
-            ty_fn_value: ty_fn_value_id,
+            subject: ty_fn_value_id,
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -2,10 +2,10 @@
 //! the corresponding stores.
 use crate::storage::{
     primitives::{
-        AccessTerm, AppTyFn, Arg, Args, EnumDef, EnumVariant, FnTy, GetNameOpt, Level0Term,
+        AccessTerm, AppSub, AppTyFn, Arg, Args, EnumDef, EnumVariant, FnTy, GetNameOpt, Level0Term,
         Level1Term, Level2Term, Level3Term, Member, ModDefId, Mutability, NominalDef, NominalDefId,
-        Param, ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Term, TermId, TrtDef,
-        TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, Var, Visibility,
+        Param, ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term, TermId,
+        TrtDef, TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, Var, Visibility,
     },
     GlobalStorage,
 };
@@ -231,6 +231,13 @@ impl<'gs> PrimitiveBuilder<'gs> {
         })))
     }
 
+    /// Create a tuple type term [Level1Term::Tuple].
+    pub fn create_tuple_ty_term(&self, members: impl IntoIterator<Item = Param>) -> TermId {
+        self.create_term(Term::Level1(Level1Term::Tuple(TupleTy {
+            members: ParamList::new(members.into_iter().collect()),
+        })))
+    }
+
     /// Create a [Level0Term::Rt] of the given type.
     pub fn create_rt_term(&self, ty_term_id: TermId) -> TermId {
         self.create_term(Term::Level0(Level0Term::Rt(ty_term_id)))
@@ -369,6 +376,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
             args: Args::new(args.into_iter().collect()),
             subject: ty_fn_value_id,
         }
+    }
+
+    /// Create a substitution application term, given a substitution and inner term.
+    pub fn create_app_sub_term(&self, sub: Sub, term: TermId) -> TermId {
+        self.create_term(Term::AppSub(AppSub { sub, term }))
     }
 
     /// Create an argument with the given name and value.

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -5,4 +5,5 @@
 pub mod building;
 pub mod reader;
 pub mod scope;
+pub mod substitute;
 pub mod unify;

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -1,0 +1,280 @@
+//! Functionality related to variable substitution inside terms/types.
+use crate::{
+    error::TcResult,
+    storage::{
+        primitives::{
+            AppTyFn, Arg, Args, Level0Term, Level1Term, Level2Term, Level3Term, Param, ParamList,
+            Params, Term, TermId, TyFn, TyFnCase, TyFnTy, UnresolvedTerm, Var,
+        },
+        AccessToStorage, AccessToStorageMut, StorageRefMut,
+    },
+};
+use std::collections::HashMap;
+
+/// The subject of a substitution, either a type variable or an unresolved type.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum SubSubject {
+    Var(Var),
+    Unresolved(UnresolvedTerm),
+}
+
+impl From<Var> for SubSubject {
+    fn from(var: Var) -> Self {
+        SubSubject::Var(var)
+    }
+}
+
+impl From<UnresolvedTerm> for SubSubject {
+    fn from(unresolved: UnresolvedTerm) -> Self {
+        SubSubject::Unresolved(unresolved)
+    }
+}
+
+/// A substitution containing pairs of `(SubSubject, TermId)` to be applied to a type or types.
+#[derive(Debug, Default, Clone)]
+pub struct Sub {
+    data: HashMap<SubSubject, TermId>,
+}
+
+impl Sub {
+    /// Create an empty substitution.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Create a substitution from pairs of `(TySubSubject, TermId)`.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (SubSubject, TermId)>) -> Self {
+        Self {
+            data: pairs.into_iter().collect(),
+        }
+    }
+
+    /// Get the substitution for the given [SubSubject], if any.
+    pub fn get_sub_for(&self, subject: SubSubject) -> Option<TermId> {
+        self.data.get(&subject).copied()
+    }
+
+    /// Merge the substitution with another.
+    ///
+    /// Modifies `self`.
+    pub fn merge_with(&mut self, _other: &Sub) {
+        todo!()
+    }
+}
+
+/// kkImplements equality of substitutions in terms of functional equality---will applying A produce
+/// the same type as B?
+///
+/// @@Volatile: This might require having access to the storage to check equality of some things..
+impl PartialEq for Sub {
+    fn eq(&self, other: &Self) -> bool {
+        // @@Todo: more sophisticated substitution equivalence
+        self.data == other.data
+    }
+}
+
+/// A judgement as to whether two values are equal, which also might be unclear (for example if
+/// higher order type variables are involved).
+pub enum TermsAreEqual {
+    Yes,
+    No,
+    Unsure,
+}
+
+/// Can perform substitutions (see [Sub]) on terms.
+pub struct Substitutor<'gs, 'ls, 'cd> {
+    storage: StorageRefMut<'gs, 'ls, 'cd>,
+}
+
+impl<'gs, 'ls, 'cd> AccessToStorage for Substitutor<'gs, 'ls, 'cd> {
+    fn storages(&self) -> crate::storage::StorageRef {
+        self.storage.storages()
+    }
+}
+
+impl<'gs, 'ls, 'cd> AccessToStorageMut for Substitutor<'gs, 'ls, 'cd> {
+    fn storages_mut(&mut self) -> StorageRefMut {
+        self.storage.storages_mut()
+    }
+}
+
+impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
+    pub fn new(storage: StorageRefMut<'gs, 'ls, 'cd>) -> Self {
+        Self { storage }
+    }
+
+    /// Apply the given substitution to the given arguments, producing a new set of arguments
+    /// with the substituted variables.
+    pub fn apply_sub_to_args(&mut self, sub: &Sub, args: &Args) -> TcResult<Args> {
+        let new_args = args
+            .positional()
+            .iter()
+            .map(|arg| {
+                Ok(Arg {
+                    name: arg.name,
+                    value: self.apply_sub_to_term(sub, arg.value)?,
+                })
+            })
+            .collect::<TcResult<Vec<_>>>()?;
+        Ok(ParamList::new(new_args))
+    }
+
+    /// Apply the given substitution to the given parameters, producing a new set of parameters
+    /// with the substituted variables.
+    pub fn apply_sub_to_params(&mut self, sub: &Sub, params: &Params) -> TcResult<Params> {
+        let new_params = params
+            .positional()
+            .iter()
+            .map(|param| {
+                Ok(Param {
+                    name: param.name,
+                    ty: self.apply_sub_to_term(sub, param.ty)?,
+                    default_value: param
+                        .default_value
+                        .map(|value| self.apply_sub_to_term(sub, value))
+                        .transpose()?,
+                })
+            })
+            .collect::<TcResult<Vec<_>>>()?;
+        Ok(ParamList::new(new_params))
+    }
+
+    /// Apply the given substitution to the given [Level3Term], producing a new [Level3Term] with
+    /// the substituted variables.
+    pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TcResult<Level3Term> {
+        match term {
+            Level3Term::TrtKind => Ok(Level3Term::TrtKind),
+        }
+    }
+
+    /// Apply the given substitution to the given [Level2Term], producing a new [Level2Term] with
+    /// the substituted variables.
+    pub fn apply_sub_to_level2_term(
+        &mut self,
+        _sub: &Sub,
+        term: Level2Term,
+    ) -> TcResult<Level2Term> {
+        match term {
+            Level2Term::Trt(_) => {
+                todo!()
+            }
+            Level2Term::AnyTy => todo!(),
+        }
+    }
+
+    /// Apply the given substitution to the given [Level1Term], producing a new [Level1Term] with
+    /// the substituted variables.
+    pub fn apply_sub_to_level1_term(
+        &mut self,
+        _sub: &Sub,
+        _term: Level1Term,
+    ) -> TcResult<Level1Term> {
+        todo!()
+    }
+
+    /// Apply the given substitution to the given [Level0Term], producing a new [Level0Term] with
+    /// the substituted variables.
+    pub fn apply_sub_to_level0_term(
+        &mut self,
+        _sub: &Sub,
+        _term: Level0Term,
+    ) -> TcResult<Level0Term> {
+        todo!()
+    }
+
+    /// Apply the given substitution to the term indexed by the given [TermId], producing a new
+    /// term with the substituted variables.
+    pub fn apply_sub_to_term(&mut self, sub: &Sub, term_id: TermId) -> TcResult<TermId> {
+        // @@Performance: here we copy a lot, maybe there is a way to avoid all this copying by
+        // first checking that the variables to be substituted actually exist in the term.
+
+        let term = self.reader().get_term(term_id).clone();
+        match term {
+            Term::Access(access) => {
+                // Just apply the substitution to the subject:
+                let subbed_subject_id = self.apply_sub_to_term(sub, access.subject_id)?;
+                Ok(self.builder().create_access(subbed_subject_id, access.name))
+            }
+            Term::Var(var) => {
+                // If the variable is in the substitution, substitute it, otherwise do nothing.
+                match sub.get_sub_for(var.into()) {
+                    Some(subbed_term_id) => Ok(subbed_term_id),
+                    None => Ok(term_id),
+                }
+            }
+            Term::Merge(terms) => {
+                // Apply the substitution to each element of the merge.
+                let terms = terms
+                    .into_iter()
+                    .map(|term| self.apply_sub_to_term(sub, term))
+                    .collect::<TcResult<Vec<_>>>()?;
+                Ok(self.builder().create_term(Term::Merge(terms)))
+            }
+            Term::TyFn(ty_fn) => {
+                // Apply the substitution to the general parameters, return type, and each case.
+                let subbed_general_params = self.apply_sub_to_params(sub, &ty_fn.general_params)?;
+                let subbed_general_return_ty =
+                    self.apply_sub_to_term(sub, ty_fn.general_return_ty)?;
+                let subbed_cases = ty_fn
+                    .cases
+                    .into_iter()
+                    .map(|case| -> TcResult<_> {
+                        Ok(TyFnCase {
+                            params: self.apply_sub_to_params(sub, &case.params)?,
+                            return_ty: self.apply_sub_to_term(sub, case.return_ty)?,
+                            return_value: self.apply_sub_to_term(sub, case.return_value)?,
+                        })
+                    })
+                    .collect::<TcResult<Vec<_>>>()?;
+                Ok(self.builder().create_term(Term::TyFn(TyFn {
+                    name: ty_fn.name,
+                    general_params: subbed_general_params,
+                    general_return_ty: subbed_general_return_ty,
+                    cases: subbed_cases,
+                })))
+            }
+            Term::TyFnTy(ty_fn_ty) => {
+                // Apply the substitution to the parameters and return type.
+                let subbed_params = self.apply_sub_to_params(sub, &ty_fn_ty.params)?;
+                let subbed_return_ty = self.apply_sub_to_term(sub, ty_fn_ty.return_ty)?;
+                Ok(self.builder().create_term(Term::TyFnTy(TyFnTy {
+                    params: subbed_params,
+                    return_ty: subbed_return_ty,
+                })))
+            }
+            Term::AppTyFn(app_ty_fn) => {
+                // Apply the substitution to the subject and arguments.
+                let subbed_subject = self.apply_sub_to_term(sub, app_ty_fn.subject)?;
+                let subbed_args = self.apply_sub_to_args(sub, &app_ty_fn.args)?;
+                Ok(self.builder().create_term(Term::AppTyFn(AppTyFn {
+                    subject: subbed_subject,
+                    args: subbed_args,
+                })))
+            }
+            Term::Unresolved(unresolved) => {
+                // If the variable is in the substitution, substitute it, otherwise do nothing.
+                match sub.get_sub_for(unresolved.into()) {
+                    Some(subbed_term_id) => Ok(subbed_term_id),
+                    None => Ok(term_id),
+                }
+            }
+            // For the definite-level terms, recurse:
+            Term::Level3(term) => {
+                let subbed_term = self.apply_sub_to_level3_term(sub, term)?;
+                Ok(self.builder().create_term(Term::Level3(subbed_term)))
+            }
+            Term::Level2(term) => {
+                let subbed_term = self.apply_sub_to_level2_term(sub, term)?;
+                Ok(self.builder().create_term(Term::Level2(subbed_term)))
+            }
+            Term::Level1(term) => {
+                let subbed_term = self.apply_sub_to_level1_term(sub, term)?;
+                Ok(self.builder().create_term(Term::Level1(subbed_term)))
+            }
+            Term::Level0(term) => {
+                let subbed_term = self.apply_sub_to_level0_term(sub, term)?;
+                Ok(self.builder().create_term(Term::Level0(subbed_term)))
+            }
+        }
+    }
+}

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -175,8 +175,8 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
     /// term with the substituted variables.
     ///
     /// Sometimes, this will actually create a [Term::AppSub] somewhere inside the term tree, and
-    /// those are the leaf nodes of the substitution application. This will happen with [ModDef],
-    /// [TrtDef], [NominalDef], and [EnumVariant]. This is so that when [Access] is resolved for
+    /// those are the leaf nodes of the substitution application. This will happen with `ModDef`,
+    /// `TrtDef`, `NominalDef`, and `EnumVariant`. This is so that when `Access` is resolved for
     /// those types, the substitution is carried forward into the member term.
     pub fn apply_sub_to_term(&mut self, sub: &Sub, term_id: TermId) -> TcResult<TermId> {
         // @@Performance: here we copy a lot, maybe there is a way to avoid all this copying by
@@ -337,9 +337,8 @@ mod tests {
             ],
             builder.create_var_term("T"),
         );
-        drop(builder);
 
-        println!("");
+        println!();
 
         println!("{}", target.for_formatting(storage_ref.global_storage()));
 
@@ -354,7 +353,6 @@ mod tests {
                 ],
             ),
         )]);
-        drop(builder);
 
         let mut substitutor = Substitutor::new(storage_ref.storages_mut());
         let subbed_target = substitutor.apply_sub_to_term(&sub, target).unwrap();
@@ -364,6 +362,6 @@ mod tests {
             subbed_target.for_formatting(storage_ref.global_storage())
         );
 
-        println!("");
+        println!();
     }
 }

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -5,10 +5,11 @@
 // @@Remove
 #![allow(unused)]
 
+use super::building::PrimitiveBuilder;
 use crate::{
     error::{TcError, TcResult},
     storage::{
-        primitives::{AppTyFn, Arg, Args, Param, Params, Term, TermId, UnresolvedTerm, Var},
+        primitives::{AppTyFn, Arg, Args, Param, Params, Sub, Term, TermId, UnresolvedTerm, Var},
         scope::ScopeStack,
         AccessToStorage, AccessToStorageMut, GlobalStorage, StorageRefMut,
     },
@@ -19,8 +20,6 @@ use std::{
     collections::{HashMap, HashSet},
     ops::{Deref, DerefMut},
 };
-
-use super::{building::PrimitiveBuilder, substitute::Sub};
 
 /// Options that are received by the unifier when unifying types.
 pub struct UnifyTysOpts {}

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -46,44 +46,49 @@ impl CoreDefs {
         let builder = PrimitiveBuilder::new_with_scope(global_storage, global_storage.root_scope);
 
         // Primitive integers
-        let i8_ty = builder.create_opaque_struct_def("i8");
-        let i16_ty = builder.create_opaque_struct_def("i16");
-        let i32_ty = builder.create_opaque_struct_def("i32");
-        let i64_ty = builder.create_opaque_struct_def("i64");
+        let i8_ty = builder.create_opaque_struct_def("i8", []);
+        let i16_ty = builder.create_opaque_struct_def("i16", []);
+        let i32_ty = builder.create_opaque_struct_def("i32", []);
+        let i64_ty = builder.create_opaque_struct_def("i64", []);
 
-        let u8_ty = builder.create_opaque_struct_def("u8");
-        let u16_ty = builder.create_opaque_struct_def("u16");
-        let u32_ty = builder.create_opaque_struct_def("u32");
-        let u64_ty = builder.create_opaque_struct_def("u64");
+        let u8_ty = builder.create_opaque_struct_def("u8", []);
+        let u16_ty = builder.create_opaque_struct_def("u16", []);
+        let u32_ty = builder.create_opaque_struct_def("u32", []);
+        let u64_ty = builder.create_opaque_struct_def("u64", []);
 
-        let f32_ty = builder.create_opaque_struct_def("f32");
-        let f64_ty = builder.create_opaque_struct_def("f64");
+        let f32_ty = builder.create_opaque_struct_def("f32", []);
+        let f64_ty = builder.create_opaque_struct_def("f64", []);
 
         // Char and bool
-        let char_ty = builder.create_opaque_struct_def("char");
+        let char_ty = builder.create_opaque_struct_def("char", []);
         let bool_ty = builder.create_enum_def(
             "bool",
             [
                 builder.create_enum_variant("true", []),
                 builder.create_enum_variant("false", []),
             ],
+            [],
         );
 
         // String
-        let str_ty = builder.create_opaque_struct_def("str");
+        let str_ty = builder.create_opaque_struct_def("str", []);
 
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
-            "Ref",
+            Some("Ref"),
             [builder.create_param("T", builder.create_any_ty_term())],
             builder.create_any_ty_term(),
-            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
         );
         let raw_reference_ty_fn = builder.create_ty_fn_term(
-            "RawRef",
+            Some("RawRef"),
             [builder.create_param("T", builder.create_any_ty_term())],
             builder.create_any_ty_term(),
-            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
         );
 
         // Handy shorthand for &Self type
@@ -102,6 +107,7 @@ impl CoreDefs {
                     builder.create_nominal_def_term(u64_ty),
                 ),
             )],
+            [],
         );
         let eq_trt = builder.create_trait_def(
             "Eq",
@@ -115,25 +121,30 @@ impl CoreDefs {
                     builder.create_nominal_def_term(u64_ty),
                 ),
             )],
+            [],
         );
 
         // Collection types
         let list_ty_fn = builder.create_ty_fn_term(
-            "List",
+            Some("List"),
             [builder.create_param("T", builder.create_any_ty_term())],
             builder.create_any_ty_term(),
-            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
         );
 
         let set_ty_fn = builder.create_ty_fn_term(
-            "Set",
+            Some("Set"),
             [builder.create_param("T", builder.create_any_ty_term())],
             builder.create_any_ty_term(),
-            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
         );
 
         let map_ty_fn = builder.create_ty_fn_term(
-            "Map",
+            Some("Map"),
             [
                 builder.create_param(
                     "K",
@@ -145,7 +156,10 @@ impl CoreDefs {
                 builder.create_param("V", builder.create_any_ty_term()),
             ],
             builder.create_any_ty_term(),
-            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
+            builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def([
+                builder.create_var("K"),
+                builder.create_var("V"),
+            ])),
         );
 
         Self {

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -370,10 +370,10 @@ pub struct Var {
 ///
 /// When this type is unified with another type, the function is applied by first instantiating
 /// its return value over its type parameters, and then unifying the instantiated type parameters
-/// with the given type arguments of the function (the `ty_args` field).
+/// with the given type arguments of the function (the `args` field).
 #[derive(Debug, Clone)]
 pub struct AppTyFn {
-    pub ty_fn_value: TermId,
+    pub subject: TermId,
     pub args: Args,
 }
 

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -598,7 +598,7 @@ impl Sub {
                 .iter()
                 .filter_map(|(from, to)| match from {
                     SubSubject::Var(var) => {
-                        if bound_vars.contains(&var) {
+                        if bound_vars.contains(var) {
                             Some((*from, *to))
                         } else {
                             None


### PR DESCRIPTION
This is a major step towards unification. Substitution has been entirely implemented, including various technicalities for type functions and definitions (see code docs). Furthermore, a `AppSub` term has been added which is added when a definition tries to be substituted. This is to be resolved when namespace access is resolved, so that the substitution can be forwarded onto the type and values of the members.

Closes #261.