### PR TITLE
semantics: check that `return` statements are only used within functions

### DIFF
--- a/compiler/hash-ast-passes/src/analysis/block.rs
+++ b/compiler/hash-ast-passes/src/analysis/block.rs
@@ -1,0 +1,70 @@
+use std::collections::HashSet;
+
+use hash_ast::{
+    ast::{AstNodes, BodyBlock, Expression, ExpressionKind},
+    visitor::AstVisitor,
+};
+
+use crate::visitor::SemanticAnalysisContext;
+
+use super::{
+    error::{AnalysisErrorKind, BlockOrigin},
+    SemanticAnalyser,
+};
+
+impl SemanticAnalyser {
+    /// This function will verify that all of the given expressions are declarations.
+    /// During the checking process, the function also collects the indices of
+    /// the erroneous statements in the provided [AstNodes<Expression>]. This is
+    /// so that the caller can later 'skip' these statements when performing further checks.
+    pub(crate) fn check_statements_are_declarative(
+        &mut self,
+        ctx: &SemanticAnalysisContext,
+        statements: &AstNodes<Expression>,
+        origin: BlockOrigin,
+    ) -> HashSet<usize> {
+        let mut error_indices = HashSet::new();
+
+        for (index, statement) in statements.iter().enumerate() {
+            if !matches!(
+                statement.kind(),
+                ExpressionKind::Declaration(_) | ExpressionKind::MergeDeclaration(_)
+            ) {
+                self.append_error(
+                    AnalysisErrorKind::NonDeclarativeExpression { origin },
+                    statement.span(),
+                    ctx.source_id,
+                );
+
+                error_indices.insert(index);
+            }
+        }
+
+        error_indices
+    }
+
+    /// This function is used that a given 'constant' block adheres to the
+    /// specified semantic rules:
+    ///
+    /// - All members must be only declarative
+    ///
+    /// - No member can declare themselves to be `mutable`
+    pub(crate) fn check_constant_body_block(
+        &mut self,
+        ctx: &SemanticAnalysisContext,
+        body: &BodyBlock,
+        origin: BlockOrigin,
+    ) {
+        assert!(body.expr.is_none());
+
+        let errors = self.check_statements_are_declarative(ctx, &body.statements, origin);
+
+        // We have to manually walk this block because we want to skip any erroneous
+        // statements.
+        for (index, statement) in body.statements.iter().enumerate() {
+            if errors.contains(&index) {
+                self.visit_expression(ctx, statement.ast_ref()).unwrap();
+            }
+        }
+    }
+}

--- a/compiler/hash-ast-passes/src/analysis/error.rs
+++ b/compiler/hash-ast-passes/src/analysis/error.rs
@@ -31,6 +31,9 @@ pub(crate) enum AnalysisErrorKind {
     UsingBreakOutsideLoop,
     /// When a `continue` expression is found outside of a loop.
     UsingContinueOutsideLoop,
+    /// When a `return` statement is found outside of a function or in scope that doesn't relate
+    /// to the function.
+    UsingReturnOutsideOfFunction,
     /// When multiple spread patterns `...` are present within a list pattern
     MultipleSpreadPatterns {
         /// Where the use of the pattern originated from
@@ -99,6 +102,16 @@ impl From<AnalysisError> for Report {
 
                 builder
                     .with_message("You cannot use a `continue` clause outside of a loop")
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        err.location,
+                        "here",
+                    )));
+            }
+            AnalysisErrorKind::UsingReturnOutsideOfFunction => {
+                builder.with_error_code(HashErrorCode::UsingReturnOutsideFunction);
+
+                builder
+                    .with_message("You cannot use a `return` expression outside of a function")
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         err.location,
                         "here",

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -13,7 +13,7 @@ pub struct SemanticAnalyser {
     /// Whether the current visitor is within a loop construct.
     pub(super) is_in_loop: bool,
     /// Whether the current visitor is within a function definition.
-    pub(super) _is_in_function: bool,
+    pub(super) is_in_function: bool,
     /// Any collected errors when passing through the tree
     pub(super) errors: Vec<AnalysisError>,
 }
@@ -23,7 +23,7 @@ impl SemanticAnalyser {
     pub fn new() -> Self {
         Self {
             is_in_loop: false,
-            _is_in_function: false,
+            is_in_function: false,
             errors: vec![],
         }
     }

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -5,6 +5,7 @@ use hash_source::{
 
 use self::error::{AnalysisError, AnalysisErrorKind};
 
+mod block;
 pub(super) mod error;
 mod pat;
 

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -2,7 +2,7 @@
 //!
 //! All rights reserved 2022 (c) The Hash Language authors
 
-use std::{convert::Infallible, mem};
+use std::{collections::HashSet, convert::Infallible, mem};
 
 use hash_ast::{
     ast::{DestructuringPattern, Pattern, TuplePatternEntry},
@@ -11,7 +11,7 @@ use hash_ast::{
 use hash_source::SourceId;
 
 use crate::analysis::{
-    error::{AnalysisErrorKind, PatternOrigin},
+    error::{AnalysisErrorKind, BlockOrigin, PatternOrigin},
     SemanticAnalyser,
 };
 
@@ -682,7 +682,7 @@ impl AstVisitor for SemanticAnalyser {
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ModBlock>,
     ) -> Result<Self::ModBlockRet, Self::Error> {
-        let _ = walk::walk_mod_block(self, ctx, node);
+        self.check_constant_body_block(ctx, &node.body().0, BlockOrigin::Mod);
         Ok(())
     }
 
@@ -693,7 +693,7 @@ impl AstVisitor for SemanticAnalyser {
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ImplBlock>,
     ) -> Result<Self::ImplBlockRet, Self::Error> {
-        let _ = walk::walk_impl_block(self, ctx, node);
+        self.check_constant_body_block(ctx, &node.body().0, BlockOrigin::Impl);
         Ok(())
     }
 
@@ -1146,14 +1146,16 @@ impl AstVisitor for SemanticAnalyser {
         Ok(())
     }
 
-    type ModuleRet = ();
+    type ModuleRet = HashSet<usize>;
 
     fn visit_module(
         &mut self,
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::Module>,
     ) -> Result<Self::ModuleRet, Self::Error> {
-        let _ = walk::walk_module(self, ctx, node);
-        Ok(())
+        let error_indices =
+            self.check_statements_are_declarative(ctx, &node.contents, BlockOrigin::Root);
+
+        Ok(error_indices)
     }
 }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1040,10 +1040,10 @@ pub struct IfBlock {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct ModBlock(pub AstNode<Block>);
+pub struct ModBlock(pub AstNode<BodyBlock>);
 
 #[derive(Debug, PartialEq)]
-pub struct ImplBlock(pub AstNode<Block>);
+pub struct ImplBlock(pub AstNode<BodyBlock>);
 
 /// A block.
 #[derive(Debug, PartialEq)]

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -2039,24 +2039,24 @@ pub mod walk {
         })
     }
 
-    pub struct ModBlock<V: AstVisitor>(pub V::BlockRet);
+    pub struct ModBlock<V: AstVisitor>(pub V::BodyBlockRet);
 
     pub fn walk_mod_block<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::ModBlock>,
     ) -> Result<ModBlock<V>, V::Error> {
-        Ok(ModBlock(visitor.visit_block(ctx, node.0.ast_ref())?))
+        Ok(ModBlock(visitor.visit_body_block(ctx, node.0.ast_ref())?))
     }
 
-    pub struct ImplBlock<V: AstVisitor>(pub V::BlockRet);
+    pub struct ImplBlock<V: AstVisitor>(pub V::BodyBlockRet);
 
     pub fn walk_impl_block<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::ImplBlock>,
     ) -> Result<ImplBlock<V>, V::Error> {
-        Ok(ImplBlock(visitor.visit_block(ctx, node.0.ast_ref())?))
+        Ok(ImplBlock(visitor.visit_body_block(ctx, node.0.ast_ref())?))
     }
 
     pub struct IfClause<V: AstVisitor> {
@@ -3873,24 +3873,28 @@ pub mod walk_mut {
         })
     }
 
-    pub struct ModBlock<V: AstVisitorMut>(pub V::BlockRet);
+    pub struct ModBlock<V: AstVisitorMut>(pub V::BodyBlockRet);
 
     pub fn walk_mod_block<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::ModBlock>,
     ) -> Result<ModBlock<V>, V::Error> {
-        Ok(ModBlock(visitor.visit_block(ctx, node.0.ast_ref_mut())?))
+        Ok(ModBlock(
+            visitor.visit_body_block(ctx, node.0.ast_ref_mut())?,
+        ))
     }
 
-    pub struct ImplBlock<V: AstVisitorMut>(pub V::BlockRet);
+    pub struct ImplBlock<V: AstVisitorMut>(pub V::BodyBlockRet);
 
     pub fn walk_impl_block<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::ImplBlock>,
     ) -> Result<ImplBlock<V>, V::Error> {
-        Ok(ImplBlock(visitor.visit_block(ctx, node.0.ast_ref_mut())?))
+        Ok(ImplBlock(
+            visitor.visit_body_block(ctx, node.0.ast_ref_mut())?,
+        ))
     }
 
     pub struct IfClause<V: AstVisitorMut> {

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -152,7 +152,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 ))),
                 &token.span,
             ),
-            // @@Note: This doesn't cover '{' case.
             TokenKind::Keyword(Keyword::Impl)
                 if self.peek().map_or(false, |tok| !tok.is_brace_tree()) =>
             {
@@ -185,10 +184,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                         .node_with_joined_span(Block::Loop(LoopBlock(self.parse_block()?)), &start),
                     TokenKind::Keyword(Keyword::If) => self.parse_if_block()?,
                     TokenKind::Keyword(Keyword::Match) => self.parse_match_block()?,
-                    TokenKind::Keyword(Keyword::Mod) => self
-                        .node_with_joined_span(Block::Mod(ModBlock(self.parse_block()?)), &start),
-                    TokenKind::Keyword(Keyword::Impl) => self
-                        .node_with_joined_span(Block::Impl(ImplBlock(self.parse_block()?)), &start),
+                    TokenKind::Keyword(Keyword::Mod) => self.node_with_joined_span(
+                        Block::Mod(ModBlock(self.parse_body_block()?)),
+                        &start,
+                    ),
+                    TokenKind::Keyword(Keyword::Impl) => self.node_with_joined_span(
+                        Block::Impl(ImplBlock(self.parse_body_block()?)),
+                        &start,
+                    ),
                     _ => unreachable!(),
                 };
 

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -441,9 +441,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_expression_from_interactive(&self) -> AstGenResult<AstNode<BodyBlock>> {
         let start = self.current_location();
 
-        match self.parse_block_inner()?.into_body() {
-            Block::Body(body) => Ok(self.node_with_joined_span(body, &start)),
-            _ => unreachable!(),
-        }
+        let body = self.parse_body_block_inner()?;
+        Ok(self.node_with_joined_span(body, &start))
     }
 }

--- a/compiler/hash-typecheck/src/storage/state.rs
+++ b/compiler/hash-typecheck/src/storage/state.rs
@@ -11,8 +11,6 @@ use std::cell::Cell;
 /// should be in the traverse module?
 #[derive(Debug)]
 pub struct TcState {
-    /// Whether or not the typecheker is in a `loop` AST block.
-    pub in_loop: Cell<bool>,
     /// Whether the current function has returned explicitly at least once.
     pub ret_once: Cell<bool>,
     /// The return type of the function being currently checked (if any).
@@ -27,7 +25,6 @@ impl TcState {
     /// Create an empty [TcState] for the given source.
     pub fn new(current_source: SourceId) -> Self {
         Self {
-            in_loop: Cell::new(false),
             ret_once: Cell::new(false),
             func_ret_ty: Cell::new(None),
             current_source: Cell::new(current_source),


### PR DESCRIPTION
closes #275
closes #274 