### PR TITLE
TC: Implement getting the type of a term

### DIFF
--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -212,7 +212,7 @@ impl<'gs> TcFormatter<'gs> {
         match self.global_storage.term_store.get(term_id) {
             Term::Access(access_term) => {
                 is_atomic.set(true);
-                self.fmt_term_as_single(f, access_term.subject_id)?;
+                self.fmt_term_as_single(f, access_term.subject)?;
                 write!(f, "::{}", access_term.name)?;
                 Ok(())
             }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -244,7 +244,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a [Term::Access] with the given subject and name, and namespace operator.
     pub fn create_ns_access(&self, subject_id: TermId, name: impl Into<Identifier>) -> TermId {
         self.create_term(Term::Access(AccessTerm {
-            subject_id,
+            subject: subject_id,
             name: name.into(),
             op: AccessOp::Namespace,
         }))
@@ -253,7 +253,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a [Term::Access] with the given subject and name, and property operator.
     pub fn create_prop_access(&self, subject_id: TermId, name: impl Into<Identifier>) -> TermId {
         self.create_term(Term::Access(AccessTerm {
-            subject_id,
+            subject: subject_id,
             name: name.into(),
             op: AccessOp::Property,
         }))
@@ -400,7 +400,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a trait definition with the given name, and members.
     ///
     /// This adds the name to the scope.
-    pub fn create_trait_def(
+    pub fn create_trt_def(
         &self,
         trait_name: impl Into<Identifier>,
         members: impl IntoIterator<Item = Member>,

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -3,14 +3,16 @@
 //! Code from this module is to be used while traversing and typing the AST, in order to unify
 //! types and ensure correctness.
 use self::{
-    building::PrimitiveBuilder, reader::PrimitiveReader, substitute::Substituter, typing::Typer,
-    unify::Unifier, validate::Validator,
+    building::PrimitiveBuilder, reader::PrimitiveReader, scope::ScopeResolver,
+    simplify::Simplifier, substitute::Substituter, typing::Typer, unify::Unifier,
+    validate::Validator,
 };
 use crate::storage::{primitives::ScopeId, AccessToStorage, AccessToStorageMut};
 
 pub mod building;
 pub mod params;
 pub mod reader;
+pub mod scope;
 pub mod simplify;
 pub mod substitute;
 pub mod typing;
@@ -23,6 +25,11 @@ pub trait AccessToOps: AccessToStorage {
     /// Create an instance ofa [PrimitiveReader].
     fn reader(&self) -> PrimitiveReader {
         PrimitiveReader::new(self.global_storage())
+    }
+
+    /// Create an instance of [ScopeResolver].
+    fn scope_resolver(&self) -> ScopeResolver {
+        ScopeResolver::new(self.storages())
     }
 }
 
@@ -56,6 +63,11 @@ pub trait AccessToOpsMut: AccessToStorageMut {
     /// Create an instance of [Typer].
     fn typer(&mut self) -> Typer {
         Typer::new(self.storages_mut())
+    }
+
+    /// Create an instance of [Simplifier].
+    fn simplifier(&mut self) -> Simplifier {
+        Simplifier::new(self.storages_mut())
     }
 
     /// Create an instance of [Validator].

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -1,0 +1,38 @@
+//! Functionality related to resolving variables in scopes.
+use super::AccessToOps;
+use crate::{
+    error::{TcError, TcResult},
+    storage::{primitives::Member, AccessToStorage, StorageRef},
+};
+use hash_source::identifier::Identifier;
+
+/// Contains actions related to variable resolution.
+pub struct ScopeResolver<'gs, 'ls, 'cd> {
+    storage: StorageRef<'gs, 'ls, 'cd>,
+}
+
+impl<'gs, 'ls, 'cd> AccessToStorage for ScopeResolver<'gs, 'ls, 'cd> {
+    fn storages(&self) -> StorageRef {
+        self.storage.storages()
+    }
+}
+
+impl<'gs, 'ls, 'cd> ScopeResolver<'gs, 'ls, 'cd> {
+    pub fn new(storage: StorageRef<'gs, 'ls, 'cd>) -> Self {
+        Self { storage }
+    }
+
+    pub fn resolve_name_in_scopes(&self, name: Identifier) -> TcResult<Member> {
+        // Here, we have to look in the scopes:
+        for scope_id in self.scopes().iter_up() {
+            match self.reader().get_scope(scope_id).get(name) {
+                // Found in this scope, return the member.
+                Some(result) => return Ok(result),
+                // Continue to the next (higher) scope:
+                None => continue,
+            }
+        }
+        // Name was not found, error:
+        Err(TcError::UnresolvedVariable { name })
+    }
+}

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -211,7 +211,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     }
                 }
                 // Otherwise return none.
-                return Ok(None);
+                Ok(None)
             }
             _ => Ok(None),
         }

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -192,7 +192,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             // Recursive cases:
             Term::Access(access) => {
                 // Just apply the substitution to the subject:
-                let subbed_subject_id = self.apply_sub_to_term(sub, access.subject_id);
+                let subbed_subject_id = self.apply_sub_to_term(sub, access.subject);
                 self.builder()
                     .create_ns_access(subbed_subject_id, access.name)
             }
@@ -432,7 +432,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             }
             Term::Access(term) => {
                 // Just the free vars in the subject:
-                self.add_free_vars_in_term_to_set(term.subject_id, result);
+                self.add_free_vars_in_term_to_set(term.subject, result);
             }
             Term::Merge(terms) => {
                 // Free vars in each term:

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -1,8 +1,15 @@
 //! Contains operations to get the type of a term.
 use crate::{
-    error::TcResult,
-    storage::{primitives::TermId, AccessToStorage, AccessToStorageMut, StorageRefMut},
+    error::{TcError, TcResult},
+    storage::{
+        primitives::{
+            AccessOp, Level0Term, Level1Term, Level2Term, Level3Term, ModDefOrigin, Term, TermId,
+        },
+        AccessToStorage, AccessToStorageMut, StorageRefMut,
+    },
 };
+
+use super::{AccessToOps, AccessToOpsMut};
 
 /// Can resolve the type of a given term, as another term.
 pub struct Typer<'gs, 'ls, 'cd> {
@@ -27,7 +34,144 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
     }
 
     /// Get the type of the given term, as another term.
-    pub fn ty_of_term(&mut self, _term_id: TermId) -> TcResult<TermId> {
-        todo!()
+    ///
+    /// First simplifies the term. If you already know you have a simplified term, you can use
+    /// [Self::ty_of_simplified_term].
+    pub fn ty_of_term(&mut self, term_id: TermId) -> TcResult<TermId> {
+        let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
+        self.ty_of_simplified_term(simplified_term_id)
+    }
+
+    /// Get the type of the given term, given that it is simplified, as another term.
+    ///
+    /// **Warning**: This might produce unexpected behaviour if the term is not simplified.
+    pub fn ty_of_simplified_term(&mut self, term_id: TermId) -> TcResult<TermId> {
+        let term = self.reader().get_term(term_id).clone();
+        match term {
+            Term::Access(access_term) => {
+                // Here we want to get the type of the subject, and ensure it contains this
+                // property, and if so return it.
+                let ty_id_of_subject = self.ty_of_term(access_term.subject)?;
+                match access_term.op {
+                    // Only namespace is allowed by this point:
+                    AccessOp::Namespace => {
+                        let ty_access_term = self
+                            .builder()
+                            .create_ns_access(ty_id_of_subject, access_term.name);
+                        self.simplifier().potentially_simplify_term(ty_access_term)
+                    }
+                    AccessOp::Property => {
+                        panic!("Property access should have already been simplified away!")
+                    }
+                }
+            }
+            Term::AppTyFn(app_ty_fn) => {
+                // Here we want to get the type of the subject, and ensure it is a TyFnTy.
+                // Then, we just apply the args to the type function:
+                let ty_id_of_subject = self.ty_of_term(app_ty_fn.subject)?;
+                let reader = self.reader();
+                let ty_of_subject = reader.get_term(ty_id_of_subject);
+                match ty_of_subject {
+                    Term::TyFnTy(ty_fn_ty) => {
+                        let ty_fn_ty = ty_fn_ty.clone();
+                        // Unify the type function type params with the given args:
+                        let sub = self
+                            .unifier()
+                            .unify_params_with_args(&ty_fn_ty.params, &app_ty_fn.args)?;
+                        // Apply the substitution to the return type and use it as the result:
+                        Ok(self
+                            .substituter()
+                            .apply_sub_to_term(&sub, ty_fn_ty.return_ty))
+                    }
+                    _ => Err(TcError::UnsupportedTypeFunctionApplication {
+                        subject_id: app_ty_fn.subject,
+                    }),
+                }
+            }
+            Term::TyFnTy(_) => {
+                // The type of a type function is just TraitKind.
+                // @@Correctness: is this always consistent?
+                Ok(self.builder().create_trt_kind_term())
+            }
+            Term::Var(var) => {
+                // The type of a variable can be found by looking at the scopes to its declaration:
+                Ok(self.scope_resolver().resolve_name_in_scopes(var.name)?.ty)
+            }
+            Term::TyFn(ty_fn) => {
+                // The type of a type function is a type function type:
+                Ok(self.builder().create_ty_fn_ty_term(
+                    ty_fn.general_params.into_positional(),
+                    ty_fn.general_return_ty,
+                ))
+            }
+            Term::Merge(terms) => {
+                // The type of a merge is a merge of the inner terms:
+                let tys_of_terms: Vec<_> = terms
+                    .iter()
+                    .map(|term| self.ty_of_term(*term))
+                    .collect::<TcResult<_>>()?;
+                Ok(self.builder().create_merge_term(tys_of_terms))
+            }
+            Term::AppSub(app_sub) => {
+                // The type of an AppSub is the type of the subject, with the substitution applied:
+                let ty_of_subject = self.ty_of_term(app_sub.term)?;
+                Ok(self
+                    .substituter()
+                    .apply_sub_to_term(&app_sub.sub, ty_of_subject))
+            }
+            Term::Unresolved(_) => {
+                // The type of an unresolved variable is unresolved:
+                Ok(self.builder().create_unresolved_term())
+            }
+            Term::Level3(level3_term) => match level3_term {
+                Level3Term::TrtKind => {
+                    // The type of TraitKind, is once again TraitKind
+                    Ok(self.builder().create_trt_kind_term())
+                }
+            },
+            Term::Level2(level2_term) => match level2_term {
+                // The type of any trait, or the "Type" trait, is just TraitKind:
+                Level2Term::Trt(_) | Level2Term::AnyTy => Ok(self.builder().create_trt_kind_term()),
+            },
+            Term::Level1(level1_term) => match level1_term {
+                Level1Term::ModDef(mod_def_id) => {
+                    // The type of a mod def depends on its origin:
+                    let reader = self.reader();
+                    let mod_def = reader.get_mod_def(mod_def_id);
+                    match mod_def.origin {
+                        ModDefOrigin::TrtImpl(trt_impl) => {
+                            // The type is the trait impl:
+                            Ok(trt_impl)
+                        }
+                        ModDefOrigin::AnonImpl | ModDefOrigin::Mod | ModDefOrigin::Source(_) => {
+                            // The rest is just "Type"
+                            Ok(self.builder().create_any_ty_term())
+                        }
+                    }
+                }
+                Level1Term::NominalDef(_) | Level1Term::Tuple(_) | Level1Term::Fn(_) => {
+                    // The type of any nominal def, function type, or tuple type, is just "Type":
+                    Ok(self.builder().create_any_ty_term())
+                }
+            },
+            Term::Level0(level0_term) => {
+                match level0_term {
+                    Level0Term::Rt(inner_ty) => {
+                        // The type of a Rt(X) is X
+                        Ok(inner_ty)
+                    }
+                    Level0Term::FnLit(fn_lit) => {
+                        // Here we just return the function type element
+                        Ok(fn_lit.fn_ty)
+                    }
+                    Level0Term::EnumVariant(enum_variant) => {
+                        // The type of an enum variant is the enum
+                        Ok(self
+                            .builder()
+                            .create_nominal_def_term(enum_variant.enum_def_id))
+                    }
+                }
+            }
+        }
     }
 }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -2,10 +2,12 @@
 use crate::{
     error::TcResult,
     storage::{
-        primitives::{FnTy, TermId},
+        primitives::{FnTy, Level1Term, ModDefId, NominalDefId, Term, TermId, TrtDefId},
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
 };
+
+use super::{AccessToOps, AccessToOpsMut};
 
 /// Represents the level of a term.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,31 +35,136 @@ impl<'gs, 'ls, 'cd> AccessToStorageMut for Validator<'gs, 'ls, 'cd> {
     }
 }
 
+/// Used to communicate the result of a successful term validation, which produces the simplified
+/// term as well as its type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TermValidation {
+    pub simplified_term_id: TermId,
+    pub term_ty_id: TermId,
+}
+
 impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
     pub fn new(storage: StorageRefMut<'gs, 'ls, 'cd>) -> Self {
         Self { storage }
     }
 
-    /// Validate the given term for correctness.
-    pub fn validate_term(&mut self, _term_id: TermId) -> TcResult<()> {
+    /// Validate the module definition of the given [ModDefId]
+    pub fn validate_mod_def(&mut self, _mod_def_id: ModDefId) -> TcResult<()> {
         todo!()
+    }
+
+    /// Validate the trait definition of the given [TrtDefId]
+    pub fn validate_trt_def(&mut self, _trt_def_id: TrtDefId) -> TcResult<()> {
+        todo!()
+    }
+
+    /// Validate the nominal definition of the given [NominalDefId]
+    pub fn validate_nominal_def(&mut self, _nominal_def_id: NominalDefId) -> TcResult<()> {
+        todo!()
+    }
+
+    /// Validate the given term for correctness.
+    ///
+    /// Returns the simplified term, along with its type, which are computed during the validation.
+    pub fn validate_term(&mut self, term_id: TermId) -> TcResult<TermValidation> {
+        // First, we try simplify the term:
+        let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
+
+        // Then, we try get its type:
+        let term_ty_id = self.typer().ty_of_simplified_term(simplified_term_id)?;
+
+        // If both of these succeeded, we can perform a few final checks:
+        let reader = self.reader();
+
+        // Prepare the result of the validation:
+        let result = TermValidation {
+            simplified_term_id,
+            term_ty_id,
+        };
+
+        let term = reader.get_term(simplified_term_id);
+        // @@PotentiallyIncomplete: there might are a few more checks we need to perform here, but
+        // this is not yet evident.
+        //
+        // @@Todo: actually implement these checks:
+        match term {
+            Term::Merge(_) => {
+                // Validate each inner term.
+                // Ensure all elements of the merge are not type functions, and are of the same level.
+                todo!()
+            }
+            Term::TyFn(_) => {
+                // Validate each member.
+                // Ensure the return value of each case is a subtype of the general return type.
+                todo!()
+            }
+            Term::Level1(level1_term) => match level1_term {
+                Level1Term::Tuple(_) => {
+                    // Validate each parameter
+                    todo!()
+                }
+                Level1Term::Fn(_) => {
+                    // Validate parameters and return type
+                    todo!()
+                }
+                Level1Term::ModDef(_) | Level1Term::NominalDef(_) => {
+                    // Nothing to do
+                    Ok(result)
+                }
+            },
+            Term::Level0(_) => {
+                // Validate the inner type and ensure it is level 1
+                todo!()
+            }
+            Term::Level2(_)
+            | Term::Level3(_)
+            | Term::Access(_)
+            | Term::Var(_)
+            | Term::AppSub(_)
+            | Term::TyFnTy(_)
+            | Term::AppTyFn(_)
+            | Term::Unresolved(_) => {
+                // Nothing to do, should have already been validated by the typer.
+                Ok(result)
+            }
+        }
     }
 
     /// Determine whether the given term is constant, i.e. has no side effects.
     ///
     /// This is the condition for the term to be able to be used as the return type of a type
     /// function, or to be used in global scope.
-    pub fn term_is_constant(&mut self, _term_id: TermId) -> TcResult<bool> {
-        todo!()
-    }
-
-    /// Determine the level of the given term.
-    pub fn get_level_of_term(&mut self, _term_id: TermId) -> TcResult<TermLevel> {
-        todo!()
+    pub fn term_is_constant(&mut self, term_id: TermId) -> TcResult<bool> {
+        // Make sure the term is valid first:
+        self.validate_term(term_id)?;
+        let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
+        let reader = self.reader();
+        let term = reader.get_term(simplified_term_id);
+        // @@Todo: actually implement this:
+        match term {
+            Term::Access(_) => todo!(),
+            Term::Var(_) => todo!(),
+            Term::Merge(_) => todo!(),
+            Term::TyFn(_) => todo!(),
+            Term::TyFnTy(_) => todo!(),
+            Term::AppTyFn(_) => todo!(),
+            Term::AppSub(_) => todo!(),
+            Term::Unresolved(_) => todo!(),
+            Term::Level3(_) => todo!(),
+            Term::Level2(_) => todo!(),
+            Term::Level1(_) => todo!(),
+            Term::Level0(_) => todo!(),
+        }
     }
 
     /// Determine if the given term is a function type, and if so return it.
-    pub fn term_is_fn_ty(&mut self, _term_id: TermId) -> TcResult<Option<FnTy>> {
-        todo!()
+    pub fn term_is_fn_ty(&mut self, term_id: TermId) -> TcResult<Option<FnTy>> {
+        let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
+        let reader = self.reader();
+        let term = reader.get_term(simplified_term_id);
+        match term {
+            Term::Level1(Level1Term::Fn(fn_ty)) => Ok(Some(fn_ty.clone())),
+            _ => Ok(None),
+        }
     }
 }

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -98,7 +98,7 @@ impl CoreDefs {
         );
 
         // Hash and Eq traits
-        let hash_trt = builder.create_trait_def(
+        let hash_trt = builder.create_trt_def(
             "Hash",
             [builder.create_unset_pub_member(
                 "hash",
@@ -109,7 +109,7 @@ impl CoreDefs {
             )],
             [],
         );
-        let eq_trt = builder.create_trait_def(
+        let eq_trt = builder.create_trt_def(
             "Eq",
             [builder.create_unset_pub_member(
                 "eq",

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -461,7 +461,7 @@ pub enum AccessOp {
 /// Has level N where N is the level of the Y property of X.
 #[derive(Debug, Clone)]
 pub struct AccessTerm {
-    pub subject_id: TermId,
+    pub subject: TermId,
     pub name: Identifier,
     pub op: AccessOp,
 }


### PR DESCRIPTION
This PR implements resolving the type of any given term, to produce another term. This is very useful for type inference and needed for unification. This operation lives in `Typer`. Also, this PR implements struct field accessing for runtime terms (which was missed in the last simplification PR #282), and also adds scaffolding for term validation in `Validator`. 

Closes #285.

The next step after this PR is to tackle #284, namely term validation, which should be relatively quick. After that, unification can be tackled directly.