### PR TITLE
semantics+ast: some minor refactoring and clean-up

### DIFF
--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -9,10 +9,11 @@
 use hash_ast::{
     ast::{
         AccessName, AstNode, AstNodes, Block, BlockExpr, BodyBlock, BoolLiteral,
-        BoolLiteralPattern, BreakStatement, ConstructorPattern, Expression, ExpressionKind,
-        ForLoopBlock, FunctionCallArg, FunctionCallArgs, FunctionCallExpr, IfBlock, IfClause,
-        IfPattern, IgnorePattern, Literal, LiteralExpr, LiteralPattern, LoopBlock, MatchBlock,
-        MatchCase, MatchOrigin, Pattern, TuplePatternEntry, VariableExpr, WhileLoopBlock,
+        BoolLiteralPattern, BreakStatement, ConstructorCallArg, ConstructorCallArgs,
+        ConstructorCallExpr, ConstructorPattern, Expression, ExpressionKind, ForLoopBlock, IfBlock,
+        IfClause, IfPattern, IgnorePattern, Literal, LiteralExpr, LiteralPattern, LoopBlock,
+        MatchBlock, MatchCase, MatchOrigin, Pattern, TuplePatternEntry, VariableExpr,
+        WhileLoopBlock,
     },
     ast_nodes,
     visitor::{walk_mut, AstVisitorMut},
@@ -207,7 +208,7 @@ fn desugar_for_loop_block(node: Block, parent_span: Span) -> Block {
     Block::Loop(LoopBlock(AstNode::new(
         Block::Match(MatchBlock {
             subject: AstNode::new(
-                Expression::new(ExpressionKind::FunctionCall(FunctionCallExpr {
+                Expression::new(ExpressionKind::ConstructorCall(ConstructorCallExpr {
                     subject: AstNode::new(
                         Expression::new(ExpressionKind::Variable(VariableExpr {
                             name: make_access_name("next"),
@@ -216,9 +217,9 @@ fn desugar_for_loop_block(node: Block, parent_span: Span) -> Block {
                         iter_span,
                     ),
                     args: AstNode::new(
-                        FunctionCallArgs {
+                        ConstructorCallArgs {
                             entries: ast_nodes![AstNode::new(
-                                FunctionCallArg {
+                                ConstructorCallArg {
                                     name: None,
                                     value: iterator,
                                 },
@@ -607,36 +608,36 @@ impl AstVisitorMut for AstDesugaring {
         Ok(())
     }
 
-    type FunctionCallArgRet = ();
+    type ConstructorCallArgRet = ();
 
-    fn visit_function_call_arg(
+    fn visit_constructor_call_arg(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::FunctionCallArg>,
-    ) -> Result<Self::FunctionCallArgRet, Self::Error> {
-        let _ = walk_mut::walk_function_call_arg(self, ctx, node);
+        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error> {
+        let _ = walk_mut::walk_constructor_call_arg(self, ctx, node);
         Ok(())
     }
 
-    type FunctionCallArgsRet = ();
+    type ConstructorCallArgsRet = ();
 
-    fn visit_function_call_args(
+    fn visit_constructor_call_args(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::FunctionCallArgs>,
-    ) -> Result<Self::FunctionCallArgsRet, Self::Error> {
-        let _ = walk_mut::walk_function_call_args(self, ctx, node);
+        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::ConstructorCallArgs>,
+    ) -> Result<Self::ConstructorCallArgsRet, Self::Error> {
+        let _ = walk_mut::walk_constructor_call_args(self, ctx, node);
         Ok(())
     }
 
-    type FunctionCallExprRet = ();
+    type ConstructorCallExprRet = ();
 
-    fn visit_function_call_expr(
+    fn visit_constructor_call_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::FunctionCallExpr>,
-    ) -> Result<Self::FunctionCallExprRet, Self::Error> {
-        let _ = walk_mut::walk_function_call_expr(self, ctx, node);
+        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error> {
+        let _ = walk_mut::walk_constructor_call_expr(self, ctx, node);
         Ok(())
     }
 

--- a/compiler/hash-ast-passes/src/analysis/block.rs
+++ b/compiler/hash-ast-passes/src/analysis/block.rs
@@ -1,3 +1,7 @@
+//! Hash semantic analysis module for validating various constructs relating to
+//! blocks within the AST.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors
 use std::{collections::HashSet, mem};
 
 use hash_ast::{
@@ -5,10 +9,9 @@ use hash_ast::{
     visitor::AstVisitor,
 };
 
-use super::{
-    error::{AnalysisErrorKind, BlockOrigin},
-    SemanticAnalyser,
-};
+use crate::diagnostics::{error::AnalysisErrorKind, BlockOrigin};
+
+use super::SemanticAnalyser;
 
 impl SemanticAnalyser {
     /// This function will verify that all of the given expressions are declarations. Additionally,

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -1,35 +1,21 @@
+//! Hash semantic analyser definitions. This file holds the [SemanticAnalyser] definition
+//! with some shared functions to append diagnostics to the analyser.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors
 use crossbeam_channel::Sender;
-use hash_reporting::reporting::Report;
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId,
 };
 
-use self::{
-    error::{AnalysisError, AnalysisErrorKind, BlockOrigin},
+use crate::diagnostics::{
+    error::{AnalysisError, AnalysisErrorKind},
     warning::{AnalysisWarning, AnalysisWarningKind},
+    BlockOrigin, Diagnostic,
 };
 
 mod block;
-pub(crate) mod error;
 mod pat;
-pub(crate) mod warning;
-
-/// Enum representing any generated message that can be emitted by the
-/// [SemanticAnalyser].
-pub(crate) enum AnalysisMessage {
-    Warning(AnalysisWarning),
-    Error(AnalysisError),
-}
-
-impl From<AnalysisMessage> for Report {
-    fn from(message: AnalysisMessage) -> Self {
-        match message {
-            AnalysisMessage::Warning(warning) => warning.into(),
-            AnalysisMessage::Error(err) => err.into(),
-        }
-    }
-}
 
 pub struct SemanticAnalyser {
     /// Whether the current visitor is within a loop construct.
@@ -83,13 +69,13 @@ impl SemanticAnalyser {
     }
 
     /// Given a [Sender], send all of the generated warnings and messaged into the sender.
-    pub(crate) fn send_generated_messages(self, sender: &Sender<AnalysisMessage>) {
+    pub(crate) fn send_generated_messages(self, sender: &Sender<Diagnostic>) {
         self.errors
             .into_iter()
-            .for_each(|err| sender.send(AnalysisMessage::Error(err)).unwrap());
+            .for_each(|err| sender.send(Diagnostic::Error(err)).unwrap());
 
         self.warnings
             .into_iter()
-            .for_each(|warning| sender.send(AnalysisMessage::Warning(warning)).unwrap());
+            .for_each(|warning| sender.send(Diagnostic::Warning(warning)).unwrap());
     }
 }

--- a/compiler/hash-ast-passes/src/analysis/pat.rs
+++ b/compiler/hash-ast-passes/src/analysis/pat.rs
@@ -1,9 +1,12 @@
+//! Hash semantic analysis module for validating various constructs relating to
+//! patterns within the AST.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors
 use hash_ast::ast::{AstNodes, Pattern, TuplePatternEntry};
 
-use super::{
-    error::{AnalysisErrorKind, PatternOrigin},
-    SemanticAnalyser,
-};
+use crate::diagnostics::{error::AnalysisErrorKind, PatternOrigin};
+
+use super::SemanticAnalyser;
 
 impl SemanticAnalyser {
     pub(crate) fn check_compound_pattern_rules(

--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -1,7 +1,6 @@
-//! Hash AST semantic passes error definitions.
+//! Hash AST semantic analysis error diagnostic definitions.
 //!
 //! All rights reserved 2022 (c) The Hash Language authors.
-use std::fmt::Display;
 
 use hash_ast::ast::Visibility;
 use hash_error_codes::error_codes::HashErrorCode;
@@ -9,6 +8,8 @@ use hash_reporting::reporting::{
     Report, ReportBuilder, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind,
 };
 use hash_source::location::SourceLocation;
+
+use super::{BlockOrigin, PatternOrigin};
 
 /// An error that can occur during the semantic pass
 pub struct AnalysisError {
@@ -60,73 +61,6 @@ pub(crate) enum AnalysisErrorKind {
         modifier: Visibility,
         origin: BlockOrigin,
     },
-}
-
-/// Denotes where a pattern was used as in the parent of the pattern. This is useful
-/// for propagating errors upwards by signalling what is the current parent of the
-/// pattern. This only contains patterns that can be compound (hold multiple children patterns).
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum PatternOrigin {
-    Tuple,
-    NamedField,
-    Constructor,
-    List,
-    Namespace,
-}
-
-impl PatternOrigin {
-    /// Convert the [PatternOrigin] into a string which can be used for displaying
-    /// within error messages.
-    fn to_str(self) -> &'static str {
-        match self {
-            PatternOrigin::Tuple => "tuple",
-            PatternOrigin::NamedField => "named field",
-            PatternOrigin::Constructor => "constructor",
-            PatternOrigin::List => "list",
-            PatternOrigin::Namespace => "namespace",
-        }
-    }
-}
-
-impl Display for PatternOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_str())
-    }
-}
-
-/// Denotes where an error occurred from which type of block. This is useful
-/// when giving more context about errors such as [AnalysisErrorKind::NonDeclarativeExpression]
-/// occur from.
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum BlockOrigin {
-    Root,
-    Mod,
-    Impl,
-    Body,
-}
-
-impl BlockOrigin {
-    /// Convert the [BlockOrigin] into a string which can be used for displaying
-    /// within error messages.
-    fn to_str(self) -> &'static str {
-        match self {
-            BlockOrigin::Root | BlockOrigin::Mod => "module",
-            BlockOrigin::Impl => "impl",
-            BlockOrigin::Body => "body",
-        }
-    }
-}
-
-impl Default for BlockOrigin {
-    fn default() -> Self {
-        BlockOrigin::Root
-    }
-}
-
-impl Display for BlockOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_str())
-    }
 }
 
 impl From<AnalysisError> for Report {

--- a/compiler/hash-ast-passes/src/diagnostics/mod.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/mod.rs
@@ -1,0 +1,93 @@
+//! Hash AST semantic passes diagnostic definitions and logic.
+//!
+//! All rights reserved 2022 (c) The Hash Language authors.
+
+use self::{error::AnalysisError, warning::AnalysisWarning};
+use hash_reporting::reporting::Report;
+use std::fmt::Display;
+
+pub(crate) mod error;
+pub(crate) mod warning;
+
+/// Denotes where a pattern was used as in the parent of the pattern. This is useful
+/// for propagating errors upwards by signalling what is the current parent of the
+/// pattern. This only contains patterns that can be compound (hold multiple children patterns).
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PatternOrigin {
+    Tuple,
+    NamedField,
+    Constructor,
+    List,
+    Namespace,
+}
+
+impl PatternOrigin {
+    /// Convert the [PatternOrigin] into a string which can be used for displaying
+    /// within error messages.
+    fn to_str(self) -> &'static str {
+        match self {
+            PatternOrigin::Tuple => "tuple",
+            PatternOrigin::NamedField => "named field",
+            PatternOrigin::Constructor => "constructor",
+            PatternOrigin::List => "list",
+            PatternOrigin::Namespace => "namespace",
+        }
+    }
+}
+
+impl Display for PatternOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+/// Denotes where an error occurred from which type of block. This is useful
+/// when giving more context about errors such as [AnalysisErrorKind::NonDeclarativeExpression]
+/// occur from.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum BlockOrigin {
+    Root,
+    Mod,
+    Impl,
+    Body,
+}
+
+impl BlockOrigin {
+    /// Convert the [BlockOrigin] into a string which can be used for displaying
+    /// within error messages.
+    fn to_str(self) -> &'static str {
+        match self {
+            BlockOrigin::Root | BlockOrigin::Mod => "module",
+            BlockOrigin::Impl => "impl",
+            BlockOrigin::Body => "body",
+        }
+    }
+}
+
+impl Default for BlockOrigin {
+    fn default() -> Self {
+        BlockOrigin::Root
+    }
+}
+
+impl Display for BlockOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+/// Enum representing any generated message that can be emitted by the
+/// [SemanticAnalyser].
+pub(crate) enum Diagnostic {
+    Warning(AnalysisWarning),
+    Error(AnalysisError),
+}
+
+impl From<Diagnostic> for Report {
+    fn from(message: Diagnostic) -> Self {
+        match message {
+            Diagnostic::Warning(warning) => warning.into(),
+            Diagnostic::Error(err) => err.into(),
+        }
+    }
+}

--- a/compiler/hash-ast-passes/src/diagnostics/warning.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/warning.rs
@@ -1,4 +1,4 @@
-//! Hash AST semantic passes warning definitions.
+//! Hash AST semantic analysis warning diagnostic definitions.
 //!
 //! All rights reserved 2022 (c) The Hash Language authors.
 

--- a/compiler/hash-ast-passes/src/lib.rs
+++ b/compiler/hash-ast-passes/src/lib.rs
@@ -6,12 +6,13 @@
 #![feature(generic_associated_types)]
 
 pub mod analysis;
+pub(crate) mod diagnostics;
 pub mod visitor;
 
-use analysis::AnalysisMessage;
 use analysis::SemanticAnalyser;
 use crossbeam_channel::unbounded;
 
+use diagnostics::Diagnostic;
 use hash_ast::visitor::AstVisitor;
 use hash_pipeline::{sources::Sources, traits::SemanticPass, CompilerResult};
 use hash_reporting::reporting::Report;
@@ -42,7 +43,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
         state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> Result<(), Vec<Report>> {
-        let (sender, receiver) = unbounded::<AnalysisMessage>();
+        let (sender, receiver) = unbounded::<Diagnostic>();
 
         pool.scope(|scope| {
             // De-sugar the target if it isn't already de-sugared

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -128,36 +128,39 @@ impl AstVisitor for SemanticAnalyser {
         Ok(())
     }
 
-    type FunctionCallArgRet = ();
+    type ConstructorCallArgRet = ();
 
-    fn visit_function_call_arg(
+    fn visit_constructor_call_arg(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionCallArg>,
-    ) -> Result<Self::FunctionCallArgRet, Self::Error> {
-        let _ = walk::walk_function_call_arg(self, ctx, node);
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error> {
+        let _ = walk::walk_constructor_call_arg(self, ctx, node);
         Ok(())
     }
 
-    type FunctionCallArgsRet = ();
+    type ConstructorCallArgsRet = ();
 
-    fn visit_function_call_args(
+    fn visit_constructor_call_args(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionCallArgs>,
-    ) -> Result<Self::FunctionCallArgsRet, Self::Error> {
-        let _ = walk::walk_function_call_args(self, ctx, node);
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallArgs>,
+    ) -> Result<Self::ConstructorCallArgsRet, Self::Error> {
+        // Here we don't validate ordering of arguments because this is done later
+        // at typechecking when we can give more context about the problem (if there is one).
+
+        let _ = walk::walk_constructor_call_args(self, ctx, node);
         Ok(())
     }
 
-    type FunctionCallExprRet = ();
+    type ConstructorCallExprRet = ();
 
-    fn visit_function_call_expr(
+    fn visit_constructor_call_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionCallExpr>,
-    ) -> Result<Self::FunctionCallExprRet, Self::Error> {
-        let _ = walk::walk_function_call_expr(self, ctx, node);
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error> {
+        let _ = walk::walk_constructor_call_expr(self, ctx, node);
         Ok(())
     }
 

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -1,4 +1,7 @@
-//! Visitor pattern for the semantic analysis stage.
+//! Visitor pattern for the semantic analysis stage. This file implements
+//! the [AstVisitor] pattern on the AST for [SemanticAnalyser]. During traversal, the
+//! visitor calls various functions that are defined on the analyser to perform
+//! a variety of semantic checks.
 //!
 //! All rights reserved 2022 (c) The Hash Language authors
 
@@ -12,10 +15,11 @@ use hash_ast::{
     visitor::{walk, AstVisitor},
 };
 
-use crate::analysis::{
-    error::{AnalysisErrorKind, BlockOrigin, PatternOrigin},
-    warning::AnalysisWarningKind,
-    SemanticAnalyser,
+use crate::{
+    analysis::SemanticAnalyser,
+    diagnostics::{
+        error::AnalysisErrorKind, warning::AnalysisWarningKind, BlockOrigin, PatternOrigin,
+    },
 };
 
 impl AstVisitor for SemanticAnalyser {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1219,7 +1219,7 @@ pub struct FunctionDef {
 
 /// Function call argument.
 #[derive(Debug, PartialEq)]
-pub struct FunctionCallArg {
+pub struct ConstructorCallArg {
     /// Optional name for the function argument, e.g `f(x = 3);`.
     pub name: Option<AstNode<Name>>,
     /// Each argument of the function call, as an expression.
@@ -1228,17 +1228,18 @@ pub struct FunctionCallArg {
 
 /// Function call arguments.
 #[derive(Debug, PartialEq)]
-pub struct FunctionCallArgs {
-    pub entries: AstNodes<FunctionCallArg>,
+pub struct ConstructorCallArgs {
+    pub entries: AstNodes<ConstructorCallArg>,
 }
 
-/// A function call expression.
+/// A constructor call expression. This can either be a function
+/// call, a struct instantiation or a enum variant instantiation.
 #[derive(Debug, PartialEq)]
-pub struct FunctionCallExpr {
+pub struct ConstructorCallExpr {
     /// An expression which evaluates to a function value.
     pub subject: AstNode<Expression>,
-    /// Arguments to the function, in the form of [FunctionCallArgs].
-    pub args: AstNode<FunctionCallArgs>,
+    /// Arguments to the function, in the form of [ConstructorCallArgs].
+    pub args: AstNode<ConstructorCallArgs>,
 }
 
 /// An directive expression.
@@ -1354,7 +1355,7 @@ pub struct IndexExpression {
 /// The kind of an expression.
 #[derive(Debug, PartialEq)]
 pub enum ExpressionKind {
-    FunctionCall(FunctionCallExpr),
+    ConstructorCall(ConstructorCallExpr),
     Directive(DirectiveExpr),
     Declaration(Declaration),
     Variable(VariableExpr),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -119,13 +119,13 @@ impl AstVisitor for AstTreeGenerator {
         ))
     }
 
-    type FunctionCallArgRet = TreeNode;
+    type ConstructorCallArgRet = TreeNode;
 
-    fn visit_function_call_arg(
+    fn visit_constructor_call_arg(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArg>,
-    ) -> Result<Self::FunctionCallArgRet, Self::Error> {
+        node: ast::AstNodeRef<ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error> {
         if let Some(name) = &node.name {
             Ok(TreeNode::branch(
                 "arg",
@@ -142,29 +142,29 @@ impl AstVisitor for AstTreeGenerator {
         }
     }
 
-    type FunctionCallArgsRet = TreeNode;
-    fn visit_function_call_args(
+    type ConstructorCallArgsRet = TreeNode;
+    fn visit_constructor_call_args(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArgs>,
-    ) -> Result<Self::FunctionCallArgsRet, Self::Error> {
+        node: ast::AstNodeRef<ast::ConstructorCallArgs>,
+    ) -> Result<Self::ConstructorCallArgsRet, Self::Error> {
         Ok(TreeNode::branch(
             "args",
-            walk::walk_function_call_args(self, ctx, node)?
+            walk::walk_constructor_call_args(self, ctx, node)?
                 .entries
                 .into_iter()
                 .collect(),
         ))
     }
 
-    type FunctionCallExprRet = TreeNode;
-    fn visit_function_call_expr(
+    type ConstructorCallExprRet = TreeNode;
+    fn visit_constructor_call_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallExpr>,
-    ) -> Result<Self::FunctionCallExprRet, Self::Error> {
+        node: ast::AstNodeRef<ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error> {
         let walk::FunctionCallExpr { subject, args } =
-            walk::walk_function_call_expr(self, ctx, node)?;
+            walk::walk_constructor_call_expr(self, ctx, node)?;
 
         let children = if !node.args.entries.is_empty() {
             vec![TreeNode::branch("subject", vec![subject]), args]
@@ -172,7 +172,7 @@ impl AstVisitor for AstTreeGenerator {
             vec![TreeNode::branch("subject", vec![subject])]
         };
 
-        Ok(TreeNode::branch("function_call", children))
+        Ok(TreeNode::branch("constructor", children))
     }
 
     type PropertyAccessExprRet = TreeNode;
@@ -442,7 +442,7 @@ impl AstVisitor for AstTreeGenerator {
             walk::walk_type_function_call(self, ctx, node)?;
 
         Ok(TreeNode::branch(
-            "function_call",
+            "type_function_call",
             vec![
                 TreeNode::branch("subject", vec![subject]),
                 TreeNode::branch("arguments", args),

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -96,26 +96,26 @@ pub trait AstVisitor: Sized {
         node: ast::AstNodeRef<ast::DirectiveExpr>,
     ) -> Result<Self::DirectiveExprRet, Self::Error>;
 
-    type FunctionCallArgRet;
-    fn visit_function_call_arg(
+    type ConstructorCallArgRet;
+    fn visit_constructor_call_arg(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArg>,
-    ) -> Result<Self::FunctionCallArgRet, Self::Error>;
+        node: ast::AstNodeRef<ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error>;
 
-    type FunctionCallArgsRet;
-    fn visit_function_call_args(
+    type ConstructorCallArgsRet;
+    fn visit_constructor_call_args(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArgs>,
-    ) -> Result<Self::FunctionCallArgsRet, Self::Error>;
+        node: ast::AstNodeRef<ast::ConstructorCallArgs>,
+    ) -> Result<Self::ConstructorCallArgsRet, Self::Error>;
 
-    type FunctionCallExprRet;
-    fn visit_function_call_expr(
+    type ConstructorCallExprRet;
+    fn visit_constructor_call_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallExpr>,
-    ) -> Result<Self::FunctionCallExprRet, Self::Error>;
+        node: ast::AstNodeRef<ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error>;
 
     type PropertyAccessExprRet;
     fn visit_property_access_expr(
@@ -800,26 +800,26 @@ pub trait AstVisitorMut: Sized {
         node: ast::AstNodeRefMut<ast::DirectiveExpr>,
     ) -> Result<Self::DirectiveExprRet, Self::Error>;
 
-    type FunctionCallArgRet;
-    fn visit_function_call_arg(
+    type ConstructorCallArgRet;
+    fn visit_constructor_call_arg(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::FunctionCallArg>,
-    ) -> Result<Self::FunctionCallArgRet, Self::Error>;
+        node: ast::AstNodeRefMut<ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error>;
 
-    type FunctionCallArgsRet;
-    fn visit_function_call_args(
+    type ConstructorCallArgsRet;
+    fn visit_constructor_call_args(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::FunctionCallArgs>,
-    ) -> Result<Self::FunctionCallArgsRet, Self::Error>;
+        node: ast::AstNodeRefMut<ast::ConstructorCallArgs>,
+    ) -> Result<Self::ConstructorCallArgsRet, Self::Error>;
 
-    type FunctionCallExprRet;
-    fn visit_function_call_expr(
+    type ConstructorCallExprRet;
+    fn visit_constructor_call_expr(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::FunctionCallExpr>,
-    ) -> Result<Self::FunctionCallExprRet, Self::Error>;
+        node: ast::AstNodeRefMut<ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error>;
 
     type PropertyAccessExprRet;
     fn visit_property_access_expr(
@@ -1483,7 +1483,7 @@ pub mod walk {
     }
 
     pub enum Expression<V: AstVisitor> {
-        FunctionCall(V::FunctionCallExprRet),
+        ConstructorCall(V::ConstructorCallExprRet),
         Directive(V::DirectiveExprRet),
         Declaration(V::DeclarationRet),
         Variable(V::VariableExprRet),
@@ -1519,8 +1519,8 @@ pub mod walk {
         node: ast::AstNodeRef<ast::Expression>,
     ) -> Result<Expression<V>, V::Error> {
         Ok(match node.kind() {
-            ast::ExpressionKind::FunctionCall(inner) => Expression::FunctionCall(
-                visitor.visit_function_call_expr(ctx, node.with_body(inner))?,
+            ast::ExpressionKind::ConstructorCall(inner) => Expression::ConstructorCall(
+                visitor.visit_constructor_call_expr(ctx, node.with_body(inner))?,
             ),
             ast::ExpressionKind::Type(inner) => {
                 Expression::Type(visitor.visit_type_expr(ctx, node.with_body(inner))?)
@@ -1613,7 +1613,7 @@ pub mod walk {
     ) -> Result<Ret, V::Error>
     where
         V: AstVisitor<
-            FunctionCallExprRet = Ret,
+            ConstructorCallExprRet = Ret,
             DirectiveExprRet = Ret,
             DeclarationRet = Ret,
             MergeDeclarationRet = Ret,
@@ -1644,7 +1644,7 @@ pub mod walk {
         >,
     {
         Ok(match walk_expression(visitor, ctx, node)? {
-            Expression::FunctionCall(r) => r,
+            Expression::ConstructorCall(r) => r,
             Expression::Directive(r) => r,
             Expression::Declaration(r) => r,
             Expression::MergeDeclaration(r) => r,
@@ -1712,17 +1712,17 @@ pub mod walk {
         })
     }
 
-    pub struct FunctionCallArg<V: AstVisitor> {
+    pub struct ConstructorCallArg<V: AstVisitor> {
         pub name: Option<V::NameRet>,
         pub value: V::ExpressionRet,
     }
 
-    pub fn walk_function_call_arg<V: AstVisitor>(
+    pub fn walk_constructor_call_arg<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArg>,
-    ) -> Result<FunctionCallArg<V>, V::Error> {
-        Ok(FunctionCallArg {
+        node: ast::AstNodeRef<ast::ConstructorCallArg>,
+    ) -> Result<ConstructorCallArg<V>, V::Error> {
+        Ok(ConstructorCallArg {
             name: node
                 .name
                 .as_ref()
@@ -1732,38 +1732,38 @@ pub mod walk {
         })
     }
 
-    pub struct FunctionCallArgs<V: AstVisitor> {
-        pub entries: V::CollectionContainer<V::FunctionCallArgRet>,
+    pub struct ConstructorCallArgs<V: AstVisitor> {
+        pub entries: V::CollectionContainer<V::ConstructorCallArgRet>,
     }
 
-    pub fn walk_function_call_args<V: AstVisitor>(
+    pub fn walk_constructor_call_args<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallArgs>,
-    ) -> Result<FunctionCallArgs<V>, V::Error> {
-        Ok(FunctionCallArgs {
+        node: ast::AstNodeRef<ast::ConstructorCallArgs>,
+    ) -> Result<ConstructorCallArgs<V>, V::Error> {
+        Ok(ConstructorCallArgs {
             entries: V::try_collect_items(
                 ctx,
                 node.entries
                     .iter()
-                    .map(|e| visitor.visit_function_call_arg(ctx, e.ast_ref())),
+                    .map(|e| visitor.visit_constructor_call_arg(ctx, e.ast_ref())),
             )?,
         })
     }
 
     pub struct FunctionCallExpr<V: AstVisitor> {
         pub subject: V::ExpressionRet,
-        pub args: V::FunctionCallArgsRet,
+        pub args: V::ConstructorCallArgsRet,
     }
 
-    pub fn walk_function_call_expr<V: AstVisitor>(
+    pub fn walk_constructor_call_expr<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::FunctionCallExpr>,
+        node: ast::AstNodeRef<ast::ConstructorCallExpr>,
     ) -> Result<FunctionCallExpr<V>, V::Error> {
         Ok(FunctionCallExpr {
             subject: visitor.visit_expression(ctx, node.subject.ast_ref())?,
-            args: visitor.visit_function_call_args(ctx, node.args.ast_ref())?,
+            args: visitor.visit_constructor_call_args(ctx, node.args.ast_ref())?,
         })
     }
 
@@ -3305,7 +3305,7 @@ pub mod walk_mut {
     }
 
     pub enum Expression<V: AstVisitorMut> {
-        FunctionCall(V::FunctionCallExprRet),
+        FunctionCall(V::ConstructorCallExprRet),
         Directive(V::DirectiveExprRet),
         Declaration(V::DeclarationRet),
         Variable(V::VariableExprRet),
@@ -3344,8 +3344,8 @@ pub mod walk_mut {
         let id = node.id;
 
         Ok(match &mut node.kind {
-            ast::ExpressionKind::FunctionCall(inner) => Expression::FunctionCall(
-                visitor.visit_function_call_expr(ctx, AstNodeRefMut::new(inner, span, id))?,
+            ast::ExpressionKind::ConstructorCall(inner) => Expression::FunctionCall(
+                visitor.visit_constructor_call_expr(ctx, AstNodeRefMut::new(inner, span, id))?,
             ),
             ast::ExpressionKind::Type(inner) => {
                 Expression::Type(visitor.visit_type_expr(ctx, AstNodeRefMut::new(inner, span, id))?)
@@ -3438,7 +3438,7 @@ pub mod walk_mut {
     ) -> Result<Ret, V::Error>
     where
         V: AstVisitorMut<
-            FunctionCallExprRet = Ret,
+            ConstructorCallExprRet = Ret,
             DirectiveExprRet = Ret,
             DeclarationRet = Ret,
             MergeDeclarationRet = Ret,
@@ -3537,17 +3537,17 @@ pub mod walk_mut {
         })
     }
 
-    pub struct FunctionCallArg<V: AstVisitorMut> {
+    pub struct ConstructorCallArg<V: AstVisitorMut> {
         pub name: Option<V::NameRet>,
         pub value: V::ExpressionRet,
     }
 
-    pub fn walk_function_call_arg<V: AstVisitorMut>(
+    pub fn walk_constructor_call_arg<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::FunctionCallArg>,
-    ) -> Result<FunctionCallArg<V>, V::Error> {
-        Ok(FunctionCallArg {
+        mut node: ast::AstNodeRefMut<ast::ConstructorCallArg>,
+    ) -> Result<ConstructorCallArg<V>, V::Error> {
+        Ok(ConstructorCallArg {
             name: node
                 .name
                 .as_mut()
@@ -3557,38 +3557,38 @@ pub mod walk_mut {
         })
     }
 
-    pub struct FunctionCallArgs<V: AstVisitorMut> {
-        pub entries: V::CollectionContainer<V::FunctionCallArgRet>,
+    pub struct ConstructorCallArgs<V: AstVisitorMut> {
+        pub entries: V::CollectionContainer<V::ConstructorCallArgRet>,
     }
 
-    pub fn walk_function_call_args<V: AstVisitorMut>(
+    pub fn walk_constructor_call_args<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::FunctionCallArgs>,
-    ) -> Result<FunctionCallArgs<V>, V::Error> {
-        Ok(FunctionCallArgs {
+        mut node: ast::AstNodeRefMut<ast::ConstructorCallArgs>,
+    ) -> Result<ConstructorCallArgs<V>, V::Error> {
+        Ok(ConstructorCallArgs {
             entries: V::try_collect_items(
                 ctx,
                 node.entries
                     .iter_mut()
-                    .map(|e| visitor.visit_function_call_arg(ctx, e.ast_ref_mut())),
+                    .map(|e| visitor.visit_constructor_call_arg(ctx, e.ast_ref_mut())),
             )?,
         })
     }
 
     pub struct FunctionCallExpr<V: AstVisitorMut> {
         pub subject: V::ExpressionRet,
-        pub args: V::FunctionCallArgsRet,
+        pub args: V::ConstructorCallArgsRet,
     }
 
-    pub fn walk_function_call_expr<V: AstVisitorMut>(
+    pub fn walk_constructor_call_expr<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::FunctionCallExpr>,
+        mut node: ast::AstNodeRefMut<ast::ConstructorCallExpr>,
     ) -> Result<FunctionCallExpr<V>, V::Error> {
         Ok(FunctionCallExpr {
             subject: visitor.visit_expression(ctx, node.subject.ast_ref_mut())?,
-            args: visitor.visit_function_call_args(ctx, node.args.ast_ref_mut())?,
+            args: visitor.visit_constructor_call_args(ctx, node.args.ast_ref_mut())?,
         })
     }
 


### PR DESCRIPTION
It was decided that argument ordering validation should occur at the tc stage rather than the semantic stage since more information can be provided about the error.