### PR TITLE
TC: Implement discovering free variables in a term

### DIFF
--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -5,7 +5,7 @@ use crate::storage::{
         AccessTerm, AppSub, AppTyFn, Arg, Args, EnumDef, EnumVariant, FnTy, GetNameOpt, Level0Term,
         Level1Term, Level2Term, Level3Term, Member, ModDefId, Mutability, NominalDef, NominalDefId,
         Param, ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term, TermId,
-        TrtDef, TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, Var, Visibility,
+        TrtDef, TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, UnresolvedTerm, Var, Visibility,
     },
     GlobalStorage,
 };
@@ -416,6 +416,17 @@ impl<'gs> PrimitiveBuilder<'gs> {
             args: Args::new(args.into_iter().collect()),
             subject,
         }
+    }
+
+    /// Create a new unresolved term value, of type [Term::Unresolved].
+    pub fn create_unresolved(&self) -> UnresolvedTerm {
+        let resolution_id = self.gs.borrow().term_store.new_resolution_id();
+        UnresolvedTerm { resolution_id }
+    }
+
+    /// Create a new unresolved term, of type [Term::Unresolved].
+    pub fn create_unresolved_term(&self) -> TermId {
+        self.create_term(Term::Unresolved(self.create_unresolved()))
     }
 
     /// Create a substitution application term, given a substitution and inner term.

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -2,7 +2,7 @@
 use crate::storage::{
     primitives::{
         AppSub, AppTyFn, Arg, Args, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Param,
-        ParamList, Params, Sub, SubSubject, Term, TermId, TupleTy, TyFn, TyFnCase, TyFnTy,
+        ParamList, Params, Sub, SubSubject, Term, TermId, TupleTy, TyFn, TyFnCase, TyFnTy, Var,
     },
     AccessToStorage, AccessToStorageMut, StorageRefMut,
 };
@@ -242,7 +242,7 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
                 }))
             }
             Term::AppSub(app_sub) => {
-                // @@Reconsider: do we not want to unify substitutions here?
+                // @@Correctness: do we not want to unify substitutions here?
                 //
                 // Here, we have to substitute all X in * -> X pairs of the substitution, as well
                 // as the subject term itself.
@@ -265,12 +265,231 @@ impl<'gs, 'ls, 'cd> Substitutor<'gs, 'ls, 'cd> {
         }
     }
 
+    /// Add the free variables in the parameter default values and types to the given [HashSet].
+    pub fn add_free_vars_in_params_to_set(
+        &self,
+        params: &Params,
+        result: &mut HashSet<SubSubject>,
+    ) {
+        // Add default value and type free vars
+        for param in params.positional() {
+            self.add_free_vars_in_term_to_set(param.ty, result);
+            if let Some(default_value_id) = param.default_value {
+                self.add_free_vars_in_term_to_set(default_value_id, result);
+            }
+        }
+    }
+
+    /// Remove the free variables that exist in the given params as names, from the given
+    /// [HashSet], and add the free variables in the default values and types.
+    ///
+    /// This is to be used for type functions.
+    pub fn add_and_remove_free_vars_in_params_from_set(
+        &self,
+        params: &Params,
+        result: &mut HashSet<SubSubject>,
+    ) {
+        self.add_free_vars_in_params_to_set(params, result);
+        // Remove param names
+        for param in params.positional() {
+            if let Some(name) = param.name {
+                let subject = Var { name };
+                result.remove(&subject.into());
+            }
+        }
+    }
+
+    /// Add the free variables that exist in the given args, to the given [HashSet].
+    pub fn add_free_vars_in_args_to_set(&self, args: &Args, result: &mut HashSet<SubSubject>) {
+        for arg in args.positional() {
+            self.add_free_vars_in_term_to_set(arg.value, result);
+        }
+    }
+
+    /// Add the free variables that exist in the given [Level0Term], to the given [HashSet].
+    pub fn add_free_vars_in_level0_term_to_set(
+        &self,
+        term: &Level0Term,
+        result: &mut HashSet<SubSubject>,
+    ) {
+        match term {
+            Level0Term::Rt(ty_term_id) => self.add_free_vars_in_term_to_set(*ty_term_id, result),
+            Level0Term::EnumVariant(enum_variant) => {
+                // Forward to the nominal enum definition
+                let enum_def = Level1Term::NominalDef(enum_variant.enum_def_id);
+                self.add_free_vars_in_level1_term_to_set(&enum_def, result);
+            }
+        }
+    }
+
+    /// Add the free variables that exist in the given [Level1Term], to the given [HashSet].
+    pub fn add_free_vars_in_level1_term_to_set(
+        &self,
+        term: &Level1Term,
+        result: &mut HashSet<SubSubject>,
+    ) {
+        match term {
+            Level1Term::ModDef(mod_def_id) => {
+                // Add the bound vars of the module (they are not bound because they are not behind
+                // a type function anymore).
+                result.extend(
+                    self.reader()
+                        .get_mod_def(*mod_def_id)
+                        .bound_vars
+                        .iter()
+                        .copied()
+                        .map(SubSubject::from),
+                )
+            }
+            Level1Term::NominalDef(nominal_def_id) => {
+                // Add the bound vars of the nominal definition (they are not bound because they are not behind
+                // a type function anymore).
+                result.extend(
+                    self.reader()
+                        .get_nominal_def(*nominal_def_id)
+                        .bound_vars()
+                        .iter()
+                        .copied()
+                        .map(SubSubject::from),
+                )
+            }
+            Level1Term::Tuple(tuple_ty) => {
+                // Add the free variables in the parameters (don't remove the parameter names)
+                self.add_free_vars_in_params_to_set(&tuple_ty.members, result);
+            }
+            Level1Term::Fn(fn_ty) => {
+                // Add the free variables in the parameters and return type.
+                self.add_free_vars_in_params_to_set(&fn_ty.params, result);
+                self.add_free_vars_in_term_to_set(fn_ty.return_ty, result);
+            }
+        }
+    }
+
+    /// Add the free variables that exist in the given [Level2Term], to the given [HashSet].
+    pub fn add_free_vars_in_level2_term_to_set(
+        &self,
+        term: &Level2Term,
+        result: &mut HashSet<SubSubject>,
+    ) {
+        match term {
+            Level2Term::Trt(trt_def_id) => {
+                // Add the bound vars of the trait definition (they are not bound because they are not behind
+                // a type function anymore).
+                result.extend(
+                    self.reader()
+                        .get_trt_def(*trt_def_id)
+                        .bound_vars
+                        .iter()
+                        .copied()
+                        .map(SubSubject::from),
+                )
+            }
+            Level2Term::AnyTy => {}
+        }
+    }
+
+    /// Add the free variables that exist in the given [Level3Term], to the given [HashSet].
+    pub fn add_free_vars_in_level3_term_to_set(
+        &self,
+        term: &Level3Term,
+        _: &mut HashSet<SubSubject>,
+    ) {
+        match term {
+            Level3Term::TrtKind => {}
+        }
+    }
+
+    /// Add the free variables that exist in the given term, to the given [HashSet].
+    ///
+    /// Free variables are either `Var` or `Unresolved`, and this function collects both.
+    pub fn add_free_vars_in_term_to_set(&self, term_id: TermId, result: &mut HashSet<SubSubject>) {
+        let reader = self.reader();
+        let term = reader.get_term(term_id);
+        match term {
+            Term::Var(var) => {
+                // Found a free variable:
+                // @@Correctness: what if this is bound in the scope?
+                result.insert((*var).into());
+            }
+            Term::Unresolved(unresolved) => {
+                // Found an unresolved free variable:
+                result.insert((*unresolved).into());
+            }
+            Term::Access(term) => {
+                // Just the free vars in the subject:
+                self.add_free_vars_in_term_to_set(term.subject_id, result);
+            }
+            Term::Merge(terms) => {
+                // Free vars in each term:
+                for inner_term_id in terms {
+                    self.add_free_vars_in_term_to_set(*inner_term_id, result);
+                }
+            }
+            Term::TyFn(ty_fn) => {
+                // Add the vars in the subjects and return:
+                self.add_free_vars_in_term_to_set(ty_fn.general_return_ty, result);
+                for case in &ty_fn.cases {
+                    self.add_free_vars_in_term_to_set(case.return_ty, result);
+                    self.add_free_vars_in_term_to_set(case.return_value, result);
+                }
+
+                // Remove the ones which are bound:
+                self.add_and_remove_free_vars_in_params_from_set(&ty_fn.general_params, result);
+                // And from the cases:
+                for case in &ty_fn.cases {
+                    // @@Correctness: is this right? is it necessary?
+                    self.add_and_remove_free_vars_in_params_from_set(&case.params, result);
+                }
+            }
+            Term::TyFnTy(ty_fn_ty) => {
+                // Add the vars in the subjects and return:
+                self.add_free_vars_in_term_to_set(ty_fn_ty.return_ty, result);
+
+                // Remove the ones which are bound:
+                self.add_and_remove_free_vars_in_params_from_set(&ty_fn_ty.params, result);
+            }
+            Term::AppTyFn(app_ty_fn) => {
+                // Free vars in subject and args
+                self.add_free_vars_in_term_to_set(app_ty_fn.subject, result);
+                self.add_free_vars_in_args_to_set(&app_ty_fn.args, result);
+            }
+            Term::AppSub(app_sub) => {
+                // Add free vars in the subject term
+                self.add_free_vars_in_term_to_set(app_sub.term, result);
+
+                // Remove free vars in the domain of the substitution
+                for var in app_sub.sub.domain() {
+                    result.remove(&var);
+                }
+
+                // Add free vars in the range of the substitution
+                for range_el in app_sub.sub.range() {
+                    self.add_free_vars_in_term_to_set(range_el, result);
+                }
+            }
+            // Definite-level terms:
+            Term::Level3(term) => {
+                self.add_free_vars_in_level3_term_to_set(term, result);
+            }
+            Term::Level2(term) => {
+                self.add_free_vars_in_level2_term_to_set(term, result);
+            }
+            Term::Level1(term) => {
+                self.add_free_vars_in_level1_term_to_set(term, result);
+            }
+            Term::Level0(term) => {
+                self.add_free_vars_in_level0_term_to_set(term, result);
+            }
+        }
+    }
+
     /// Get the set of free variables that exist in the given term.
     ///
     /// Free variables are either `Var` or `Unresolved`, and this function collects both.
-    pub fn get_free_vars_in_term(&self, _term: TermId) -> HashSet<SubSubject> {
-        // @@Todo
-        todo!()
+    pub fn get_free_vars_in_term(&self, term_id: TermId) -> HashSet<SubSubject> {
+        let mut result = HashSet::new();
+        self.add_free_vars_in_term_to_set(term_id, &mut result);
+        result
     }
 }
 

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -499,8 +499,9 @@ mod tests {
     use crate::{
         fmt::PrepareForFormatting,
         storage::{
-            core::CoreDefs, primitives::Sub, AccessToStorage, AccessToStorageMut, GlobalStorage,
-            LocalStorage, StorageRefMut,
+            core::CoreDefs,
+            primitives::{ModDefOrigin, Sub},
+            AccessToStorage, AccessToStorageMut, GlobalStorage, LocalStorage, StorageRefMut,
         },
     };
     use hash_source::{InteractiveId, SourceId};
@@ -523,6 +524,11 @@ mod tests {
         let builder = storage_ref.builder();
 
         // Visual testing for now, until term unification is implemented and we can actually write proper tests here:
+        let hash_impl = builder.create_nameless_mod_def(
+            ModDefOrigin::TrtImpl(builder.create_trt_term(core_defs.hash_trt)),
+            builder.create_constant_scope([]),
+            [],
+        );
 
         let inner = builder.create_nameless_ty_fn_term(
             [builder.create_param("T", builder.create_any_ty_term())],
@@ -531,7 +537,7 @@ mod tests {
                 core_defs.set_ty_fn,
                 [
                     builder.create_arg("T", builder.create_var_term("T")),
-                    builder.create_arg("X", builder.create_unresolved_term()),
+                    builder.create_arg("X", builder.create_mod_def_term(hash_impl)),
                 ],
             ),
         );

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -279,6 +279,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
             // Remove elements of dom(result) from t, and remove a from result.
             let subbed_t = substitutor.apply_sub_to_term(&result, t);
             if substitutor.get_free_vars_in_term(subbed_t).contains(&a) {
+                // @@ErrorReporting: here we can error with the span for more info.
                 panic!("Unexpected free variable in one of the substitutions being unified (occurs error)");
             }
 

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -240,8 +240,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         // })
     }
 
-    /// Convenience method to get a substitutor.
-    fn substitutor(&mut self) -> Substituter {
+    /// Convenience method to get a substituter.
+    fn substituter(&mut self) -> Substituter {
         Substituter::new(self.storages_mut())
     }
 
@@ -256,20 +256,20 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
     pub fn unify_subs(&mut self, s0: &Sub, s1: &Sub) -> TcResult<Sub> {
         let dom_s0: HashSet<_> = s0.domain().collect();
         let dom_s1: HashSet<_> = s1.domain().collect();
-        let mut substitutor = self.substitutor();
+        let mut substituter = self.substituter();
 
         /// First split the domains into three parts: d0, d1, and the intersection (see second
         /// loop)
         let d0: HashSet<_> = dom_s0.difference(&dom_s1).copied().collect();
         let t0 = Sub::from_pairs(
             d0.iter()
-                .map(|&a| (a, substitutor.apply_sub_to_subject(s0, a))),
+                .map(|&a| (a, substituter.apply_sub_to_subject(s0, a))),
         );
 
         let d1: HashSet<_> = dom_s1.difference(&dom_s0).copied().collect();
         let t1 = Sub::from_pairs(
             d1.iter()
-                .map(|&a| (a, substitutor.apply_sub_to_subject(s1, a))),
+                .map(|&a| (a, substituter.apply_sub_to_subject(s1, a))),
         );
 
         // Start with t0 and add terms for d1 one at a time, always producing well formed
@@ -277,8 +277,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         let mut result = t0.clone();
         for (a, t) in t0.pairs() {
             // Remove elements of dom(result) from t, and remove a from result.
-            let subbed_t = substitutor.apply_sub_to_term(&result, t);
-            if substitutor.get_free_vars_in_term(subbed_t).contains(&a) {
+            let subbed_t = substituter.apply_sub_to_term(&result, t);
+            if substituter.get_free_vars_in_term(subbed_t).contains(&a) {
                 // @@ErrorReporting: here we can error with the span for more info.
                 panic!("Unexpected free variable in one of the substitutions being unified (occurs error)");
             }
@@ -289,14 +289,14 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
         // Now deal with the intersection:
         for &b in dom_s0.intersection(&dom_s1) {
-            let mut substitutor = self.substitutor();
-            let subbed0_b = substitutor.apply_sub_to_subject(s0, b);
-            let subbed1_b = substitutor.apply_sub_to_subject(s1, b);
-            let x0 = substitutor.apply_sub_to_term(&result, subbed0_b);
-            let x1 = substitutor.apply_sub_to_term(&result, subbed1_b);
+            let mut substituter = self.substituter();
+            let subbed0_b = substituter.apply_sub_to_subject(s0, b);
+            let subbed1_b = substituter.apply_sub_to_subject(s1, b);
+            let x0 = substituter.apply_sub_to_term(&result, subbed0_b);
+            let x1 = substituter.apply_sub_to_term(&result, subbed1_b);
 
-            if substitutor.get_free_vars_in_term(x0).contains(&b)
-                || substitutor.get_free_vars_in_term(x1).contains(&b)
+            if substituter.get_free_vars_in_term(x0).contains(&b)
+                || substituter.get_free_vars_in_term(x1).contains(&b)
             {
                 panic!("Unexpected free variable in intersection of substitutions being unified (occurs error)");
             }

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -5,7 +5,7 @@
 // @@Remove
 #![allow(unused)]
 
-use super::{building::PrimitiveBuilder, substitute::Substitutor};
+use super::{building::PrimitiveBuilder, substitute::Substituter};
 use crate::{
     error::{TcError, TcResult},
     storage::{
@@ -241,8 +241,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
     }
 
     /// Convenience method to get a substitutor.
-    fn substitutor(&mut self) -> Substitutor {
-        Substitutor::new(self.storages_mut())
+    fn substitutor(&mut self) -> Substituter {
+        Substituter::new(self.storages_mut())
     }
 
     /// Unify two substitutions to produce another substitution.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -170,7 +170,7 @@ pub type BoundVars = HashSet<Var>;
 
 /// The origin of a module: was it defined in a `mod` block, an anonymous `impl` block, or an
 /// `impl Trait` block?
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum ModDefOrigin {
     /// Defined as a trait implementation (for the given term that should resolve to a trait
     /// value).


### PR DESCRIPTION
This is another important step towards type inference. By doing this, one can now instantiate type function return values based on their type arguments, which can be used to implement type function application. This is needed for implementing #271 as well as #232.

Closes #270.