### PR TITLE
TC: Implement term unification

### DIFF
--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -7,7 +7,7 @@ use hash_utils::counter;
 use lazy_static::lazy_static;
 use std::{
     borrow::{Borrow, Cow},
-    fmt::Display,
+    fmt::{Debug, Display},
     thread_local,
 };
 
@@ -16,11 +16,20 @@ counter! {
     counter_name: IDENTIFIER_COUNTER,
     visibility: pub,
     method_visibility:,
+    derives: (Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd),
 }
 
 impl Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", IDENTIFIER_MAP.get_ident(*self))
+    }
+}
+
+impl Debug for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Identifier")
+            .field(&IDENTIFIER_MAP.get_ident(*self).to_owned())
+            .finish()
     }
 }
 

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -12,12 +12,29 @@ pub type TcResult<T> = Result<T, TcError>;
 #[derive(Debug, Clone)]
 pub enum TcError {
     /// Cannot unify the two terms, where the first is the source and the second is the target.
-    CannotUnify(TermId, TermId),
-    NotATypeFunction(TermId),
-    CannotUseValueAsTy(TermId),
-    MismatchingArgParamLength(Args, Params),
-    ParamNotFound(Params, Identifier),
-    ParamGivenTwice(Args, Params, usize),
+    CannotUnify {
+        src: TermId,
+        target: TermId,
+    },
+    NotATypeFunction {
+        term: TermId,
+    },
+    CannotUseValueAsTy {
+        value: TermId,
+    },
+    MismatchingArgParamLength {
+        args: Args,
+        params: Params,
+    },
+    ParamNotFound {
+        field1: Params,
+        field2: Identifier,
+    },
+    ParamGivenTwice {
+        args: Args,
+        params: Params,
+        param_index_given_twice: usize,
+    },
     UnresolvedNameInValue {
         name: Identifier,
         value: TermId,

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -16,6 +16,10 @@ pub enum TcError {
         src: TermId,
         target: TermId,
     },
+    CannotUnifyParams {
+        src_params: Params,
+        target_params: Params,
+    },
     NotATypeFunction {
         term: TermId,
     },
@@ -34,6 +38,10 @@ pub enum TcError {
         args: Args,
         params: Params,
         param_index_given_twice: usize,
+    },
+    CannotUsePositionalArgAfterNamedArg {
+        args: Args,
+        problematic_arg_index: usize,
     },
     UnresolvedNameInValue {
         name: Identifier,

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -22,10 +22,10 @@ pub fn pair_args_with_params<'p, 'a>(
 
     // Ensure the length of params and args is the same
     if params.positional().len() != args.positional().len() {
-        return Err(TcError::MismatchingArgParamLength(
-            args.clone(),
-            params.clone(),
-        ));
+        return Err(TcError::MismatchingArgParamLength {
+            args: args.clone(),
+            params: params.clone(),
+        });
     }
 
     // Keep track of the first non-positional argument
@@ -39,17 +39,22 @@ pub fn pair_args_with_params<'p, 'a>(
                     Some((param_i, param)) => {
                         if params_used.contains(&i) {
                             // Ensure not already used
-                            return Err(TcError::ParamGivenTwice(
-                                args.clone(),
-                                params.clone(),
-                                param_i,
-                            ));
+                            return Err(TcError::ParamGivenTwice {
+                                args: args.clone(),
+                                params: params.clone(),
+                                param_index_given_twice: param_i,
+                            });
                         } else {
                             params_used.insert(param_i);
                             result.push((param, arg));
                         }
                     }
-                    None => return Err(TcError::ParamNotFound(params.clone(), arg_name)),
+                    None => {
+                        return Err(TcError::ParamNotFound {
+                            field1: params.clone(),
+                            field2: arg_name,
+                        })
+                    }
                 }
             }
             None => {
@@ -60,7 +65,11 @@ pub fn pair_args_with_params<'p, 'a>(
                     panic!("Found positional arguments after named args, should have been caught during semantic analysis.")
                 } else if params_used.contains(&i) {
                     // Ensure not already used
-                    return Err(TcError::ParamGivenTwice(args.clone(), params.clone(), i));
+                    return Err(TcError::ParamGivenTwice {
+                        args: args.clone(),
+                        params: params.clone(),
+                        param_index_given_twice: i,
+                    });
                 } else {
                     params_used.insert(i);
                     result.push((params.positional().get(i).unwrap(), arg));

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -60,9 +60,11 @@ pub fn pair_args_with_params<'p, 'a>(
             None => {
                 // Positional argument
                 if done_positional {
-                    // Using positional args after named args is an error that should have been
-                    // caught at semantic analysis.
-                    panic!("Found positional arguments after named args, should have been caught during semantic analysis.")
+                    // Using positional args after named args is an error
+                    return Err(TcError::CannotUsePositionalArgAfterNamedArg {
+                        args: args.clone(),
+                        problematic_arg_index: i,
+                    });
                 } else if params_used.contains(&i) {
                     // Ensure not already used
                     return Err(TcError::ParamGivenTwice {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -1,9 +1,11 @@
 //! Utilities related to type unification and substitution.
-use super::AccessToOpsMut;
+use super::{AccessToOps, AccessToOpsMut};
 use crate::{
-    error::TcResult,
+    error::{TcError, TcResult},
     storage::{
-        primitives::{Args, Params, Sub, TermId},
+        primitives::{
+            Args, Level0Term, Level1Term, Level2Term, Level3Term, Params, Sub, Term, TermId,
+        },
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
 };
@@ -47,17 +49,12 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         let dom_s1: HashSet<_> = s1.domain().collect();
         let mut substituter = self.substituter();
 
-        // First split the domains into three parts: d0, d1, and the intersection (see second loop)
+        // First split the domains into three parts: d0, d1 (not directly needed), and the
+        // intersection (see second loop)
         let d0: HashSet<_> = dom_s0.difference(&dom_s1).copied().collect();
         let t0 = Sub::from_pairs(
             d0.iter()
                 .map(|&a| (a, substituter.apply_sub_to_subject(s0, a))),
-        );
-
-        let d1: HashSet<_> = dom_s1.difference(&dom_s0).copied().collect();
-        let _t1 = Sub::from_pairs(
-            d1.iter()
-                .map(|&a| (a, substituter.apply_sub_to_subject(s1, a))),
         );
 
         // Start with t0 and add terms for d1 one at a time, always producing well formed
@@ -104,182 +101,276 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         todo!()
     }
 
+    /// Unify the two given argument lists, by argument-wise unifying terms.
+    pub fn unify_args(&mut self, _src_args: &Args, _target_args: &Args) -> TcResult<Sub> {
+        todo!()
+    }
+
+    /// Unify the two given parameter lists, by parameter-wise unifying terms.
+    pub fn unify_params(&mut self, _src_params: &Params, _target_params: &Params) -> TcResult<Sub> {
+        todo!()
+    }
+
     /// Unify the two given terms, producing a substitution.
     ///
     /// The relation between src and target is that src must be a subtype (or eq) of target.
-    pub fn unify_terms(&mut self, _src_id: TermId, _target_id: TermId) -> TcResult<Sub> {
-        todo!()
-        // let src = self.storage.ty_store().get(src_id).clone();
-        // let target = self.storage.ty_store().get(target_id).clone();
-        // let cannot_unify = || -> TcResult<Sub> { Err(TcError::CannotUnify(src_id, target_id)) };
+    pub fn unify_terms(&mut self, src_id: TermId, target_id: TermId) -> TcResult<Sub> {
+        // Shortcut: terms have the same ID:
+        if src_id == target_id {
+            return Ok(Sub::empty());
+        }
 
-        // // Basically, can src be used where a target is required?
-        // match (src, target) {
-        //     // First, type functions:
-        //     (Ty::AppTyFn(_), Ty::AppTyFn(_)) => {
-        //         // Check if same subject and unify, otherwise evaluate and unify
-        //         // match self.values_are_equal(src_ty_fn_value, target_ty_fn_value) {
-        //         //     ValuesAreEqual::Yes => {
-        //         //             // If the values are equal, then if the arguments unify then we have
-        //         //             // the same tys
-        //         //             self.unify_tys(src_args, target_args, opts)
-        //         //         }
-        //         //     ValuesAreEqual::No => {}
-        //         //     ValuesAreEqual::Unsure => {}
-        //         // }
-        //         todo!()
-        //     }
-        //     (_, Ty::AppTyFn(_)) => {
-        //         // Try to apply the RHS, if it works then try to unify again, else error:
-        //         let simplified_target = self.simplify_ty(target_id)?;
-        //         match simplified_target {
-        //             Some(simplified_target_id) => {
-        //                 self.unify_tys(src_id, simplified_target_id, opts)
-        //             }
-        //             None => cannot_unify(),
-        //         }
-        //     }
-        //     (Ty::AppTyFn(_), _) => {
-        //         // Try to apply the LHS, if it works then try to unify again, else error:
-        //         let simplified_src = self.simplify_ty(src_id)?;
-        //         match simplified_src {
-        //             Some(simplified_src_id) => self.unify_tys(simplified_src_id, target_id, opts),
-        //             None => cannot_unify(),
-        //         }
-        //     }
+        // First we want to simplify the terms:
+        let simplified_src_id = self.simplifier().potentially_simplify_term(src_id)?;
+        let simplified_target_id = self.simplifier().potentially_simplify_term(target_id)?;
+        let simplified_src = self.reader().get_term(simplified_src_id).clone();
+        let simplified_target = self.reader().get_term(simplified_target_id).clone();
 
-        //     // Merging:
-        //     (Ty::Merge(_), Ty::Merge(inner_target)) => {
-        //         // Try to merge source with each individual type in target. If all succeed,
-        //         // then the whole thing should succeed.
-        //         let mut subs = Sub::empty();
-        //         for inner_target_id in inner_target {
-        //             match self.unify_tys(src_id, inner_target_id, opts) {
-        //                 Ok(result) => {
-        //                     subs.merge_with(&result);
-        //                     continue;
-        //                 }
-        //                 Err(e) => return Err(e),
-        //             }
-        //         }
-        //         Ok(subs)
-        //     }
-        //     (_, Ty::Merge(inner_target)) => {
-        //         // This is only valid if the merge has one element and unifies with source
-        //         match inner_target.as_slice() {
-        //             [inner_target_id] => self.unify_tys(src_id, *inner_target_id, opts),
-        //             _ => cannot_unify(),
-        //         }
-        //     }
-        //     (Ty::Merge(inner_src), _) => {
-        //         // Try to merge each individual type in source, with target. If any one succeeds,
-        //         // then the whole thing should succeed.
-        //         let mut first_error = None;
-        //         for inner_src_id in inner_src {
-        //             match self.unify_tys(inner_src_id, target_id, opts) {
-        //                 Ok(result) => {
-        //                     return Ok(result);
-        //                 }
-        //                 Err(e) if first_error.is_none() => {
-        //                     first_error = Some(e);
-        //                     continue;
-        //                 }
-        //                 _ => continue,
-        //             }
-        //         }
-        //         match first_error {
-        //             Some(first_error) => Err(first_error),
-        //             None => cannot_unify(),
-        //         }
-        //     }
+        // Helper to return a unification error
+        let cannot_unify = || {
+            Err(TcError::CannotUnify {
+                src: src_id,
+                target: target_id,
+            })
+        };
 
-        //     // Traits:
-        //     (Ty::Trt, Ty::Trt) => Ok(Sub::empty()),
-        //     (Ty::Trt, Ty::Unresolved(unresolved)) => Ok(Sub::from_pairs([(
-        //         SubSubject::Unresolved(unresolved),
-        //         self.primitive_builder().create_ty_value(src_id),
-        //     )])),
-        //     (Ty::Trt, _) => cannot_unify(),
-        //     (Ty::Ty(_), Ty::Unresolved(unresolved)) => Ok(Sub::from_pairs([(
-        //         SubSubject::Unresolved(unresolved),
-        //         self.primitive_builder().create_ty_value(src_id),
-        //     )])),
+        match (simplified_src, simplified_target) {
+            // Unresolved
+            (Term::Unresolved(unresolved_src), _) => {
+                // Substitute target for source
+                Ok(Sub::from_pairs([(unresolved_src, simplified_target_id)]))
+            }
+            (_, Term::Unresolved(unresolved_target)) => {
+                // Substitute source for target
+                Ok(Sub::from_pairs([(unresolved_target, simplified_src_id)]))
+            }
 
-        //     // Types:
-        //     (Ty::Ty(src_bound), Ty::Ty(target_bound)) => {
-        //         match target_bound {
-        //             Some(target_bound) => {
-        //                 match src_bound {
-        //                     // Trait bounds are the same
-        //                     Some(src_bound) if src_bound == target_bound => Ok(Sub::empty()),
-        //                     Some(_) | None => {
-        //                         // Missing bound on source required by target
-        //                         cannot_unify()
-        //                     }
-        //                 }
-        //             }
-        //             // No bounds on target
-        //             None => Ok(Sub::empty()),
-        //         }
-        //     }
-        //     (Ty::Ty(_), _) => cannot_unify(),
+            // Merging:
+            (Term::Merge(_), Term::Merge(inner_target)) => {
+                // Try to merge source with each individual term in target. If all succeed,
+                // then the whole thing should succeed.
+                let mut subs = Sub::empty();
+                for inner_target_id in inner_target {
+                    match self.unify_terms(src_id, inner_target_id) {
+                        Ok(result) => {
+                            subs = self.unify_subs(&subs, &result)?;
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                Ok(subs)
+            }
+            (_, Term::Merge(inner_target)) => {
+                // This is only valid if the merge has one element and unifies with source
+                match inner_target.as_slice() {
+                    [inner_target_id] => self.unify_terms(src_id, *inner_target_id),
+                    _ => cannot_unify(),
+                }
+            }
+            (Term::Merge(inner_src), _) => {
+                // Try to merge each individual term in source, with target. If any one succeeds,
+                // then the whole thing should succeed.
+                let mut first_error = None;
+                for inner_src_id in inner_src {
+                    match self.unify_terms(inner_src_id, target_id) {
+                        Ok(result) => {
+                            return Ok(result);
+                        }
+                        Err(e) if first_error.is_none() => {
+                            first_error = Some(e);
+                            continue;
+                        }
+                        _ => continue,
+                    }
+                }
+                match first_error {
+                    Some(first_error) => Err(first_error),
+                    None => cannot_unify(),
+                }
+            }
 
-        //     // Nominals
-        //     (Ty::NominalDef(_), Ty::NominalDef(_)) => todo!(),
-        //     (Ty::NominalDef(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::NominalDef(_), _) => cannot_unify(),
+            // Access:
+            (Term::Access(src_access), Term::Access(target_access))
+                if src_access.name == target_access.name =>
+            {
+                // Unify the subjects
+                self.unify_terms(src_access.subject, target_access.subject)
+            }
+            (Term::Access(_), _) | (_, Term::Access(_)) => {
+                // Since these cannot be simplified further, we don't know if they can be unified:
+                cannot_unify()
+            }
 
-        //     // TyFns
-        //     (Ty::TyFn(_), Ty::TyFn(_)) => todo!(),
-        //     (Ty::TyFn(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::TyFn(_), _) => cannot_unify(),
+            // Variables:
+            (Term::Var(src_var), Term::Var(target_var)) if src_var.name == target_var.name => {
+                // Same variables unify
+                Ok(Sub::empty())
+            }
+            (Term::Var(_), _) | (_, Term::Var(_)) => {
+                // Different variables do not unify (since they cannot be simplified)
+                cannot_unify()
+            }
 
-        //     // Unresolved source
-        //     (Ty::Unresolved(_), Ty::Trt) => todo!(),
-        //     (Ty::Unresolved(_), Ty::Ty(_)) => todo!(),
-        //     (Ty::Unresolved(_), Ty::TyFn(_)) => todo!(),
-        //     (Ty::Unresolved(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::Unresolved(_), _) => todo!(),
+            // Apply substitution:
+            (Term::AppSub(src_app_sub), Term::AppSub(target_app_sub))
+                if self
+                    .validator()
+                    .subs_are_equivalent(&src_app_sub.sub, &target_app_sub.sub)? =>
+            {
+                // Unify inner, then unify the resultant substitution with the ones given here:
+                let inner_sub = self.unify_terms(src_app_sub.term, target_app_sub.term)?;
+                self.unify_subs(&src_app_sub.sub, &inner_sub)
+            }
+            (Term::AppSub(_), _) | (_, Term::AppSub(_)) => {
+                // Otherwise they don't unify (since we start with simplified terms)
+                cannot_unify()
+            }
 
-        //     // Modules
-        //     (Ty::ModDef(_), Ty::ModDef(_)) => todo!(),
-        //     (Ty::ModDef(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::ModDef(_), _) => todo!(),
+            // Type functions:
+            (Term::TyFn(_), _) | (_, Term::TyFn(_)) => {
+                // For now, type functions never unify, because unifying them would require a lot
+                // of work to match each of the cases.
+                //  @@Enhancement: in principle this is possible, though unclear if useful.
+                cannot_unify()
+            }
 
-        //     // Tuples
-        //     (Ty::Tuple(_), Ty::Tuple(_)) => todo!(),
-        //     (Ty::Tuple(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::Tuple(_), _) => cannot_unify(),
+            // Type function application:
+            (Term::AppTyFn(src_app_ty_fn), Term::AppTyFn(target_app_ty_fn)) => {
+                // Unify the subject, and unify the arguments:
+                // This case would be hit if the subject is a variable, for example.
+                let subject_sub =
+                    self.unify_terms(src_app_ty_fn.subject, target_app_ty_fn.subject)?;
 
-        //     // Functions
-        //     (Ty::Fn(_), Ty::Fn(_)) => todo!(),
-        //     (Ty::Fn(_), Ty::TyFn(_)) => todo!(), // Should type functions unify? we infer type args anyway...
-        //     (Ty::Fn(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::Fn(_), _) => cannot_unify(),
+                // Here we have to unify both ways, because of potential invariance:
+                // @@Future: find a way to specify variance on type function arguments.
+                let args_sub1 = self.unify_args(&src_app_ty_fn.args, &target_app_ty_fn.args)?;
+                let args_sub2 = self.unify_args(&target_app_ty_fn.args, &src_app_ty_fn.args)?;
 
-        //     // Type variables
-        //     (Ty::Var(_), Ty::Var(_)) => todo!(),
-        //     (Ty::Var(_), Ty::Unresolved(_)) => todo!(),
-        //     (Ty::Var(_), _) => todo!(),
-        // }
-    }
-}
+                // Unify all the created substitutions
+                let args_unified_sub = self.unify_subs(&args_sub1, &args_sub2)?;
+                self.unify_subs(&args_unified_sub, &subject_sub)
+            }
+            (Term::AppTyFn(_), _) | (_, Term::AppTyFn(_)) => {
+                // Any other type function application (asymmetric) doesn't unify
+                cannot_unify()
+            }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn unify_test() {
-        // let mut gs = GlobalStorage::new();
-        // let core_defs = CoreDefs::new(&mut gs);
-        // let builder = PrimitiveBuilder::new(&mut gs);
+            // Type function type:
+            (Term::TyFnTy(src_ty_fn_ty), Term::TyFnTy(target_ty_fn_ty)) => {
+                // Unify params and return:
 
-        // let hash_ty_1 = builder.create_ty_of_ty_with_bound(core_defs.hash_trt);
-        // let hash_ty_2 = builder.create_ty_of_ty_with_bound(core_defs.eq_trt);
+                // Params need to be unified inversely.
+                // @@Todo: figure out exact variance rules.
+                let params_sub =
+                    self.unify_params(&target_ty_fn_ty.params, &src_ty_fn_ty.params)?;
+                let return_sub =
+                    self.unify_terms(src_ty_fn_ty.return_ty, target_ty_fn_ty.return_ty)?;
 
-        // drop(builder);
+                // Merge the subs
+                self.unify_subs(&params_sub, &return_sub)
+            }
+            (Term::TyFnTy(_), _) | (_, Term::TyFnTy(_)) => cannot_unify(),
 
-        // let mut unifier = Unifier::new(&mut gs);
-        // let unify_result = unifier.unify_tys(hash_ty_1, hash_ty_2, &UnifyTysOpts {});
-        // println!("{:?}", unify_result);
+            // Level 3 terms:
+            (Term::Level3(src_level3_term), Term::Level3(target_level3_term)) => {
+                match (src_level3_term, target_level3_term) {
+                    // "TraitKind" always unifies:
+                    (Level3Term::TrtKind, Level3Term::TrtKind) => Ok(Sub::empty()),
+                }
+            }
+            (Term::Level3(_), _) | (_, Term::Level3(_)) => {
+                // Mismatching level:
+                cannot_unify()
+            }
+
+            // Level 2 terms:
+            (Term::Level2(src_level2_term), Term::Level2(target_level2_term)) => {
+                match (src_level2_term, target_level2_term) {
+                    // Traits only unify if the IDs are the same:
+                    (Level2Term::Trt(src_id), Level2Term::Trt(target_id)) => {
+                        if src_id == target_id {
+                            Ok(Sub::empty())
+                        } else {
+                            cannot_unify()
+                        }
+                    }
+                    // If a trait tries to be unified with "Type", it is always successful:
+                    (Level2Term::Trt(_), Level2Term::AnyTy) => Ok(Sub::empty()),
+                    // The other way around doesn't hold however:
+                    (Level2Term::AnyTy, Level2Term::Trt(_)) => cannot_unify(),
+                    // "Type" unifies with "Type":
+                    (Level2Term::AnyTy, Level2Term::AnyTy) => Ok(Sub::empty()),
+                }
+            }
+            (Term::Level2(_), _) | (_, Term::Level2(_)) => {
+                // Mismatching level:
+                cannot_unify()
+            }
+
+            // Level 1 terms:
+            (Term::Level1(src_level1_term), Term::Level1(target_level1_term)) => {
+                match (src_level1_term, target_level1_term) {
+                    // Mod defs only unify if their IDs are the same
+                    (Level1Term::ModDef(src_id), Level1Term::ModDef(target_id)) => {
+                        if src_id == target_id {
+                            Ok(Sub::empty())
+                        } else {
+                            cannot_unify()
+                        }
+                    }
+                    // Nominal defs only unify if their IDs are the same
+                    (Level1Term::NominalDef(src_id), Level1Term::NominalDef(target_id)) => {
+                        if src_id == target_id {
+                            Ok(Sub::empty())
+                        } else {
+                            cannot_unify()
+                        }
+                    }
+                    // Tuples unify if all their members unify:
+                    (Level1Term::Tuple(src_tuple), Level1Term::Tuple(target_tuple)) => {
+                        self.unify_params(&src_tuple.members, &target_tuple.members)
+                    }
+                    // Tuples unify if their parameters and return unify:
+                    (Level1Term::Fn(src_fn_ty), Level1Term::Fn(target_fn_ty)) => {
+                        // Once again, params need to be unified inversely.
+                        let params_sub =
+                            self.unify_params(&target_fn_ty.params, &src_fn_ty.params)?;
+                        let return_sub =
+                            self.unify_terms(src_fn_ty.return_ty, target_fn_ty.return_ty)?;
+
+                        // Merge the subs
+                        self.unify_subs(&params_sub, &return_sub)
+                    }
+                    // Mismatching level 1 term variants do not unify:
+                    _ => cannot_unify(),
+                }
+            }
+            (Term::Level1(_), _) | (_, Term::Level1(_)) => {
+                // Mismatching level:
+                cannot_unify()
+            }
+
+            // Level 0 terms:
+            (Term::Level0(src_level0_term), Term::Level0(target_level0_term)) => {
+                match (src_level0_term, target_level0_term) {
+                    (
+                        Level0Term::EnumVariant(src_enum_variant),
+                        Level0Term::EnumVariant(target_enum_variant),
+                    ) => {
+                        if src_enum_variant.enum_def_id == target_enum_variant.enum_def_id
+                            && src_enum_variant.variant_name == target_enum_variant.variant_name
+                        {
+                            // They are the same variant from the same enum:
+                            Ok(Sub::empty())
+                        } else {
+                            cannot_unify()
+                        }
+                    }
+                    // Any other level-0 term does not unify:
+                    _ => cannot_unify(),
+                }
+            }
+        }
     }
 }

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -250,11 +250,12 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
             (Term::AppSub(src_app_sub), Term::AppSub(target_app_sub))
                 if self
                     .validator()
-                    .subs_are_equivalent(&src_app_sub.sub, &target_app_sub.sub)? =>
+                    .subs_are_equivalent(&src_app_sub.sub, &target_app_sub.sub) =>
             {
                 // Unify inner, then unify the resultant substitution with the ones given here:
                 let inner_sub = self.unify_terms(src_app_sub.term, target_app_sub.term)?;
-                self.unify_subs(&src_app_sub.sub, &inner_sub)
+                let unified_app_subs = self.unify_subs(&src_app_sub.sub, &target_app_sub.sub)?;
+                self.unify_subs(&unified_app_subs, &inner_sub)
             }
             (Term::AppSub(_), _) | (_, Term::AppSub(_)) => {
                 // Otherwise they don't unify (since we start with simplified terms)

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -171,7 +171,38 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
     /// Determine if the two given substitutions are equivalent.
     ///
     /// That is, if for any term X, they produce the same result when applied to X
-    pub fn subs_are_equivalent(&mut self, _s0: &Sub, _s1: &Sub) -> TcResult<bool> {
-        todo!()
+    ///
+    /// @@Correctness: This is not based on any accepted algorithm, and requires testing to ensure
+    /// its correctness.
+    pub fn subs_are_equivalent(&mut self, s0: &Sub, s1: &Sub) -> bool {
+        // First we get the two substitutions as lists sorted by their domains:
+        let mut s0_list = s0.pairs().collect::<Vec<_>>();
+        let mut s1_list = s1.pairs().collect::<Vec<_>>();
+        s0_list.sort_by_key(|x| x.0);
+        s1_list.sort_by_key(|x| x.0);
+
+        // Then for each pair, we ensure the domain elements are the same, and the range elements
+        // can be unified:
+        for (s0_element, s1_element) in s0_list.iter().zip(&s1_list) {
+            if s0_element.0 != s1_element.0 {
+                return false;
+            }
+
+            // Unify bidirectionally
+            if self
+                .unifier()
+                .unify_terms(s0_element.1, s1_element.1)
+                .is_err()
+                || self
+                    .unifier()
+                    .unify_terms(s1_element.1, s0_element.1)
+                    .is_err()
+            {
+                return false;
+            }
+        }
+
+        // If all succeeded, the substitutions are equivalent!
+        true
     }
 }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -2,7 +2,7 @@
 use crate::{
     error::TcResult,
     storage::{
-        primitives::{FnTy, Level1Term, ModDefId, NominalDefId, Term, TermId, TrtDefId},
+        primitives::{FnTy, Level1Term, ModDefId, NominalDefId, Sub, Term, TermId, TrtDefId},
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
 };
@@ -166,5 +166,12 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             Term::Level1(Level1Term::Fn(fn_ty)) => Ok(Some(fn_ty.clone())),
             _ => Ok(None),
         }
+    }
+
+    /// Determine if the two given substitutions are equivalent.
+    ///
+    /// That is, if for any term X, they produce the same result when applied to X
+    pub fn subs_are_equivalent(&mut self, _s0: &Sub, _s1: &Sub) -> TcResult<bool> {
+        todo!()
     }
 }

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -91,36 +91,38 @@ impl CoreDefs {
             ),
         );
 
-        // Handy shorthand for &Self type
-        let ref_self_ty = builder.create_app_ty_fn_term(
-            reference_ty_fn,
-            [builder.create_arg("T", builder.create_var_term("Self"))],
-        );
+        // @@Incomplete: these traits should take ref self, not self.
 
         // Hash and Eq traits
         let hash_trt = builder.create_trt_def(
             "Hash",
-            [builder.create_unset_pub_member(
-                "hash",
-                builder.create_fn_ty_term(
-                    [builder.create_param("value", ref_self_ty)],
-                    builder.create_nominal_def_term(u64_ty),
+            [
+                builder.create_unset_pub_member("Self", builder.create_any_ty_term()),
+                builder.create_unset_pub_member(
+                    "hash",
+                    builder.create_fn_ty_term(
+                        [builder.create_param("value", builder.create_var_term("Self"))],
+                        builder.create_nominal_def_term(u64_ty),
+                    ),
                 ),
-            )],
+            ],
             [],
         );
         let eq_trt = builder.create_trt_def(
             "Eq",
-            [builder.create_unset_pub_member(
-                "eq",
-                builder.create_fn_ty_term(
-                    [
-                        builder.create_param("a", ref_self_ty),
-                        builder.create_param("b", ref_self_ty),
-                    ],
-                    builder.create_nominal_def_term(u64_ty),
+            [
+                builder.create_unset_pub_member("Self", builder.create_any_ty_term()),
+                builder.create_unset_pub_member(
+                    "eq",
+                    builder.create_fn_ty_term(
+                        [
+                            builder.create_param("a", builder.create_var_term("Self")),
+                            builder.create_param("b", builder.create_var_term("Self")),
+                        ],
+                        builder.create_nominal_def_term(u64_ty),
+                    ),
                 ),
-            )],
+            ],
             [],
         );
 

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -389,13 +389,13 @@ pub struct TyFnCase {
 /// Not yet resolved.
 ///
 /// The resolution ID is incremented for each new unresolved term.
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UnresolvedTerm {
     pub resolution_id: ResolutionId,
 }
 
 /// A variable, which is just a name.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Var {
     pub name: Identifier,
 }
@@ -539,7 +539,7 @@ pub enum Level0Term {
 }
 
 /// The subject of a substitution, either a variable or an unresolved term.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub enum SubSubject {
     Var(Var),
     Unresolved(UnresolvedTerm),

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -15,10 +15,11 @@ macro_rules! counter {
         counter_name: $counter_name:ident,
         visibility: $visibility:vis,
         method_visibility: $method_visibility:vis,
+        derives: ($($derive:ident),*),
     ) => {
         static $counter_name: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
-        #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+        #[derive($($derive),*)]
         $visibility struct $name(pub u32);
 
         impl $name {
@@ -41,6 +42,20 @@ macro_rules! counter {
             fn from(counter: $name) -> u32 {
                 counter.0
             }
+        }
+    };
+    (
+        name: $name:ident,
+        counter_name: $counter_name:ident,
+        visibility: $visibility:vis,
+        method_visibility: $method_visibility:vis,
+    ) => {
+        counter! {
+            name: $name,
+            counter_name: $counter_name,
+            visibility: $visibility,
+            method_visibility: $method_visibility,
+            derives: (Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd),
         }
     };
 }


### PR DESCRIPTION
This PR implements unification of terms, completing the core of the typechecker (along with simplification, substitutions, and typing). Unification takes two terms A and B, and ensures that A is a sub-term or equal term to B, that is, any instance of A can be used where B is required. This asymmetry only applies to instantiable terms (level 1 and above); for uninstantiable terms, unification is simply equality checking. Unification produces a substitution as a result, which can be applied to surrounding terms to infer more information about them (this is how type inference works).

The remaining tasks in the typechecker are:

- Implement further term validation (see `validate.rs`) (see #284)
- Write tests for simplification, unification, substitutions, and typing (see #296).
- Implement default variables (see #295)

These should be done in separate PRs, in order to keep the changes manageable.

Closes #232, closes #283, closes #297.