### PR TITLE
TC: Minor improvements to simplification and adding Root term

### DIFF
--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -67,6 +67,14 @@ pub enum TcError {
         args: Args,
         unification_errors: Vec<TcError>,
     },
+    InvalidElementOfMerge {
+        term: TermId,
+    },
+    MergeShouldOnlyContainOneNominal {
+        merge_term: TermId,
+        nominal_term: TermId,
+        second_nominal_term: TermId,
+    },
     UnsupportedTypeFunctionApplication {
         subject_id: TermId,
     },

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -217,6 +217,7 @@ impl<'gs> TcFormatter<'gs> {
                 Ok(())
             }
             Term::Var(var) => {
+                is_atomic.set(true);
                 write!(f, "{}", var.name)
             }
             Term::Merge(terms) => {
@@ -264,6 +265,7 @@ impl<'gs> TcFormatter<'gs> {
                 Ok(())
             }
             Term::AppTyFn(app_ty_fn) => {
+                is_atomic.set(true);
                 self.fmt_term_as_single(f, app_ty_fn.subject)?;
                 write!(f, "<")?;
                 self.fmt_args(f, &app_ty_fn.args)?;
@@ -272,6 +274,7 @@ impl<'gs> TcFormatter<'gs> {
             }
             Term::Unresolved(unresolved_term) => self.fmt_unresolved(f, unresolved_term),
             Term::AppSub(app_sub) => {
+                is_atomic.set(true);
                 write!(f, "[")?;
                 let pairs = app_sub.sub.pairs().collect::<Vec<_>>();
                 for (i, (from, to)) in pairs.iter().enumerate() {
@@ -294,6 +297,10 @@ impl<'gs> TcFormatter<'gs> {
             Term::Level2(term) => self.fmt_level2_term(f, term, is_atomic),
             Term::Level1(term) => self.fmt_level1_term(f, term, is_atomic),
             Term::Level0(term) => self.fmt_level0_term(f, term, is_atomic),
+            Term::Root => {
+                is_atomic.set(true);
+                write!(f, "Root")
+            }
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -286,6 +286,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         }
     }
 
+    /// Create a [Term::Root].
+    pub fn create_root_term(&self) -> TermId {
+        self.create_term(Term::Root)
+    }
+
     /// Create a term [Level3Term::TrtKind].
     pub fn create_trt_kind_term(&self) -> TermId {
         self.create_term(Term::Level3(Level3Term::TrtKind))

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -514,6 +514,8 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                 let mut results = vec![];
 
                 // First, ensure they unify with general params:
+                //
+                // @@Correctness: do we need to apply this sub anywhere?
                 let _ = self
                     .unifier()
                     .unify_params_with_args(&ty_fn.general_params, &apply_ty_fn.args)?;

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -188,6 +188,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             // Leaves:
             Term::Var(var) => self.apply_sub_to_subject(sub, var.into()),
             Term::Unresolved(unresolved) => self.apply_sub_to_subject(sub, unresolved.into()),
+            Term::Root => term_id,
 
             // Recursive cases:
             Term::Access(access) => {
@@ -495,6 +496,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             Term::Level0(term) => {
                 self.add_free_vars_in_level0_term_to_set(term, result);
             }
+            // No vars:
+            Term::Root => {}
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -89,9 +89,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                 }
             }
             Term::TyFnTy(_) => {
-                // The type of a type function is just TraitKind.
-                // @@Correctness: is this always consistent?
-                Ok(self.builder().create_trt_kind_term())
+                // The type of a type function type is Root
+                Ok(self.builder().create_root_term())
             }
             Term::Var(var) => {
                 // The type of a variable can be found by looking at the scopes to its declaration:
@@ -125,8 +124,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
             }
             Term::Level3(level3_term) => match level3_term {
                 Level3Term::TrtKind => {
-                    // The type of TraitKind, is once again TraitKind
-                    Ok(self.builder().create_trt_kind_term())
+                    // The type of TraitKind, is Root
+                    Ok(self.builder().create_root_term())
                 }
             },
             Term::Level2(level2_term) => match level2_term {
@@ -172,6 +171,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                     }
                 }
             }
+            // The type of root is root
+            Term::Root => Ok(self.builder().create_root_term()),
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -427,6 +427,10 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                     _ => cannot_unify(),
                 }
             }
+
+            // Root unifies with root and nothing else:
+            (Term::Root, Term::Root) => Ok(Sub::empty()),
+            (_, Term::Root) | (Term::Root, _) => cannot_unify(),
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -94,32 +94,34 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             Term::Merge(terms) => {
                 // First, validate each term:
                 let terms = terms.clone();
-                let term_validations: Vec<_> = terms
-                    .iter()
-                    .copied()
-                    .map(|term| self.validate_term(term))
-                    .collect::<TcResult<_>>()?;
-
-                // Merge all the terms:
-                let terms_ty_id = self.builder().create_merge_term(
-                    term_validations
-                        .iter()
-                        .map(|validation| validation.term_ty_id),
-                );
-                let simplified_terms_id = self.builder().create_merge_term(
-                    term_validations
-                        .iter()
-                        .map(|validation| validation.simplified_term_id),
-                );
+                for term in terms.iter().copied() {
+                    self.validate_term(term)?;
+                }
 
                 // Ensure all elements of the merge are not type functions, and are of the same
                 // level (either level 1 or level 2, if they are level 1 then there should only be
                 // one nominal definition).
+                let mut _first_term: Option<TermLevel> = None;
+                for term in terms.iter().copied() {
+                    let reader = self.reader();
+                    let term = reader.get_term(term);
+                    match term {
+                        Term::Access(_) => todo!(),
+                        Term::Var(_) => todo!(),
+                        Term::Merge(_) => todo!(),
+                        Term::TyFn(_) => todo!(),
+                        Term::TyFnTy(_) => todo!(),
+                        Term::AppTyFn(_) => todo!(),
+                        Term::AppSub(_) => todo!(),
+                        Term::Unresolved(_) => todo!(),
+                        Term::Level3(_) => todo!(),
+                        Term::Level2(_) => todo!(),
+                        Term::Level1(_) => todo!(),
+                        Term::Level0(_) => todo!(),
+                    }
+                }
 
-                Ok(TermValidation {
-                    term_ty_id: terms_ty_id,
-                    simplified_term_id: simplified_terms_id,
-                })
+                Ok(result)
             }
             Term::TyFn(_) => {
                 // Validate each member.

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -103,10 +103,10 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                 // definition attached.
                 enum MergeKind {
                     Unknown,
-                    Level2,
-                    Level1 { nominal_attached: Option<TermId> },
+                    _Level2,
+                    _Level1 { nominal_attached: Option<TermId> },
                 }
-                let mut merge_kind = MergeKind::Unknown;
+                let _merge_kind = MergeKind::Unknown;
                 for term_id in terms.iter().copied() {
                     let reader = self.reader();
                     let term = reader.get_term(term_id);

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -159,6 +159,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             | Term::AppSub(_)
             | Term::TyFnTy(_)
             | Term::AppTyFn(_)
+            | Term::Root
             | Term::Unresolved(_) => {
                 // Nothing to do, should have already been validated by the typer.
                 Ok(result)
@@ -190,6 +191,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             Term::Level2(_) => todo!(),
             Term::Level1(_) => todo!(),
             Term::Level0(_) => todo!(),
+            Term::Root => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -738,6 +738,10 @@ pub enum Term {
 
     /// A level 0 term.
     Level0(Level0Term),
+
+    /// The only level 4 term, which is the "endpoint" of the typing hierarchy. This is the type of
+    /// "TraitKind" and "TyFnTy".
+    Root,
 }
 
 // IDs for all the primitives to be stored on mapped storage.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -697,7 +697,7 @@ pub enum Term {
 
     /// Merge of multiple terms.
     ///
-    /// Inner types must have the same level.
+    /// Inner types must have the same level. Merging is also idempotent, associative, and commutative.
     ///
     /// Is level N, where N is the level of the inner types.
     Merge(Vec<TermId>),


### PR DESCRIPTION
This PR includes a set of minor improvements to term simplification, notably flattening nested `Term::Merge`s. Furthermore, the `Root` term is introduced, which is used as the type of `TraitKind` and `TyFnTy`. This is needed because typing `TyFnTy` as `TraitKind` is not consistent (since it is not a trait). The `Root` term is also typed as `Root`, and is the only term to do so. This PR is a precursor to tackling #284.