### PR TITLE
reporting: implement `block` mode for larger spans

### DIFF
--- a/compiler/hash-reporting/src/builder.rs
+++ b/compiler/hash-reporting/src/builder.rs
@@ -1,8 +1,6 @@
 //! Hash compiler diagnostic report builder.
-
-use hash_error_codes::error_codes::HashErrorCode;
-
 use crate::report::{Report, ReportElement, ReportKind};
+use hash_error_codes::error_codes::HashErrorCode;
 
 /// A utility struct that allows for a [Report] to be built incrementally
 /// adding annotations and other metadata to the report.

--- a/compiler/hash-reporting/src/lib.rs
+++ b/compiler/hash-reporting/src/lib.rs
@@ -2,5 +2,6 @@
 pub mod builder;
 pub mod errors;
 pub mod highlight;
+mod render;
 pub mod report;
 pub mod writer;

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -1,11 +1,20 @@
-//! Hash diagnostic report rendering logic.
+//! Hash diagnostic report rendering logic. Within this renderer,
+//! there are currently two modes: `line` and `block`. Within this
+//! module, the modes are often referred to either being line or block.
+//! The difference between the two modes is how they are displayed
+//! when rendered. The `line` mode is designed to highlight spans that
+//! are contained to a single line, whereas `block` mode is designed to
+//! for bulkier spans that might take up many lines. More specific examples
+//! of both modes are located in the documentation of the functions
+//! that are responsible for rendering either mode.
 
 use std::{
     fmt,
-    iter::{once, repeat},
+    iter::{once, repeat, Enumerate, Skip, Take},
+    str::Split,
 };
 
-use hash_source::SourceMap;
+use hash_source::{location::SourceLocation, SourceMap};
 use hash_utils::path::adjust_canonicalization;
 
 use crate::{
@@ -13,8 +22,14 @@ use crate::{
     report::{ReportCodeBlock, ReportCodeBlockInfo, ReportElement, ReportKind, ReportNote},
 };
 
-/// Character used to denote the location of the error.
-pub const ERROR_MARKING_CHAR: &str = "^";
+/// Character used to denote the span of the diagnostic for the `line` view.
+const LINE_DIAGNOSTIC_MARKER: char = '^';
+
+/// Character used to denote the span of the diagnostic for the `block` view.
+const BLOCK_DIAGNOSTIC_MARKER: char = '-';
+
+/// Character used to connect block views
+const DIAGNOSTIC_CONNECTING_CHAR: &str = "|";
 
 /// Function to compute a row and column number from a given source string
 /// and an offset within the source. This will take into account the number
@@ -61,12 +76,30 @@ pub(crate) fn offset_col_row(
     ))
 }
 
+/// This function holds inner rules for calculating what the selected top
+/// and bottom buffer sizes should be.
+fn adjust_initial_span_size(span: usize) -> usize {
+    // @@Correctness: This is an arbitrary rule and should be decided upon more concretely. It's
+    //                even possible that we might not want to get any additional lines for even larger
+    //                spans
+    match span {
+        3..=4 => 2,
+        5.. => 1,
+        _ => span,
+    }
+}
+
 /// Compute the top buffer and bottom buffer sizes from the given start and
 /// end row for a code block.
 fn compute_buffers(start_row: usize, end_row: usize) -> (usize, usize) {
     const MAX_BUFFER: usize = 5;
-    let top_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
-    let bottom_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
+
+    let diff = adjust_initial_span_size(end_row - start_row + 1);
+
+    // Cap the buffers to a maximum of 5
+    let top_buffer = diff.min(MAX_BUFFER);
+    let bottom_buffer = diff.min(MAX_BUFFER);
+
     (top_buffer, bottom_buffer)
 }
 
@@ -76,16 +109,18 @@ impl ReportCodeBlock {
         match self.info.get() {
             Some(info) => info,
             None => {
-                let source_id = self.source_location.source_id;
+                let SourceLocation { span, source_id } = self.source_location;
                 let source = modules.contents_by_id(source_id);
 
-                let location = self.source_location.span;
-
-                let (start_col, start_row) = offset_col_row(location.start(), source, true);
-                let (end_col, end_row) = offset_col_row(location.end(), source, false);
+                // Compute offset rows and columns from the provided span
+                let (start_col, start_row) = offset_col_row(span.start(), source, true);
+                let (end_col, end_row) = offset_col_row(span.end(), source, false);
                 let (_, last_row) = offset_col_row(source.len(), source, false);
 
+                // Compute the selected span outside of the diagnostic span
                 let (top_buf, bottom_buf) = compute_buffers(start_row, end_row);
+
+                // Compute the size of the indent based on the line numbers
                 let indent_width = (start_row.saturating_sub(top_buf) + 1)
                     .max((end_row + bottom_buf).min(last_row) + 1)
                     .to_string()
@@ -106,6 +141,231 @@ impl ReportCodeBlock {
         }
     }
 
+    /// Function to extract the block of the code that will be used to display the span
+    /// of the diagnostic.
+    fn get_source_view<'a, T: SourceMap>(
+        &self,
+        modules: &'a T,
+    ) -> Take<Skip<Enumerate<Split<'a, char>>>> {
+        // Get the actual contents of the erroneous span
+        let source_id = self.source_location.source_id;
+        let source = modules.contents_by_id(source_id);
+
+        let ReportCodeBlockInfo {
+            start_row, end_row, ..
+        } = self.info(modules);
+
+        let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
+
+        source
+            .trim_end_matches('\n')
+            .split('\n')
+            .enumerate()
+            .skip(start_row.saturating_sub(top_buffer))
+            .take(top_buffer + end_row - start_row + 1 + bottom_buffer)
+    }
+
+    /// Function that performs the rendering of the `line` view for a diagnostic. In this mode,
+    /// only a single line is highlighted using the [LINE_DIAGNOSTIC_MARKER]. It will highlight
+    /// the entire span using this mode. Here is an example of a diagnostic using the `line`
+    /// mode:
+    ///
+    /// ```text
+    /// error: non-declarative expressions are not allowed in `module` pattern
+    /// --> ~/examples/weird.hash:1:1
+    /// 1 |   a = "2";
+    ///   |   ^^^^^^^ not allowed here
+    /// 2 |   
+    /// 3 |   // main := () => {
+    /// ```
+    fn render_line_view<T: SourceMap>(
+        &self,
+        f: &mut fmt::Formatter,
+        modules: &T,
+        longest_indent_width: usize,
+        report_kind: ReportKind,
+    ) -> fmt::Result {
+        let error_view = self.get_source_view(modules);
+
+        let ReportCodeBlockInfo {
+            start_row,
+            end_row,
+            start_col,
+            end_col,
+            ..
+        } = self.info(modules);
+
+        // Print each selected line with the line number
+        for (index, line) in error_view {
+            let index_str = format!(
+                "{:>pad_width$}",
+                index + 1,
+                pad_width = longest_indent_width
+            );
+
+            let line_number = if (start_row..=end_row).contains(&index) {
+                highlight(report_kind.as_colour(), &index_str)
+            } else {
+                index_str
+            };
+
+            writeln!(
+                f,
+                "{} {}   {}",
+                line_number,
+                highlight(Colour::Blue, "|"),
+                line
+            )?;
+
+            if (start_row..=end_row).contains(&index) && !line.is_empty() {
+                let dashes: String = repeat(LINE_DIAGNOSTIC_MARKER)
+                    .take(if index == start_row && start_row == end_row {
+                        end_col - start_col
+                    } else if index == start_row {
+                        line.len().saturating_sub(start_col)
+                    } else if index == end_row {
+                        end_col
+                    } else {
+                        line.len()
+                    })
+                    .collect();
+
+                let mut code_note: String = repeat(" ")
+                    .take(if index == start_row { start_col } else { 0 })
+                    .chain(once(dashes.as_str()))
+                    .collect();
+
+                if index == end_row {
+                    code_note.extend(once(" ").chain(once(self.code_message.as_str())));
+                }
+
+                writeln!(
+                    f,
+                    "{} {}   {}",
+                    " ".repeat(longest_indent_width),
+                    highlight(Colour::Blue, "|"),
+                    highlight(report_kind.as_colour(), &code_note)
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Function that performs the rendering of the `block` view for a diagnostic.
+    /// The `block` view works by drawing an initial arrow that points to the start
+    /// of the diagnostic span, and an arrow to the end of the span in the same
+    /// format (with a label at the end). The two arrows are connected by a vertical
+    /// connector on the left hand-side. Here is an example of the `block` mode:
+    ///
+    /// ```text
+    /// error: non-declarative expressions are not allowed in `module` pattern
+    ///   --> /Users/alex/Documents/hash-org/lang/examples/weird.hash:11:1
+    ///  9 |    // };
+    /// 10 |    
+    /// 11 |    IoError = struct(
+    ///    |  __-
+    /// 12 | |      error: IoErrorType,
+    /// 13 | |      message: str,
+    /// 14 | |  );
+    ///    | |___- not allowed here
+    /// 15 |    
+    /// 16 |    // Make this a test case:
+    /// ```
+    ///
+    /// As seen in this example, there are two arrows which look like `__-` and which
+    /// are connected by a vertical arrow on the left side of the span.
+    fn render_block_view<T: SourceMap>(
+        &self,
+        f: &mut fmt::Formatter,
+        modules: &T,
+        longest_indent_width: usize,
+        report_kind: ReportKind,
+    ) -> fmt::Result {
+        let error_view = self.get_source_view(modules);
+
+        let ReportCodeBlockInfo {
+            start_row,
+            end_row,
+            start_col,
+            end_col,
+            ..
+        } = self.info(modules);
+
+        // So here, we want to iterate over all of the line and on the starting line, we want to
+        // draw an arrow from the left hand-side up until the beginning which then points up, on
+        // lines that are in the middle, we just want to draw a connecting character of the arrow,
+        // and finally on the line below the final line we want to draw an arrow leading up until
+        // the end of the span.
+        for (index, line) in error_view {
+            let index_str = format!(
+                "{:>pad_width$}",
+                index + 1,
+                pad_width = longest_indent_width
+            );
+
+            let line_number = if (start_row..=end_row).contains(&index) {
+                highlight(report_kind.as_colour(), &index_str)
+            } else {
+                index_str
+            };
+
+            // Compute the connector, if the current index is within the diagnostic span, we also need
+            // to add a connector that connects the bottom and top spans by a vertical line to the left
+            // hand-side of the diagnostic span.
+            let connector = if (start_row + 1..=end_row).contains(&index) {
+                DIAGNOSTIC_CONNECTING_CHAR
+            } else {
+                " "
+            };
+
+            writeln!(
+                f,
+                "{} {} {}  {}",
+                line_number,
+                highlight(Colour::Blue, "|"),
+                highlight(report_kind.as_colour(), connector),
+                line
+            )?;
+
+            // If this is th first row of the diagnostic span, then we want to draw an arrow leading up to it
+            if index == start_row {
+                let arrow: String = repeat('_')
+                    .take(start_col + 2)
+                    .chain(once(BLOCK_DIAGNOSTIC_MARKER))
+                    .collect();
+
+                writeln!(
+                    f,
+                    "{} {}  {}",
+                    " ".repeat(longest_indent_width),
+                    highlight(Colour::Blue, "|"),
+                    highlight(report_kind.as_colour(), arrow)
+                )?;
+            }
+
+            // Now we perform the same operator for creating an arrow to join the end span, and of course
+            // we write the note at the end of the span.
+            if index == end_row {
+                let arrow: String = once('|')
+                    .chain(repeat('_').take(end_col + 2))
+                    .chain(format!("{BLOCK_DIAGNOSTIC_MARKER} ").chars())
+                    .chain(self.code_message.as_str().chars())
+                    .collect();
+
+                writeln!(
+                    f,
+                    "{} {} {}",
+                    " ".repeat(longest_indent_width),
+                    highlight(Colour::Blue, "|"),
+                    highlight(report_kind.as_colour(), arrow)
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Function to render the [ReportCodeBlock] using the provided [SourceLocation], message and
     /// [ReportKind].
     pub(crate) fn render<T: SourceMap>(
@@ -115,29 +375,13 @@ impl ReportCodeBlock {
         longest_indent_width: usize,
         report_kind: ReportKind,
     ) -> fmt::Result {
-        // Print line numbers, separator, then the code itself, split by newlines
-        // Should put the code_message where it is supposed to be with a caret (^) followed by (_)
-        // or equivalent unicode character.
-        //
-        // Print a few lines before and after location/code_message.
         let source_id = self.source_location.source_id;
-        let source = modules.contents_by_id(source_id);
         let ReportCodeBlockInfo {
             start_row,
             end_row,
             start_col,
-            end_col,
             ..
         } = self.info(modules);
-
-        let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
-
-        let error_view = source
-            .trim_end_matches('\n')
-            .split('\n')
-            .enumerate()
-            .skip(start_row.saturating_sub(top_buffer))
-            .take(top_buffer + end_row - start_row + 1 + bottom_buffer);
 
         // Print the filename of the code block...
         writeln!(
@@ -156,59 +400,14 @@ impl ReportCodeBlock {
             )
         )?;
 
-        // Print each selected line with the line number
-        for (index, line) in error_view {
-            let index_str = format!(
-                "{:>pad_width$}",
-                index + 1,
-                pad_width = longest_indent_width
-            );
-
-            writeln!(
-                f,
-                "{} {}   {}",
-                if (start_row..=end_row).contains(&index) && !line.is_empty() {
-                    highlight(report_kind.as_colour(), &index_str)
-                } else {
-                    index_str
-                },
-                highlight(Colour::Blue, "|"),
-                line
-            )?;
-
-            if (start_row..=end_row).contains(&index) && !line.is_empty() {
-                let dashes = repeat(ERROR_MARKING_CHAR).take(
-                    if index == start_row && start_row == end_row {
-                        end_col - start_col
-                    } else if index == start_row {
-                        line.len().saturating_sub(start_col)
-                    } else if index == end_row {
-                        end_col
-                    } else {
-                        line.len()
-                    },
-                );
-
-                let mut code_note: String = repeat(" ")
-                    .take(if index == start_row { start_col } else { 0 })
-                    .chain(dashes)
-                    .collect();
-
-                if index == end_row {
-                    code_note.extend(once(" ").chain(once(self.code_message.as_str())));
-                }
-
-                writeln!(
-                    f,
-                    "{} {}   {}",
-                    " ".repeat(longest_indent_width),
-                    highlight(Colour::Blue, "|"),
-                    highlight(report_kind.as_colour(), &code_note)
-                )?;
-            }
+        // Now we can determine whether we want to use the `block` or the `line` view. The
+        // block view is for displaying large spans for multiple lines, whilst the line view
+        // is for a single line span.
+        if start_row == end_row {
+            self.render_line_view(f, modules, longest_indent_width, report_kind)
+        } else {
+            self.render_block_view(f, modules, longest_indent_width, report_kind)
         }
-
-        Ok(())
     }
 }
 

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -1,0 +1,265 @@
+//! Hash diagnostic report rendering logic.
+
+use std::{
+    fmt,
+    iter::{once, repeat},
+};
+
+use hash_source::SourceMap;
+use hash_utils::path::adjust_canonicalization;
+
+use crate::{
+    highlight::{highlight, Colour, Modifier},
+    report::{ReportCodeBlock, ReportCodeBlockInfo, ReportElement, ReportKind, ReportNote},
+};
+
+/// Character used to denote the location of the error.
+pub const ERROR_MARKING_CHAR: &str = "^";
+
+/// Function to compute a row and column number from a given source string
+/// and an offset within the source. This will take into account the number
+/// of encountered newlines and characters per line in order to compute
+/// precise row and column numbers of the span.
+pub(crate) fn offset_col_row(
+    offset: usize,
+    source: &str,
+    non_inclusive: bool,
+) -> (/* col: */ usize, /* row: */ usize) {
+    let source_lines = source.split('\n');
+
+    let mut bytes_skipped = 0;
+    let mut total_lines: usize = 0;
+    let mut last_line_len = 0;
+
+    let mut line_index = None;
+    for (line_idx, line) in source_lines.enumerate() {
+        // One byte for the newline
+        let skip_width = line.len() + 1;
+
+        // Here, we don't want an inclusive range because we don't want to get the last byte because
+        // that will always point to the newline character and this isn't necessary to be included
+        // when selecting a span for printing.
+        let range = if non_inclusive {
+            bytes_skipped..bytes_skipped + skip_width
+        } else {
+            bytes_skipped..bytes_skipped + skip_width + 1
+        };
+
+        if range.contains(&offset) {
+            line_index = Some((offset - bytes_skipped, line_idx));
+            break;
+        }
+
+        bytes_skipped += skip_width;
+        total_lines += 1;
+        last_line_len = line.len();
+    }
+
+    line_index.unwrap_or((
+        last_line_len.saturating_sub(1),
+        total_lines.saturating_sub(1),
+    ))
+}
+
+/// Compute the top buffer and bottom buffer sizes from the given start and
+/// end row for a code block.
+fn compute_buffers(start_row: usize, end_row: usize) -> (usize, usize) {
+    const MAX_BUFFER: usize = 5;
+    let top_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
+    let bottom_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
+    (top_buffer, bottom_buffer)
+}
+
+impl ReportCodeBlock {
+    // Get the indent widths of this code block as (outer, inner).
+    pub(crate) fn info<T: SourceMap>(&self, modules: &T) -> ReportCodeBlockInfo {
+        match self.info.get() {
+            Some(info) => info,
+            None => {
+                let source_id = self.source_location.source_id;
+                let source = modules.contents_by_id(source_id);
+
+                let location = self.source_location.span;
+
+                let (start_col, start_row) = offset_col_row(location.start(), source, true);
+                let (end_col, end_row) = offset_col_row(location.end(), source, false);
+                let (_, last_row) = offset_col_row(source.len(), source, false);
+
+                let (top_buf, bottom_buf) = compute_buffers(start_row, end_row);
+                let indent_width = (start_row.saturating_sub(top_buf) + 1)
+                    .max((end_row + bottom_buf).min(last_row) + 1)
+                    .to_string()
+                    .chars()
+                    .count();
+
+                let info = ReportCodeBlockInfo {
+                    indent_width,
+                    start_col,
+                    start_row,
+                    end_col,
+                    end_row,
+                };
+
+                self.info.replace(Some(info));
+                info
+            }
+        }
+    }
+
+    /// Function to render the [ReportCodeBlock] using the provided [SourceLocation], message and
+    /// [ReportKind].
+    pub(crate) fn render<T: SourceMap>(
+        &self,
+        f: &mut fmt::Formatter,
+        modules: &T,
+        longest_indent_width: usize,
+        report_kind: ReportKind,
+    ) -> fmt::Result {
+        // Print line numbers, separator, then the code itself, split by newlines
+        // Should put the code_message where it is supposed to be with a caret (^) followed by (_)
+        // or equivalent unicode character.
+        //
+        // Print a few lines before and after location/code_message.
+        let source_id = self.source_location.source_id;
+        let source = modules.contents_by_id(source_id);
+        let ReportCodeBlockInfo {
+            start_row,
+            end_row,
+            start_col,
+            end_col,
+            ..
+        } = self.info(modules);
+
+        let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
+
+        let error_view = source
+            .trim_end_matches('\n')
+            .split('\n')
+            .enumerate()
+            .skip(start_row.saturating_sub(top_buffer))
+            .take(top_buffer + end_row - start_row + 1 + bottom_buffer);
+
+        // Print the filename of the code block...
+        writeln!(
+            f,
+            "{}{} {}",
+            " ".repeat(longest_indent_width),
+            highlight(Colour::Blue, "-->"),
+            highlight(
+                Modifier::Underline,
+                format!(
+                    "{}:{}:{}",
+                    adjust_canonicalization(modules.path_by_id(source_id)),
+                    start_row + 1,
+                    start_col + 1,
+                )
+            )
+        )?;
+
+        // Print each selected line with the line number
+        for (index, line) in error_view {
+            let index_str = format!(
+                "{:>pad_width$}",
+                index + 1,
+                pad_width = longest_indent_width
+            );
+
+            writeln!(
+                f,
+                "{} {}   {}",
+                if (start_row..=end_row).contains(&index) && !line.is_empty() {
+                    highlight(report_kind.as_colour(), &index_str)
+                } else {
+                    index_str
+                },
+                highlight(Colour::Blue, "|"),
+                line
+            )?;
+
+            if (start_row..=end_row).contains(&index) && !line.is_empty() {
+                let dashes = repeat(ERROR_MARKING_CHAR).take(
+                    if index == start_row && start_row == end_row {
+                        end_col - start_col
+                    } else if index == start_row {
+                        line.len().saturating_sub(start_col)
+                    } else if index == end_row {
+                        end_col
+                    } else {
+                        line.len()
+                    },
+                );
+
+                let mut code_note: String = repeat(" ")
+                    .take(if index == start_row { start_col } else { 0 })
+                    .chain(dashes)
+                    .collect();
+
+                if index == end_row {
+                    code_note.extend(once(" ").chain(once(self.code_message.as_str())));
+                }
+
+                writeln!(
+                    f,
+                    "{} {}   {}",
+                    " ".repeat(longest_indent_width),
+                    highlight(Colour::Blue, "|"),
+                    highlight(report_kind.as_colour(), &code_note)
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ReportNote {
+    pub(crate) fn render(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        longest_indent_width: usize,
+    ) -> fmt::Result {
+        writeln!(
+            f,
+            "{} {} {}: {}",
+            " ".repeat(longest_indent_width),
+            highlight(Colour::Blue, "="),
+            highlight(Modifier::Bold, &self.label),
+            self.message
+        )?;
+
+        Ok(())
+    }
+}
+
+impl ReportElement {
+    pub(crate) fn render<T: SourceMap>(
+        &self,
+        f: &mut fmt::Formatter,
+        modules: &T,
+        longest_indent_width: usize,
+        report_kind: ReportKind,
+    ) -> fmt::Result {
+        match self {
+            ReportElement::CodeBlock(code_block) => {
+                code_block.render(f, modules, longest_indent_width, report_kind)
+            }
+            ReportElement::Note(note) => note.render(f, longest_indent_width),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_test() {
+        let contents = "Hello, world!\nGoodbye, world, it has been fun.";
+
+        let (col, row) = offset_col_row(contents.len() - 1, contents, false);
+        assert_eq!((col, row), (31, 1));
+
+        let (col, row) = offset_col_row(contents.len() + 3, contents, false);
+        assert_eq!((col, row), (31, 1));
+    }
+}

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -1,17 +1,24 @@
-use std::{
-    cell::Cell,
-    fmt,
-    iter::{once, repeat},
-};
+//! Hash diagnostic report data structures.
+use std::{cell::Cell, fmt};
 
+use crate::highlight::{highlight, Colour, Modifier};
 use hash_error_codes::error_codes::HashErrorCode;
-use hash_source::{location::SourceLocation, SourceMap};
-use hash_utils::path::adjust_canonicalization;
+use hash_source::location::SourceLocation;
 
-use crate::{
-    highlight::{highlight, Colour, Modifier},
-    writer::{offset_col_row, ReportCodeBlockInfo, ERROR_MARKING_CHAR},
-};
+/// A data type representing a comment/message on a specific span in a code block.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ReportCodeBlockInfo {
+    /// How many characters should be used for line numbers on the side.
+    pub indent_width: usize,
+    /// The beginning column of the code block.
+    pub start_col: usize,
+    /// The beginning row of the code block.
+    pub start_row: usize,
+    /// The end column of the code block.
+    pub end_col: usize,
+    /// The end row of the code block.
+    pub end_row: usize,
+}
 
 /// Enumeration describing the kind of [Report]; either being a warning, info or an
 /// error.
@@ -89,19 +96,6 @@ impl ReportNote {
             message: message.to_string(),
         }
     }
-
-    fn render(&self, f: &mut fmt::Formatter<'_>, longest_indent_width: usize) -> fmt::Result {
-        writeln!(
-            f,
-            "{} {} {}: {}",
-            " ".repeat(longest_indent_width),
-            highlight(Colour::Blue, "="),
-            highlight(Modifier::Bold, &self.label),
-            self.message
-        )?;
-
-        Ok(())
-    }
 }
 
 /// Data structure representing an associated block of code with a report. The type
@@ -123,155 +117,6 @@ impl ReportCodeBlock {
             info: Cell::new(None),
         }
     }
-
-    // Get the indent widths of this code block as (outer, inner).
-    pub(crate) fn info<T: SourceMap>(&self, modules: &T) -> ReportCodeBlockInfo {
-        match self.info.get() {
-            Some(info) => info,
-            None => {
-                let source_id = self.source_location.source_id;
-                let source = modules.contents_by_id(source_id);
-
-                let location = self.source_location.span;
-
-                let (start_col, start_row) = offset_col_row(location.start(), source, true);
-                let (end_col, end_row) = offset_col_row(location.end(), source, false);
-                let (_, last_row) = offset_col_row(source.len(), source, false);
-
-                let (top_buf, bottom_buf) = compute_buffers(start_row, end_row);
-                let indent_width = (start_row.saturating_sub(top_buf) + 1)
-                    .max((end_row + bottom_buf).min(last_row) + 1)
-                    .to_string()
-                    .chars()
-                    .count();
-
-                let info = ReportCodeBlockInfo {
-                    indent_width,
-                    start_col,
-                    start_row,
-                    end_col,
-                    end_row,
-                };
-
-                self.info.replace(Some(info));
-                info
-            }
-        }
-    }
-
-    /// Function to render the [ReportCodeBlock] using the provided [SourceLocation], message and
-    /// [ReportKind].
-    fn render<T: SourceMap>(
-        &self,
-        f: &mut fmt::Formatter,
-        modules: &T,
-        longest_indent_width: usize,
-        report_kind: ReportKind,
-    ) -> fmt::Result {
-        // Print line numbers, separator, then the code itself, split by newlines
-        // Should put the code_message where it is supposed to be with a caret (^) followed by (_)
-        // or equivalent unicode character.
-        //
-        // Print a few lines before and after location/code_message.
-        let source_id = self.source_location.source_id;
-        let source = modules.contents_by_id(source_id);
-        let ReportCodeBlockInfo {
-            start_row,
-            end_row,
-            start_col,
-            end_col,
-            ..
-        } = self.info(modules);
-
-        let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
-
-        let error_view = source
-            .trim_end_matches('\n')
-            .split('\n')
-            .enumerate()
-            .skip(start_row.saturating_sub(top_buffer))
-            .take(top_buffer + end_row - start_row + 1 + bottom_buffer);
-
-        // Print the filename of the code block...
-        writeln!(
-            f,
-            "{}{} {}",
-            " ".repeat(longest_indent_width),
-            highlight(Colour::Blue, "-->"),
-            highlight(
-                Modifier::Underline,
-                format!(
-                    "{}:{}:{}",
-                    adjust_canonicalization(modules.path_by_id(source_id)),
-                    start_row + 1,
-                    start_col + 1,
-                )
-            )
-        )?;
-
-        // Print each selected line with the line number
-        for (index, line) in error_view {
-            let index_str = format!(
-                "{:>pad_width$}",
-                index + 1,
-                pad_width = longest_indent_width
-            );
-
-            writeln!(
-                f,
-                "{} {}   {}",
-                if (start_row..=end_row).contains(&index) && !line.is_empty() {
-                    highlight(report_kind.as_colour(), &index_str)
-                } else {
-                    index_str
-                },
-                highlight(Colour::Blue, "|"),
-                line
-            )?;
-
-            if (start_row..=end_row).contains(&index) && !line.is_empty() {
-                let dashes = repeat(ERROR_MARKING_CHAR).take(
-                    if index == start_row && start_row == end_row {
-                        end_col - start_col
-                    } else if index == start_row {
-                        line.len().saturating_sub(start_col)
-                    } else if index == end_row {
-                        end_col
-                    } else {
-                        line.len()
-                    },
-                );
-
-                let mut code_note: String = repeat(" ")
-                    .take(if index == start_row { start_col } else { 0 })
-                    .chain(dashes)
-                    .collect();
-
-                if index == end_row {
-                    code_note.extend(once(" ").chain(once(self.code_message.as_str())));
-                }
-
-                writeln!(
-                    f,
-                    "{} {}   {}",
-                    " ".repeat(longest_indent_width),
-                    highlight(Colour::Blue, "|"),
-                    highlight(report_kind.as_colour(), &code_note)
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// Compute the top buffer and bottom buffer sizes from the given start and
-/// end row for a code block.
-fn compute_buffers(start_row: usize, end_row: usize) -> (usize, usize) {
-    const MAX_BUFFER: usize = 5;
-    let top_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
-    let bottom_buffer: usize = (end_row - start_row + 1).min(MAX_BUFFER);
-    (top_buffer, bottom_buffer)
 }
 
 /// Enumeration representing types of components of a [Report]. A [Report] can be made of
@@ -280,23 +125,6 @@ fn compute_buffers(start_row: usize, end_row: usize) -> (usize, usize) {
 pub enum ReportElement {
     CodeBlock(ReportCodeBlock),
     Note(ReportNote),
-}
-
-impl ReportElement {
-    pub(crate) fn render<T: SourceMap>(
-        &self,
-        f: &mut fmt::Formatter,
-        modules: &T,
-        longest_indent_width: usize,
-        report_kind: ReportKind,
-    ) -> fmt::Result {
-        match self {
-            ReportElement::CodeBlock(code_block) => {
-                code_block.render(f, modules, longest_indent_width, report_kind)
-            }
-            ReportElement::Note(note) => note.render(f, longest_indent_width),
-        }
-    }
 }
 
 /// The report data type represents the entire report which might contain many [ReportElement]s. The

--- a/compiler/hash-reporting/src/writer.rs
+++ b/compiler/hash-reporting/src/writer.rs
@@ -1,74 +1,10 @@
-use std::fmt;
-
-use hash_source::SourceMap;
-
+//! Hash diagnostic report writing utilities and definitions.
 use crate::{
     highlight::{highlight, Modifier},
     report::{Report, ReportElement},
 };
-
-/// Character used to denote the location of the error.
-pub const ERROR_MARKING_CHAR: &str = "^";
-
-/// A data type representing a comment/message on a specific span in a code block.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct ReportCodeBlockInfo {
-    /// How many characters should be used for line numbers on the side.
-    pub indent_width: usize,
-    /// The beginning column of the code block.
-    pub start_col: usize,
-    /// The beginning row of the code block.
-    pub start_row: usize,
-    /// The end column of the code block.
-    pub end_col: usize,
-    /// The end row of the code block.
-    pub end_row: usize,
-}
-
-/// Function to compute a row and column number from a given source string
-/// and an offset within the source. This will take into account the number
-/// of encountered newlines and characters per line in order to compute
-/// precise row and column numbers of the span.
-pub(crate) fn offset_col_row(
-    offset: usize,
-    source: &str,
-    non_inclusive: bool,
-) -> (/* col: */ usize, /* row: */ usize) {
-    let source_lines = source.split('\n');
-
-    let mut bytes_skipped = 0;
-    let mut total_lines: usize = 0;
-    let mut last_line_len = 0;
-
-    let mut line_index = None;
-    for (line_idx, line) in source_lines.enumerate() {
-        // One byte for the newline
-        let skip_width = line.len() + 1;
-
-        // Here, we don't want an inclusive range because we don't want to get the last byte because
-        // that will always point to the newline character and this isn't necessary to be included
-        // when selecting a span for printing.
-        let range = if non_inclusive {
-            bytes_skipped..bytes_skipped + skip_width
-        } else {
-            bytes_skipped..bytes_skipped + skip_width + 1
-        };
-
-        if range.contains(&offset) {
-            line_index = Some((offset - bytes_skipped, line_idx));
-            break;
-        }
-
-        bytes_skipped += skip_width;
-        total_lines += 1;
-        last_line_len = line.len();
-    }
-
-    line_index.unwrap_or((
-        last_line_len.saturating_sub(1),
-        total_lines.saturating_sub(1),
-    ))
-}
+use hash_source::SourceMap;
+use std::fmt;
 
 /// General data type for displaying [Report]s. This is needed due to the
 /// [Report] rendering process needing access to the program modules to get
@@ -127,21 +63,5 @@ impl<T: SourceMap> fmt::Display for ReportWriter<'_, T> {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn offset_test() {
-        let contents = "Hello, world!\nGoodbye, world, it has been fun.";
-
-        let (col, row) = offset_col_row(contents.len() - 1, contents, false);
-        assert_eq!((col, row), (31, 1));
-
-        let (col, row) = offset_col_row(contents.len() + 3, contents, false);
-        assert_eq!((col, row), (31, 1));
     }
 }


### PR DESCRIPTION
This patch adds a separation of logic for rendering reports and the actual definitions of the data structures. This patch also introduces modes for printing reports, specifically `block` and `line` modes. The `line` mode is self-explanatory and is used to render reports with single line spans, whereas the `block` mode is used for larger spans.

closes #290 

There is still some work to be done when shortening even larger spans by omitting line spans and replacing the lines with `..` as detailed in #290