### PR TITLE
TC: Implement substitution unification

### DIFF
--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -242,6 +242,8 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 }))
             }
             Term::AppSub(app_sub) => {
+                // @@Reconsider: do we not want to unify substitutions here?
+                //
                 // Here, we have to substitute all X in * -> X pairs of the substitution, as well
                 // as the subject term itself.
                 let subbed_sub = app_sub

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -1,15 +1,12 @@
 //! Functionality related to variable substitution inside terms/types.
-use crate::{
-    error::TcResult,
-    storage::{
-        primitives::{
-            AppSub, AppTyFn, Arg, Args, FnTy, Level0Term, Level1Term, Level2Term, Level3Term,
-            Param, ParamList, Params, Sub, Term, TermId, TupleTy, TyFn, TyFnCase, TyFnTy,
-        },
-        AccessToStorage, AccessToStorageMut, StorageRefMut,
+use crate::storage::{
+    primitives::{
+        AppSub, AppTyFn, Arg, Args, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Param,
+        ParamList, Params, Sub, SubSubject, Term, TermId, TupleTy, TyFn, TyFnCase, TyFnTy,
     },
+    AccessToStorage, AccessToStorageMut, StorageRefMut,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Can perform substitutions (see [Sub]) on terms.
 pub struct Substitutor<'gs, 'ls, 'cd> {
@@ -35,53 +32,48 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
 
     /// Apply the given substitution to the given arguments, producing a new set of arguments
     /// with the substituted variables.
-    pub fn apply_sub_to_args(&mut self, sub: &Sub, args: &Args) -> TcResult<Args> {
+    pub fn apply_sub_to_args(&mut self, sub: &Sub, args: &Args) -> Args {
         let new_args = args
             .positional()
             .iter()
-            .map(|arg| {
-                Ok(Arg {
-                    name: arg.name,
-                    value: self.apply_sub_to_term(sub, arg.value)?,
-                })
+            .map(|arg| Arg {
+                name: arg.name,
+                value: self.apply_sub_to_term(sub, arg.value),
             })
-            .collect::<TcResult<Vec<_>>>()?;
-        Ok(ParamList::new(new_args))
+            .collect::<Vec<_>>();
+        ParamList::new(new_args)
     }
 
     /// Apply the given substitution to the given parameters, producing a new set of parameters
     /// with the substituted variables.
-    pub fn apply_sub_to_params(&mut self, sub: &Sub, params: &Params) -> TcResult<Params> {
+    pub fn apply_sub_to_params(&mut self, sub: &Sub, params: &Params) -> Params {
         let new_params = params
             .positional()
             .iter()
-            .map(|param| {
-                Ok(Param {
-                    name: param.name,
-                    ty: self.apply_sub_to_term(sub, param.ty)?,
-                    default_value: param
-                        .default_value
-                        .map(|value| self.apply_sub_to_term(sub, value))
-                        .transpose()?,
-                })
+            .map(|param| Param {
+                name: param.name,
+                ty: self.apply_sub_to_term(sub, param.ty),
+                default_value: param
+                    .default_value
+                    .map(|value| self.apply_sub_to_term(sub, value)),
             })
-            .collect::<TcResult<Vec<_>>>()?;
-        Ok(ParamList::new(new_params))
+            .collect::<Vec<_>>();
+        ParamList::new(new_params)
     }
 
     /// Apply the given substitution to the given [Level3Term], producing a new [Level3Term] with
     /// the substituted variables.
-    pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TcResult<TermId> {
+    pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TermId {
         match term {
-            Level3Term::TrtKind => Ok(self
+            Level3Term::TrtKind => self
                 .builder()
-                .create_term(Term::Level3(Level3Term::TrtKind))),
+                .create_term(Term::Level3(Level3Term::TrtKind)),
         }
     }
 
     /// Apply the given substitution to the given [Level2Term], producing a new [Level2Term] with
     /// the substituted variables.
-    pub fn apply_sub_to_level2_term(&mut self, sub: &Sub, term: Level2Term) -> TcResult<TermId> {
+    pub fn apply_sub_to_level2_term(&mut self, sub: &Sub, term: Level2Term) -> TermId {
         match term {
             Level2Term::Trt(trt_def_id) => {
                 // Here we add the substitution to the term using only vars in the trat definition.
@@ -89,67 +81,62 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 let trt_def_vars = &reader.get_trt_def(trt_def_id).bound_vars;
                 let selected_sub = sub.select(trt_def_vars);
                 let builder = self.builder();
-                Ok(builder
-                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level2(term))))
+                builder.create_app_sub_term(selected_sub, builder.create_term(Term::Level2(term)))
             }
-            Level2Term::AnyTy => Ok(self.builder().create_term(Term::Level2(Level2Term::AnyTy))),
+            Level2Term::AnyTy => (self.builder().create_term(Term::Level2(Level2Term::AnyTy))),
         }
     }
 
     /// Apply the given substitution to the given [Level1Term], producing a new [Level1Term] with
     /// the substituted variables.
-    pub fn apply_sub_to_level1_term(&mut self, sub: &Sub, term: Level1Term) -> TcResult<TermId> {
+    pub fn apply_sub_to_level1_term(&mut self, sub: &Sub, term: Level1Term) -> TermId {
         match term {
             Level1Term::ModDef(mod_def_id) => {
                 // Here we add the substitution to the term using only vars in the mod definition.
                 let reader = self.reader();
                 let mod_def_vars = &reader.get_mod_def(mod_def_id).bound_vars;
-                let selected_sub = sub.select(&mod_def_vars);
+                let selected_sub = sub.select(mod_def_vars);
                 let builder = self.builder();
-                Ok(builder
-                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term))))
+                builder.create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term)))
             }
             Level1Term::NominalDef(nominal_def_id) => {
                 // Here we add the substitution to the term using only vars in the nominal
                 // definition.
                 let reader = self.reader();
                 let nominal_def_vars = reader.get_nominal_def(nominal_def_id).bound_vars();
-                let selected_sub = sub.select(&nominal_def_vars);
+                let selected_sub = sub.select(nominal_def_vars);
                 let builder = self.builder();
-                Ok(builder
-                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term))))
+                builder.create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term)))
             }
             Level1Term::Tuple(tuple_ty) => {
                 // Apply to all members
-                let subbed_members = self.apply_sub_to_params(sub, &tuple_ty.members)?;
-                Ok(self
-                    .builder()
+                let subbed_members = self.apply_sub_to_params(sub, &tuple_ty.members);
+                self.builder()
                     .create_term(Term::Level1(Level1Term::Tuple(TupleTy {
                         members: subbed_members,
-                    }))))
+                    })))
             }
             Level1Term::Fn(fn_ty) => {
                 // Apply to parameters and return type
-                let subbed_params = self.apply_sub_to_params(sub, &fn_ty.params)?;
-                let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty)?;
-                Ok(self
-                    .builder()
+                let subbed_params = self.apply_sub_to_params(sub, &fn_ty.params);
+                let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty);
+                self.builder()
                     .create_term(Term::Level1(Level1Term::Fn(FnTy {
                         params: subbed_params,
                         return_ty: subbed_return_ty,
-                    }))))
+                    })))
             }
         }
     }
 
     /// Apply the given substitution to the given [Level0Term], producing a new [Level0Term] with
     /// the substituted variables.
-    pub fn apply_sub_to_level0_term(&mut self, sub: &Sub, term: Level0Term) -> TcResult<TermId> {
+    pub fn apply_sub_to_level0_term(&mut self, sub: &Sub, term: Level0Term) -> TermId {
         match term {
             Level0Term::Rt(ty_term_id) => {
                 // Apply to the type of the runtime value
-                let subbed_ty_term_id = self.apply_sub_to_term(sub, ty_term_id)?;
-                Ok(self.builder().create_rt_term(subbed_ty_term_id))
+                let subbed_ty_term_id = self.apply_sub_to_term(sub, ty_term_id);
+                self.builder().create_rt_term(subbed_ty_term_id)
             }
             Level0Term::EnumVariant(enum_variant) => {
                 // Here we add the substitution to the term using only vars in the enum definition.
@@ -157,13 +144,22 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 let enum_def_vars = reader
                     .get_nominal_def(enum_variant.enum_def_id)
                     .bound_vars();
-                let selected_sub = sub.select(&enum_def_vars);
+                let selected_sub = sub.select(enum_def_vars);
                 let builder = self.builder();
-                Ok(builder.create_app_sub_term(
+                builder.create_app_sub_term(
                     selected_sub,
                     builder.create_term(Term::Level0(Level0Term::EnumVariant(enum_variant))),
-                ))
+                )
             }
+        }
+    }
+
+    /// Apply the given substitution to the given [SubSubject], producing a new term with the
+    /// substituted result.
+    pub fn apply_sub_to_subject(&mut self, sub: &Sub, subject: SubSubject) -> TermId {
+        match sub.get_sub_for(subject) {
+            Some(subbed_term_id) => subbed_term_id,
+            None => self.builder().create_term(subject.into()),
         }
     }
 
@@ -174,31 +170,29 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
     /// those are the leaf nodes of the substitution application. This will happen with `ModDef`,
     /// `TrtDef`, `NominalDef`, and `EnumVariant`. This is so that when `Access` is resolved for
     /// those types, the substitution is carried forward into the member term.
-    pub fn apply_sub_to_term(&mut self, sub: &Sub, term_id: TermId) -> TcResult<TermId> {
+    pub fn apply_sub_to_term(&mut self, sub: &Sub, term_id: TermId) -> TermId {
         // @@Performance: here we copy a lot, maybe there is a way to avoid all this copying by
         // first checking that the variables to be substituted actually exist in the term.
 
         let term = self.reader().get_term(term_id).clone();
         match term {
+            // Leaves:
+            Term::Var(var) => self.apply_sub_to_subject(sub, var.into()),
+            Term::Unresolved(unresolved) => self.apply_sub_to_subject(sub, unresolved.into()),
+
+            // Recursive cases:
             Term::Access(access) => {
                 // Just apply the substitution to the subject:
-                let subbed_subject_id = self.apply_sub_to_term(sub, access.subject_id)?;
-                Ok(self.builder().create_access(subbed_subject_id, access.name))
-            }
-            Term::Var(var) => {
-                // If the variable is in the substitution, substitute it, otherwise do nothing.
-                match sub.get_sub_for(var.into()) {
-                    Some(subbed_term_id) => Ok(subbed_term_id),
-                    None => Ok(term_id),
-                }
+                let subbed_subject_id = self.apply_sub_to_term(sub, access.subject_id);
+                self.builder().create_access(subbed_subject_id, access.name)
             }
             Term::Merge(terms) => {
                 // Apply the substitution to each element of the merge.
                 let terms = terms
                     .into_iter()
                     .map(|term| self.apply_sub_to_term(sub, term))
-                    .collect::<TcResult<Vec<_>>>()?;
-                Ok(self.builder().create_term(Term::Merge(terms)))
+                    .collect::<Vec<_>>();
+                self.builder().create_term(Term::Merge(terms))
             }
             Term::TyFn(ty_fn) => {
                 // Apply the substitution to the general parameters, return type, and each case.
@@ -208,54 +202,44 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 // because T is bound in the term, not free.
                 let shadowed_sub = sub.filter(&ty_fn.general_params);
                 let subbed_general_params =
-                    self.apply_sub_to_params(&shadowed_sub, &ty_fn.general_params)?;
+                    self.apply_sub_to_params(&shadowed_sub, &ty_fn.general_params);
                 let subbed_general_return_ty =
-                    self.apply_sub_to_term(&shadowed_sub, ty_fn.general_return_ty)?;
+                    self.apply_sub_to_term(&shadowed_sub, ty_fn.general_return_ty);
                 let subbed_cases = ty_fn
                     .cases
                     .into_iter()
-                    .map(|case| -> TcResult<_> {
-                        Ok(TyFnCase {
-                            params: self.apply_sub_to_params(&shadowed_sub, &case.params)?,
-                            return_ty: self.apply_sub_to_term(&shadowed_sub, case.return_ty)?,
-                            return_value: self
-                                .apply_sub_to_term(&shadowed_sub, case.return_value)?,
-                        })
+                    .map(|case| TyFnCase {
+                        params: self.apply_sub_to_params(&shadowed_sub, &case.params),
+                        return_ty: self.apply_sub_to_term(&shadowed_sub, case.return_ty),
+                        return_value: self.apply_sub_to_term(&shadowed_sub, case.return_value),
                     })
-                    .collect::<TcResult<Vec<_>>>()?;
-                Ok(self.builder().create_term(Term::TyFn(TyFn {
+                    .collect::<Vec<_>>();
+                self.builder().create_term(Term::TyFn(TyFn {
                     name: ty_fn.name,
                     general_params: subbed_general_params,
                     general_return_ty: subbed_general_return_ty,
                     cases: subbed_cases,
-                })))
+                }))
             }
             Term::TyFnTy(ty_fn_ty) => {
                 // Apply the substitution to the parameters and return type.
                 // Same rule applies about binding as above.
                 let shadowed_sub = sub.filter(&ty_fn_ty.params);
-                let subbed_params = self.apply_sub_to_params(&shadowed_sub, &ty_fn_ty.params)?;
-                let subbed_return_ty = self.apply_sub_to_term(&shadowed_sub, ty_fn_ty.return_ty)?;
-                Ok(self.builder().create_term(Term::TyFnTy(TyFnTy {
+                let subbed_params = self.apply_sub_to_params(&shadowed_sub, &ty_fn_ty.params);
+                let subbed_return_ty = self.apply_sub_to_term(&shadowed_sub, ty_fn_ty.return_ty);
+                self.builder().create_term(Term::TyFnTy(TyFnTy {
                     params: subbed_params,
                     return_ty: subbed_return_ty,
-                })))
+                }))
             }
             Term::AppTyFn(app_ty_fn) => {
                 // Apply the substitution to the subject and arguments.
-                let subbed_subject = self.apply_sub_to_term(sub, app_ty_fn.subject)?;
-                let subbed_args = self.apply_sub_to_args(sub, &app_ty_fn.args)?;
-                Ok(self.builder().create_term(Term::AppTyFn(AppTyFn {
+                let subbed_subject = self.apply_sub_to_term(sub, app_ty_fn.subject);
+                let subbed_args = self.apply_sub_to_args(sub, &app_ty_fn.args);
+                self.builder().create_term(Term::AppTyFn(AppTyFn {
                     subject: subbed_subject,
                     args: subbed_args,
-                })))
-            }
-            Term::Unresolved(unresolved) => {
-                // If the variable is in the substitution, substitute it, otherwise do nothing.
-                match sub.get_sub_for(unresolved.into()) {
-                    Some(subbed_term_id) => Ok(subbed_term_id),
-                    None => Ok(term_id),
-                }
+                }))
             }
             Term::AppSub(app_sub) => {
                 // Here, we have to substitute all X in * -> X pairs of the substitution, as well
@@ -263,20 +247,28 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 let subbed_sub = app_sub
                     .sub
                     .pairs()
-                    .map(|(from, to)| Ok((from, self.apply_sub_to_term(sub, to)?)))
-                    .collect::<TcResult<HashMap<_, _>>>()?;
-                let subbed_term = self.apply_sub_to_term(sub, app_sub.term)?;
-                Ok(self.builder().create_term(Term::AppSub(AppSub {
+                    .map(|(from, to)| (from, self.apply_sub_to_term(sub, to)))
+                    .collect::<HashMap<_, _>>();
+                let subbed_term = self.apply_sub_to_term(sub, app_sub.term);
+                self.builder().create_term(Term::AppSub(AppSub {
                     sub: Sub::from_map(subbed_sub),
                     term: subbed_term,
-                })))
+                }))
             }
-            // For the definite-level terms, recurse:
+            // Definite-level terms:
             Term::Level3(term) => self.apply_sub_to_level3_term(sub, term),
             Term::Level2(term) => self.apply_sub_to_level2_term(sub, term),
             Term::Level1(term) => self.apply_sub_to_level1_term(sub, term),
             Term::Level0(term) => self.apply_sub_to_level0_term(sub, term),
         }
+    }
+
+    /// Get the set of free variables that exist in the given term.
+    ///
+    /// Free variables are either `Var` or `Unresolved`, and this function collects both.
+    pub fn get_free_vars_in_term(&self, _term: TermId) -> HashSet<SubSubject> {
+        // @@Todo
+        todo!()
     }
 }
 
@@ -351,7 +343,7 @@ mod tests {
         )]);
 
         let mut substitutor = Substitutor::new(storage_ref.storages_mut());
-        let subbed_target = substitutor.apply_sub_to_term(&sub, target).unwrap();
+        let subbed_target = substitutor.apply_sub_to_term(&sub, target);
 
         println!(
             "{}",

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -85,12 +85,12 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
         match term {
             Level2Term::Trt(trt_def_id) => {
                 // Here we add the substitution to the term using only vars in the trat definition.
-                let trt_def_vars = self.reader().get_trt_def(trt_def_id).bound_vars.clone();
+                let reader = self.reader();
+                let trt_def_vars = &reader.get_trt_def(trt_def_id).bound_vars;
+                let selected_sub = sub.select(trt_def_vars);
                 let builder = self.builder();
-                Ok(builder.create_app_sub_term(
-                    sub.select(&trt_def_vars),
-                    builder.create_term(Term::Level2(term)),
-                ))
+                Ok(builder
+                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level2(term))))
             }
             Level2Term::AnyTy => Ok(self.builder().create_term(Term::Level2(Level2Term::AnyTy))),
         }
@@ -102,26 +102,22 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
         match term {
             Level1Term::ModDef(mod_def_id) => {
                 // Here we add the substitution to the term using only vars in the mod definition.
-                let mod_def_vars = self.reader().get_mod_def(mod_def_id).bound_vars.clone();
+                let reader = self.reader();
+                let mod_def_vars = &reader.get_mod_def(mod_def_id).bound_vars;
+                let selected_sub = sub.select(&mod_def_vars);
                 let builder = self.builder();
-                Ok(builder.create_app_sub_term(
-                    sub.select(&mod_def_vars),
-                    builder.create_term(Term::Level1(term)),
-                ))
+                Ok(builder
+                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term))))
             }
             Level1Term::NominalDef(nominal_def_id) => {
                 // Here we add the substitution to the term using only vars in the nominal
                 // definition.
-                let nominal_def_vars = self
-                    .reader()
-                    .get_nominal_def(nominal_def_id)
-                    .bound_vars()
-                    .clone();
+                let reader = self.reader();
+                let nominal_def_vars = reader.get_nominal_def(nominal_def_id).bound_vars();
+                let selected_sub = sub.select(&nominal_def_vars);
                 let builder = self.builder();
-                Ok(builder.create_app_sub_term(
-                    sub.select(&nominal_def_vars),
-                    builder.create_term(Term::Level1(term)),
-                ))
+                Ok(builder
+                    .create_app_sub_term(selected_sub, builder.create_term(Term::Level1(term))))
             }
             Level1Term::Tuple(tuple_ty) => {
                 // Apply to all members
@@ -157,14 +153,14 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
             }
             Level0Term::EnumVariant(enum_variant) => {
                 // Here we add the substitution to the term using only vars in the enum definition.
-                let enum_def_vars = self
-                    .reader()
+                let reader = self.reader();
+                let enum_def_vars = reader
                     .get_nominal_def(enum_variant.enum_def_id)
-                    .bound_vars()
-                    .clone();
+                    .bound_vars();
+                let selected_sub = sub.select(&enum_def_vars);
                 let builder = self.builder();
                 Ok(builder.create_app_sub_term(
-                    sub.select(&enum_def_vars),
+                    selected_sub,
                     builder.create_term(Term::Level0(Level0Term::EnumVariant(enum_variant))),
                 ))
             }


### PR DESCRIPTION
A critical aspect of type inference is to be able to merge/unify substitutions in order to accumulate inferred types and resolve unknown type variables across the program. This PR implements unification of substitutions, as detailed in the paper <https://www.researchgate.net/publication/221600544_On_the_Unification_of_Substitutions_in_Type_Interfaces>. This is another step towards the completion of term unification in the typechecker. Closes #263. 