### PR TITLE
pipeline: continue running stages when diagnostics are only warnings

### DIFF
--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -151,9 +151,8 @@ where
         println!("{: <12}: {total:?}\n", format!("{}", CompilerMode::Full));
     }
 
-
-    /// Utility function used by AST like stages in order to print the 
-    /// current [Sources]. 
+    /// Utility function used by AST like stages in order to print the
+    /// current [Sources].
     fn print_sources(&self, sources: &Sources, entry_point: SourceId) {
         match entry_point {
             SourceId::Interactive(id) => {
@@ -309,9 +308,9 @@ where
         Ok(())
     }
 
-    /// Helper function in order to check if the pipeline needs to terminate after 
-    /// any stage on the condition that the [CompilerJobParams] specify that this 
-    /// is the last stage, or if the previous stage had generated any errors that 
+    /// Helper function in order to check if the pipeline needs to terminate after
+    /// any stage on the condition that the [CompilerJobParams] specify that this
+    /// is the last stage, or if the previous stage had generated any errors that
     /// are fatal and an abort is necessary.
     fn maybe_terminate(
         &self,

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -7,7 +7,7 @@ use hash_source::{InteractiveId, ModuleId, SourceId};
 
 use crate::sources::Sources;
 
-pub type CompilerResult<T> = Result<T, Report>;
+pub type CompilerResult<T> = Result<T, Vec<Report>>;
 
 /// The [Parser] represents an abstract parser that can parse all aspects of the Hash programming
 /// language.

--- a/compiler/hash-reporting/src/reporting.rs
+++ b/compiler/hash-reporting/src/reporting.rs
@@ -349,6 +349,18 @@ pub struct Report {
     pub contents: Vec<ReportElement>,
 }
 
+impl Report {
+    /// Check if the report denotes an occurred error.
+    pub fn is_error(&self) -> bool {
+        self.kind == ReportKind::Error
+    }
+
+    /// Check if the report denotes an occurred warning.
+    pub fn is_warning(&self) -> bool {
+        self.kind == ReportKind::Warning
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ReportBuilder {
     kind: Option<ReportKind>,

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -920,6 +920,6 @@ impl VirtualMachine<'_> for Interpreter {
     }
 
     fn run(&mut self, _state: &mut Self::State) -> hash_pipeline::CompilerResult<()> {
-        self.run().map_err(Report::from)
+        self.run().map_err(|err| vec![Report::from(err)])
     }
 }

--- a/tests/parser/tests/test_runner.rs
+++ b/tests/parser/tests/test_runner.rs
@@ -31,7 +31,7 @@ lazy_static! {
 /// entry within the case.
 fn handle_failure_case(
     input: TestingInput,
-    result: Result<(), Report>,
+    result: Result<(), Vec<Report>>,
     sources: Sources,
 ) -> std::io::Result<()> {
     let content_path = input.path.join("case.hash");
@@ -43,11 +43,15 @@ fn handle_failure_case(
         content_path
     );
 
-    let report = result.unwrap_err();
-    let report_contents = format!("{}", ReportWriter::new(report, &sources));
+    let diagnostics = result.unwrap_err();
+    let contents = diagnostics
+        .into_iter()
+        .map(|report| format!("{}", ReportWriter::new(report, &sources)))
+        .collect::<Vec<_>>()
+        .join("\n");
 
     // Remove any ANSI escape codes generated from the reporting...
-    let report_contents = ANSI_REGEX.replace_all(report_contents.as_str(), "");
+    let report_contents = ANSI_REGEX.replace_all(contents.as_str(), "");
 
     // Replace the directory by `$DIR`
     let dir_regex = Regex::new(input.path.as_path().to_str().unwrap()).unwrap();


### PR DESCRIPTION
This patch re-works the pipeline in order to cope with the fact
that some diagnostics might be warnings, and it is ok to
continue compiling. This also generalises how the pipeline
deals with diagnostics from all the generated stages.

The pipeline now collects errors within `compiler_state` and
only prints them when the pipeline terminates. It also reports
how many warnings and errors were generated when running a particular
job.

closes #289