### PR TITLE
TC: Implement general term validation

### DIFF
--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -73,6 +73,12 @@ pub enum TcError {
     InvalidTypeFunctionParameterType {
         param_ty: TermId,
     },
+    InvalidTypeFunctionReturnType {
+        return_ty: TermId,
+    },
+    InvalidTypeFunctionReturnValue {
+        return_value: TermId,
+    },
     MergeShouldOnlyContainOneNominal {
         merge_term: TermId,
         nominal_term: TermId,

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -70,6 +70,9 @@ pub enum TcError {
     InvalidElementOfMerge {
         term: TermId,
     },
+    InvalidTypeFunctionParameterType {
+        param_ty: TermId,
+    },
     MergeShouldOnlyContainOneNominal {
         merge_term: TermId,
         nominal_term: TermId,

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -83,6 +83,9 @@ pub enum TcError {
         merge_term: TermId,
         offending_term: TermId,
     },
+    TermIsNotRuntimeInstantiable {
+        term: TermId,
+    },
     UnsupportedTypeFunctionApplication {
         subject_id: TermId,
     },

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -75,6 +75,14 @@ pub enum TcError {
         nominal_term: TermId,
         second_nominal_term: TermId,
     },
+    MergeShouldBeLevel1 {
+        merge_term: TermId,
+        offending_term: TermId,
+    },
+    MergeShouldBeLevel2 {
+        merge_term: TermId,
+        offending_term: TermId,
+    },
     UnsupportedTypeFunctionApplication {
         subject_id: TermId,
     },

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -88,6 +88,9 @@ pub enum TcError {
         merge_term: TermId,
         offending_term: TermId,
     },
+    NeedMoreTypeAnnotationsToResolve {
+        term_to_resolve: TermId,
+    },
     MergeShouldBeLevel2 {
         merge_term: TermId,
         offending_term: TermId,

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -149,8 +149,9 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                     }
                 }
                 Level1Term::NominalDef(_) | Level1Term::Tuple(_) | Level1Term::Fn(_) => {
-                    // The type of any nominal def, function type, or tuple type, is just "Type":
-                    Ok(self.builder().create_any_ty_term())
+                    // The type of any nominal def, function type, or tuple type, is "RuntimeInstantiable":
+                    let rt_instantiable_def = self.core_defs().runtime_instantiable_trt;
+                    Ok(self.builder().create_trt_term(rt_instantiable_def))
                 }
             },
             Term::Level0(level0_term) => {

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -3,8 +3,8 @@ use crate::{
     error::{TcError, TcResult},
     storage::{
         primitives::{
-            FnTy, Level1Term, Level2Term, ModDefId, NominalDefId, Params, Sub, Term, TermId,
-            TrtDefId,
+            FnTy, Level0Term, Level1Term, Level2Term, ModDefId, NominalDefId, Params, Sub, Term,
+            TermId, TrtDefId,
         },
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
@@ -378,7 +378,24 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             },
 
             // Level 0 terms:
-            Term::Level0(_) => todo!(),
+            Term::Level0(level0_term) => match level0_term {
+                Level0Term::Rt(rt_inner_term) => {
+                    // Validate the inner term, and ensure it is runtime instantiable:
+                    let rt_inner_term = *rt_inner_term;
+                    self.validate_term(rt_inner_term)?;
+                    self.ensure_term_is_runtime_instantiable(rt_inner_term)?;
+                    Ok(result)
+                }
+                Level0Term::FnLit(_) => {
+                    // Validate constituents, and ensure that the function's return type unifies
+                    // with the type of the return value:
+                    todo!()
+                }
+                Level0Term::EnumVariant(_) => {
+                    // Ensure the variant exists
+                    todo!()
+                }
+            },
 
             Term::Access(_) => todo!(),
             Term::AppSub(_) => todo!(),

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -454,10 +454,22 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             }
 
             // Type function type:
-            Term::TyFnTy(_ty_fn_ty) => {
-                // We just validate the params and return type; furthermore we ensure each
-                // parameter is at least level 2.
-                todo!()
+            Term::TyFnTy(ty_fn_ty) => {
+                // Validate the params and return type:
+                let ty_fn_ty = ty_fn_ty.clone();
+                self.validate_params(&ty_fn_ty.params)?;
+                let _ = self.validate_term(ty_fn_ty.return_ty);
+
+                // Ensure each parameter's type can be used as a type function parameter type:
+                for param in ty_fn_ty.params.positional() {
+                    if !(self.term_can_be_used_as_ty_fn_param_ty(param.ty)?) {
+                        return Err(TcError::InvalidTypeFunctionParameterType {
+                            param_ty: param.ty,
+                        });
+                    }
+                }
+
+                Ok(result)
             }
 
             // Type function application:
@@ -523,6 +535,16 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             Term::Level0(_) => todo!(),
             Term::Root => todo!(),
         }
+    }
+
+    /// Determine if the given term can be used as the parameter type of a type function.
+    ///
+    /// This extends to level 2, as well as type function types returning level 2 terms.
+    /// **Note**: assumes the term has been simplified.
+    ///
+    /// @@Extension: we could allow level 3 terms as parameters too (TraitKind).
+    pub fn term_can_be_used_as_ty_fn_param_ty(&mut self, _term_id: TermId) -> TcResult<bool> {
+        todo!()
     }
 
     /// Determine if the given term is a function type, and if so return it.

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -1,7 +1,5 @@
 //! Contains utilities to validate terms.
 
-
-
 use crate::{
     error::{TcError, TcResult},
     storage::{
@@ -48,6 +46,8 @@ pub struct TermValidation {
     pub term_ty_id: TermId,
 }
 
+/// Helper type for [Validator::validate_merge_element], to keep track of the kind of the merge
+/// (whether it is level 2, level 1, or not known yet).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MergeKind {
     Unknown,

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -33,6 +33,7 @@ pub struct CoreDefs {
     pub raw_reference_ty_fn: TermId,
     pub hash_trt: TrtDefId,
     pub eq_trt: TrtDefId,
+    pub runtime_instantiable_trt: TrtDefId,
 }
 
 impl CoreDefs {
@@ -126,6 +127,9 @@ impl CoreDefs {
             [],
         );
 
+        // Marker trait for types that are runtime instantiable
+        let runtime_instantiable_trt = builder.create_trt_def("RuntimeInstantiable", [], []);
+
         // Collection types
         let list_ty_fn = builder.create_ty_fn_term(
             Some("List"),
@@ -185,6 +189,7 @@ impl CoreDefs {
             raw_reference_ty_fn,
             hash_trt,
             eq_trt,
+            runtime_instantiable_trt,
         }
     }
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -437,7 +437,7 @@ pub struct TyFnTy {
 /// variant of the enum in the form of an [Identifier].
 ///
 /// Has a level 0 type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct EnumVariantValue {
     pub enum_def_id: NominalDefId,
     pub variant_name: Identifier,
@@ -516,7 +516,7 @@ pub enum Level1Term {
 }
 
 /// Represents a function literal, with a function type, as well as a return value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct FnLit {
     pub fn_ty: TermId,
     pub return_value: TermId,


### PR DESCRIPTION
This PR implements term validation, which forms the final major element of the typechecker's core. Term validation focuses on checks that are not carried out by simplification, typing, or unification, but are still necessary to have a consistent language. Because this PR is already quite large, validation of definitions (nominals, modules, traits) will be happening in a separate PR (see issue #304). On another note, we should start AST traversal now, concurrently to working on #304, in order to be able to do some proper TC testing (it is very cumbersome without being able to write Hash code to test it). 