### PR TITLE
Add rustfmt options to group imports and format comments

### DIFF
--- a/compiler/hash-alloc/src/brick.rs
+++ b/compiler/hash-alloc/src/brick.rs
@@ -24,9 +24,7 @@ impl<'c, T> Brick<'c, T> {
     /// Create a new `Brick` within the given [`Wall`], containing the given
     /// value.
     pub fn new(value: T, wall: &Wall<'c>) -> Self {
-        Self {
-            data: wall.alloc_value(value),
-        }
+        Self { data: wall.alloc_value(value) }
     }
 
     /// Move the value inside this `Brick` out, consuming the brick.

--- a/compiler/hash-alloc/src/brick.rs
+++ b/compiler/hash-alloc/src/brick.rs
@@ -1,4 +1,5 @@
-//! Contains a [`Box`]-like implementation for allocating values within a [`Wall`].
+//! Contains a [`Box`]-like implementation for allocating values within a
+//! [`Wall`].
 
 use crate::Wall;
 use core::fmt;
@@ -10,16 +11,18 @@ use std::{
 
 /// A [`Box`]-like implementation for allocating values within a [`Wall`].
 ///
-/// This is generic over the castle `'c` lifetime, and implements `Deref<Target=T>`.
+/// This is generic over the castle `'c` lifetime, and implements
+/// `Deref<Target=T>`.
 ///
-/// It should mostly be used in the same way as [`Box`], and is a zero-cost abstraction over a
-/// pointer into the memory arena.
+/// It should mostly be used in the same way as [`Box`], and is a zero-cost
+/// abstraction over a pointer into the memory arena.
 pub struct Brick<'c, T> {
     data: &'c mut ManuallyDrop<T>,
 }
 
 impl<'c, T> Brick<'c, T> {
-    /// Create a new `Brick` within the given [`Wall`], containing the given value.
+    /// Create a new `Brick` within the given [`Wall`], containing the given
+    /// value.
     pub fn new(value: T, wall: &Wall<'c>) -> Self {
         Self {
             data: wall.alloc_value(value),
@@ -31,8 +34,8 @@ impl<'c, T> Brick<'c, T> {
     /// This will always perform a bitwise-copy of the data stored in the arena.
     pub fn move_out(self) -> T {
         let no_drop_self = ManuallyDrop::new(self);
-        // ##Safety: this value will never be used again (and no destructors will run), so it is
-        // safe to bitwise copy out of the castle.
+        // ##Safety: this value will never be used again (and no destructors will run),
+        // so it is safe to bitwise copy out of the castle.
         //
         // @@Verify: make sure that this is completely valid in all cases.
         unsafe {

--- a/compiler/hash-alloc/src/collections/mod.rs
+++ b/compiler/hash-alloc/src/collections/mod.rs
@@ -1,6 +1,5 @@
 //! Various collection types that store data inside the memory arena provided by
 //! [`Wall`](super::Wall).
-//!
 
 pub mod row;
 pub mod string;

--- a/compiler/hash-alloc/src/collections/row.rs
+++ b/compiler/hash-alloc/src/collections/row.rs
@@ -42,19 +42,13 @@ const ROW_REALLOC_MULT_DIV: (usize, usize) = (2, 1);
 impl<'c, T> Row<'c, T> {
     /// Create a new [`Row`] with zero length and capacity.
     pub fn new() -> Self {
-        Self {
-            data: &mut [],
-            length: 0,
-        }
+        Self { data: &mut [], length: 0 }
     }
 
     /// Create a new `Row` within the given [`Wall`] with zero length and a
     /// given capacity.
     pub fn with_capacity(initial_capacity: usize, wall: &Wall<'c>) -> Self {
-        Self {
-            data: wall.alloc_uninit_slice(initial_capacity),
-            length: 0,
-        }
+        Self { data: wall.alloc_uninit_slice(initial_capacity), length: 0 }
     }
 
     /// Get the current capacity of the `Row`.
@@ -70,10 +64,7 @@ impl<'c, T> Row<'c, T> {
     /// - Panics if `new_capacity` is greater than [`isize::MAX`].
     /// - Panics if `new_capacity` is less than the current length of the `Row`.
     pub fn reserve(&mut self, new_capacity: usize, wall: &Wall<'c>) {
-        assert!(
-            new_capacity <= isize::MAX as usize,
-            "Reallocation target capacity is too large"
-        );
+        assert!(new_capacity <= isize::MAX as usize, "Reallocation target capacity is too large");
 
         assert!(
             new_capacity >= self.len(),
@@ -146,9 +137,7 @@ impl<'c, T> Row<'c, T> {
         // ##Safety: value has been initialised because it was within (0..self.len()).
         //
         // We give responsibility of dropping to the caller.
-        Some(ManuallyDrop::into_inner(unsafe {
-            last_element.assume_init()
-        }))
+        Some(ManuallyDrop::into_inner(unsafe { last_element.assume_init() }))
     }
 
     /// Insert an element at a given index inside the `Row`.

--- a/compiler/hash-alloc/src/collections/row.rs
+++ b/compiler/hash-alloc/src/collections/row.rs
@@ -1,4 +1,5 @@
-//! Contains a [`Vec`]-like implementation for allocating contiguous sequences within a [`Wall`].
+//! Contains a [`Vec`]-like implementation for allocating contiguous sequences
+//! within a [`Wall`].
 
 use crate::Wall;
 use core::fmt;
@@ -8,15 +9,18 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-/// A [`Vec`]-like implementation for allocating contiguous sequences within a [`Wall`].
+/// A [`Vec`]-like implementation for allocating contiguous sequences within a
+/// [`Wall`].
 ///
-/// This is generic over the castle `'c` lifetime, and implements `Deref<Target=T>`.
+/// This is generic over the castle `'c` lifetime, and implements
+/// `Deref<Target=T>`.
 ///
 /// It should mostly be used in the same way as [`Vec`].
 ///
-/// Note: Reallocations require copying the data every time, as opposed to [`Vec`] (which calls
-/// `realloc`, which in turn might grow the memory block without extra copying). This means that
-/// reserving space is even more important when using `Row` than when using [`Vec`].
+/// Note: Reallocations require copying the data every time, as opposed to
+/// [`Vec`] (which calls `realloc`, which in turn might grow the memory block
+/// without extra copying). This means that reserving space is even more
+/// important when using `Row` than when using [`Vec`].
 pub struct Row<'c, T> {
     data: &'c mut [MaybeUninit<ManuallyDrop<T>>],
     length: usize,
@@ -31,7 +35,8 @@ impl<T> Default for Row<'_, T> {
 /// How much to initially reserve in the row.
 const ROW_INITIAL_REALLOC_SIZE: usize = 4;
 
-/// How much to multiply (.0) and divide (.1) the current capacity by when reallocating.
+/// How much to multiply (.0) and divide (.1) the current capacity by when
+/// reallocating.
 const ROW_REALLOC_MULT_DIV: (usize, usize) = (2, 1);
 
 impl<'c, T> Row<'c, T> {
@@ -43,7 +48,8 @@ impl<'c, T> Row<'c, T> {
         }
     }
 
-    /// Create a new `Row` within the given [`Wall`] with zero length and a given capacity.
+    /// Create a new `Row` within the given [`Wall`] with zero length and a
+    /// given capacity.
     pub fn with_capacity(initial_capacity: usize, wall: &Wall<'c>) -> Self {
         Self {
             data: wall.alloc_uninit_slice(initial_capacity),
@@ -56,7 +62,8 @@ impl<'c, T> Row<'c, T> {
         self.data.len()
     }
 
-    /// Reserve some capacity within the `Row` by reallocating inside the given [`Wall`].
+    /// Reserve some capacity within the `Row` by reallocating inside the given
+    /// [`Wall`].
     ///
     /// # Panics
     ///
@@ -91,8 +98,8 @@ impl<'c, T> Row<'c, T> {
 
     /// Push an element to the end of the `Row`.
     ///
-    /// This will reallocate the data inside the given [`Wall`] if there is not enough capacity to
-    /// add the element.
+    /// This will reallocate the data inside the given [`Wall`] if there is not
+    /// enough capacity to add the element.
     ///
     /// # Panics
     ///
@@ -121,15 +128,16 @@ impl<'c, T> Row<'c, T> {
 
     /// Pop an element from the end of the `Row`
     ///
-    /// Returns `None` if there are no elements in the `Row`, otherwise the popped element.
+    /// Returns `None` if there are no elements in the `Row`, otherwise the
+    /// popped element.
     pub fn pop(&mut self) -> Option<T> {
         if self.len() == 0 {
             return None;
         }
 
         let last_element = std::mem::replace(
-            // ##Safety: self.len() - 1 is always a valid index as long as self.len() != 0 (which has
-            // just been checked).
+            // ##Safety: self.len() - 1 is always a valid index as long as self.len() != 0 (which
+            // has just been checked).
             unsafe { self.data.get_unchecked_mut(self.len() - 1) },
             MaybeUninit::uninit(),
         );
@@ -147,7 +155,8 @@ impl<'c, T> Row<'c, T> {
     ///
     /// # Panics
     ///
-    /// If index is not within the range `(0..=self.len())`. Also see [`Row::reserve`].
+    /// If index is not within the range `(0..=self.len())`. Also see
+    /// [`Row::reserve`].
     pub fn insert(&mut self, index: usize, element: T, wall: &Wall<'c>) {
         // Insert at the end means push.
         if index == self.len() {
@@ -167,7 +176,8 @@ impl<'c, T> Row<'c, T> {
         let target_point = &mut self.data[index + 1] as *mut _;
         let shift_length = self.len() - index;
 
-        // ##Safety: We have reserved one more element than the length so the shift is valid.
+        // ##Safety: We have reserved one more element than the length so the shift is
+        // valid.
         unsafe {
             std::ptr::copy(current_point, target_point, shift_length);
         }
@@ -179,10 +189,11 @@ impl<'c, T> Row<'c, T> {
         self.length += 1;
     }
 
-    /// Construct a [Row] from an iterator, allocating inside the given [`Wall`].
+    /// Construct a [Row] from an iterator, allocating inside the given
+    /// [`Wall`].
     ///
-    /// This uses `Iterator::size_hint` to predict how many elements are inside the iterator, and
-    /// avoid extraneous reallocations.
+    /// This uses `Iterator::size_hint` to predict how many elements are inside
+    /// the iterator, and avoid extraneous reallocations.
     pub fn from_iter<I>(iter: I, wall: &Wall<'c>) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -204,13 +215,14 @@ impl<'c, T> Row<'c, T> {
         Self::from_iter(vec.into_iter(), wall)
     }
 
-    /// Construct a `Row` from an iterator of [`Result`]s, allocating inside the given [`Wall`].
+    /// Construct a `Row` from an iterator of [`Result`]s, allocating inside the
+    /// given [`Wall`].
     ///
-    /// Returns a `Result` of either the collected `Row` or the first error encountered in the
-    /// iterator.
+    /// Returns a `Result` of either the collected `Row` or the first error
+    /// encountered in the iterator.
     ///
-    /// This uses `Iterator::size_hint` to predict how many elements are inside the iterator, and
-    /// avoid extraneous reallocations.
+    /// This uses `Iterator::size_hint` to predict how many elements are inside
+    /// the iterator, and avoid extraneous reallocations.
     pub fn try_from_iter<I, E>(iter: I, wall: &Wall<'c>) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<T, E>>,
@@ -227,7 +239,8 @@ impl<'c, T> Row<'c, T> {
         Ok(row)
     }
 
-    /// Produce a reference to the data inside the `Row` as a mutable slice, consuming `self`.
+    /// Produce a reference to the data inside the `Row` as a mutable slice,
+    /// consuming `self`.
     pub fn into_slice(self) -> &'c mut [T] {
         // ##Safety: values until self.length are initialised.
         // Also, the slice will live as long as 'c, which might outlive self.
@@ -245,15 +258,18 @@ impl<'c, T: Clone> Row<'c, T> {
         self.iter().cloned().collect()
     }
 
-    /// Clone the data inside `self` into a [`Row`] allocated using the given [`Wall`].
+    /// Clone the data inside `self` into a [`Row`] allocated using the given
+    /// [`Wall`].
     pub fn clone_in<'cc>(&self, wall: &Wall<'cc>) -> Row<'cc, T> {
         Row::from_iter(self.iter().cloned(), wall)
     }
 }
 
-/// A macro to help in the creation of [`Row`] objects. Similar to the [`vec!`] macro.
+/// A macro to help in the creation of [`Row`] objects. Similar to the [`vec!`]
+/// macro.
 ///
-/// Usage is the same as `vec!`, but with an explicit argument providing the [`Wall`] to allocate into.
+/// Usage is the same as `vec!`, but with an explicit argument providing the
+/// [`Wall`] to allocate into.
 ///
 /// # Examples
 ///
@@ -361,7 +377,8 @@ impl<'r, 'c, T> IntoIterator for &'r mut Row<'c, T> {
 
 impl<T> Drop for Row<'_, T> {
     fn drop(&mut self) {
-        // ##Safety: values until self.length are initialised, and ManuallyDrop<T> has the same layout as T.
+        // ##Safety: values until self.length are initialised, and ManuallyDrop<T> has
+        // the same layout as T.
         let data_to_drop = unsafe {
             std::mem::transmute::<&mut [MaybeUninit<ManuallyDrop<T>>], &mut ManuallyDrop<[T]>>(
                 &mut self.data[0..self.length],

--- a/compiler/hash-alloc/src/collections/string.rs
+++ b/compiler/hash-alloc/src/collections/string.rs
@@ -1,24 +1,25 @@
-//! Contains a [`String`]-like implementation for allocating strings within a [`Wall`].
-//!
+//! Contains a [`String`]-like implementation for allocating strings within a
+//! [`Wall`].
 
 use super::row::Row;
 use crate::Wall;
 use core::fmt;
-use std::borrow::Borrow;
-use std::hash::Hash;
-use std::ops::Deref;
+use std::{borrow::Borrow, hash::Hash, ops::Deref};
 
 /// A [`String`]-like implementation for allocating strings within a [`Wall`].
 ///
-/// This is generic over the castle `'c` lifetime, and implements `Deref<Target=str>`.
+/// This is generic over the castle `'c` lifetime, and implements
+/// `Deref<Target=str>`.
 ///
-/// It should mostly be used in the same way as [`String`], and uses a `Row<u8>` internally.
+/// It should mostly be used in the same way as [`String`], and uses a `Row<u8>`
+/// internally.
 pub struct BrickString<'c> {
     inner: Row<'c, u8>,
 }
 
 impl<'c> BrickString<'c> {
-    /// Create a new `BrickString` within the given [`Wall`], copying the given string value.
+    /// Create a new `BrickString` within the given [`Wall`], copying the given
+    /// string value.
     pub fn new(value: &str, wall: &Wall<'c>) -> Self {
         let mut brick_str = Self::with_capacity(value.len(), wall);
         for v in value.bytes() {
@@ -27,7 +28,8 @@ impl<'c> BrickString<'c> {
         brick_str
     }
 
-    /// Create an empty `BrickString` within the given [`Wall`] with a given capacity.
+    /// Create an empty `BrickString` within the given [`Wall`] with a given
+    /// capacity.
     pub fn with_capacity(initial_capacity: usize, wall: &Wall<'c>) -> Self {
         Self {
             inner: Row::with_capacity(initial_capacity, wall),
@@ -39,7 +41,8 @@ impl<'c> BrickString<'c> {
         self.inner.capacity()
     }
 
-    /// Reserve some capacity within the `BrickString` by reallocating inside the given [`Wall`].
+    /// Reserve some capacity within the `BrickString` by reallocating inside
+    /// the given [`Wall`].
     ///
     /// # Panics
     ///
@@ -55,8 +58,8 @@ impl<'c> BrickString<'c> {
 
     /// Produce a string reference to the data inside `self`, consuming self.
     ///
-    /// This is valid because the data is stored within the underlying [`crate::Castle`], which can
-    /// outlive `Self`.
+    /// This is valid because the data is stored within the underlying
+    /// [`crate::Castle`], which can outlive `Self`.
     pub fn into_str(self) -> &'c str {
         unsafe { std::str::from_utf8_unchecked(self.inner.into_slice()) }
     }

--- a/compiler/hash-alloc/src/collections/string.rs
+++ b/compiler/hash-alloc/src/collections/string.rs
@@ -31,9 +31,7 @@ impl<'c> BrickString<'c> {
     /// Create an empty `BrickString` within the given [`Wall`] with a given
     /// capacity.
     pub fn with_capacity(initial_capacity: usize, wall: &Wall<'c>) -> Self {
-        Self {
-            inner: Row::with_capacity(initial_capacity, wall),
-        }
+        Self { inner: Row::with_capacity(initial_capacity, wall) }
     }
 
     /// Get the current capacity of the `Row`.

--- a/compiler/hash-alloc/src/lib.rs
+++ b/compiler/hash-alloc/src/lib.rs
@@ -48,15 +48,15 @@ impl Castle {
 ///   pointer incrementation).
 ///
 /// * All allocations are very well spatially localised---they are arranged /
-///   sequentially in / memory. This means that traversing graph/tree structures
-///   allocated on the / [`Wall`] is very cache-friendly, as the elements will
-///   be right next to each / other.
+///   sequentially in memory. This means that traversing graph/tree structures
+///   allocated on the[`Wall`] is very cache-friendly, as the elements will be
+///   right next to each other.
 ///
 /// * All allocations live for the same amount of time, which is the lifetime of
-///   /   the underlying / [`Castle`]. However, values allocated inside a
-///   [`Wall`] can be dropped / because the allocations are wrapped in
-///   [`ManuallyDrop`]. For a more / ergonomic way of allocating values and
-///   collections, take a look at the / [`collections`] and [`brick`] modules.
+///   the underlying[`Castle`]. However, values allocated inside a [`Wall`] can
+///   be dropped because the allocations are wrapped in [`ManuallyDrop`]. For a
+///   more ergonomic way of allocating values and collections, take a look at
+///   the[`collections`] and [`brick`] modules.
 ///
 /// Currently, this is implemented using [`bumpalo`], but this will (probably) /
 /// change in the  future as the compiler acquires more niche requirements.

--- a/compiler/hash-alloc/src/lib.rs
+++ b/compiler/hash-alloc/src/lib.rs
@@ -67,9 +67,7 @@ pub struct Wall<'c> {
 
 impl std::fmt::Debug for Wall<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Wall")
-            .field("castle", &self.castle)
-            .finish()
+        f.debug_struct("Wall").field("castle", &self.castle).finish()
     }
 }
 
@@ -112,8 +110,7 @@ impl<'c> Wall<'c> {
     /// Despite the fact that `MaybeUninit` implies `ManuallyDrop`, Rust does
     /// not yet provide a stable way of in-place dropping a `MaybeUninit` (until [#63567](https://github.com/rust-lang/rust/issues/63567) lands).
     pub fn alloc_uninit_slice<T>(&self, len: usize) -> &'c mut [MaybeUninit<ManuallyDrop<T>>] {
-        self.member
-            .alloc_slice_fill_with(len, |_| MaybeUninit::uninit())
+        self.member.alloc_slice_fill_with(len, |_| MaybeUninit::uninit())
     }
 }
 
@@ -152,11 +149,8 @@ mod test {
             c: [Color; 3],
         }
 
-        const COMPLEX_VALUE: MyComplexStruct = MyComplexStruct {
-            a: 43,
-            b: 'R',
-            c: [Color::Red, Color::Green, Color::Blue],
-        };
+        const COMPLEX_VALUE: MyComplexStruct =
+            MyComplexStruct { a: 43, b: 'R', c: [Color::Red, Color::Green, Color::Blue] };
 
         let castle = Castle::new();
         let wall = castle.wall();
@@ -181,9 +175,8 @@ mod test {
             *v = MaybeUninit::new(ManuallyDrop::new(i.pow(2)));
         }
 
-        let mut values_eq = (0..ARRAY_SIZE)
-            .map(|i| ManuallyDrop::new(i.pow(2)))
-            .collect::<Vec<_>>();
+        let mut values_eq =
+            (0..ARRAY_SIZE).map(|i| ManuallyDrop::new(i.pow(2))).collect::<Vec<_>>();
 
         assert_eq!(
             unsafe {

--- a/compiler/hash-alloc/src/lib.rs
+++ b/compiler/hash-alloc/src/lib.rs
@@ -47,21 +47,18 @@ impl Castle {
 /// * Cost of allocation is really tiny (just an integer comparison and a
 ///   pointer incrementation).
 ///
-/// * All allocations are very well spatially localised---they are arranged
-///   sequentially in
-/// memory. This means that traversing graph/tree structures allocated on the
-/// [`Wall`] is very cache-friendly, as the elements will be right next to each
-/// other.
+/// * All allocations are very well spatially localised---they are arranged /
+///   sequentially in / memory. This means that traversing graph/tree structures
+///   allocated on the / [`Wall`] is very cache-friendly, as the elements will
+///   be right next to each / other.
 ///
 /// * All allocations live for the same amount of time, which is the lifetime of
-///   the underlying
-/// [`Castle`]. However, values allocated inside a [`Wall`] can be dropped
-/// because the allocations are wrapped in [`ManuallyDrop`]. For a more
-/// ergonomic way of allocating values and collections, take a look at the
-/// [`collections`] and [`brick`] modules.
+///   /   the underlying / [`Castle`]. However, values allocated inside a
+///   [`Wall`] can be dropped / because the allocations are wrapped in
+///   [`ManuallyDrop`]. For a more / ergonomic way of allocating values and
+///   collections, take a look at the / [`collections`] and [`brick`] modules.
 ///
-///
-///  Currently, this is implemented using [`bumpalo`], but this will (probably)
+/// Currently, this is implemented using [`bumpalo`], but this will (probably) /
 /// change in the  future as the compiler acquires more niche requirements.
 pub struct Wall<'c> {
     castle: &'c Castle,

--- a/compiler/hash-alloc/src/lib.rs
+++ b/compiler/hash-alloc/src/lib.rs
@@ -1,5 +1,4 @@
 //! Arena allocator implementation for use within the Hash compiler sources.
-//!
 
 pub mod brick;
 pub mod collections;
@@ -8,13 +7,14 @@ use std::mem::{ManuallyDrop, MaybeUninit};
 
 /// The root primitive of arena allocation.
 ///
-/// A `Castle` can create [`Wall`]s, which in turn can allocate values onto an arena. The existence
-/// of these two primitives, rather than a single one, is due to the requirement of thread-safety
-/// in memory allocation. Each [`Wall`] in a `Castle` lives inside its own thread, and it cannot
-/// cross thread boundaries (although the allocations themselves can).
+/// A `Castle` can create [`Wall`]s, which in turn can allocate values onto an
+/// arena. The existence of these two primitives, rather than a single one, is
+/// due to the requirement of thread-safety in memory allocation. Each [`Wall`]
+/// in a `Castle` lives inside its own thread, and it cannot cross thread
+/// boundaries (although the allocations themselves can).
 ///
-/// This means that there is no need to acquire any mutex or lock whenever an allocation occurs,
-/// but this is needed when a new [`Wall`] is created.
+/// This means that there is no need to acquire any mutex or lock whenever an
+/// allocation occurs, but this is needed when a new [`Wall`] is created.
 #[derive(Default)]
 pub struct Castle {
     herd: bumpalo_herd::Herd,
@@ -27,14 +27,14 @@ impl std::fmt::Debug for Castle {
 }
 
 impl Castle {
-    /// Create a new [`Castle`]. All values allocated within [`Wall`]s created from this castle
-    /// will be dropped once the `Castle` is dropped.
+    /// Create a new [`Castle`]. All values allocated within [`Wall`]s created
+    /// from this castle will be dropped once the `Castle` is dropped.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a new [`Wall`] inside this `Castle`. The created [`Wall`] lives as long as the
-    /// reference to this `Castle`.
+    /// Create a new [`Wall`] inside this `Castle`. The created [`Wall`] lives
+    /// as long as the reference to this `Castle`.
     pub fn wall(&self) -> Wall {
         Wall::with_member(self.herd.get(), self)
     }
@@ -44,20 +44,25 @@ impl Castle {
 ///
 /// Some features of this style of allocation:
 ///
-/// * Cost of allocation is really tiny (just an integer comparison and a pointer incrementation).
+/// * Cost of allocation is really tiny (just an integer comparison and a
+///   pointer incrementation).
 ///
-/// * All allocations are very well spatially localised---they are arranged sequentially in
-/// memory. This means that traversing graph/tree structures allocated on the [`Wall`] is very
-/// cache-friendly, as the elements will be right next to each other.
+/// * All allocations are very well spatially localised---they are arranged
+///   sequentially in
+/// memory. This means that traversing graph/tree structures allocated on the
+/// [`Wall`] is very cache-friendly, as the elements will be right next to each
+/// other.
 ///
-/// * All allocations live for the same amount of time, which is the lifetime of the underlying
-/// [`Castle`]. However, values allocated inside a [`Wall`] can be dropped because the allocations
-/// are wrapped in [`ManuallyDrop`]. For a more ergonomic way of allocating values and collections,
-/// take a look at the [`collections`] and [`brick`] modules.
+/// * All allocations live for the same amount of time, which is the lifetime of
+///   the underlying
+/// [`Castle`]. However, values allocated inside a [`Wall`] can be dropped
+/// because the allocations are wrapped in [`ManuallyDrop`]. For a more
+/// ergonomic way of allocating values and collections, take a look at the
+/// [`collections`] and [`brick`] modules.
 ///
 ///
-///  Currently, this is implemented using [`bumpalo`], but this will (probably) change in the
-///  future as the compiler acquires more niche requirements.
+///  Currently, this is implemented using [`bumpalo`], but this will (probably)
+/// change in the  future as the compiler acquires more niche requirements.
 pub struct Wall<'c> {
     castle: &'c Castle,
     member: bumpalo_herd::Member<'c>,
@@ -79,8 +84,9 @@ impl<'c> Wall<'c> {
         castle.wall()
     }
 
-    /// *Bumpalo-specific*: create a wall with the given [`bumpalo_herd::Member`], which is the
-    /// underlying `bumpalo` primitive that [`Wall`] uses.
+    /// *Bumpalo-specific*: create a wall with the given
+    /// [`bumpalo_herd::Member`], which is the underlying `bumpalo`
+    /// primitive that [`Wall`] uses.
     fn with_member(member: bumpalo_herd::Member<'c>, castle: &'c Castle) -> Self {
         Self { member, castle }
     }
@@ -92,28 +98,30 @@ impl<'c> Wall<'c> {
 
     /// Allocate a given value on the [`Wall`].
     ///
-    /// This returns a mutable reference to the given value, wrapped in [`ManuallyDrop`] which
-    /// allows one to drop the value even though it is still physically present in the arena. Keep
-    /// in mind that this sort of manually dropping is an unsafe operation.
+    /// This returns a mutable reference to the given value, wrapped in
+    /// [`ManuallyDrop`] which allows one to drop the value even though it
+    /// is still physically present in the arena. Keep in mind that this
+    /// sort of manually dropping is an unsafe operation.
     pub fn alloc_value<T>(&self, value: T) -> &'c mut ManuallyDrop<T> {
         self.member.alloc(ManuallyDrop::new(value))
     }
 
     /// Allocate an uninitialised slice on the [`Wall`] with the given length.
     ///
-    /// This returns a mutable reference to the allocated slice, wrapped in [`MaybeUninit`] and
-    /// [`ManuallyDrop`]. All the values are initially set to `MaybeUninit::uninit()`.
+    /// This returns a mutable reference to the allocated slice, wrapped in
+    /// [`MaybeUninit`] and [`ManuallyDrop`]. All the values are initially
+    /// set to `MaybeUninit::uninit()`.
     ///
-    /// Despite the fact that `MaybeUninit` implies `ManuallyDrop`, Rust does not yet provide a stable
-    /// way of in-place dropping a `MaybeUninit` (until [#63567](https://github.com/rust-lang/rust/issues/63567) lands).
+    /// Despite the fact that `MaybeUninit` implies `ManuallyDrop`, Rust does
+    /// not yet provide a stable way of in-place dropping a `MaybeUninit` (until [#63567](https://github.com/rust-lang/rust/issues/63567) lands).
     pub fn alloc_uninit_slice<T>(&self, len: usize) -> &'c mut [MaybeUninit<ManuallyDrop<T>>] {
         self.member
             .alloc_slice_fill_with(len, |_| MaybeUninit::uninit())
     }
 }
 
-// We will probably need more tests here once we replace bumpalo with a custom implementation
-// again.
+// We will probably need more tests here once we replace bumpalo with a custom
+// implementation again.
 #[cfg(test)]
 mod test {
     use super::*;

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -411,11 +411,11 @@ fn desugar_if_clause(node: AstNode<IfClause>) -> AstNode<MatchCase> {
 /// }
 /// ```
 ///
-/// This is done so that the typechecker can perform that the whole
-/// block returns the same type. If the previous branches do not return
-/// anything, omitting an `else` case is ok and this will pass later stages,
-/// however when an if block returns something from a previous branch, then
-/// this will fail compilation and it will be reported.
+/// This is done so that the typechecker can perform that the whole block
+/// returns the same type. If the previous branches do not return anything,
+/// omitting an `else` case is ok and this will pass later stages,however
+/// when an if block returns something from a previous branch, then this will
+/// fail compilation and it will be reported.
 ///
 /// @@Note: We could just add some flag on the match-case to say that when it
 /// was lowered from a if-block, it was missing an else case, and this would
@@ -463,12 +463,11 @@ fn desugar_if_block(node: Block, parent_span: Span) -> Block {
         )
     } else {
         // @@Hack: We don't have a span for the branch, so we rely on using the span of
-        // the         entire if-clause. This might not be the exactly right
-        // approach because some         later checks (within typechecking)
-        // might report errors that are related to a         missing else-branch
-        // because the return type of the block doesn't become the same
-        //         anymore. Therefore, we might later want to re-think which span we use
-        // for         generating the else-branch.
+        // the entire if-clause. This might not be the exactly right approach because
+        // some later checks (within typechecking) might report errors that are related
+        // to a missing else-branch because the return type of the block doesn't become
+        // the same anymore. Therefore, we might later want to re-think which span we
+        // use for generating the else-branch.
         AstNode::new(
             MatchCase {
                 pattern: AstNode::new(Pattern::Ignore(IgnorePattern), parent_span),

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -1,7 +1,7 @@
 //! Hash AST lowering passes crate. This crate holds an implementation for the
-//! visitor pattern on the AST in order to `lower` it to a simpler version so that
-//! later stages can work on it without having to operate on similar constructs and
-//! duplicating logic.
+//! visitor pattern on the AST in order to `lower` it to a simpler version so
+//! that later stages can work on it without having to operate on similar
+//! constructs and duplicating logic.
 #![feature(generic_associated_types)]
 
 use hash_ast::{
@@ -44,11 +44,12 @@ impl<'pool> Desugar<'pool> for AstDesugaring {
     /// the loop breaks, otherwise the body of the while-loop is executed.
     ///
     /// Any if-statements are transformed into equivalent match cases by using
-    /// the "if-guard" pattern to express all of the branches in the if-statement.
+    /// the "if-guard" pattern to express all of the branches in the
+    /// if-statement.
     ///
-    /// This function utilised the pipeline thread pool in order to make the transformations
-    /// as parallel as possible. There is a queue that is queues all of the expressions within
-    /// each [hash_ast::ast::Module].
+    /// This function utilised the pipeline thread pool in order to make the
+    /// transformations as parallel as possible. There is a queue that is
+    /// queues all of the expressions within each [hash_ast::ast::Module].
     fn desugar(
         &mut self,
         entry_point: SourceId,
@@ -77,13 +78,13 @@ impl<'pool> Desugar<'pool> for AstDesugaring {
                 }
 
                 // @@Future: So here, it would be nice that the de-sugaring visitor could have a
-                //           context that has access to the pool so that it could just push other jobs into
-                //           the queue rather than only splitting the job by top-level expressions.
-                //           This would work by the visitor pushing expressions into the work queue
-                //           whenever it hits body-blocks that have a list of expressions. This would
-                //           definitely make this process even faster, but it might add overhead to the
-                //           process of adding these items to the queue. However, it might be worth
-                //           investigating this in the future.
+                // context that has access to the pool so that it could just push other jobs
+                // into the queue rather than only splitting the job by top-level expressions.
+                // This would work by the visitor pushing expressions into the work queue
+                // whenever it hits body-blocks that have a list of expressions. This would
+                // definitely make this process even faster, but it might add overhead to the
+                // process of adding these items to the queue. However, it might be worth
+                // investigating this in the future.
                 for expr in module.node_mut().contents.iter_mut() {
                     scope.spawn(|_| {
                         AstDesugaring
@@ -126,8 +127,8 @@ impl<'pool> Desugar<'pool> for AstDesugaring {
 /// }
 /// ```
 ///
-/// So essentially the for-loop becomes a simple loop with a match block on the given
-/// iterator since for-loops only support iterators.
+/// So essentially the for-loop becomes a simple loop with a match block on the
+/// given iterator since for-loops only support iterators.
 fn desugar_for_loop_block(node: Block, parent_span: Span) -> Block {
     // Since this function expects it to be a for-loop block, we match it and unwrap
     let block = match node {
@@ -263,8 +264,8 @@ fn desugar_for_loop_block(node: Block, parent_span: Span) -> Block {
 /// The de-sugaring process is similar to the for-loop de-sugaring
 /// process. The condition that is specified for the while-loop to continue
 /// executing is treated like a matchable pattern, and then matched on whether
-/// if it is true or not. If it is true, the body block is executed, otherwise the loop
-/// breaks.
+/// if it is true or not. If it is true, the body block is executed, otherwise
+/// the loop breaks.
 fn desugar_while_loop_block(node: Block, parent_span: Span) -> Block {
     // Since this function expects it to be a for-loop block, we match it and unwrap
     let block = match node {
@@ -315,10 +316,10 @@ fn desugar_while_loop_block(node: Block, parent_span: Span) -> Block {
     )))
 }
 
-/// This function converts a [AstNode<IfClause>] into a [AstNode<MatchCase>]. This
-/// is part of the de-sugaring process for if-statements. Each branch in the
-/// if-block is converted into a branch within a match block using the `if-guard`
-/// pattern.
+/// This function converts a [AstNode<IfClause>] into a [AstNode<MatchCase>].
+/// This is part of the de-sugaring process for if-statements. Each branch in
+/// the if-block is converted into a branch within a match block using the
+/// `if-guard` pattern.
 ///
 /// For example, take the branch:
 ///
@@ -361,11 +362,11 @@ fn desugar_if_clause(node: AstNode<IfClause>) -> AstNode<MatchCase> {
     )
 }
 
-/// This function is responsible for de-sugaring an if-block into a match case. This
-/// function converts a [IfBlock] into a [MatchBlock]. This is not obvious from the
-/// function definition because it accepts a [Block], not specifically a [IfBlock].
-/// This is because it operates by using [AstNode<T>::replace] in order to convert
-/// the if-block into a match-block.
+/// This function is responsible for de-sugaring an if-block into a match case.
+/// This function converts a [IfBlock] into a [MatchBlock]. This is not obvious
+/// from the function definition because it accepts a [Block], not specifically
+/// a [IfBlock]. This is because it operates by using [AstNode<T>::replace] in
+/// order to convert the if-block into a match-block.
 ///
 /// The de-sugaring process is as follows, take the following if block:
 ///
@@ -381,19 +382,21 @@ fn desugar_if_clause(node: AstNode<IfClause>) -> AstNode<MatchCase> {
 ///     _ if b => b_branch
 ///     _ => c_branch
 /// }
-///```
+/// ```
 ///
-/// The condition of the if-branch is converted into a [hash_ast::ast::MatchCase] by using
-/// the `if-guard` pattern with the condition being the guard. As can be seen in the example,
-/// the condition that the match-block is matching is `true`. This is essentially a filler for
-/// the de-sugaring process and will be optimised out. This process is done so that the
-/// later stages of the compiler don't need to deal with multiple constructs that resemble
-/// each other in functionality. An if-block is de-sugared into a match-block because it
-/// captures all of the features of an if-block, but the relationship is not mutual and thus
-/// converting to a match-block is the only case.
+/// The condition of the if-branch is converted into a
+/// [hash_ast::ast::MatchCase] by using the `if-guard` pattern with the
+/// condition being the guard. As can be seen in the example, the condition that
+/// the match-block is matching is `true`. This is essentially a filler for
+/// the de-sugaring process and will be optimised out. This process is done so
+/// that the later stages of the compiler don't need to deal with multiple
+/// constructs that resemble each other in functionality. An if-block is
+/// de-sugared into a match-block because it captures all of the features of an
+/// if-block, but the relationship is not mutual and thus converting to a
+/// match-block is the only case.
 ///
-/// In the event that there is no `else` branch, this function will add a default branch that
-/// adds a default branch with an empty block like so:
+/// In the event that there is no `else` branch, this function will add a
+/// default branch that adds a default branch with an empty block like so:
 ///
 /// ```text
 /// if x == 3 { <body> }
@@ -414,12 +417,12 @@ fn desugar_if_clause(node: AstNode<IfClause>) -> AstNode<MatchCase> {
 /// however when an if block returns something from a previous branch, then
 /// this will fail compilation and it will be reported.
 ///
-/// @@Note: We could just add some flag on the match-case to say that when
-///         it was lowered from a if-block, it was missing an else case, and this
-///         would mean we don't always have to add it. However, this might complicate
-///         things with pattern exhaustiveness because then there would be no base case
-///         branch, thus the exhaustiveness checking would also need to know about
-///         the omitted else branch.
+/// @@Note: We could just add some flag on the match-case to say that when it
+/// was lowered from a if-block, it was missing an else case, and this would
+/// mean we don't always have to add it. However, this might complicate things
+/// with pattern exhaustiveness because then there would be no base case branch,
+/// thus the exhaustiveness checking would also need to know about the omitted
+/// else branch.
 fn desugar_if_block(node: Block, parent_span: Span) -> Block {
     // Since this function expects it to be a for-loop block, we match it and unwrap
     let block = match node {
@@ -442,9 +445,9 @@ fn desugar_if_block(node: Block, parent_span: Span) -> Block {
         .map(desugar_if_clause)
         .collect::<Vec<_>>();
 
-    // Deal with the `otherwise` case, if there is no otherwise case then we can just
-    // push an ignore branch and the body of the else block, otherwise it is replaces by
-    // just an empty block
+    // Deal with the `otherwise` case, if there is no otherwise case then we can
+    // just push an ignore branch and the body of the else block, otherwise it
+    // is replaces by just an empty block
     let else_block = if let Some(block) = otherwise {
         let else_block_span = block.span();
 
@@ -459,12 +462,13 @@ fn desugar_if_block(node: Block, parent_span: Span) -> Block {
             else_block_span,
         )
     } else {
-        // @@Hack: We don't have a span for the branch, so we rely on using the span of the
-        //         entire if-clause. This might not be the exactly right approach because some
-        //         later checks (within typechecking) might report errors that are related to a
-        //         missing else-branch because the return type of the block doesn't become the same
-        //         anymore. Therefore, we might later want to re-think which span we use for
-        //         generating the else-branch.
+        // @@Hack: We don't have a span for the branch, so we rely on using the span of
+        // the         entire if-clause. This might not be the exactly right
+        // approach because some         later checks (within typechecking)
+        // might report errors that are related to a         missing else-branch
+        // because the return type of the block doesn't become the same
+        //         anymore. Therefore, we might later want to re-think which span we use
+        // for         generating the else-branch.
         AstNode::new(
             MatchCase {
                 pattern: AstNode::new(Pattern::Ignore(IgnorePattern), parent_span),
@@ -974,7 +978,8 @@ impl AstVisitorMut for AstDesugaring {
     ) -> Result<Self::BlockRet, Self::Error> {
         let parent_span = node.span();
 
-        // Check if this is a for, while, or if block and then apply the appropriate transformations.
+        // Check if this is a for, while, or if block and then apply the appropriate
+        // transformations.
         match node.body() {
             Block::For(_) => {
                 node.replace(|old| desugar_for_loop_block(old, parent_span));

--- a/compiler/hash-ast-passes/src/analysis/block.rs
+++ b/compiler/hash-ast-passes/src/analysis/block.rs
@@ -13,13 +13,15 @@ use crate::diagnostics::{error::AnalysisErrorKind, BlockOrigin};
 use super::SemanticAnalyser;
 
 impl SemanticAnalyser {
-    /// This function will verify that all of the given expressions are declarations. Additionally,
-    /// the function checks that all of the declarations within the scope do not attempt to
-    /// declare the binding to be `mutable` as this is disallowed.
+    /// This function will verify that all of the given expressions are
+    /// declarations. Additionally, the function checks that all of the
+    /// declarations within the scope do not attempt to declare the binding
+    /// to be `mutable` as this is disallowed.
     ///
     /// During the checking process, the function also collects the indices of
     /// the erroneous statements in the provided [AstNodes<Expression>]. This is
-    /// so that the caller can later 'skip' these statements when performing further checks.
+    /// so that the caller can later 'skip' these statements when performing
+    /// further checks.
     pub(crate) fn check_statements_are_declarative(
         &mut self,
         statements: &AstNodes<Expression>,

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -1,5 +1,5 @@
-//! Hash semantic analyser definitions. This file holds the [SemanticAnalyser] definition
-//! with some shared functions to append diagnostics to the analyser.
+//! Hash semantic analyser definitions. This file holds the [SemanticAnalyser]
+//! definition with some shared functions to append diagnostics to the analyser.
 
 use crossbeam_channel::Sender;
 use hash_source::{
@@ -27,7 +27,8 @@ pub struct SemanticAnalyser {
     pub(crate) warnings: Vec<AnalysisWarning>,
     /// The current id of the source that is being passed.
     pub(crate) source_id: SourceId,
-    /// The current scope of the traversal, representing which block the analyser is walking.
+    /// The current scope of the traversal, representing which block the
+    /// analyser is walking.
     pub(crate) current_block: BlockOrigin,
 }
 
@@ -44,8 +45,9 @@ impl SemanticAnalyser {
         }
     }
 
-    /// Function to check whether the current traversal state is within a constant block.
-    /// This means that the [BlockOrigin] is currently not set to [BlockOrigin::Body].
+    /// Function to check whether the current traversal state is within a
+    /// constant block. This means that the [BlockOrigin] is currently not
+    /// set to [BlockOrigin::Body].
     #[inline]
     pub(crate) fn is_in_constant_block(&self) -> bool {
         !matches!(self.current_block, BlockOrigin::Body)
@@ -67,7 +69,8 @@ impl SemanticAnalyser {
         ))
     }
 
-    /// Given a [Sender], send all of the generated warnings and messaged into the sender.
+    /// Given a [Sender], send all of the generated warnings and messaged into
+    /// the sender.
     pub(crate) fn send_generated_messages(self, sender: &Sender<Diagnostic>) {
         self.errors
             .into_iter()

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -55,26 +55,18 @@ impl SemanticAnalyser {
 
     /// Append an error to the error queue.
     pub(crate) fn append_error(&mut self, error: AnalysisErrorKind, span: Span) {
-        self.errors.push(AnalysisError::new(
-            error,
-            SourceLocation::new(span, self.source_id),
-        ))
+        self.errors.push(AnalysisError::new(error, SourceLocation::new(span, self.source_id)))
     }
 
     /// Append an warning to the warning queue.
     pub(crate) fn append_warning(&mut self, warning: AnalysisWarningKind, span: Span) {
-        self.warnings.push(AnalysisWarning::new(
-            warning,
-            SourceLocation::new(span, self.source_id),
-        ))
+        self.warnings.push(AnalysisWarning::new(warning, SourceLocation::new(span, self.source_id)))
     }
 
     /// Given a [Sender], send all of the generated warnings and messaged into
     /// the sender.
     pub(crate) fn send_generated_messages(self, sender: &Sender<Diagnostic>) {
-        self.errors
-            .into_iter()
-            .for_each(|err| sender.send(Diagnostic::Error(err)).unwrap());
+        self.errors.into_iter().for_each(|err| sender.send(Diagnostic::Error(err)).unwrap());
 
         self.warnings
             .into_iter()

--- a/compiler/hash-ast-passes/src/analysis/pat.rs
+++ b/compiler/hash-ast-passes/src/analysis/pat.rs
@@ -68,8 +68,8 @@ impl SemanticAnalyser {
     /// ambiguous and should be disallowed within the list patten.
     pub(crate) fn check_list_pattern(&mut self, fields: &AstNodes<Pattern>) {
         // @@TODO: Rather than use a boolean, we should use a reference to the pattern
-        //         so that we can report an auxiliary span of where the initial use of
-        // the         pattern occurs.
+        // so that we can report an auxiliary span of where the initial use of the
+        // pattern occurs.
         let mut seen_spread_pattern = false;
 
         for field in fields.iter() {

--- a/compiler/hash-ast-passes/src/analysis/pat.rs
+++ b/compiler/hash-ast-passes/src/analysis/pat.rs
@@ -76,9 +76,7 @@ impl SemanticAnalyser {
             if matches!(field.body(), Pattern::Spread(_)) {
                 if seen_spread_pattern {
                     self.append_error(
-                        AnalysisErrorKind::MultipleSpreadPatterns {
-                            origin: PatternOrigin::List,
-                        },
+                        AnalysisErrorKind::MultipleSpreadPatterns { origin: PatternOrigin::List },
                         field.span(),
                     );
                 } else {

--- a/compiler/hash-ast-passes/src/analysis/pat.rs
+++ b/compiler/hash-ast-passes/src/analysis/pat.rs
@@ -52,23 +52,24 @@ impl SemanticAnalyser {
         }
     }
 
-    /// Here we need to check that the list pattern only contains a single spread pattern since
-    /// it wouldn't make sense for there to be multiple spread patterns. This is primarily because
-    /// having multiple spreads would introduce ambiguity about which elements are captured by the spread.
-    /// For example in the following pattern:
+    /// Here we need to check that the list pattern only contains a single
+    /// spread pattern since it wouldn't make sense for there to be multiple
+    /// spread patterns. This is primarily because having multiple spreads
+    /// would introduce ambiguity about which elements are captured by the
+    /// spread. For example in the following pattern:
     /// ```ignore
     /// >>> [..., ...x]
     /// ```
     ///
-    /// Note: this isn't the only case that is erroneous, in general any list pattern with multiple
-    /// spread patterns is considered to be incorrect.
+    /// Note: this isn't the only case that is erroneous, in general any list
+    /// pattern with multiple spread patterns is considered to be incorrect.
     ///
-    /// Which parts does the `x` spread pattern capture? It's clear that this is ambiguous and should
-    /// be disallowed within the list patten.
+    /// Which parts does the `x` spread pattern capture? It's clear that this is
+    /// ambiguous and should be disallowed within the list patten.
     pub(crate) fn check_list_pattern(&mut self, fields: &AstNodes<Pattern>) {
         // @@TODO: Rather than use a boolean, we should use a reference to the pattern
-        //         so that we can report an auxiliary span of where the initial use of the
-        //         pattern occurs.
+        //         so that we can report an auxiliary span of where the initial use of
+        // the         pattern occurs.
         let mut seen_spread_pattern = false;
 
         for field in fields.iter() {

--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -57,10 +57,7 @@ pub(crate) enum AnalysisErrorKind {
     IllegalBindingMutability,
     /// When bindings declare themselves to be `pub` or `priv` within
     /// non-constant blocks like function bodies.
-    IllegalBindingVisibilityModifier {
-        modifier: Visibility,
-        origin: BlockOrigin,
-    },
+    IllegalBindingVisibilityModifier { modifier: Visibility, origin: BlockOrigin },
 }
 
 impl From<AnalysisError> for Report {
@@ -72,22 +69,16 @@ impl From<AnalysisError> for Report {
             AnalysisErrorKind::UsingBreakOutsideLoop => {
                 builder.with_error_code(HashErrorCode::UsingBreakOutsideLoop);
 
-                builder
-                    .with_message("use of a `break` clause outside of a loop")
-                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        err.location,
-                        "here",
-                    )));
+                builder.with_message("use of a `break` clause outside of a loop").add_element(
+                    ReportElement::CodeBlock(ReportCodeBlock::new(err.location, "here")),
+                );
             }
             AnalysisErrorKind::UsingContinueOutsideLoop => {
                 builder.with_error_code(HashErrorCode::UsingContinueOutsideLoop);
 
-                builder
-                    .with_message("use of a `continue` clause outside of a loop")
-                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        err.location,
-                        "here",
-                    )));
+                builder.with_message("use of a `continue` clause outside of a loop").add_element(
+                    ReportElement::CodeBlock(ReportCodeBlock::new(err.location, "here")),
+                );
             }
             AnalysisErrorKind::UsingReturnOutsideOfFunction => {
                 builder.with_error_code(HashErrorCode::UsingReturnOutsideFunction);
@@ -162,10 +153,7 @@ impl From<AnalysisError> for Report {
                 builder
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         err.location,
-                        format!(
-                            "{} blocks cannot have `{}` explicit visibility",
-                            origin, modifier
-                        ),
+                        format!("{} blocks cannot have `{}` explicit visibility", origin, modifier),
                     )))
                     .add_element(ReportElement::Note(ReportNote::new(
                         ReportNoteKind::Note,

--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -32,30 +32,31 @@ pub(crate) enum AnalysisErrorKind {
     UsingBreakOutsideLoop,
     /// When a `continue` expression is found outside of a loop.
     UsingContinueOutsideLoop,
-    /// When a `return` statement is found outside of a function or in scope that doesn't relate
-    /// to the function.
+    /// When a `return` statement is found outside of a function or in scope
+    /// that doesn't relate to the function.
     UsingReturnOutsideOfFunction,
-    /// When there is a non-declarative expression in either the root scope (module) or in a
-    /// `impl` / `mod` block.
+    /// When there is a non-declarative expression in either the root scope
+    /// (module) or in a `impl` / `mod` block.
     NonDeclarativeExpression { origin: BlockOrigin },
     /// When multiple spread patterns `...` are present within a list pattern
     MultipleSpreadPatterns {
         /// Where the use of the pattern originated from
         origin: PatternOrigin,
     },
-    /// When a spread pattern is used within a parent pattern that does not allow them to be used.
+    /// When a spread pattern is used within a parent pattern that does not
+    /// allow them to be used.
     IllegalSpreadPatternUse {
         /// Where the use of the pattern originated from
         origin: PatternOrigin,
     },
-    /// When compound patterns such as constructors and tuples have named fields before un-named
-    /// fields.
+    /// When compound patterns such as constructors and tuples have named fields
+    /// before un-named fields.
     AmbiguousPatternFieldOrder { origin: PatternOrigin },
     /// When a top-level declaration features a pattern that has a binding which
     /// is declared to be mutable.
     IllegalBindingMutability,
-    /// When bindings declare themselves to be `pub` or `priv` within non-constant blocks
-    /// like function bodies.
+    /// When bindings declare themselves to be `pub` or `priv` within
+    /// non-constant blocks like function bodies.
     IllegalBindingVisibilityModifier {
         modifier: Visibility,
         origin: BlockOrigin,

--- a/compiler/hash-ast-passes/src/diagnostics/mod.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/mod.rs
@@ -7,9 +7,10 @@ use std::fmt::Display;
 pub(crate) mod error;
 pub(crate) mod warning;
 
-/// Denotes where a pattern was used as in the parent of the pattern. This is useful
-/// for propagating errors upwards by signalling what is the current parent of the
-/// pattern. This only contains patterns that can be compound (hold multiple children patterns).
+/// Denotes where a pattern was used as in the parent of the pattern. This is
+/// useful for propagating errors upwards by signalling what is the current
+/// parent of the pattern. This only contains patterns that can be compound
+/// (hold multiple children patterns).
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum PatternOrigin {
     Tuple,
@@ -20,8 +21,8 @@ pub(crate) enum PatternOrigin {
 }
 
 impl PatternOrigin {
-    /// Convert the [PatternOrigin] into a string which can be used for displaying
-    /// within error messages.
+    /// Convert the [PatternOrigin] into a string which can be used for
+    /// displaying within error messages.
     fn to_str(self) -> &'static str {
         match self {
             PatternOrigin::Tuple => "tuple",
@@ -40,8 +41,8 @@ impl Display for PatternOrigin {
 }
 
 /// Denotes where an error occurred from which type of block. This is useful
-/// when giving more context about errors such as [AnalysisErrorKind::NonDeclarativeExpression]
-/// occur from.
+/// when giving more context about errors such as
+/// [AnalysisErrorKind::NonDeclarativeExpression] occur from.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum BlockOrigin {
     Root,

--- a/compiler/hash-ast-passes/src/lib.rs
+++ b/compiler/hash-ast-passes/src/lib.rs
@@ -21,20 +21,23 @@ use std::collections::HashSet;
 pub struct HashSemanticAnalysis;
 
 impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
-    /// A store representing modules that have already been analysed in the current pipeline.
+    /// A store representing modules that have already been analysed in the
+    /// current pipeline.
     type State = HashSet<SourceId>;
 
     fn make_state(&mut self) -> CompilerResult<Self::State> {
         Ok(HashSet::default())
     }
 
-    /// This will perform a pass on the AST by checking the semantic rules that are within
-    /// the language specification. The function will attempt to perform a pass on the
-    /// `entry_point` which happens on the main thread. The target may be either an interactive
-    /// block or a module. A pass is performed and then remaining modules are processed if they
-    /// have not already been processed. This is a sound implementation because it always considers
-    /// the `entry_point` which might not always occur within the modules map. Each time the pipeline
-    /// runs (in the interactive case), the most recent block is always passed.
+    /// This will perform a pass on the AST by checking the semantic rules that
+    /// are within the language specification. The function will attempt to
+    /// perform a pass on the `entry_point` which happens on the main
+    /// thread. The target may be either an interactive block or a module. A
+    /// pass is performed and then remaining modules are processed if they
+    /// have not already been processed. This is a sound implementation because
+    /// it always considers the `entry_point` which might not always occur
+    /// within the modules map. Each time the pipeline runs (in the
+    /// interactive case), the most recent block is always passed.
     fn perform_pass(
         &mut self,
         entry_point: SourceId,

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -1,7 +1,7 @@
 //! Visitor pattern for the semantic analysis stage. This file implements
-//! the [AstVisitor] pattern on the AST for [SemanticAnalyser]. During traversal, the
-//! visitor calls various functions that are defined on the analyser to perform
-//! a variety of semantic checks.
+//! the [AstVisitor] pattern on the AST for [SemanticAnalyser]. During
+//! traversal, the visitor calls various functions that are defined on the
+//! analyser to perform a variety of semantic checks.
 
 use std::{collections::HashSet, convert::Infallible, mem};
 
@@ -145,7 +145,8 @@ impl AstVisitor for SemanticAnalyser {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallArgs>,
     ) -> Result<Self::ConstructorCallArgsRet, Self::Error> {
         // Here we don't validate ordering of arguments because this is done later
-        // at typechecking when we can give more context about the problem (if there is one).
+        // at typechecking when we can give more context about the problem (if there is
+        // one).
 
         let _ = walk::walk_constructor_call_args(self, ctx, node);
         Ok(())
@@ -689,8 +690,9 @@ impl AstVisitor for SemanticAnalyser {
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::BodyBlock>,
     ) -> Result<Self::BodyBlockRet, Self::Error> {
-        // Iterate over the statements in a body block to check if there are any 'useless'
-        // expressions... a literal that is constant of made of other constant literals
+        // Iterate over the statements in a body block to check if there are any
+        // 'useless' expressions... a literal that is constant of made of other
+        // constant literals
         for statement in node.statements.iter() {
             match statement.kind() {
                 ExpressionKind::LiteralExpr(LiteralExpr(lit)) if lit.body().is_constant() => {
@@ -921,7 +923,8 @@ impl AstVisitor for SemanticAnalyser {
 
     type ConstructorPatternRet = ();
 
-    /// This function verifies that constructor patterns adhere to the following rules:
+    /// This function verifies that constructor patterns adhere to the following
+    /// rules:
     ///
     /// - All named fields must after before any nameless fields.
     ///
@@ -975,7 +978,8 @@ impl AstVisitor for SemanticAnalyser {
 
     type TuplePatternRet = ();
 
-    /// This function verifies that tuple patterns adhere to the following rules:
+    /// This function verifies that tuple patterns adhere to the following
+    /// rules:
     ///
     /// - All named fields must after before any nameless fields.
     ///
@@ -1101,10 +1105,10 @@ impl AstVisitor for SemanticAnalyser {
             ..
         } = node.body();
 
-        // If the pattern is present in a declaration that is within a constant block, it
-        // it not allowed to be declared to be mutable. If we are not in a constant scope, then
-        // we should check if binding contains a visibility modifier which is disallowed within
-        // body blocks.
+        // If the pattern is present in a declaration that is within a constant block,
+        // it it not allowed to be declared to be mutable. If we are not in a
+        // constant scope, then we should check if binding contains a visibility
+        // modifier which is disallowed within body blocks.
         if self.is_in_constant_block() {
             if let Some(node) = mutability {
                 if *node.body() == Mutability::Mutable {

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -963,9 +963,7 @@ impl AstVisitor for SemanticAnalyser {
         // Spread patterns are always disallowed within a named field entry
         if name.is_some() && matches!(pattern.body(), Pattern::Spread(_)) {
             self.append_error(
-                AnalysisErrorKind::IllegalSpreadPatternUse {
-                    origin: PatternOrigin::NamedField,
-                },
+                AnalysisErrorKind::IllegalSpreadPatternUse { origin: PatternOrigin::NamedField },
                 pattern.span(),
             );
         } else {
@@ -1099,11 +1097,7 @@ impl AstVisitor for SemanticAnalyser {
         _: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::BindingPattern>,
     ) -> Result<Self::BindingPatternRet, Self::Error> {
-        let BindingPattern {
-            mutability,
-            visibility,
-            ..
-        } = node.body();
+        let BindingPattern { mutability, visibility, .. } = node.body();
 
         // If the pattern is present in a declaration that is within a constant block,
         // it it not allowed to be declared to be mutable. If we are not in a
@@ -1160,9 +1154,7 @@ impl AstVisitor for SemanticAnalyser {
         // Spread patterns are always disallowed within a named field entry
         if matches!(pattern.body(), Pattern::Spread(_)) {
             self.append_error(
-                AnalysisErrorKind::IllegalSpreadPatternUse {
-                    origin: PatternOrigin::Namespace,
-                },
+                AnalysisErrorKind::IllegalSpreadPatternUse { origin: PatternOrigin::Namespace },
                 pattern.span(),
             );
         } else {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -36,11 +36,7 @@ impl<T> PartialEq for AstNode<T> {
 impl<T> AstNode<T> {
     /// Create a new node with a given body and location.
     pub fn new(body: T, span: Span) -> Self {
-        Self {
-            body: Box::new(body),
-            span,
-            id: AstNodeId::new(),
-        }
+        Self { body: Box::new(body), span, id: AstNodeId::new() }
     }
 
     /// Get a reference to the body contained within this node.
@@ -69,30 +65,18 @@ impl<T> AstNode<T> {
 
     /// Create an [AstNodeRef] from this [AstNode].
     pub fn ast_ref(&self) -> AstNodeRef<T> {
-        AstNodeRef {
-            body: self.body.as_ref(),
-            span: self.span,
-            id: self.id,
-        }
+        AstNodeRef { body: self.body.as_ref(), span: self.span, id: self.id }
     }
 
     /// Create an [AstNodeRefMut] from this [AstNode].
     pub fn ast_ref_mut(&mut self) -> AstNodeRefMut<T> {
-        AstNodeRefMut {
-            body: self.body.as_mut(),
-            span: self.span,
-            id: self.id,
-        }
+        AstNodeRefMut { body: self.body.as_mut(), span: self.span, id: self.id }
     }
 
     /// Create an [AstNodeRef] by providing a body and copying over the
     /// [Span] and [AstNodeId] that belong to this [AstNode].
     pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
-        AstNodeRef {
-            body,
-            span: self.span,
-            id: self.id,
-        }
+        AstNodeRef { body, span: self.span, id: self.id }
     }
 }
 
@@ -109,11 +93,7 @@ pub struct AstNodeRef<'t, T> {
 
 impl<T> Clone for AstNodeRef<'_, T> {
     fn clone(&self) -> Self {
-        Self {
-            body: self.body,
-            span: self.span,
-            id: self.id,
-        }
+        Self { body: self.body, span: self.span, id: self.id }
     }
 }
 
@@ -126,11 +106,7 @@ impl<'t, T> AstNodeRef<'t, T> {
     }
 
     pub fn with_body<'u, U>(&self, body: &'u U) -> AstNodeRef<'u, U> {
-        AstNodeRef {
-            body,
-            span: self.span,
-            id: self.id,
-        }
+        AstNodeRef { body, span: self.span, id: self.id }
     }
 
     /// Get the [Span] of this node in the input.
@@ -170,11 +146,7 @@ impl<'t, T> AstNodeRefMut<'t, T> {
     }
 
     pub fn with_body<'u, U>(&self, body: &'u mut U) -> AstNodeRefMut<'u, U> {
-        AstNodeRefMut {
-            body,
-            span: self.span,
-            id: self.id,
-        }
+        AstNodeRefMut { body, span: self.span, id: self.id }
     }
 
     /// Function to replace the body of the node with a newly generated body
@@ -232,10 +204,7 @@ macro_rules! ast_nodes {
 
 impl<T> AstNodes<T> {
     pub fn empty() -> Self {
-        Self {
-            nodes: vec![],
-            span: None,
-        }
+        Self { nodes: vec![], span: None }
     }
 
     pub fn new(nodes: Vec<AstNode<T>>, span: Option<Span>) -> Self {
@@ -251,8 +220,7 @@ impl<T> AstNodes<T> {
     }
 
     pub fn span(&self) -> Option<Span> {
-        self.span
-            .or_else(|| Some(self.nodes.first()?.span().join(self.nodes.last()?.span())))
+        self.span.or_else(|| Some(self.nodes.first()?.span().join(self.nodes.last()?.span())))
     }
 }
 
@@ -299,17 +267,11 @@ pub struct AccessName {
 
 impl AccessName {
     pub fn path(&self) -> Vec<Identifier> {
-        self.path
-            .iter()
-            .map(|part| *part.body())
-            .collect::<Vec<_>>()
+        self.path.iter().map(|part| *part.body()).collect::<Vec<_>>()
     }
 
     pub fn path_with_locations(&self) -> Vec<(Identifier, Span)> {
-        self.path
-            .iter()
-            .map(|part| (*part.body(), part.span()))
-            .collect::<Vec<_>>()
+        self.path.iter().map(|part| (*part.body(), part.span())).collect::<Vec<_>>()
     }
 }
 
@@ -537,9 +499,9 @@ impl Literal {
             Literal::List(ListLiteral { elements }) | Literal::Set(SetLiteral { elements }) => {
                 !elements.iter().any(|expr| !is_expr_literal_and_const(expr))
             }
-            Literal::Tuple(TupleLiteral { elements }) => !elements
-                .iter()
-                .any(|entry| !is_expr_literal_and_const(&entry.body().value)),
+            Literal::Tuple(TupleLiteral { elements }) => {
+                !elements.iter().any(|entry| !is_expr_literal_and_const(&entry.body().value))
+            }
             Literal::Map(MapLiteral { elements }) => !elements.iter().any(|entry| {
                 !is_expr_literal_and_const(&entry.body().key)
                     || !is_expr_literal_and_const(&entry.body().value)

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1,12 +1,14 @@
 //! Frontend-agnostic Hash AST (abstract syntax tree) type definitions.
 
-use hash_source::location::Span;
-use hash_source::{identifier::Identifier, string::StringLiteral};
+use hash_source::{identifier::Identifier, location::Span, string::StringLiteral};
 use hash_utils::counter;
 use replace_with::replace_with_or_abort;
-use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
-use std::{fmt::Display, hash::Hash};
+use std::{
+    fmt::Display,
+    hash::Hash,
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+};
 
 counter! {
     name: AstNodeId,
@@ -332,7 +334,8 @@ pub enum RefKind {
 pub struct RefType {
     /// Inner type of the reference type
     pub inner: AstNode<Type>,
-    /// Whether this reference is a `raw` reference or normal reference (normal by default).
+    /// Whether this reference is a `raw` reference or normal reference (normal
+    /// by default).
     pub kind: Option<AstNode<RefKind>>,
     /// Mutability of the reference (immutable by default)
     pub mutability: Option<AstNode<Mutability>>,
@@ -364,8 +367,8 @@ pub struct SetType {
 }
 
 /// The grouped type (essentially a type within parenthesees), e.g. `(str)`. It
-/// differs from a tuple that it does not contain a trailing comma which signifies that
-/// this is a single element tuple.
+/// differs from a tuple that it does not contain a trailing comma which
+/// signifies that this is a single element tuple.
 #[derive(Debug, PartialEq)]
 pub struct GroupedType(pub AstNode<Type>);
 
@@ -383,9 +386,9 @@ pub struct FnType {
     pub return_ty: AstNode<Type>,
 }
 
-/// A [TypeFunctionParam] is a parameter that appears within a [TypeFunction]. This specifies
-/// that the type function takes a particular parameter with a specific name, a bound and a default
-/// value.
+/// A [TypeFunctionParam] is a parameter that appears within a [TypeFunction].
+/// This specifies that the type function takes a particular parameter with a
+/// specific name, a bound and a default value.
 #[derive(Debug, PartialEq)]
 pub struct TypeFunctionParam {
     pub name: AstNode<Name>,
@@ -401,8 +404,9 @@ pub struct TypeFunction {
 }
 
 /// A type function call specifies a call to a type function with the specified
-/// function name in the form of a [Type] (which can only be a [NamedType] or a [GroupedType])
-/// and then followed by arguments. For example: `Conv<u32>` or `(Foo<bar>)<baz>`
+/// function name in the form of a [Type] (which can only be a [NamedType] or a
+/// [GroupedType]) and then followed by arguments. For example: `Conv<u32>` or
+/// `(Foo<bar>)<baz>`
 #[derive(Debug, PartialEq)]
 pub struct TypeFunctionCall {
     pub subject: AstNode<Type>,
@@ -516,9 +520,9 @@ pub enum Literal {
 impl Literal {
     /// This function is used to determine if the current literal tree only
     /// contains constants. Constants are other literals that are not subject
-    /// to change, e.g. a number like `5` or a string `hello`. This function implements
-    /// short circuiting behaviour and thus should check if the literal is constant
-    /// in the minimal time possible.
+    /// to change, e.g. a number like `5` or a string `hello`. This function
+    /// implements short circuiting behaviour and thus should check if the
+    /// literal is constant in the minimal time possible.
     pub fn is_constant(&self) -> bool {
         let is_expr_literal_and_const = |expr: &AstNode<Expression>| -> bool {
             match expr.kind() {
@@ -527,7 +531,8 @@ impl Literal {
             }
         };
 
-        // Recurse over the literals for `set`, `map` and `tuple to see if they are constant.
+        // Recurse over the literals for `set`, `map` and `tuple to see if they are
+        // constant.
         match self {
             Literal::List(ListLiteral { elements }) | Literal::Set(SetLiteral { elements }) => {
                 !elements.iter().any(|expr| !is_expr_literal_and_const(expr))
@@ -603,8 +608,8 @@ pub struct TuplePattern {
 
 impl TuplePattern {
     /// Function used to check if the pattern is nameless or not. If the pattern
-    /// has at least one member that contains a `name` field, then it is considered
-    /// to be named.
+    /// has at least one member that contains a `name` field, then it is
+    /// considered to be named.
     pub fn is_nameless_pat(&self) -> bool {
         !self.fields.iter().any(|pat| pat.body().name.is_some())
     }
@@ -760,7 +765,8 @@ pub struct Declaration {
     pub value: Option<AstNode<Expression>>,
 }
 
-/// A merge declaration (adding implementations to traits/structs), e.g. `x ~= impl { ... };`.
+/// A merge declaration (adding implementations to traits/structs), e.g. `x ~=
+/// impl { ... };`.
 #[derive(Debug, PartialEq)]
 pub struct MergeDeclaration {
     /// The expression to bind the right-hand side to.
@@ -882,10 +888,12 @@ impl BinOp {
         }
     }
 
-    /// This returns if an operator is actually re-assignable. By re-assignable, this is in the sense
-    /// that you can add a '=' to mean that you are performing a re-assigning operation using the left
-    /// hand-side expression as a starting point and the rhs as the other argument to the operator.
-    /// For example, `a += b` is re-assigning because it means `a = a + b`.
+    /// This returns if an operator is actually re-assignable. By re-assignable,
+    /// this is in the sense that you can add a '=' to mean that you are
+    /// performing a re-assigning operation using the left
+    /// hand-side expression as a starting point and the rhs as the other
+    /// argument to the operator. For example, `a += b` is re-assigning
+    /// because it means `a = a + b`.
     pub fn is_re_assignable(&self) -> bool {
         matches!(
             self,
@@ -931,7 +939,8 @@ pub struct AssignOpExpression {
     /// The value will be assigned to the left-hand side.
     pub rhs: AstNode<Expression>,
 
-    /// Operator that is applied with the assignment on the lhs with the rhs value.
+    /// Operator that is applied with the assignment on the lhs with the rhs
+    /// value.
     ///
     /// Note: Some binary operators are not allowed to be in the location.
     pub operator: AstNode<BinOp>,
@@ -1060,7 +1069,8 @@ pub struct IfClause {
     pub body: AstNode<Block>,
 }
 
-/// An `if` block consisting of the condition, block and an optional else clause e.g. `if x { ... } else { y }`
+/// An `if` block consisting of the condition, block and an optional else clause
+/// e.g. `if x { ... } else { y }`
 #[derive(Debug, PartialEq)]
 pub struct IfBlock {
     pub clauses: AstNodes<IfClause>,
@@ -1084,13 +1094,16 @@ pub enum Block {
     /// A for-loop block. This is later transpiled into a more simpler
     /// construct using a `loop` and a `match` clause.
     ///
-    /// Since for loops are used for iterators in hash, we transpile the construct into a primitive loop.
-    /// An iterator can be traversed by calling the next function on the iterator.
-    /// Since next returns a Option type, we need to check if there is a value or if it returns None.
-    /// If a value does exist, we essentially perform an assignment to the pattern provided.
-    /// If None, the branch immediately breaks the for loop.
+    /// Since for loops are used for iterators in hash, we transpile the
+    /// construct into a primitive loop. An iterator can be traversed by
+    /// calling the next function on the iterator. Since next returns a
+    /// Option type, we need to check if there is a value or if it returns None.
+    /// If a value does exist, we essentially perform an assignment to the
+    /// pattern provided. If None, the branch immediately breaks the for
+    /// loop.
     ///
-    /// A rough outline of what the transpilation process for a for loop looks like:
+    /// A rough outline of what the transpilation process for a for loop looks
+    /// like:
     ///
     /// Take the original for-loop:
     ///
@@ -1111,12 +1124,15 @@ pub enum Block {
     /// }
     /// ```
     For(ForLoopBlock),
-    /// A while-loop block. This is later transpiled into a `loop` and `match` clause.
+    /// A while-loop block. This is later transpiled into a `loop` and `match`
+    /// clause.
     ///
-    /// In general, a while loop transpilation process occurs by transferring the looping
-    /// condition into a match block, which compares a boolean condition. If the boolean condition
-    /// evaluates to false, the loop will immediately break. Otherwise the body expression is expected.
-    /// A rough outline of what the transpilation process for a while loop looks like:
+    /// In general, a while loop transpilation process occurs by transferring
+    /// the looping condition into a match block, which compares a boolean
+    /// condition. If the boolean condition evaluates to false, the loop
+    /// will immediately break. Otherwise the body expression is expected. A
+    /// rough outline of what the transpilation process for a while loop looks
+    /// like:
     ///
     /// ```text
     /// while <condition> {
@@ -1157,14 +1173,15 @@ pub enum Block {
     ///     _ if b => b_branch
     ///     _ => c_branch
     /// }
-    ///```
+    /// ```
     ///
     /// Additionally, if no 'else' clause is specified, we fill it with an
-    /// empty block since an if-block could be assigned to any variable and therefore
-    /// we need to know the outcome of all branches for typechecking.
+    /// empty block since an if-block could be assigned to any variable and
+    /// therefore we need to know the outcome of all branches for
+    /// typechecking.
     If(IfBlock),
-    /// A module block. The inner block becomes an inner module of the current module.
-    ///
+    /// A module block. The inner block becomes an inner module of the current
+    /// module.
     Mod(ModBlock),
     /// A body block.
     Body(BodyBlock),
@@ -1267,7 +1284,8 @@ pub struct CastExpr {
     pub expr: AstNode<Expression>,
 }
 
-/// Represents a path to a module, given as a string literal to an `import` call.
+/// Represents a path to a module, given as a string literal to an `import`
+/// call.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Import {
     pub path: StringLiteral,
@@ -1287,7 +1305,8 @@ pub struct VariableExpr {
 #[derive(Debug, PartialEq)]
 pub struct RefExpr {
     pub inner_expr: AstNode<Expression>,
-    /// The kind of reference, either being a normal reference or a `raw` reference
+    /// The kind of reference, either being a normal reference or a `raw`
+    /// reference
     pub kind: RefKind,
     /// Mutability modifier on the expression.
     pub mutability: Option<AstNode<Mutability>>,
@@ -1384,7 +1403,8 @@ pub enum ExpressionKind {
     AssignOp(AssignOpExpression),
     MergeDeclaration(MergeDeclaration),
     TraitImpl(TraitImpl),
-    /// Binary Expression composed of a left and right hand-side with a binary operator
+    /// Binary Expression composed of a left and right hand-side with a binary
+    /// operator
     BinaryExpr(BinaryExpression),
     /// Unary Expression composed of a unary operator and an expression
     UnaryExpr(UnaryExpression),
@@ -1424,6 +1444,7 @@ impl Expression {
 /// Represents a parsed `.hash` file.
 #[derive(Debug, PartialEq)]
 pub struct Module {
-    /// The contents of the module, as a list of expressions terminated with a semi-colon.
+    /// The contents of the module, as a list of expressions terminated with a
+    /// semi-colon.
     pub contents: AstNodes<Expression>,
 }

--- a/compiler/hash-ast/src/lib.rs
+++ b/compiler/hash-ast/src/lib.rs
@@ -1,5 +1,4 @@
 //! Hash Compiler AST library file
-//!
 
 #![feature(generic_associated_types, box_into_inner, iter_intersperse)]
 

--- a/compiler/hash-ast/src/operator.rs
+++ b/compiler/hash-ast/src/operator.rs
@@ -121,10 +121,12 @@ impl std::fmt::Display for OperatorKind {
 }
 
 impl OperatorKind {
-    /// This returns if an operator is actually re-assignable. By re-assignable, this is in the sense
-    /// that you can add a '=' to mean that you are performing a re-assigning operation using the left
-    /// hand-side expression as a starting point and the rhs as the other argument to the operator.
-    /// For example, `a += b` is re-assigning because it means `a = a + b`.
+    /// This returns if an operator is actually re-assignable. By re-assignable,
+    /// this is in the sense that you can add a '=' to mean that you are
+    /// performing a re-assigning operation using the left
+    /// hand-side expression as a starting point and the rhs as the other
+    /// argument to the operator. For example, `a += b` is re-assigning
+    /// because it means `a = a + b`.
     pub fn is_re_assignable(&self) -> bool {
         matches!(
             self,
@@ -149,7 +151,8 @@ impl OperatorKind {
         matches!(self, OperatorKind::And | OperatorKind::Or,)
     }
 
-    /// Compound functions that use multiple function calls when they are transformed.
+    /// Compound functions that use multiple function calls when they are
+    /// transformed.
     pub fn is_compound(&self) -> bool {
         matches!(
             self,

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -1,18 +1,20 @@
 //! AST visualisation utilities.
 
-use std::convert::Infallible;
-use std::iter;
+use std::{convert::Infallible, iter};
 
 use hash_utils::tree_writing::TreeNode;
 
-use crate::{ast, visitor::walk, visitor::AstVisitor};
+use crate::{
+    ast,
+    visitor::{walk, AstVisitor},
+};
 
-/// Struct implementing [AstVisitor], for the purpose of transforming the AST tree into a
-/// [TreeNode] tree, for visualisation purposes.
+/// Struct implementing [AstVisitor], for the purpose of transforming the AST
+/// tree into a [TreeNode] tree, for visualisation purposes.
 pub struct AstTreeGenerator;
 
-/// Easy way to format a [TreeNode] label with a main label as well as short contents, and a
-/// quoting string.
+/// Easy way to format a [TreeNode] label with a main label as well as short
+/// contents, and a quoting string.
 fn labelled(label: impl ToString, contents: impl ToString, quote_str: &str) -> String {
     format!(
         "{} {}{}{}",
@@ -1032,7 +1034,11 @@ impl AstVisitor for AstTreeGenerator {
         let walk::EnumDefEntry { name, args } = walk::walk_enum_def_entry(self, ctx, node)?;
         Ok(TreeNode::branch(
             labelled("variant", name.label, "\""),
-            if args.is_empty() { vec![] } else { vec![TreeNode::branch("args", args)] },
+            if args.is_empty() {
+                vec![]
+            } else {
+                vec![TreeNode::branch("args", args)]
+            },
         ))
     }
 
@@ -1138,8 +1144,12 @@ impl AstVisitor for AstTreeGenerator {
             "enum",
             iter::once(TreeNode::leaf(labelled("name", name.label, "\"")))
                 .chain(
-                    (if args.is_empty() { None } else { Some(TreeNode::branch("args", args)) })
-                        .into_iter(),
+                    (if args.is_empty() {
+                        None
+                    } else {
+                        Some(TreeNode::branch("args", args))
+                    })
+                    .into_iter(),
                 )
                 .collect(),
         ))

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -16,13 +16,7 @@ pub struct AstTreeGenerator;
 /// Easy way to format a [TreeNode] label with a main label as well as short
 /// contents, and a quoting string.
 fn labelled(label: impl ToString, contents: impl ToString, quote_str: &str) -> String {
-    format!(
-        "{} {}{}{}",
-        label.to_string(),
-        quote_str,
-        contents.to_string(),
-        quote_str
-    )
+    format!("{} {}{}{}", label.to_string(), quote_str, contents.to_string(), quote_str)
 }
 
 impl AstVisitor for AstTreeGenerator {
@@ -63,11 +57,7 @@ impl AstVisitor for AstTreeGenerator {
         node: ast::AstNodeRef<ast::AccessName>,
     ) -> Result<Self::AccessNameRet, Self::Error> {
         Ok(TreeNode::leaf(
-            node.path
-                .iter()
-                .map(|p| (*p.body()).into())
-                .intersperse("::")
-                .collect::<String>(),
+            node.path.iter().map(|p| (*p.body()).into()).intersperse("::").collect::<String>(),
         ))
     }
 
@@ -114,10 +104,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::DirectiveExprRet, Self::Error> {
         let walk::DirectiveExpr { subject, .. } = walk::walk_directive_expr(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            labelled("directive", node.name.ident, "\""),
-            vec![subject],
-        ))
+        Ok(TreeNode::branch(labelled("directive", node.name.ident, "\""), vec![subject]))
     }
 
     type ConstructorCallArgRet = TreeNode;
@@ -151,10 +138,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::ConstructorCallArgsRet, Self::Error> {
         Ok(TreeNode::branch(
             "args",
-            walk::walk_constructor_call_args(self, ctx, node)?
-                .entries
-                .into_iter()
-                .collect(),
+            walk::walk_constructor_call_args(self, ctx, node)?.entries.into_iter().collect(),
         ))
     }
 
@@ -199,10 +183,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::RefExpr>,
     ) -> Result<Self::RefExprRet, Self::Error> {
-        let walk::RefExpr {
-            inner_expr,
-            mutability,
-        } = walk::walk_ref_expr(self, ctx, node)?;
+        let walk::RefExpr { inner_expr, mutability } = walk::walk_ref_expr(self, ctx, node)?;
         Ok(TreeNode::branch(
             "ref",
             iter::once(inner_expr)
@@ -250,10 +231,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::AsExpr { ty, expr } = walk::walk_cast_expr(self, ctx, node)?;
         Ok(TreeNode::branch(
             "typed_expr",
-            vec![
-                TreeNode::branch("subject", vec![expr]),
-                TreeNode::branch("type", vec![ty]),
-            ],
+            vec![TreeNode::branch("subject", vec![expr]), TreeNode::branch("type", vec![ty])],
         ))
     }
 
@@ -297,10 +275,7 @@ impl AstVisitor for AstTreeGenerator {
         if let Some(name) = name {
             Ok(TreeNode::branch(
                 "field",
-                vec![
-                    TreeNode::branch("name", vec![name]),
-                    TreeNode::branch("type", vec![ty]),
-                ],
+                vec![TreeNode::branch("name", vec![name]), TreeNode::branch("type", vec![ty])],
             ))
         } else {
             Ok(ty)
@@ -359,10 +334,7 @@ impl AstVisitor for AstTreeGenerator {
 
         Ok(TreeNode::branch(
             "map",
-            vec![
-                TreeNode::branch("key", vec![key]),
-                TreeNode::branch("key", vec![value]),
-            ],
+            vec![TreeNode::branch("key", vec![key]), TreeNode::branch("key", vec![value])],
         ))
     }
 
@@ -405,11 +377,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::RefTypeRet, Self::Error> {
         let walk::RefType { inner, mutability } = walk::walk_ref_type(self, ctx, node)?;
 
-        let label = if node
-            .kind
-            .as_ref()
-            .map_or(false, |t| *t.body() == ast::RefKind::Raw)
-        {
+        let label = if node.kind.as_ref().map_or(false, |t| *t.body() == ast::RefKind::Raw) {
             "raw_ref"
         } else {
             "ref"
@@ -444,10 +412,7 @@ impl AstVisitor for AstTreeGenerator {
 
         Ok(TreeNode::branch(
             "type_function_call",
-            vec![
-                TreeNode::branch("subject", vec![subject]),
-                TreeNode::branch("arguments", args),
-            ],
+            vec![TreeNode::branch("subject", vec![subject]), TreeNode::branch("arguments", args)],
         ))
     }
 
@@ -457,11 +422,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionParam>,
     ) -> Result<Self::TypeFunctionParamRet, Self::Error> {
-        let walk::TypeFunctionParam {
-            name,
-            bound,
-            default,
-        } = walk::walk_type_function_param(self, ctx, node)?;
+        let walk::TypeFunctionParam { name, bound, default } =
+            walk::walk_type_function_param(self, ctx, node)?;
 
         Ok(TreeNode::branch(
             "arg",
@@ -499,10 +461,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::MapLiteral>,
     ) -> Result<Self::MapLiteralRet, Self::Error> {
-        Ok(TreeNode::branch(
-            "map",
-            walk::walk_map_literal(self, ctx, node)?.entries,
-        ))
+        Ok(TreeNode::branch("map", walk::walk_map_literal(self, ctx, node)?.entries))
     }
 
     type MapLiteralEntryRet = TreeNode;
@@ -514,10 +473,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::MapLiteralEntry { key, value } = walk::walk_map_literal_entry(self, ctx, node)?;
         Ok(TreeNode::branch(
             "entry",
-            vec![
-                TreeNode::branch("key", vec![key]),
-                TreeNode::branch("value", vec![value]),
-            ],
+            vec![TreeNode::branch("key", vec![key]), TreeNode::branch("value", vec![value])],
         ))
     }
 
@@ -621,11 +577,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::FunctionDef>,
     ) -> Result<Self::FunctionDefRet, Self::Error> {
-        let walk::FunctionDef {
-            args,
-            fn_body,
-            return_ty,
-        } = walk::walk_function_def(self, ctx, node)?;
+        let walk::FunctionDef { args, fn_body, return_ty } =
+            walk::walk_function_def(self, ctx, node)?;
 
         Ok(TreeNode::branch(
             "function_def",
@@ -669,10 +622,7 @@ impl AstVisitor for AstTreeGenerator {
         node: ast::AstNodeRef<ast::MatchCase>,
     ) -> Result<Self::MatchCaseRet, Self::Error> {
         let walk::MatchCase { expr, pattern } = walk::walk_match_case(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            "case",
-            vec![pattern, TreeNode::branch("branch", vec![expr])],
-        ))
+        Ok(TreeNode::branch("case", vec![pattern, TreeNode::branch("branch", vec![expr])]))
     }
 
     type MatchBlockRet = TreeNode;
@@ -685,10 +635,7 @@ impl AstVisitor for AstTreeGenerator {
 
         Ok(TreeNode::branch(
             "match",
-            vec![
-                TreeNode::branch("subject", vec![subject]),
-                TreeNode::branch("cases", cases),
-            ],
+            vec![TreeNode::branch("subject", vec![subject]), TreeNode::branch("cases", cases)],
         ))
     }
 
@@ -708,11 +655,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::ForLoopBlock>,
     ) -> Result<Self::LoopBlockRet, Self::Error> {
-        let walk::ForLoopBlock {
-            pattern,
-            iterator,
-            body,
-        } = walk::walk_for_loop_block(self, ctx, node)?;
+        let walk::ForLoopBlock { pattern, iterator, body } =
+            walk::walk_for_loop_block(self, ctx, node)?;
 
         Ok(TreeNode::branch("for_loop", vec![pattern, iterator, body]))
     }
@@ -879,10 +823,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::MergeDeclaration>,
     ) -> Result<Self::MergeDeclarationRet, Self::Error> {
-        let walk::MergeDeclaration {
-            decl: pattern,
-            value,
-        } = walk::walk_merge_declaration(self, ctx, node)?;
+        let walk::MergeDeclaration { decl: pattern, value } =
+            walk::walk_merge_declaration(self, ctx, node)?;
 
         Ok(TreeNode::branch("merge_declaration", vec![pattern, value]))
     }
@@ -914,10 +856,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::AssignStatement { lhs, rhs } = walk::walk_assign_statement(self, ctx, node)?;
         Ok(TreeNode::branch(
             "assign",
-            vec![
-                TreeNode::branch("lhs", vec![lhs]),
-                TreeNode::branch("rhs", vec![rhs]),
-            ],
+            vec![TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
         ))
     }
 
@@ -933,11 +872,7 @@ impl AstVisitor for AstTreeGenerator {
 
         Ok(TreeNode::branch(
             "binary_expr",
-            vec![
-                operator,
-                TreeNode::branch("lhs", vec![lhs]),
-                TreeNode::branch("rhs", vec![rhs]),
-            ],
+            vec![operator, TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
         ))
     }
 
@@ -950,10 +885,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::UnaryExpressionRet, Self::Error> {
         let walk::UnaryExpression { operator, expr } = walk::walk_unary_expr(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            "unary_expr",
-            vec![operator, TreeNode::branch("expr", vec![expr])],
-        ))
+        Ok(TreeNode::branch("unary_expr", vec![operator, TreeNode::branch("expr", vec![expr])]))
     }
 
     type IndexExpressionRet = TreeNode;
@@ -963,10 +895,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::IndexExpression>,
     ) -> Result<Self::IndexExpressionRet, Self::Error> {
-        let walk::IndexExpr {
-            subject,
-            index_expr,
-        } = walk::walk_index_expr(self, ctx, node)?;
+        let walk::IndexExpr { subject, index_expr } = walk::walk_index_expr(self, ctx, node)?;
 
         Ok(TreeNode::branch(
             "index",
@@ -987,11 +916,7 @@ impl AstVisitor for AstTreeGenerator {
             walk::walk_assign_op_statement(self, ctx, node)?;
         Ok(TreeNode::branch(
             "assign",
-            vec![
-                operator,
-                TreeNode::branch("lhs", vec![lhs]),
-                TreeNode::branch("rhs", vec![rhs]),
-            ],
+            vec![operator, TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
         ))
     }
 
@@ -1034,11 +959,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::EnumDefEntry { name, args } = walk::walk_enum_def_entry(self, ctx, node)?;
         Ok(TreeNode::branch(
             labelled("variant", name.label, "\""),
-            if args.is_empty() {
-                vec![]
-            } else {
-                vec![TreeNode::branch("args", args)]
-            },
+            if args.is_empty() { vec![] } else { vec![TreeNode::branch("args", args)] },
         ))
     }
 
@@ -1063,10 +984,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::TraitDefRet, Self::Error> {
         let walk::TraitDef { members } = walk::walk_trait_def(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            "trait_def",
-            vec![TreeNode::branch("members", members)],
-        ))
+        Ok(TreeNode::branch("trait_def", vec![TreeNode::branch("members", members)]))
     }
 
     type TraitImplRet = TreeNode;
@@ -1076,10 +994,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TraitImpl>,
     ) -> Result<Self::TraitImplRet, Self::Error> {
-        let walk::TraitImpl {
-            implementation,
-            ty: name,
-        } = walk::walk_trait_impl(self, ctx, node)?;
+        let walk::TraitImpl { implementation, ty: name } = walk::walk_trait_impl(self, ctx, node)?;
 
         Ok(TreeNode::branch(
             "trait_impl",
@@ -1102,11 +1017,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionDef>,
     ) -> Result<Self::TypeFunctionDefRet, Self::Error> {
-        let walk::TypeFunctionDef {
-            args,
-            return_ty,
-            expression,
-        } = walk::walk_type_function_def(self, ctx, node)?;
+        let walk::TypeFunctionDef { args, return_ty, expression } =
+            walk::walk_type_function_def(self, ctx, node)?;
 
         Ok(TreeNode::branch(
             "type_function",
@@ -1126,10 +1038,7 @@ impl AstVisitor for AstTreeGenerator {
         let walk::TypeFunctionDefArg { name, ty } =
             walk::walk_type_function_def_arg(self, ctx, node)?;
 
-        Ok(TreeNode::branch(
-            "arg",
-            iter::once(name).chain(ty).collect(),
-        ))
+        Ok(TreeNode::branch("arg", iter::once(name).chain(ty).collect()))
     }
 
     type ConstructorPatternRet = TreeNode;
@@ -1144,12 +1053,8 @@ impl AstVisitor for AstTreeGenerator {
             "enum",
             iter::once(TreeNode::leaf(labelled("name", name.label, "\"")))
                 .chain(
-                    (if args.is_empty() {
-                        None
-                    } else {
-                        Some(TreeNode::branch("args", args))
-                    })
-                    .into_iter(),
+                    (if args.is_empty() { None } else { Some(TreeNode::branch("args", args)) })
+                        .into_iter(),
                 )
                 .collect(),
         ))
@@ -1162,10 +1067,7 @@ impl AstVisitor for AstTreeGenerator {
         node: ast::AstNodeRef<ast::NamespacePattern>,
     ) -> Result<Self::NamespacePatternRet, Self::Error> {
         let walk::NamespacePattern { patterns } = walk::walk_namespace_pattern(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            "namespace",
-            vec![TreeNode::branch("members", patterns)],
-        ))
+        Ok(TreeNode::branch("namespace", vec![TreeNode::branch("members", patterns)]))
     }
 
     type TuplePatternEntryRet = TreeNode;
@@ -1344,10 +1246,7 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::DestructuringPatternRet, Self::Error> {
         let walk::DestructuringPattern { name, pattern } =
             walk::walk_destructuring_pattern(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            labelled("binding", name.label, "\""),
-            vec![pattern],
-        ))
+        Ok(TreeNode::branch(labelled("binding", name.label, "\""), vec![pattern]))
     }
 
     type ModuleRet = TreeNode;

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -5,23 +5,26 @@ use std::convert::Infallible;
 
 /// The main visitor trait for [crate::ast] nodes.
 ///
-/// This contains a method for each AST structure, as well as a dedicated return type for it.
-/// These can be implemented using the functions defined in [walk] that can traverse the children
-/// of each node.
+/// This contains a method for each AST structure, as well as a dedicated return
+/// type for it. These can be implemented using the functions defined in [walk]
+/// that can traverse the children of each node.
 pub trait AstVisitor: Sized {
-    /// Context type immutably passed to each visitor method for separating mutable from immutable context.
+    /// Context type immutably passed to each visitor method for separating
+    /// mutable from immutable context.
     type Ctx;
 
     /// What container to use to collect multiple children, used by [walk].
     type CollectionContainer<T>: Sized;
 
-    /// Try collect an iterator of results into a container specified by [Self::CollectionContainer].
+    /// Try collect an iterator of results into a container specified by
+    /// [Self::CollectionContainer].
     fn try_collect_items<T, E, I: Iterator<Item = Result<T, E>>>(
         ctx: &Self::Ctx,
         items: I,
     ) -> Result<Self::CollectionContainer<T>, E>;
 
-    /// Collect an iterator of items into a container specified by [Self::CollectionContainer].
+    /// Collect an iterator of items into a container specified by
+    /// [Self::CollectionContainer].
     fn collect_items<T, E, I: Iterator<Item = T>>(
         ctx: &Self::Ctx,
         items: I,
@@ -713,19 +716,22 @@ pub trait AstVisitor: Sized {
 }
 
 pub trait AstVisitorMut: Sized {
-    /// Context type immutably passed to each visitor method for separating mutable from immutable context.
+    /// Context type immutably passed to each visitor method for separating
+    /// mutable from immutable context.
     type Ctx;
 
     /// What container to use to collect multiple children, used by [walk].
     type CollectionContainer<T>: Sized;
 
-    /// Try collect an iterator of results into a container specified by [Self::CollectionContainer].
+    /// Try collect an iterator of results into a container specified by
+    /// [Self::CollectionContainer].
     fn try_collect_items<T, E, I: Iterator<Item = Result<T, E>>>(
         ctx: &Self::Ctx,
         items: I,
     ) -> Result<Self::CollectionContainer<T>, E>;
 
-    /// Collect an iterator of items into a container specified by [Self::CollectionContainer].
+    /// Collect an iterator of items into a container specified by
+    /// [Self::CollectionContainer].
     fn collect_items<T, E, I: Iterator<Item = T>>(
         ctx: &Self::Ctx,
         items: I,
@@ -1416,17 +1422,18 @@ pub trait AstVisitorMut: Sized {
     ) -> Result<Self::ModuleRet, Self::Error>;
 }
 
-/// Contains helper functions and structures to traverse AST nodes using a given visitor.
+/// Contains helper functions and structures to traverse AST nodes using a given
+/// visitor.
 ///
-/// Structures are defined which mirror the layout of the AST nodes, but instead of having AST
-/// nodes as children, they have the [AstVisitor] output type for each node.
+/// Structures are defined which mirror the layout of the AST nodes, but instead
+/// of having AST nodes as children, they have the [AstVisitor] output type for
+/// each node.
 ///
-/// For enums, there is an additional `*_same_children` function, which traverses the member of
-/// each variant and returns the inner type, given that all variants have the same declared type
-/// within the visitor.
+/// For enums, there is an additional `*_same_children` function, which
+/// traverses the member of each variant and returns the inner type, given that
+/// all variants have the same declared type within the visitor.
 pub mod walk {
-    use super::ast;
-    use super::AstVisitor;
+    use super::{ast, AstVisitor};
 
     pub struct FunctionDefArg<V: AstVisitor> {
         pub name: V::NameRet,
@@ -3247,8 +3254,7 @@ pub mod walk {
 pub mod walk_mut {
     use crate::ast::AstNodeRefMut;
 
-    use super::ast;
-    use super::AstVisitorMut;
+    use super::{ast, AstVisitorMut};
 
     pub struct FunctionDefArg<V: AstVisitorMut> {
         pub name: V::NameRet,

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1448,11 +1448,7 @@ pub mod walk {
     ) -> Result<FunctionDefArg<V>, V::Error> {
         Ok(FunctionDefArg {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
-            ty: node
-                .ty
-                .as_ref()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref()))
-                .transpose()?,
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(ctx, t.ast_ref())).transpose()?,
             default: node
                 .default
                 .as_ref()
@@ -1475,9 +1471,7 @@ pub mod walk {
         Ok(FunctionDef {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref())),
+                node.args.iter().map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref())),
             )?,
             return_ty: node
                 .return_ty
@@ -1695,9 +1689,7 @@ pub mod walk {
             name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
             type_args: V::try_collect_items(
                 ctx,
-                node.type_args
-                    .iter()
-                    .map(|t| visitor.visit_named_field_type(ctx, t.ast_ref())),
+                node.type_args.iter().map(|t| visitor.visit_named_field_type(ctx, t.ast_ref())),
             )?,
         })
     }
@@ -1729,11 +1721,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::ConstructorCallArg>,
     ) -> Result<ConstructorCallArg<V>, V::Error> {
         Ok(ConstructorCallArg {
-            name: node
-                .name
-                .as_ref()
-                .map(|t| visitor.visit_name(ctx, t.ast_ref()))
-                .transpose()?,
+            name: node.name.as_ref().map(|t| visitor.visit_name(ctx, t.ast_ref())).transpose()?,
             value: visitor.visit_expression(ctx, node.value.ast_ref())?,
         })
     }
@@ -1750,9 +1738,7 @@ pub mod walk {
         Ok(ConstructorCallArgs {
             entries: V::try_collect_items(
                 ctx,
-                node.entries
-                    .iter()
-                    .map(|e| visitor.visit_constructor_call_arg(ctx, e.ast_ref())),
+                node.entries.iter().map(|e| visitor.visit_constructor_call_arg(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -1994,9 +1980,7 @@ pub mod walk {
             subject: visitor.visit_expression(ctx, node.subject.ast_ref())?,
             cases: V::try_collect_items(
                 ctx,
-                node.cases
-                    .iter()
-                    .map(|c| visitor.visit_match_case(ctx, c.ast_ref())),
+                node.cases.iter().map(|c| visitor.visit_match_case(ctx, c.ast_ref())),
             )?,
         })
     }
@@ -2094,9 +2078,7 @@ pub mod walk {
         Ok(IfBlock {
             clauses: V::try_collect_items(
                 ctx,
-                node.clauses
-                    .iter()
-                    .map(|clause| visitor.visit_if_clause(ctx, clause.ast_ref())),
+                node.clauses.iter().map(|clause| visitor.visit_if_clause(ctx, clause.ast_ref())),
             )?,
             otherwise: node
                 .otherwise
@@ -2119,9 +2101,7 @@ pub mod walk {
         Ok(BodyBlock {
             statements: V::try_collect_items(
                 ctx,
-                node.statements
-                    .iter()
-                    .map(|s| visitor.visit_expression(ctx, s.ast_ref())),
+                node.statements.iter().map(|s| visitor.visit_expression(ctx, s.ast_ref())),
             )?,
             expr: node
                 .expr
@@ -2204,9 +2184,7 @@ pub mod walk {
         Ok(SetLiteral {
             elements: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter()
-                    .map(|e| visitor.visit_expression(ctx, e.ast_ref())),
+                node.elements.iter().map(|e| visitor.visit_expression(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -2239,9 +2217,7 @@ pub mod walk {
         Ok(MapLiteral {
             entries: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter()
-                    .map(|e| visitor.visit_map_literal_entry(ctx, e.ast_ref())),
+                node.elements.iter().map(|e| visitor.visit_map_literal_entry(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -2258,9 +2234,7 @@ pub mod walk {
         Ok(ListLiteral {
             elements: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter()
-                    .map(|e| visitor.visit_expression(ctx, e.ast_ref())),
+                node.elements.iter().map(|e| visitor.visit_expression(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -2277,16 +2251,8 @@ pub mod walk {
         node: ast::AstNodeRef<ast::TupleLiteralEntry>,
     ) -> Result<TupleLiteralEntry<V>, V::Error> {
         Ok(TupleLiteralEntry {
-            name: node
-                .name
-                .as_ref()
-                .map(|t| visitor.visit_name(ctx, t.ast_ref()))
-                .transpose()?,
-            ty: node
-                .ty
-                .as_ref()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref()))
-                .transpose()?,
+            name: node.name.as_ref().map(|t| visitor.visit_name(ctx, t.ast_ref())).transpose()?,
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(ctx, t.ast_ref())).transpose()?,
             value: visitor.visit_expression(ctx, node.value.ast_ref())?,
         })
     }
@@ -2303,9 +2269,7 @@ pub mod walk {
         Ok(TupleLiteral {
             elements: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter()
-                    .map(|e| visitor.visit_tuple_literal_entry(ctx, e.ast_ref())),
+                node.elements.iter().map(|e| visitor.visit_tuple_literal_entry(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -2322,11 +2286,7 @@ pub mod walk {
     ) -> Result<NamedFieldTypeEntry<V>, V::Error> {
         Ok(NamedFieldTypeEntry {
             ty: visitor.visit_type(ctx, node.ty.ast_ref())?,
-            name: node
-                .name
-                .as_ref()
-                .map(|t| visitor.visit_name(ctx, t.ast_ref()))
-                .transpose()?,
+            name: node.name.as_ref().map(|t| visitor.visit_name(ctx, t.ast_ref())).transpose()?,
         })
     }
 
@@ -2343,9 +2303,7 @@ pub mod walk {
         Ok(FnType {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|e| visitor.visit_named_field_type(ctx, e.ast_ref())),
+                node.args.iter().map(|e| visitor.visit_named_field_type(ctx, e.ast_ref())),
             )?,
             return_ty: visitor.visit_type(ctx, node.return_ty.ast_ref())?,
         })
@@ -2363,9 +2321,7 @@ pub mod walk {
         Ok(TupleType {
             entries: V::try_collect_items(
                 ctx,
-                node.entries
-                    .iter()
-                    .map(|e| visitor.visit_named_field_type(ctx, e.ast_ref())),
+                node.entries.iter().map(|e| visitor.visit_named_field_type(ctx, e.ast_ref())),
             )?,
         })
     }
@@ -2379,9 +2335,7 @@ pub mod walk {
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::ListType>,
     ) -> Result<ListType<V>, V::Error> {
-        Ok(ListType {
-            inner: visitor.visit_type(ctx, node.inner.ast_ref())?,
-        })
+        Ok(ListType { inner: visitor.visit_type(ctx, node.inner.ast_ref())? })
     }
 
     pub struct SetType<V: AstVisitor> {
@@ -2393,9 +2347,7 @@ pub mod walk {
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::SetType>,
     ) -> Result<SetType<V>, V::Error> {
-        Ok(SetType {
-            inner: visitor.visit_type(ctx, node.inner.ast_ref())?,
-        })
+        Ok(SetType { inner: visitor.visit_type(ctx, node.inner.ast_ref())? })
     }
 
     pub struct MapType<V: AstVisitor> {
@@ -2423,9 +2375,7 @@ pub mod walk {
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::NamedType>,
     ) -> Result<NamedType<V>, V::Error> {
-        Ok(NamedType {
-            name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
-        })
+        Ok(NamedType { name: visitor.visit_access_name(ctx, node.name.ast_ref())? })
     }
 
     pub struct RefType<V: AstVisitor> {
@@ -2475,9 +2425,7 @@ pub mod walk {
             subject: visitor.visit_type(ctx, node.subject.ast_ref())?,
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|a| visitor.visit_named_field_type(ctx, a.ast_ref())),
+                node.args.iter().map(|a| visitor.visit_named_field_type(ctx, a.ast_ref())),
             )?,
         })
     }
@@ -2521,9 +2469,7 @@ pub mod walk {
         Ok(TypeFunction {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|a| visitor.visit_type_function_param(ctx, a.ast_ref())),
+                node.args.iter().map(|a| visitor.visit_type_function_param(ctx, a.ast_ref())),
             )?,
             return_ty: visitor.visit_type(ctx, node.return_ty.ast_ref())?,
         })
@@ -2692,9 +2638,7 @@ pub mod walk {
         Ok(OrPattern {
             variants: V::try_collect_items(
                 ctx,
-                node.variants
-                    .iter()
-                    .map(|v| visitor.visit_pattern(ctx, v.ast_ref())),
+                node.variants.iter().map(|v| visitor.visit_pattern(ctx, v.ast_ref())),
             )?,
         })
     }
@@ -2712,9 +2656,7 @@ pub mod walk {
             name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
             args: V::try_collect_items(
                 ctx,
-                node.fields
-                    .iter()
-                    .map(|a| visitor.visit_tuple_pattern_entry(ctx, a.ast_ref())),
+                node.fields.iter().map(|a| visitor.visit_tuple_pattern_entry(ctx, a.ast_ref())),
             )?,
         })
     }
@@ -2730,9 +2672,7 @@ pub mod walk {
         Ok(NamespacePattern {
             patterns: V::try_collect_items(
                 ctx,
-                node.fields
-                    .iter()
-                    .map(|a| visitor.visit_destructuring_pattern(ctx, a.ast_ref())),
+                node.fields.iter().map(|a| visitor.visit_destructuring_pattern(ctx, a.ast_ref())),
             )?,
         })
     }
@@ -2748,11 +2688,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::TuplePatternEntry>,
     ) -> Result<TuplePatternEntry<V>, V::Error> {
         Ok(TuplePatternEntry {
-            name: node
-                .name
-                .as_ref()
-                .map(|t| visitor.visit_name(ctx, t.ast_ref()))
-                .transpose()?,
+            name: node.name.as_ref().map(|t| visitor.visit_name(ctx, t.ast_ref())).transpose()?,
             pattern: visitor.visit_pattern(ctx, node.pattern.ast_ref())?,
         })
     }
@@ -2769,9 +2705,7 @@ pub mod walk {
         Ok(TuplePattern {
             elements: V::try_collect_items(
                 ctx,
-                node.fields
-                    .iter()
-                    .map(|a| visitor.visit_tuple_pattern_entry(ctx, a.ast_ref())),
+                node.fields.iter().map(|a| visitor.visit_tuple_pattern_entry(ctx, a.ast_ref())),
             )?,
         })
     }
@@ -2788,9 +2722,7 @@ pub mod walk {
         Ok(ListPattern {
             elements: V::try_collect_items(
                 ctx,
-                node.fields
-                    .iter()
-                    .map(|a| visitor.visit_pattern(ctx, a.ast_ref())),
+                node.fields.iter().map(|a| visitor.visit_pattern(ctx, a.ast_ref())),
             )?,
         })
     }
@@ -2847,11 +2779,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::SpreadPattern>,
     ) -> Result<SpreadPattern<V>, V::Error> {
         Ok(SpreadPattern {
-            name: node
-                .name
-                .as_ref()
-                .map(|t| visitor.visit_name(ctx, t.ast_ref()))
-                .transpose()?,
+            name: node.name.as_ref().map(|t| visitor.visit_name(ctx, t.ast_ref())).transpose()?,
         })
     }
 
@@ -2932,10 +2860,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::ReturnStatement>,
     ) -> Result<ReturnStatement<V>, V::Error> {
         Ok(ReturnStatement(
-            node.0
-                .as_ref()
-                .map(|n| visitor.visit_expression(ctx, n.ast_ref()))
-                .transpose()?,
+            node.0.as_ref().map(|n| visitor.visit_expression(ctx, n.ast_ref())).transpose()?,
         ))
     }
 
@@ -2952,11 +2877,7 @@ pub mod walk {
     ) -> Result<Declaration<V>, V::Error> {
         Ok(Declaration {
             pattern: visitor.visit_pattern(ctx, node.pattern.ast_ref())?,
-            ty: node
-                .ty
-                .as_ref()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref()))
-                .transpose()?,
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(ctx, t.ast_ref())).transpose()?,
             value: node
                 .value
                 .as_ref()
@@ -3075,11 +2996,7 @@ pub mod walk {
     ) -> Result<StructDefEntry<V>, V::Error> {
         Ok(StructDefEntry {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
-            ty: node
-                .ty
-                .as_ref()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref()))
-                .transpose()?,
+            ty: node.ty.as_ref().map(|t| visitor.visit_type(ctx, t.ast_ref())).transpose()?,
             default: node
                 .default
                 .as_ref()
@@ -3099,9 +3016,7 @@ pub mod walk {
         Ok(StructDef {
             entries: V::try_collect_items(
                 ctx,
-                node.entries
-                    .iter()
-                    .map(|b| visitor.visit_struct_def_entry(ctx, b.ast_ref())),
+                node.entries.iter().map(|b| visitor.visit_struct_def_entry(ctx, b.ast_ref())),
             )?,
         })
     }
@@ -3119,9 +3034,7 @@ pub mod walk {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|b| visitor.visit_type(ctx, b.ast_ref())),
+                node.args.iter().map(|b| visitor.visit_type(ctx, b.ast_ref())),
             )?,
         })
     }
@@ -3137,9 +3050,7 @@ pub mod walk {
         Ok(EnumDef {
             entries: V::try_collect_items(
                 ctx,
-                node.entries
-                    .iter()
-                    .map(|b| visitor.visit_enum_def_entry(ctx, b.ast_ref())),
+                node.entries.iter().map(|b| visitor.visit_enum_def_entry(ctx, b.ast_ref())),
             )?,
         })
     }
@@ -3158,9 +3069,7 @@ pub mod walk {
         Ok(TypeFunctionDef {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter()
-                    .map(|t| visitor.visit_type_function_def_arg(ctx, t.ast_ref())),
+                node.args.iter().map(|t| visitor.visit_type_function_def_arg(ctx, t.ast_ref())),
             )?,
             return_ty: node
                 .return_ty
@@ -3203,9 +3112,7 @@ pub mod walk {
         Ok(TraitDef {
             members: V::try_collect_items(
                 ctx,
-                node.members
-                    .iter()
-                    .map(|t| visitor.visit_expression(ctx, t.ast_ref())),
+                node.members.iter().map(|t| visitor.visit_expression(ctx, t.ast_ref())),
             )?,
         })
     }
@@ -3224,9 +3131,7 @@ pub mod walk {
             ty: visitor.visit_type(ctx, node.ty.ast_ref())?,
             implementation: V::try_collect_items(
                 ctx,
-                node.implementation
-                    .iter()
-                    .map(|t| visitor.visit_expression(ctx, t.ast_ref())),
+                node.implementation.iter().map(|t| visitor.visit_expression(ctx, t.ast_ref())),
             )?,
         })
     }
@@ -3243,9 +3148,7 @@ pub mod walk {
         Ok(Module {
             contents: V::try_collect_items(
                 ctx,
-                node.contents
-                    .iter()
-                    .map(|s| visitor.visit_expression(ctx, s.ast_ref())),
+                node.contents.iter().map(|s| visitor.visit_expression(ctx, s.ast_ref())),
             )?,
         })
     }
@@ -3269,11 +3172,7 @@ pub mod walk_mut {
     ) -> Result<FunctionDefArg<V>, V::Error> {
         Ok(FunctionDefArg {
             name: visitor.visit_name(ctx, node.name.ast_ref_mut())?,
-            ty: node
-                .ty
-                .as_mut()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref_mut()))
-                .transpose()?,
+            ty: node.ty.as_mut().map(|t| visitor.visit_type(ctx, t.ast_ref_mut())).transpose()?,
             default: node
                 .default
                 .as_mut()
@@ -3296,9 +3195,7 @@ pub mod walk_mut {
         Ok(FunctionDef {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter_mut()
-                    .map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref_mut())),
+                node.args.iter_mut().map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref_mut())),
             )?,
             return_ty: node
                 .return_ty
@@ -3640,9 +3537,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::DerefExpr>,
     ) -> Result<DerefExpr<V>, V::Error> {
-        Ok(DerefExpr(
-            visitor.visit_expression(ctx, node.0.ast_ref_mut())?,
-        ))
+        Ok(DerefExpr(visitor.visit_expression(ctx, node.0.ast_ref_mut())?))
     }
 
     pub struct UnsafeExpr<V: AstVisitorMut>(pub V::ExpressionRet);
@@ -3652,9 +3547,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::UnsafeExpr>,
     ) -> Result<UnsafeExpr<V>, V::Error> {
-        Ok(UnsafeExpr(
-            visitor.visit_expression(ctx, node.0.ast_ref_mut())?,
-        ))
+        Ok(UnsafeExpr(visitor.visit_expression(ctx, node.0.ast_ref_mut())?))
     }
 
     pub struct LiteralExpr<V: AstVisitorMut>(pub V::LiteralRet);
@@ -3664,9 +3557,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::LiteralExpr>,
     ) -> Result<LiteralExpr<V>, V::Error> {
-        Ok(LiteralExpr(
-            visitor.visit_literal(ctx, node.0.ast_ref_mut())?,
-        ))
+        Ok(LiteralExpr(visitor.visit_literal(ctx, node.0.ast_ref_mut())?))
     }
 
     pub struct AsExpr<V: AstVisitorMut> {
@@ -3827,9 +3718,7 @@ pub mod walk_mut {
             subject: visitor.visit_expression(ctx, node.subject.ast_ref_mut())?,
             cases: V::try_collect_items(
                 ctx,
-                node.cases
-                    .iter_mut()
-                    .map(|c| visitor.visit_match_case(ctx, c.ast_ref_mut())),
+                node.cases.iter_mut().map(|c| visitor.visit_match_case(ctx, c.ast_ref_mut())),
             )?,
         })
     }
@@ -3885,9 +3774,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::ModBlock>,
     ) -> Result<ModBlock<V>, V::Error> {
-        Ok(ModBlock(
-            visitor.visit_body_block(ctx, node.0.ast_ref_mut())?,
-        ))
+        Ok(ModBlock(visitor.visit_body_block(ctx, node.0.ast_ref_mut())?))
     }
 
     pub struct ImplBlock<V: AstVisitorMut>(pub V::BodyBlockRet);
@@ -3897,9 +3784,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::ImplBlock>,
     ) -> Result<ImplBlock<V>, V::Error> {
-        Ok(ImplBlock(
-            visitor.visit_body_block(ctx, node.0.ast_ref_mut())?,
-        ))
+        Ok(ImplBlock(visitor.visit_body_block(ctx, node.0.ast_ref_mut())?))
     }
 
     pub struct IfClause<V: AstVisitorMut> {
@@ -3956,9 +3841,7 @@ pub mod walk_mut {
         Ok(BodyBlock {
             statements: V::try_collect_items(
                 ctx,
-                node.statements
-                    .iter_mut()
-                    .map(|s| visitor.visit_expression(ctx, s.ast_ref_mut())),
+                node.statements.iter_mut().map(|s| visitor.visit_expression(ctx, s.ast_ref_mut())),
             )?,
             expr: node
                 .expr
@@ -4056,9 +3939,7 @@ pub mod walk_mut {
         Ok(SetLiteral {
             elements: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter_mut()
-                    .map(|e| visitor.visit_expression(ctx, e.ast_ref_mut())),
+                node.elements.iter_mut().map(|e| visitor.visit_expression(ctx, e.ast_ref_mut())),
             )?,
         })
     }
@@ -4110,9 +3991,7 @@ pub mod walk_mut {
         Ok(ListLiteral {
             elements: V::try_collect_items(
                 ctx,
-                node.elements
-                    .iter_mut()
-                    .map(|e| visitor.visit_expression(ctx, e.ast_ref_mut())),
+                node.elements.iter_mut().map(|e| visitor.visit_expression(ctx, e.ast_ref_mut())),
             )?,
         })
     }
@@ -4134,11 +4013,7 @@ pub mod walk_mut {
                 .as_mut()
                 .map(|t| visitor.visit_name(ctx, t.ast_ref_mut()))
                 .transpose()?,
-            ty: node
-                .ty
-                .as_mut()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref_mut()))
-                .transpose()?,
+            ty: node.ty.as_mut().map(|t| visitor.visit_type(ctx, t.ast_ref_mut())).transpose()?,
             value: visitor.visit_expression(ctx, node.value.ast_ref_mut())?,
         })
     }
@@ -4195,9 +4070,7 @@ pub mod walk_mut {
         Ok(FnType {
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter_mut()
-                    .map(|e| visitor.visit_named_field_type(ctx, e.ast_ref_mut())),
+                node.args.iter_mut().map(|e| visitor.visit_named_field_type(ctx, e.ast_ref_mut())),
             )?,
             return_ty: visitor.visit_type(ctx, node.return_ty.ast_ref_mut())?,
         })
@@ -4231,9 +4104,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::ListType>,
     ) -> Result<ListType<V>, V::Error> {
-        Ok(ListType {
-            inner: visitor.visit_type(ctx, node.inner.ast_ref_mut())?,
-        })
+        Ok(ListType { inner: visitor.visit_type(ctx, node.inner.ast_ref_mut())? })
     }
 
     pub struct SetType<V: AstVisitorMut> {
@@ -4245,9 +4116,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::SetType>,
     ) -> Result<SetType<V>, V::Error> {
-        Ok(SetType {
-            inner: visitor.visit_type(ctx, node.inner.ast_ref_mut())?,
-        })
+        Ok(SetType { inner: visitor.visit_type(ctx, node.inner.ast_ref_mut())? })
     }
 
     pub struct MapType<V: AstVisitorMut> {
@@ -4275,9 +4144,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::NamedType>,
     ) -> Result<NamedType<V>, V::Error> {
-        Ok(NamedType {
-            name: visitor.visit_access_name(ctx, node.name.ast_ref_mut())?,
-        })
+        Ok(NamedType { name: visitor.visit_access_name(ctx, node.name.ast_ref_mut())? })
     }
 
     pub struct RefType<V: AstVisitorMut> {
@@ -4309,9 +4176,7 @@ pub mod walk_mut {
     ) -> Result<MergedType<V>, V::Error> {
         Ok(MergedType(V::try_collect_items(
             ctx,
-            node.0
-                .iter_mut()
-                .map(|a| visitor.visit_type(ctx, a.ast_ref_mut())),
+            node.0.iter_mut().map(|a| visitor.visit_type(ctx, a.ast_ref_mut())),
         )?))
     }
 
@@ -4329,9 +4194,7 @@ pub mod walk_mut {
             subject: visitor.visit_type(ctx, node.subject.ast_ref_mut())?,
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter_mut()
-                    .map(|a| visitor.visit_named_field_type(ctx, a.ast_ref_mut())),
+                node.args.iter_mut().map(|a| visitor.visit_named_field_type(ctx, a.ast_ref_mut())),
             )?,
         })
     }
@@ -4570,9 +4433,7 @@ pub mod walk_mut {
         Ok(OrPattern {
             variants: V::try_collect_items(
                 ctx,
-                node.variants
-                    .iter_mut()
-                    .map(|v| visitor.visit_pattern(ctx, v.ast_ref_mut())),
+                node.variants.iter_mut().map(|v| visitor.visit_pattern(ctx, v.ast_ref_mut())),
             )?,
         })
     }
@@ -4666,9 +4527,7 @@ pub mod walk_mut {
         Ok(ListPattern {
             elements: V::try_collect_items(
                 ctx,
-                node.fields
-                    .iter_mut()
-                    .map(|a| visitor.visit_pattern(ctx, a.ast_ref_mut())),
+                node.fields.iter_mut().map(|a| visitor.visit_pattern(ctx, a.ast_ref_mut())),
             )?,
         })
     }
@@ -4813,10 +4672,7 @@ pub mod walk_mut {
         mut node: ast::AstNodeRefMut<ast::ReturnStatement>,
     ) -> Result<ReturnStatement<V>, V::Error> {
         Ok(ReturnStatement(
-            node.0
-                .as_mut()
-                .map(|n| visitor.visit_expression(ctx, n.ast_ref_mut()))
-                .transpose()?,
+            node.0.as_mut().map(|n| visitor.visit_expression(ctx, n.ast_ref_mut())).transpose()?,
         ))
     }
 
@@ -4833,11 +4689,7 @@ pub mod walk_mut {
     ) -> Result<Declaration<V>, V::Error> {
         Ok(Declaration {
             pattern: visitor.visit_pattern(ctx, node.pattern.ast_ref_mut())?,
-            ty: node
-                .ty
-                .as_mut()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref_mut()))
-                .transpose()?,
+            ty: node.ty.as_mut().map(|t| visitor.visit_type(ctx, t.ast_ref_mut())).transpose()?,
             value: node
                 .value
                 .as_mut()
@@ -4956,11 +4808,7 @@ pub mod walk_mut {
     ) -> Result<StructDefEntry<V>, V::Error> {
         Ok(StructDefEntry {
             name: visitor.visit_name(ctx, node.name.ast_ref_mut())?,
-            ty: node
-                .ty
-                .as_mut()
-                .map(|t| visitor.visit_type(ctx, t.ast_ref_mut()))
-                .transpose()?,
+            ty: node.ty.as_mut().map(|t| visitor.visit_type(ctx, t.ast_ref_mut())).transpose()?,
             default: node
                 .default
                 .as_mut()
@@ -5000,9 +4848,7 @@ pub mod walk_mut {
             name: visitor.visit_name(ctx, node.name.ast_ref_mut())?,
             args: V::try_collect_items(
                 ctx,
-                node.args
-                    .iter_mut()
-                    .map(|b| visitor.visit_type(ctx, b.ast_ref_mut())),
+                node.args.iter_mut().map(|b| visitor.visit_type(ctx, b.ast_ref_mut())),
             )?,
         })
     }
@@ -5018,9 +4864,7 @@ pub mod walk_mut {
         Ok(EnumDef {
             entries: V::try_collect_items(
                 ctx,
-                node.entries
-                    .iter_mut()
-                    .map(|b| visitor.visit_enum_def_entry(ctx, b.ast_ref_mut())),
+                node.entries.iter_mut().map(|b| visitor.visit_enum_def_entry(ctx, b.ast_ref_mut())),
             )?,
         })
     }
@@ -5084,9 +4928,7 @@ pub mod walk_mut {
         Ok(TraitDef {
             members: V::try_collect_items(
                 ctx,
-                node.members
-                    .iter_mut()
-                    .map(|t| visitor.visit_expression(ctx, t.ast_ref_mut())),
+                node.members.iter_mut().map(|t| visitor.visit_expression(ctx, t.ast_ref_mut())),
             )?,
         })
     }
@@ -5124,9 +4966,7 @@ pub mod walk_mut {
         Ok(Module {
             contents: V::try_collect_items(
                 ctx,
-                node.contents
-                    .iter_mut()
-                    .map(|s| visitor.visit_expression(ctx, s.ast_ref_mut())),
+                node.contents.iter_mut().map(|s| visitor.visit_expression(ctx, s.ast_ref_mut())),
             )?,
         })
     }

--- a/compiler/hash-interactive/build.rs
+++ b/compiler/hash-interactive/build.rs
@@ -2,7 +2,8 @@
 //! executable version into the executable.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// This is run at compile time to compute some meta data about the produced executable
+/// This is run at compile time to compute some meta data about the produced
+/// executable
 fn main() {
     println!("cargo:rustc-env=EXECUTABLE_VERSION={}", VERSION);
 }

--- a/compiler/hash-interactive/src/command.rs
+++ b/compiler/hash-interactive/src/command.rs
@@ -44,9 +44,7 @@ impl<'i> CommandDelegator<'i> {
 
     fn with_arg(&self, f: impl FnOnce(&'i str) -> InteractiveResult<'i>) -> InteractiveResult<'i> {
         match self.arg {
-            "" => Err(InteractiveCommandError::ArgumentMismatchError(
-                self.command.to_string(),
-            )),
+            "" => Err(InteractiveCommandError::ArgumentMismatchError(self.command.to_string())),
             arg => f(arg),
         }
     }
@@ -54,9 +52,7 @@ impl<'i> CommandDelegator<'i> {
     fn without_arg(&self, command: InteractiveCommand<'i>) -> InteractiveResult<'i> {
         match self.arg {
             "" => Ok(command),
-            _ => Err(InteractiveCommandError::ZeroArguments(
-                self.command.to_string(),
-            )),
+            _ => Err(InteractiveCommandError::ZeroArguments(self.command.to_string())),
         }
     }
 }
@@ -71,10 +67,7 @@ impl InteractiveCommand<'_> {
         }
 
         // get the index of the first white space character
-        let index = input
-            .trim_start()
-            .find(char::is_whitespace)
-            .unwrap_or(input.len());
+        let index = input.trim_start().find(char::is_whitespace).unwrap_or(input.len());
         let (command, rest) = input.split_at(index);
 
         let d = CommandDelegator::new(command, rest);
@@ -84,9 +77,7 @@ impl InteractiveCommand<'_> {
             ":v" => d.without_arg(InteractiveCommand::Version),
             ":t" => d.with_arg(|arg| Ok(InteractiveCommand::Type(arg))),
             ":d" => d.with_arg(|arg| Ok(InteractiveCommand::Display(arg))),
-            _ => Err(InteractiveCommandError::UnrecognisedCommand(
-                command.to_string(),
-            )),
+            _ => Err(InteractiveCommandError::UnrecognisedCommand(command.to_string())),
         }
     }
 }

--- a/compiler/hash-interactive/src/command.rs
+++ b/compiler/hash-interactive/src/command.rs
@@ -22,8 +22,8 @@ pub enum InteractiveCommand<'i> {
 impl From<&InteractiveCommand<'_>> for CompilerJobParams {
     fn from(command: &InteractiveCommand<'_>) -> Self {
         // Here, we don't care about all of the other modes except `Type` and `Display`
-        // since these will either be pre-emptively handled by the REPL, or it will execute
-        // the full stage.
+        // since these will either be pre-emptively handled by the REPL, or it will
+        // execute the full stage.
         match command {
             InteractiveCommand::Display(_) => CompilerJobParams::new(CompilerMode::Parse, true),
             InteractiveCommand::Type(_) => CompilerJobParams::new(CompilerMode::Typecheck, true),

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -115,19 +115,15 @@ where
         ) => {
             // Add the interactive block to the state
             let new_interactive_block = InteractiveBlock::new(expr.to_string());
-            let interactive_id = compiler_state
-                .sources
-                .add_interactive_block(new_interactive_block);
+            let interactive_id =
+                compiler_state.sources.add_interactive_block(new_interactive_block);
 
             // Compute the mode of the job based on provided arguments via the interactive
             // command
             let settings: CompilerJobParams = inner.into();
 
-            let new_state = compiler.run(
-                SourceId::Interactive(interactive_id),
-                compiler_state,
-                settings,
-            );
+            let new_state =
+                compiler.run(SourceId::Interactive(interactive_id), compiler_state, settings);
             return new_state;
         }
         Err(e) => CompilerError::from(e).report(),

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -12,8 +12,7 @@ use hash_pipeline::{
 use hash_reporting::errors::{CompilerError, InteractiveCommandError};
 use hash_source::SourceId;
 use rustyline::{error::ReadlineError, Editor};
-use std::env;
-use std::process::exit;
+use std::{env, process::exit};
 
 type CompilerResult<T> = Result<T, CompilerError>;
 
@@ -32,8 +31,9 @@ pub fn goodbye() {
     exit(0)
 }
 
-/// Function that initialises the interactive mode. Setup all the resources required to perform
-/// execution of provided statements and then initiate the REPL.
+/// Function that initialises the interactive mode. Setup all the resources
+/// required to perform execution of provided statements and then initiate the
+/// REPL.
 pub fn init<'c, 'pool, P, D, S, C, V>(
     mut compiler: Compiler<'pool, P, D, S, C, V>,
 ) -> CompilerResult<()>
@@ -119,7 +119,8 @@ where
                 .sources
                 .add_interactive_block(new_interactive_block);
 
-            // Compute the mode of the job based on provided arguments via the interactive command
+            // Compute the mode of the job based on provided arguments via the interactive
+            // command
             let settings: CompilerJobParams = inner.into();
 
             let new_state = compiler.run(

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1,8 +1,7 @@
-//! Hash Compiler Intermediate Representation (IR) crate. This module is still under
-//! construction and is subject to change.
+//! Hash Compiler Intermediate Representation (IR) crate. This module is still
+//! under construction and is subject to change.
 
-use hash_source::identifier::Identifier;
-use hash_source::location::Span;
+use hash_source::{identifier::Identifier, location::Span};
 use hash_utils::counter;
 
 counter! {
@@ -12,8 +11,8 @@ counter! {
     method_visibility: pub,
 }
 
-// TODO: do we need namespaces, we could just de-sugar them into binds that are associated
-//       with symbols?
+// TODO: do we need namespaces, we could just de-sugar them into binds that are
+// associated       with symbols?
 
 // TODO: We could just de-sugar guard patterns into:
 //
@@ -24,7 +23,7 @@ counter! {
 //    1 if x => ...
 //}
 // ```
-//
+// 
 // Into:
 // ```
 // match k {
@@ -33,7 +32,7 @@ counter! {
 //     }
 // }
 // ```
-//
+// 
 // But, this means that we have to perform exhaustiveness checking before transforming into IR?
 
 #[derive(Debug, PartialEq, Eq)]
@@ -129,7 +128,8 @@ pub struct Expr<'i> {
 /// The kind of an expression
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExprKind<'i> {
-    /// Filler kind when expressions are optimised out or removed for other reasons.
+    /// Filler kind when expressions are optimised out or removed for other
+    /// reasons.
     Nop,
     /// A constant value.
     Const(Const),
@@ -143,12 +143,12 @@ pub enum ExprKind<'i> {
     Call(&'i Expr<'i>, &'i [Expr<'i>]),
     /// An index expression e.g. `x[3]`
     Index(&'i Expr<'i>, &'i Expr<'i>),
-    /// An assignment expression, a right hand-side expression is assigned to a left hand-side
-    /// pattern e.g. `x = 2`
+    /// An assignment expression, a right hand-side expression is assigned to a
+    /// left hand-side pattern e.g. `x = 2`
     Assign(&'i Pat<'i>, &'i Expr<'i>),
-    /// An expression which represents a re-assignment to a pattern with a right hand-side
-    /// expression and a binary operator that combines assignment and an operator, e.g.
-    /// `x += 2`
+    /// An expression which represents a re-assignment to a pattern with a right
+    /// hand-side expression and a binary operator that combines assignment
+    /// and an operator, e.g. `x += 2`
     AssignOp(&'i Pat<'i>, BinOp, &'i Expr<'i>),
     /// An expression which is taking the address of another expression with an
     /// mutability modifier e.g. `&mut x`.

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -8,9 +8,10 @@ use thiserror::Error;
 /// Utility type that wraps a [Result] and a [LexerError]
 pub type LexerResult<T> = Result<T, LexerError>;
 
-/// A [LexerError] represents a encountered error during tokenisation, which includes an optional message
-/// with the error, the [LexerErrorKind] which classifies the error, and a [Span] that represents
-/// where the tokenisation error occurred.
+/// A [LexerError] represents a encountered error during tokenisation, which
+/// includes an optional message with the error, the [LexerErrorKind] which
+/// classifies the error, and a [Span] that represents where the tokenisation
+/// error occurred.
 #[derive(Debug, Constructor, Error)]
 #[error("{kind}{}", .message.as_ref().map(|s| format!(". {s}")).unwrap_or_else(|| String::from("")))]
 pub struct LexerError {
@@ -23,20 +24,23 @@ pub struct LexerError {
 /// with foreign module types.
 pub struct LexerErrorWrapper(pub SourceId, pub LexerError);
 
-/// A [LexerErrorKind] represents the kind of [LexerError] which gives additional context to the error
-/// with the provided message in [LexerError]
+/// A [LexerErrorKind] represents the kind of [LexerError] which gives
+/// additional context to the error with the provided message in [LexerError]
 #[derive(Debug, Error)]
 pub enum LexerErrorKind {
-    /// Occurs when a escape sequence (within a character or a string) is malformed.
+    /// Occurs when a escape sequence (within a character or a string) is
+    /// malformed.
     #[error("Invalid character escape sequence")]
     BadEscapeSequence,
-    /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
+    /// Occurs when a numerical literal doesn't follow the language
+    /// specification, or is too large.
     #[error("Malformed numerical literal")]
     MalformedNumericalLiteral,
     /// Occurs when a float literal exponent has no proceeding digits.
     #[error("Expected float exponent to have at least one digit")]
     MissingExponentDigits,
-    /// Occurs when a numerical literal doesn't follow the language specification, or is too large.
+    /// Occurs when a numerical literal doesn't follow the language
+    /// specification, or is too large.
     #[error("Unclosed string literal")]
     UnclosedStringLiteral,
     /// Occurs when a character literal is comprised of more than one character
@@ -45,7 +49,8 @@ pub enum LexerErrorKind {
     /// Occurs when a char is unexpected in the current context
     #[error("Encountered unexpected character `{0}`")]
     Unexpected(char),
-    /// Occurs when the tokeniser expects a particular token next, but could not derive one.
+    /// Occurs when the tokeniser expects a particular token next, but could not
+    /// derive one.
     #[error("Expected token `{0}`")]
     Expected(TokenKind),
     /// Unclosed tree block
@@ -53,12 +58,12 @@ pub enum LexerErrorKind {
     Unclosed(Delimiter),
 }
 
-// For now, we don't use the reporting capabilities within the lexer and just let the
-// `hash-parser` crate handle the reporting. This is partially due to the fact that
-// the current infrastructure within the compiler will lex and parse at the same time
-// within the thread pool. Ideally, instead of passing `<Lexer|Parser>Error` around, we
-// could just use the `Report` type which is agnostic and can also be sent as messages
-// around the sub-systems.
+// For now, we don't use the reporting capabilities within the lexer and just
+// let the `hash-parser` crate handle the reporting. This is partially due to
+// the fact that the current infrastructure within the compiler will lex and
+// parse at the same time within the thread pool. Ideally, instead of passing
+// `<Lexer|Parser>Error` around, we could just use the `Report` type which is
+// agnostic and can also be sent as messages around the sub-systems.
 
 // impl LexerError {
 //     pub fn create_report(&self, source_id: SourceId) -> Report {

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -61,8 +61,7 @@ impl<'a> Lexer<'a> {
     pub fn tokenise(&mut self) -> Result<Vec<Token>, LexerErrorWrapper> {
         let iter = std::iter::from_fn(|| self.advance_token().transpose());
 
-        iter.collect::<Result<_, _>>()
-            .map_err(|err| LexerErrorWrapper(self.source_id, err))
+        iter.collect::<Result<_, _>>().map_err(|err| LexerErrorWrapper(self.source_id, err))
 
         // Row::try_from_iter(iter, wall).map_err(|err|
         // LexerErrorWrapper(self.source_id, err))
@@ -358,9 +357,8 @@ impl<'a> Lexer<'a> {
         }
 
         // @@Performance: could avoid allocating the string here?
-        let pre_digits = iter::once(prev)
-            .chain(self.eat_decimal_digits(10).chars())
-            .filter(|c| *c != '_');
+        let pre_digits =
+            iter::once(prev).chain(self.eat_decimal_digits(10).chars()).filter(|c| *c != '_');
 
         // peek next to check if this is an actual float literal...
         match self.peek() {
@@ -419,11 +417,7 @@ impl<'a> Lexer<'a> {
 
                 // if an exponent was specified, as in it is non-zero, we need to apply the
                 // exponent to the float literal.
-                let value = if exp != 0 {
-                    value * 10f64.powi(exp)
-                } else {
-                    value
-                };
+                let value = if exp != 0 { value * 10f64.powi(exp) } else { value };
 
                 Ok(TokenKind::FloatLiteral(value))
             }

--- a/compiler/hash-parser/src/import_resolver.rs
+++ b/compiler/hash-parser/src/import_resolver.rs
@@ -1,5 +1,5 @@
-//! Self hosted hash parser, this function contains the implementations for `hash-ast`
-//! which provides a general interface to write a parser.
+//! Self hosted hash parser, this function contains the implementations for
+//! `hash-ast` which provides a general interface to write a parser.
 use std::path::{Path, PathBuf};
 
 use crossbeam_channel::Sender;

--- a/compiler/hash-parser/src/import_resolver.rs
+++ b/compiler/hash-parser/src/import_resolver.rs
@@ -16,11 +16,7 @@ pub struct ImportResolver {
 
 impl ImportResolver {
     pub fn new(source_id: SourceId, root_dir: PathBuf, sender: Sender<ParserAction>) -> Self {
-        Self {
-            root_dir,
-            sender,
-            source_id,
-        }
+        Self { root_dir, sender, source_id }
     }
 
     pub fn current_source_id(&self) -> SourceId {

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -1,5 +1,5 @@
-//! Self hosted hash parser, this function contains the implementations for `hash-ast`
-//! which provides a general interface to write a parser.
+//! Self hosted hash parser, this function contains the implementations for
+//! `hash-ast` which provides a general interface to write a parser.
 #![feature(cell_update)]
 #![feature(is_some_with)]
 
@@ -10,15 +10,17 @@ mod source;
 use crossbeam_channel::{unbounded, Sender};
 use hash_ast::ast;
 use hash_lexer::Lexer;
-use hash_pipeline::sources::{Module, Sources};
-use hash_pipeline::{traits::Parser, CompilerResult};
+use hash_pipeline::{
+    sources::{Module, Sources},
+    traits::Parser,
+    CompilerResult,
+};
 use hash_reporting::report::Report;
 use hash_source::{InteractiveId, ModuleId, SourceId};
 use import_resolver::ImportResolver;
 use parser::{error::ParseError, AstGen};
 use source::ParseSource;
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 #[derive(Debug)]
 pub enum ParserAction {

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -25,22 +25,10 @@ use std::{env, path::PathBuf};
 #[derive(Debug)]
 pub enum ParserAction {
     Error(ParseError),
-    ParseImport {
-        resolved_path: PathBuf,
-        sender: Sender<ParserAction>,
-    },
-    SetInteractiveInfo {
-        interactive_id: InteractiveId,
-        node: ast::AstNode<ast::BodyBlock>,
-    },
-    SetModuleNode {
-        module_id: ModuleId,
-        node: ast::AstNode<ast::Module>,
-    },
-    SetModuleContents {
-        module_id: ModuleId,
-        contents: String,
-    },
+    ParseImport { resolved_path: PathBuf, sender: Sender<ParserAction> },
+    SetInteractiveInfo { interactive_id: InteractiveId, node: ast::AstNode<ast::BodyBlock> },
+    SetModuleNode { module_id: ModuleId, node: ast::AstNode<ast::Module> },
+    SetModuleContents { module_id: ModuleId, contents: String },
 }
 
 fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
@@ -59,10 +47,7 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     // We need to send the source either way
     if let SourceId::Module(module_id) = source_id {
         sender
-            .send(ParserAction::SetModuleContents {
-                contents: contents.to_string(),
-                module_id,
-            })
+            .send(ParserAction::SetModuleContents { contents: contents.to_string(), module_id })
             .unwrap();
     }
 
@@ -80,18 +65,14 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     let action = match &source {
         ParseSource::Module { module_id, .. } => match gen.parse_module() {
             Err(err) => ParserAction::Error(err.into()),
-            Ok(node) => ParserAction::SetModuleNode {
-                module_id: *module_id,
-                node,
-            },
+            Ok(node) => ParserAction::SetModuleNode { module_id: *module_id, node },
         },
         ParseSource::Interactive { interactive_id, .. } => {
             match gen.parse_expression_from_interactive() {
                 Err(err) => ParserAction::Error(err.into()),
-                Ok(node) => ParserAction::SetInteractiveInfo {
-                    interactive_id: *interactive_id,
-                    node,
-                },
+                Ok(node) => {
+                    ParserAction::SetInteractiveInfo { interactive_id: *interactive_id, node }
+                }
             }
         }
     };
@@ -125,10 +106,7 @@ impl<'pool> HashParser {
         let mut errors = Vec::new();
         let (sender, receiver) = unbounded::<ParserAction>();
 
-        assert!(
-            pool.current_num_threads() > 1,
-            "Parser loop requires at least 2 workers"
-        );
+        assert!(pool.current_num_threads() > 1, "Parser loop requires at least 2 workers");
 
         // Parse the entry point
         let entry_source_kind = ParseSource::from_source(entry_point_id, sources, current_dir);
@@ -137,18 +115,10 @@ impl<'pool> HashParser {
         pool.scope(|scope| {
             while let Ok(message) = receiver.recv() {
                 match message {
-                    ParserAction::SetInteractiveInfo {
-                        interactive_id,
-                        node,
-                    } => {
-                        sources
-                            .get_interactive_block_mut(interactive_id)
-                            .set_node(node);
+                    ParserAction::SetInteractiveInfo { interactive_id, node } => {
+                        sources.get_interactive_block_mut(interactive_id).set_node(node);
                     }
-                    ParserAction::SetModuleContents {
-                        module_id,
-                        contents,
-                    } => {
+                    ParserAction::SetModuleContents { module_id, contents } => {
                         let module = sources.get_module_mut(module_id);
                         module.set_contents(contents);
                     }
@@ -156,10 +126,7 @@ impl<'pool> HashParser {
                         let module = sources.get_module_mut(module_id);
                         module.set_node(node);
                     }
-                    ParserAction::ParseImport {
-                        resolved_path,
-                        sender,
-                    } => {
+                    ParserAction::ParseImport { resolved_path, sender } => {
                         if sources.get_module_id_by_path(&resolved_path).is_some() {
                             continue;
                         }
@@ -186,9 +153,8 @@ impl<'pool> Parser<'pool> for HashParser {
         sources: &mut Sources,
         pool: &'pool rayon::ThreadPool,
     ) -> CompilerResult<()> {
-        let current_dir = env::current_dir()
-            .map_err(ParseError::from)
-            .map_err(|err| vec![Report::from(err)])?;
+        let current_dir =
+            env::current_dir().map_err(ParseError::from).map_err(|err| vec![Report::from(err)])?;
         let errors = self.parse_main(sources, target, current_dir, pool);
 
         // @@Todo: merge errors

--- a/compiler/hash-parser/src/parser/block.rs
+++ b/compiler/hash-parser/src/parser/block.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
 use hash_token::{delimiter::Delimiter, keyword::Keyword, TokenKind, TokenKindVector};
 
@@ -26,9 +26,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_span(gen.parse_body_block_inner()?, self.current_location()))
     }
 
-    /// Parse a body block that uses itself as the inner generator. This function
-    /// will advance the current generator than expecting that the next token
-    /// is a brace tree.
+    /// Parse a body block that uses itself as the inner generator. This
+    /// function will advance the current generator than expecting that the
+    /// next token is a brace tree.
     pub(crate) fn parse_body_block_inner(&self) -> AstGenResult<BodyBlock> {
         // Append the initial statement if there is one.
         let mut block = BodyBlock {
@@ -41,8 +41,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             return Ok(block);
         }
 
-        // firstly check if the first token signals a beginning of a statement, we can tell
-        // this by checking for keywords that must begin a statement...
+        // firstly check if the first token signals a beginning of a statement, we can
+        // tell this by checking for keywords that must begin a statement...
         while self.has_token() {
             let (has_semi, statement) = self.parse_top_level_expression(false)?;
 
@@ -112,8 +112,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(MatchCase { pattern, expr }, &start))
     }
 
-    /// Parse a match block statement, which is composed of a subject and an arbitrary
-    /// number of match cases that are surrounded in braces.
+    /// Parse a match block statement, which is composed of a subject and an
+    /// arbitrary number of match cases that are surrounded in braces.
     pub(crate) fn parse_match_block(&self) -> AstGenResult<AstNode<Block>> {
         debug_assert!(self
             .current_token()
@@ -158,8 +158,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     ///     }
     ///
     /// Additionally, if no 'else' clause is specified, we fill it with an
-    /// empty block since an if-block could be assigned to any variable and therefore
-    /// we need to know the outcome of all branches for typechecking.
+    /// empty block since an if-block could be assigned to any variable and
+    /// therefore we need to know the outcome of all branches for
+    /// typechecking.
     pub(crate) fn parse_if_block(&self) -> AstGenResult<AstNode<Block>> {
         debug_assert!(matches!(
             self.current_token().kind,
@@ -182,14 +183,16 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 &if_span,
             ));
 
-            // Now check if there is another branch after the else or if, and loop onwards...
+            // Now check if there is another branch after the else or if, and loop
+            // onwards...
             match self.peek() {
                 Some(token) if token.has_kind(TokenKind::Keyword(Keyword::Else)) => {
                     self.skip_token();
 
                     match self.peek() {
                         Some(token) if token.has_kind(TokenKind::Keyword(Keyword::If)) => {
-                            // skip trying to convert just an 'else' branch since this is another if-branch
+                            // skip trying to convert just an 'else' branch since this is another
+                            // if-branch
                             self.skip_token();
                             continue;
                         }

--- a/compiler/hash-parser/src/parser/block.rs
+++ b/compiler/hash-parser/src/parser/block.rs
@@ -11,10 +11,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub(crate) fn parse_block(&self) -> AstGenResult<AstNode<Block>> {
         let gen = self.parse_delim_tree(Delimiter::Brace, Some(AstGenErrorKind::Block))?;
 
-        Ok(self.node_with_span(
-            Block::Body(gen.parse_body_block_inner()?),
-            self.current_location(),
-        ))
+        Ok(self.node_with_span(Block::Body(gen.parse_body_block_inner()?), self.current_location()))
     }
 
     /// Helper function to simply parse a body block without wrapping it in
@@ -31,10 +28,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// next token is a brace tree.
     pub(crate) fn parse_body_block_inner(&self) -> AstGenResult<BodyBlock> {
         // Append the initial statement if there is one.
-        let mut block = BodyBlock {
-            statements: AstNodes::empty(),
-            expr: None,
-        };
+        let mut block = BodyBlock { statements: AstNodes::empty(), expr: None };
 
         // Just return an empty block if we don't get anything
         if !self.has_token() {
@@ -62,9 +56,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Parse a `for` loop block.
     pub(crate) fn parse_for_loop(&self) -> AstGenResult<AstNode<Block>> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::For)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::For)));
 
         let start = self.current_location();
 
@@ -76,21 +68,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let iterator = self.parse_expression_with_precedence(0)?;
         let body = self.parse_block()?;
 
-        Ok(self.node_with_joined_span(
-            Block::For(ForLoopBlock {
-                pattern,
-                iterator,
-                body,
-            }),
-            &start,
-        ))
+        Ok(self.node_with_joined_span(Block::For(ForLoopBlock { pattern, iterator, body }), &start))
     }
 
     /// Parse a `while` loop block.
     pub(crate) fn parse_while_loop(&self) -> AstGenResult<AstNode<Block>> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::While)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::While)));
 
         let start = self.current_location();
 
@@ -115,9 +98,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a match block statement, which is composed of a subject and an
     /// arbitrary number of match cases that are surrounded in braces.
     pub(crate) fn parse_match_block(&self) -> AstGenResult<AstNode<Block>> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Match)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Match)));
 
         let start = self.current_location();
         let subject = self.parse_expression_with_precedence(0)?;
@@ -132,11 +113,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
 
         Ok(self.node_with_joined_span(
-            Block::Match(MatchBlock {
-                subject,
-                cases,
-                origin: MatchOrigin::Match,
-            }),
+            Block::Match(MatchBlock { subject, cases, origin: MatchOrigin::Match }),
             &start,
         ))
     }
@@ -162,10 +139,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// therefore we need to know the outcome of all branches for
     /// typechecking.
     pub(crate) fn parse_if_block(&self) -> AstGenResult<AstNode<Block>> {
-        debug_assert!(matches!(
-            self.current_token().kind,
-            TokenKind::Keyword(Keyword::If)
-        ));
+        debug_assert!(matches!(self.current_token().kind, TokenKind::Keyword(Keyword::If)));
 
         let start = self.current_location();
 

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -11,9 +11,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a [StructDef]. The keyword `struct` begins the construct and is
     /// followed by parenthesees with inner struct fields defined.
     pub fn parse_struct_def(&self) -> AstGenResult<StructDef> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Struct)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Struct)));
 
         let gen = self.parse_delim_tree(
             Delimiter::Paren,
@@ -56,9 +54,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse an [EnumDef]. The keyword `enum` begins the construct and is
     /// followed by parenthesees with inner enum fields defined.
     pub fn parse_enum_def(&self) -> AstGenResult<EnumDef> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Enum)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Enum)));
 
         let gen = self.parse_delim_tree(
             Delimiter::Paren,
@@ -118,10 +114,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 }
                 token => self.error_with_location(
                     AstGenErrorKind::Expected,
-                    Some(TokenKindVector::from_row(vec![
-                        TokenKind::Comma,
-                        TokenKind::Gt,
-                    ])),
+                    Some(TokenKindVector::from_row(vec![TokenKind::Comma, TokenKind::Gt])),
                     token.map(|t| t.kind),
                     token.map_or_else(|| self.next_location(), |t| t.span),
                 )?,
@@ -139,11 +132,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.parse_arrow()?;
         let expr = self.parse_expression_with_precedence(0)?;
 
-        Ok(TypeFunctionDef {
-            args,
-            return_ty,
-            expr,
-        })
+        Ok(TypeFunctionDef { args, return_ty, expr })
     }
 
     // Parse a [TypeFunctionDefArg] which consists the name of the argument and then
@@ -154,10 +143,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let name = self.parse_name()?;
 
         // Now it's followed by a colon
-        let ty = self
-            .parse_token_fast(TokenKind::Colon)
-            .map(|_| self.parse_type())
-            .transpose()?;
+        let ty = self.parse_token_fast(TokenKind::Colon).map(|_| self.parse_type()).transpose()?;
 
         Ok(self.node_with_joined_span(TypeFunctionDefArg { name, ty }, &start))
     }
@@ -165,12 +151,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with
     /// `trait` that contains definitions or attach expressions to a trait.
     pub fn parse_trait_def(&self) -> AstGenResult<TraitDef> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Trait)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Trait)));
 
-        Ok(TraitDef {
-            members: self.parse_expressions_from_braces()?,
-        })
+        Ok(TraitDef { members: self.parse_expressions_from_braces()? })
     }
 }

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
 use hash_token::{delimiter::Delimiter, keyword::Keyword, TokenKind, TokenKindVector};
 
@@ -8,8 +8,8 @@ use crate::parser::error::TyArgumentKind;
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
-    /// Parse a [StructDef]. The keyword `struct` begins the construct and is followed
-    /// by parenthesees with inner struct fields defined.
+    /// Parse a [StructDef]. The keyword `struct` begins the construct and is
+    /// followed by parenthesees with inner struct fields defined.
     pub fn parse_struct_def(&self) -> AstGenResult<StructDef> {
         debug_assert!(self
             .current_token()
@@ -53,8 +53,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(StructDefEntry { name, ty, default }, &start))
     }
 
-    /// Parse an [EnumDef]. The keyword `enum` begins the construct and is followed
-    /// by parenthesees with inner enum fields defined.
+    /// Parse an [EnumDef]. The keyword `enum` begins the construct and is
+    /// followed by parenthesees with inner enum fields defined.
     pub fn parse_enum_def(&self) -> AstGenResult<EnumDef> {
         debug_assert!(self
             .current_token()
@@ -89,13 +89,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(EnumDefEntry { name, args }, &name_span))
     }
 
-    /// Parse a [TypeFunctionDef]. Type functions specify logic at the type level on expressions such as
-    /// struct, enum, function, and trait definitions.
+    /// Parse a [TypeFunctionDef]. Type functions specify logic at the type
+    /// level on expressions such as struct, enum, function, and trait
+    /// definitions.
     pub fn parse_type_function_def(&self) -> AstGenResult<TypeFunctionDef> {
         let mut args = AstNodes::empty();
 
-        // We can't do this because the parse_separated_fn() function expects a token tree and
-        // not the while tree:
+        // We can't do this because the parse_separated_fn() function expects a token
+        // tree and not the while tree:
         //
         // let args = self.parse_separated_fn(
         //     || self.parse_type_function_def_arg(),
@@ -133,7 +134,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             None => None,
         };
 
-        // Now that we parse the bound, we're expecting a fat-arrow and then some expression
+        // Now that we parse the bound, we're expecting a fat-arrow and then some
+        // expression
         self.parse_arrow()?;
         let expr = self.parse_expression_with_precedence(0)?;
 
@@ -144,8 +146,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         })
     }
 
-    // Parse a [TypeFunctionDefArg] which consists the name of the argument and then any specified bounds
-    // on the argument which are essentially types that are separated by a `~`
+    // Parse a [TypeFunctionDefArg] which consists the name of the argument and then
+    // any specified bounds on the argument which are essentially types that are
+    // separated by a `~`
     fn parse_type_function_def_arg(&self) -> AstGenResult<AstNode<TypeFunctionDefArg>> {
         let start = self.current_location();
         let name = self.parse_name()?;
@@ -159,8 +162,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(TypeFunctionDefArg { name, ty }, &start))
     }
 
-    /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with `trait` that contains
-    /// definitions or attach expressions to a trait.
+    /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with
+    /// `trait` that contains definitions or attach expressions to a trait.
     pub fn parse_trait_def(&self) -> AstGenResult<TraitDef> {
         debug_assert!(self
             .current_token()

--- a/compiler/hash-parser/src/parser/error.rs
+++ b/compiler/hash-parser/src/parser/error.rs
@@ -109,10 +109,7 @@ impl From<AstGenError> for ParseError {
             AstGenErrorKind::Keyword => {
                 let keyword = err.received.unwrap();
 
-                format!(
-                    "Encountered an unexpected keyword {}",
-                    keyword.as_error_string()
-                )
+                format!("Encountered an unexpected keyword {}", keyword.as_error_string())
             }
             AstGenErrorKind::Expected => match &err.received {
                 Some(kind) => format!("Unexpectedly encountered {}", kind.as_error_string()),
@@ -131,10 +128,7 @@ impl From<AstGenError> for ParseError {
             AstGenErrorKind::EOF => "Unexpectedly reached the end of input".to_string(),
             AstGenErrorKind::ReAssignmentOp => "Expected a re-assignment operator".to_string(),
             AstGenErrorKind::TypeDefinition(ty) => {
-                format!(
-                    "Expected {} definition entries here which begin with a '('",
-                    ty
-                )
+                format!("Expected {} definition entries here which begin with a '('", ty)
             }
             AstGenErrorKind::ExpectedValueAfterTyAnnotation => {
                 "Expected value assignment after type annotation within named tuple".to_string()
@@ -191,10 +185,7 @@ impl From<AstGenError> for ParseError {
             }
         }
 
-        Self::Parsing {
-            message: base_message,
-            src: Some(err.span),
-        }
+        Self::Parsing { message: base_message, src: Some(err.span) }
     }
 }
 
@@ -203,10 +194,7 @@ impl From<AstGenError> for ParseError {
 pub enum ParseError {
     Import(ImportError),
     IO(io::Error),
-    Parsing {
-        message: String,
-        src: Option<SourceLocation>,
-    },
+    Parsing { message: String, src: Option<SourceLocation> },
 }
 
 impl From<io::Error> for ParseError {
@@ -224,16 +212,11 @@ impl From<ParseError> for Report {
 impl ParseError {
     pub fn create_report(self) -> Report {
         let mut builder = ReportBuilder::new();
-        builder
-            .with_kind(ReportKind::Error)
-            .with_message("Failed to parse");
+        builder.with_kind(ReportKind::Error).with_message("Failed to parse");
 
         match self {
             ParseError::Import(import_error) => return import_error.create_report(),
-            ParseError::Parsing {
-                message,
-                src: Some(src),
-            } => {
+            ParseError::Parsing { message, src: Some(src) } => {
                 builder
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(src, "here")))
                     .add_element(ReportElement::Note(ReportNote::new(
@@ -267,10 +250,7 @@ impl From<LexerErrorWrapper> for ParseError {
     fn from(LexerErrorWrapper(source_id, err): LexerErrorWrapper) -> Self {
         ParseError::Parsing {
             message: err.to_string(),
-            src: Some(SourceLocation {
-                span: err.span,
-                source_id,
-            }),
+            src: Some(SourceLocation { span: err.span, source_id }),
         }
     }
 }

--- a/compiler/hash-parser/src/parser/error.rs
+++ b/compiler/hash-parser/src/parser/error.rs
@@ -12,8 +12,8 @@ use hash_source::location::SourceLocation;
 use hash_token::{TokenKind, TokenKindVector};
 use hash_utils::printing::SequenceDisplay;
 
-/// A [AstGenError] represents possible errors that occur when transforming the token
-/// stream into the AST.
+/// A [AstGenError] represents possible errors that occur when transforming the
+/// token stream into the AST.
 #[derive(Debug, Constructor)]
 pub struct AstGenError {
     /// The kind of the error.
@@ -47,13 +47,14 @@ pub enum AstGenErrorKind {
     Block,
     /// Expected end of input or token stream here, but encountered tokens.
     EOF,
-    /// Expecting a re-assignment operator at the specified location. Re-assignment operators
-    /// are like normal operators, but they expect an 'equals' sign after the specified
-    /// operator.
+    /// Expecting a re-assignment operator at the specified location.
+    /// Re-assignment operators are like normal operators, but they expect
+    /// an 'equals' sign after the specified operator.
     ReAssignmentOp,
-    /// Error representing expected type arguments. This error has two variants, it can
-    /// either be 'struct' or 'enum' type arguments. The reason why there are two variants
-    /// is to add additional information in the error message.
+    /// Error representing expected type arguments. This error has two variants,
+    /// it can either be 'struct' or 'enum' type arguments. The reason why
+    /// there are two variants is to add additional information in the error
+    /// message.
     TypeDefinition(TyArgumentKind),
     /// Expected an identifier here.
     ExpectedIdentifier,
@@ -62,8 +63,9 @@ pub enum AstGenErrorKind {
     ExpectedOperator,
     /// Expected an expression.
     ExpectedExpression,
-    /// Expected a '=>' at the current location. This error can occur in a number of places; including
-    /// but not limited to: after type arguments, lambda definition, trait bound annotation, etc.
+    /// Expected a '=>' at the current location. This error can occur in a
+    /// number of places; including but not limited to: after type
+    /// arguments, lambda definition, trait bound annotation, etc.
     ExpectedArrow,
     /// Specific error when expecting an arrow after the function definition
     ExpectedFnArrow,
@@ -76,14 +78,16 @@ pub enum AstGenErrorKind {
     /// After a dot operator, the parser expects either a property access or an
     /// infix call which is an extended version of a property access.
     InfixCall,
-    /// When the `import()` directive is used, the only argument should be a string path.
-    /// @@Future: @@CompTime: This could likely change in the future.
+    /// When the `import()` directive is used, the only argument should be a
+    /// string path. @@Future: @@CompTime: This could likely change in the
+    /// future.
     ImportPath,
     /// Expected an identifier after a name qualifier '::'.
     AccessName,
     /// If an imported module has errors, it should be reported
     ErroneousImport(ImportError),
-    /// Malformed spread pattern (if for any reason there is a problem with parsing the spread operator)
+    /// Malformed spread pattern (if for any reason there is a problem with
+    /// parsing the spread operator)
     MalformedSpreadPattern(u8),
 }
 
@@ -252,13 +256,14 @@ impl ParseError {
 }
 
 impl From<LexerErrorWrapper> for ParseError {
-    /// Implementation to convert a [`hash_lexer::error::LexerError`] with the combination of a
-    /// [`hash_source::SourceId`] into a [ParseError]. This is used in order to interface with the lexer
-    /// within the parsing stage.
+    /// Implementation to convert a [`hash_lexer::error::LexerError`] with the
+    /// combination of a [`hash_source::SourceId`] into a [ParseError]. This
+    /// is used in order to interface with the lexer within the parsing
+    /// stage.
     ///
     /// @@Future: In the future, there is a hope that we don't
-    /// need to convert between various error kinds in crates and they can just be passed
-    /// around as reports which are pipeline stage agnostic.
+    /// need to convert between various error kinds in crates and they can just
+    /// be passed around as reports which are pipeline stage agnostic.
     fn from(LexerErrorWrapper(source_id, err): LexerErrorWrapper) -> Self {
         ParseError::Parsing {
             message: err.to_string(),

--- a/compiler/hash-parser/src/parser/literal.rs
+++ b/compiler/hash-parser/src/parser/literal.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
 use hash_source::location::Span;
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
@@ -7,8 +7,9 @@ use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, Token
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
-    /// Convert the current token (provided it is a primitive literal) into a [ExpressionKind::LiteralExpr]
-    /// by simply matching on the type of the expr.
+    /// Convert the current token (provided it is a primitive literal) into a
+    /// [ExpressionKind::LiteralExpr] by simply matching on the type of the
+    /// expr.
     pub(crate) fn parse_literal(&self) -> AstNode<Expression> {
         let token = self.current_token();
         let literal = self.node_with_span(
@@ -163,8 +164,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     gen.skip_token();
                 }
                 Some(token) => {
-                    // if we haven't exhausted the whole token stream, then report this as a unexpected
-                    // token error
+                    // if we haven't exhausted the whole token stream, then report this as a
+                    // unexpected token error
                     return gen.error(
                         AstGenErrorKind::Expected,
                         Some(TokenKindVector::singleton(TokenKind::Comma)),

--- a/compiler/hash-parser/src/parser/literal.rs
+++ b/compiler/hash-parser/src/parser/literal.rs
@@ -45,17 +45,13 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a map literal which is made of braces with an arbitrary number of
     /// fields separated by commas.
     pub(crate) fn parse_map_literal(&self) -> AstGenResult<AstNode<Literal>> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Map)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Map)));
 
         let start = self.current_location();
         let gen = self.parse_delim_tree(Delimiter::Brace, None)?;
 
-        let elements = gen.parse_separated_fn(
-            || gen.parse_map_entry(),
-            || gen.parse_token(TokenKind::Comma),
-        )?;
+        let elements =
+            gen.parse_separated_fn(|| gen.parse_map_entry(), || gen.parse_token(TokenKind::Comma))?;
 
         Ok(self.node_with_joined_span(Literal::Map(MapLiteral { elements }), &start))
     }
@@ -63,9 +59,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a set literal which is made of braces with an arbitrary number of
     /// fields separated by commas.
     pub(crate) fn parse_set_literal(&self) -> AstGenResult<AstNode<Literal>> {
-        debug_assert!(self
-            .current_token()
-            .has_kind(TokenKind::Keyword(Keyword::Set)));
+        debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Set)));
 
         let start = self.current_location();
         let gen = self.parse_delim_tree(Delimiter::Brace, None)?;
@@ -86,13 +80,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         // Determine if this might have a tuple field name and optional type
         let entry = if let Some(name) = self.peek_resultant_fn(|| self.parse_name()) {
             // Here we can identify if we need to backtrack and just parse an expression...
-            if !matches!(
-                self.peek(),
-                Some(Token {
-                    kind: TokenKind::Colon | TokenKind::Eq,
-                    ..
-                })
-            ) {
+            if !matches!(self.peek(), Some(Token { kind: TokenKind::Colon | TokenKind::Eq, .. })) {
                 self.offset.set(offset);
                 None
             } else {

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 mod block;
 mod definitions;
 pub mod error;
@@ -65,12 +65,13 @@ pub struct AstGen<'stream, 'resolver> {
     /// Current token stream offset.
     offset: Cell<usize>,
 
-    /// The span of the current generator, the root generator does not have a parent span,
-    /// whereas as child generators might need to use the span to report errors if their
-    /// token streams are empty (and they're expecting them to be non empty.) For example,
-    /// if the expression `k[]` was being parsed, the index component `[]` is expected to be
-    /// non-empty, so the error reporting can grab the span of the `[]` and report it as an
-    /// expected expression.
+    /// The span of the current generator, the root generator does not have a
+    /// parent span, whereas as child generators might need to use the span
+    /// to report errors if their token streams are empty (and they're
+    /// expecting them to be non empty.) For example, if the expression
+    /// `k[]` was being parsed, the index component `[]` is expected to be
+    /// non-empty, so the error reporting can grab the span of the `[]` and
+    /// report it as an expected expression.
     parent_span: Option<Span>,
 
     /// The token stream
@@ -79,11 +80,13 @@ pub struct AstGen<'stream, 'resolver> {
     /// Token trees that were generated from the stream
     token_trees: &'stream [Vec<Token>],
 
-    /// State set by expression parsers for parents to let them know if the parsed expression
-    /// was made up of multiple expressions with precedence operators.
+    /// State set by expression parsers for parents to let them know if the
+    /// parsed expression was made up of multiple expressions with
+    /// precedence operators.
     is_compound_expr: Cell<bool>,
 
-    /// Instance of an [ImportResolver] to notify the parser of encountered imports.
+    /// Instance of an [ImportResolver] to notify the parser of encountered
+    /// imports.
     resolver: &'resolver ImportResolver,
 }
 
@@ -106,8 +109,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Create new AST generator from a provided token stream with inherited module resolver
-    /// and a provided parent span.
+    /// Create new AST generator from a provided token stream with inherited
+    /// module resolver and a provided parent span.
     #[must_use]
     pub fn from_stream(&self, stream: &'stream [Token], parent_span: Span) -> Self {
         Self {
@@ -120,7 +123,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Function to create a [SourceLocation] from a [Span] by using the provided resolver
+    /// Function to create a [SourceLocation] from a [Span] by using the
+    /// provided resolver
     pub(crate) fn source_location(&self, span: &Span) -> SourceLocation {
         SourceLocation {
             span: *span,
@@ -150,8 +154,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.peek_nth(1)
     }
 
-    /// Function to check if the token stream has been exhausted based on the current
-    /// offset in the generator.
+    /// Function to check if the token stream has been exhausted based on the
+    /// current offset in the generator.
     pub(crate) fn has_token(&self) -> bool {
         let length = self.stream.len();
 
@@ -179,11 +183,15 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         value
     }
 
-    /// Get the current [Token] in the stream. Panics if the current offset has passed the
-    /// size of the stream, e.g tring to get the current token after reaching the end of the
-    /// stream.
+    /// Get the current [Token] in the stream. Panics if the current offset has
+    /// passed the size of the stream, e.g tring to get the current token
+    /// after reaching the end of the stream.
     pub(crate) fn current_token(&self) -> &Token {
-        let offset = if self.offset.get() > 0 { self.offset.get() - 1 } else { 0 };
+        let offset = if self.offset.get() > 0 {
+            self.offset.get() - 1
+        } else {
+            0
+        };
 
         self.stream.get(offset).unwrap()
     }
@@ -195,15 +203,19 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.stream.get(offset).unwrap()
     }
 
-    /// Get the current location from the current token, if there is no token at the current
-    /// offset, then the location of the last token is used.
+    /// Get the current location from the current token, if there is no token at
+    /// the current offset, then the location of the last token is used.
     pub(crate) fn current_location(&self) -> Span {
         // check that the length of current generator is at least one...
         if self.stream.is_empty() {
             return self.parent_span.unwrap_or_default();
         }
 
-        let offset = if self.offset.get() > 0 { self.offset.get() - 1 } else { 0 };
+        let offset = if self.offset.get() > 0 {
+            self.offset.get() - 1
+        } else {
+            0
+        };
 
         match self.stream.get(offset) {
             Some(token) => token.span,
@@ -211,8 +223,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Get the next location of the token, if there is no token after, we use the
-    /// next character offset to determine the location.
+    /// Get the next location of the token, if there is no token after, we use
+    /// the next character offset to determine the location.
     pub(crate) fn next_location(&self) -> Span {
         match self.peek() {
             Some(token) => token.span,
@@ -235,8 +247,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         AstNode::new(inner, location)
     }
 
-    /// Create a new [AstNode] with a span that ranges from the start [Span] to the
-    /// current [Span].
+    /// Create a new [AstNode] with a span that ranges from the start [Span] to
+    /// the current [Span].
     #[inline(always)]
     pub(crate) fn node_with_joined_span<T>(&self, body: T, start: &Span) -> AstNode<T> {
         AstNode::new(body, start.join(self.current_location()))
@@ -281,10 +293,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     }
 
     /// Generate an error that represents that within the current [AstGen] the
-    /// `end of file` state should be reached. This means that either in the root
-    /// generator there are no more tokens or within a nested generator (such as
-    /// if the generator is within a brackets) that it should now read no more
-    /// tokens.
+    /// `end of file` state should be reached. This means that either in the
+    /// root generator there are no more tokens or within a nested generator
+    /// (such as if the generator is within a brackets) that it should now
+    /// read no more tokens.
     pub(crate) fn expected_eof<T>(&self) -> AstGenResult<T> {
         // move onto the next token
         self.offset.set(self.offset.get() + 1);
@@ -301,17 +313,18 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(())
     }
 
-    /// Generate an error representing that the current generator unexpectedly reached the
-    /// end of input at this point.
+    /// Generate an error representing that the current generator unexpectedly
+    /// reached the end of input at this point.
     pub(crate) fn unexpected_eof<T>(&self) -> AstGenResult<T> {
         self.error(AstGenErrorKind::EOF, None, None)
     }
 
-    /// Function to peek ahead and match some parsing function that returns a [Option<T>].
-    /// If The result is an error, the function wil reset the current offset of the token stream
-    /// to where it was the function was peeked. This is essentially a convertor from a [AstGenResult<T>]
-    /// into an [Option<T>] with the side effect of resetting the parser state back to it's original
-    /// settings.
+    /// Function to peek ahead and match some parsing function that returns a
+    /// [Option<T>]. If The result is an error, the function wil reset the
+    /// current offset of the token stream to where it was the function was
+    /// peeked. This is essentially a convertor from a [AstGenResult<T>]
+    /// into an [Option<T>] with the side effect of resetting the parser state
+    /// back to it's original settings.
     pub(crate) fn peek_resultant_fn<T, E>(&self, parse_fn: impl Fn() -> Result<T, E>) -> Option<T> {
         let start = self.offset();
 
@@ -324,10 +337,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Function to parse an arbitrary number of 'parsing functions' separated by a singular
-    /// 'separator' closure. The function has a behaviour of allowing trailing separator. This
-    /// will also parse the function until the end of the current generator, and therefore it
-    /// is intended to be used with a nested generator.
+    /// Function to parse an arbitrary number of 'parsing functions' separated
+    /// by a singular 'separator' closure. The function has a behaviour of
+    /// allowing trailing separator. This will also parse the function until
+    /// the end of the current generator, and therefore it is intended to be
+    /// used with a nested generator.
     pub(crate) fn parse_separated_fn<T>(
         &self,
         parse_fn: impl Fn() -> AstGenResult<AstNode<T>>,
@@ -336,7 +350,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let start = self.current_location();
         let mut args = vec![];
 
-        // so parse the arguments to the function here... with potential type annotations
+        // so parse the arguments to the function here... with potential type
+        // annotations
         while self.has_token() {
             match parse_fn() {
                 Ok(el) => args.push(el),
@@ -370,8 +385,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Function to parse a token atom optionally. If the appropriate token atom is
-    /// present we advance the token count, if not then just return None
+    /// Function to parse a token atom optionally. If the appropriate token atom
+    /// is present we advance the token count, if not then just return None
     pub(crate) fn parse_token_fast(&self, kind: TokenKind) -> Option<()> {
         match self.peek() {
             Some(token) if token.has_kind(kind) => {
@@ -382,8 +397,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Utility function to parse a brace tree as the next token, if a brace tree
-    /// isn't present, then an error is generated.
+    /// Utility function to parse a brace tree as the next token, if a brace
+    /// tree isn't present, then an error is generated.
     pub(crate) fn parse_delim_tree(
         &self,
         delimiter: Delimiter,
@@ -431,11 +446,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         ))
     }
 
-    /// This function is used to exclusively parse a interactive block which follows
-    /// similar rules to a an actual block. Interactive statements are like ghost blocks
-    /// without the actual braces to begin with. It follows that there are an arbitrary
-    /// number of statements, followed by an optional final expression which doesn't
-    /// need to be completed by a comma...
+    /// This function is used to exclusively parse a interactive block which
+    /// follows similar rules to a an actual block. Interactive statements
+    /// are like ghost blocks without the actual braces to begin with. It
+    /// follows that there are an arbitrary number of statements, followed
+    /// by an optional final expression which doesn't need to be completed
+    /// by a comma...
     pub(crate) fn parse_expression_from_interactive(&self) -> AstGenResult<AstNode<BodyBlock>> {
         let start = self.current_location();
 

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -126,10 +126,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Function to create a [SourceLocation] from a [Span] by using the
     /// provided resolver
     pub(crate) fn source_location(&self, span: &Span) -> SourceLocation {
-        SourceLocation {
-            span: *span,
-            source_id: self.resolver.current_source_id(),
-        }
+        SourceLocation { span: *span, source_id: self.resolver.current_source_id() }
     }
 
     /// Get the current offset of where the stream is at.
@@ -187,11 +184,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// passed the size of the stream, e.g tring to get the current token
     /// after reaching the end of the stream.
     pub(crate) fn current_token(&self) -> &Token {
-        let offset = if self.offset.get() > 0 {
-            self.offset.get() - 1
-        } else {
-            0
-        };
+        let offset = if self.offset.get() > 0 { self.offset.get() - 1 } else { 0 };
 
         self.stream.get(offset).unwrap()
     }
@@ -211,11 +204,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             return self.parent_span.unwrap_or_default();
         }
 
-        let offset = if self.offset.get() > 0 {
-            self.offset.get() - 1
-        } else {
-            0
-        };
+        let offset = if self.offset.get() > 0 { self.offset.get() - 1 } else { 0 };
 
         match self.stream.get(offset) {
             Some(token) => token.span,
@@ -363,10 +352,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        Ok(AstNodes::new(
-            args,
-            Some(start.join(self.current_location())),
-        ))
+        Ok(AstNodes::new(args, Some(start.join(self.current_location()))))
     }
 
     /// Function to parse the next [Token] with the specified [TokenKind].
@@ -405,10 +391,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         error: Option<AstGenErrorKind>,
     ) -> AstGenResult<Self> {
         match self.peek() {
-            Some(Token {
-                kind: TokenKind::Tree(inner, tree_index),
-                span,
-            }) if *inner == delimiter => {
+            Some(Token { kind: TokenKind::Tree(inner, tree_index), span })
+                if *inner == delimiter =>
+            {
                 self.skip_token();
 
                 let tree = self.token_trees.get(*tree_index).unwrap();
@@ -416,9 +401,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
             token => self.error_with_location(
                 error.unwrap_or(AstGenErrorKind::Expected),
-                Some(TokenKindVector::from_row(vec![TokenKind::Delimiter(
-                    delimiter, true,
-                )])),
+                Some(TokenKindVector::from_row(vec![TokenKind::Delimiter(delimiter, true)])),
                 token.map(|tok| tok.kind),
                 token.map_or_else(|| self.current_location(), |tok| tok.span),
             )?,
@@ -431,19 +414,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let mut contents = vec![];
 
         while self.has_token() {
-            contents.push(
-                self.parse_top_level_expression(true)
-                    .map(|(_, statement)| statement)?,
-            );
+            contents.push(self.parse_top_level_expression(true).map(|(_, statement)| statement)?);
         }
 
         let span = start.join(self.current_location());
-        Ok(self.node_with_span(
-            Module {
-                contents: AstNodes::new(contents, Some(span)),
-            },
-            span,
-        ))
+        Ok(self.node_with_span(Module { contents: AstNodes::new(contents, Some(span)) }, span))
     }
 
     /// This function is used to exclusively parse a interactive block which

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -10,10 +10,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a singular [Name] from the current token stream.
     pub fn parse_name(&self) -> AstGenResult<AstNode<Name>> {
         match self.next_token() {
-            Some(Token {
-                kind: TokenKind::Ident(ident),
-                span,
-            }) => Ok(self.node_with_span(Name { ident: *ident }, *span)),
+            Some(Token { kind: TokenKind::Ident(ident), span }) => {
+                Ok(self.node_with_span(Name { ident: *ident }, *span))
+            }
             _ => self.error(AstGenErrorKind::ExpectedIdentifier, None, None),
         }
     }
@@ -39,10 +38,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                             self.skip_token(); // :
 
                             match self.peek() {
-                                Some(Token {
-                                    kind: TokenKind::Ident(id),
-                                    span,
-                                }) => {
+                                Some(Token { kind: TokenKind::Ident(id), span }) => {
                                     self.skip_token();
                                     path.push(self.node_with_span(*id, *span));
                                 }
@@ -62,11 +58,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         let location = start.join(self.current_location());
 
-        Ok(self.node_with_span(
-            AccessName {
-                path: AstNodes::new(path, Some(location)),
-            },
-            location,
-        ))
+        Ok(self.node_with_span(AccessName { path: AstNodes::new(path, Some(location)) }, location))
     }
 }

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
 use hash_source::identifier::Identifier;
 use hash_token::{Token, TokenKind};
@@ -18,9 +18,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Parse an [AccessName] from the current token stream. An [AccessName] is defined as
-    /// a number of identifiers that are separated by the namespace operator '::'. The function
-    /// presumes that the current token is an identifier an that the next token is a colon.
+    /// Parse an [AccessName] from the current token stream. An [AccessName] is
+    /// defined as a number of identifiers that are separated by the
+    /// namespace operator '::'. The function presumes that the current
+    /// token is an identifier an that the next token is a colon.
     pub fn parse_access_name(
         &self,
         start_id: AstNode<Identifier>,

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -6,10 +6,12 @@ use hash_token::{keyword::Keyword, TokenKind};
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
-    /// This function is used to pickup 'glued' operator tokens to form more complex binary operators
-    /// that might be made up of multiple tokens. The function will peek ahead (2 tokens at most since
-    /// all binary operators are made of that many tokens). The function returns an optional derived
-    /// operator, and the number of tokens that was consumed deriving the operator, it is the responsibility
+    /// This function is used to pickup 'glued' operator tokens to form more
+    /// complex binary operators that might be made up of multiple tokens.
+    /// The function will peek ahead (2 tokens at most since all binary
+    /// operators are made of that many tokens). The function returns an
+    /// optional derived operator, and the number of tokens that was
+    /// consumed deriving the operator, it is the responsibility
     /// of the caller to increment the token stream by the provided number.
     pub(crate) fn parse_binary_operator(&self) -> (Option<BinOp>, u8) {
         let token = self.peek();

--- a/compiler/hash-parser/src/parser/pattern.rs
+++ b/compiler/hash-parser/src/parser/pattern.rs
@@ -1,5 +1,5 @@
-//! Hash Compiler AST generation sources. This file contains the sources to the logic
-//! that transforms tokens into an AST.
+//! Hash Compiler AST generation sources. This file contains the sources to the
+//! logic that transforms tokens into an AST.
 use hash_ast::{ast::*, ast_nodes};
 use hash_source::{identifier::CORE_IDENTIFIERS, location::Span};
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
@@ -7,18 +7,19 @@ use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, Token
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
-    /// Parse a compound [Pattern]. A compound [Pattern] means that this could be a
-    /// pattern that might be a combination of multiple patterns. Additionally, compound
-    /// patterns are allowed to have `if-guard` syntax which permits for conditional matching
-    /// of a pattern. There are only a few contexts where the full range of patterns is allowed
+    /// Parse a compound [Pattern]. A compound [Pattern] means that this could
+    /// be a pattern that might be a combination of multiple patterns.
+    /// Additionally, compound patterns are allowed to have `if-guard`
+    /// syntax which permits for conditional matching of a pattern. There
+    /// are only a few contexts where the full range of patterns is allowed
     /// (such as the `match` cases).
     pub fn parse_pattern(&self) -> AstGenResult<AstNode<Pattern>> {
-        // attempt to get the next token location as we're starting a pattern here, if there is no token
-        // we should exit and return an error
+        // attempt to get the next token location as we're starting a pattern here, if
+        // there is no token we should exit and return an error
         let start = self.next_location();
 
-        // Parse the first pattern, but throw away the location information since that will be
-        // computed at the end anyway...
+        // Parse the first pattern, but throw away the location information since that
+        // will be computed at the end anyway...
         let mut patterns = ast_nodes![];
 
         while self.has_token() {
@@ -43,7 +44,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Parse a [Pattern] with an optional `if-guard` after the singular pattern.
+    /// Parse a [Pattern] with an optional `if-guard` after the singular
+    /// pattern.
     pub fn parse_pattern_with_if(&self) -> AstGenResult<AstNode<Pattern>> {
         let start = self.next_location();
         let pattern = self.parse_singular_pattern()?;
@@ -61,8 +63,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Parse a singular [Pattern]. Singular [Pattern]s cannot have any grouped pattern
-    /// operators such as a `|`, if guards or any form of compound pattern.
+    /// Parse a singular [Pattern]. Singular [Pattern]s cannot have any grouped
+    /// pattern operators such as a `|`, if guards or any form of compound
+    /// pattern.
     pub(crate) fn parse_singular_pattern(&self) -> AstGenResult<AstNode<Pattern>> {
         let start = self.next_location();
         let token = self
@@ -82,10 +85,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             } => {
                 self.skip_token();
 
-                // So here we try to parse an access name, if it is only made of a single binding
-                // name, we'll just return this as a binding pattern, otherwise it must follow that
-                // it is either a enum or struct pattern, if not we report it as an error since
-                // access names cannot be used as binding patterns on their own...
+                // So here we try to parse an access name, if it is only made of a single
+                // binding name, we'll just return this as a binding pattern,
+                // otherwise it must follow that it is either a enum or struct
+                // pattern, if not we report it as an error since access names
+                // cannot be used as binding patterns on their own...
                 let name = self.parse_access_name(self.node_with_span(*ident, *span))?;
 
                 match self.peek() {
@@ -185,10 +189,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         )
     }
 
-    /// Parse a [DestructuringPattern]. The [DestructuringPattern] refers to destructuring
-    /// either a struct or a namespace to extract fields, exported members. The function
-    /// takes in a token atom because both syntaxes use different operators as pattern
-    /// assigners.
+    /// Parse a [DestructuringPattern]. The [DestructuringPattern] refers to
+    /// destructuring either a struct or a namespace to extract fields,
+    /// exported members. The function takes in a token atom because both
+    /// syntaxes use different operators as pattern assigners.
     pub(crate) fn parse_destructuring_pattern(
         &self,
     ) -> AstGenResult<AstNode<DestructuringPattern>> {
@@ -218,8 +222,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(DestructuringPattern { name, pattern }, &start))
     }
 
-    /// Parse a collection of [DestructuringPattern]s that are comma separated within a brace
-    /// tree.
+    /// Parse a collection of [DestructuringPattern]s that are comma separated
+    /// within a brace tree.
     fn parse_namespace_pattern(
         &self,
         tree: &'stream [Token],
@@ -239,10 +243,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        // @@ErrorReporting: So here, there is a problem because we do actually want to report
-        //                   that this should have been the end of the pattern but because in some
-        //                   contexts the function is being peeked and the error is being ignored,
-        //                   maybe there should be some mechanism to cause the function to hard error?
+        // @@ErrorReporting: So here, there is a problem because we do actually want to
+        // report that this should have been the end of the pattern but because in some
+        // contexts the function is being peeked and the error is being ignored, maybe
+        // there should be some mechanism to cause the function to hard error?
         gen.verify_is_empty()?;
 
         Ok(NamespacePattern {
@@ -250,8 +254,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         })
     }
 
-    /// Parse a [Pattern::List] pattern from the token vector. A list [Pattern] consists
-    /// of a list of comma separated within a square brackets .e.g `[x, 1, ..]`
+    /// Parse a [Pattern::List] pattern from the token vector. A list [Pattern]
+    /// consists of a list of comma separated within a square brackets .e.g
+    /// `[x, 1, ..]`
     pub(crate) fn parse_list_pattern(
         &self,
         tree: &'stream [Token],
@@ -264,20 +269,20 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_span(Pattern::List(ListPattern { fields }), parent_span))
     }
 
-    /// Parse a [Pattern::Tuple] from the token vector. A tuple pattern consists of
-    /// nested patterns within parenthesees which might also have an optional
-    /// named fields.
+    /// Parse a [Pattern::Tuple] from the token vector. A tuple pattern consists
+    /// of nested patterns within parenthesees which might also have an
+    /// optional named fields.
     ///
-    /// If only a singular pattern is parsed and it doesn't have a name, then the
-    /// function will assume that this is not a tuple pattern and simply a pattern
-    /// wrapped within parenthesees.
+    /// If only a singular pattern is parsed and it doesn't have a name, then
+    /// the function will assume that this is not a tuple pattern and simply
+    /// a pattern wrapped within parenthesees.
     pub(crate) fn parse_tuple_pattern(
         &self,
         tree: &'stream [Token],
         parent_span: Span,
     ) -> AstGenResult<AstNode<Pattern>> {
-        // check here if the tree length is 1, and the first token is the comma to check if it is an
-        // empty tuple pattern...
+        // check here if the tree length is 1, and the first token is the comma to check
+        // if it is an empty tuple pattern...
         if let Some(token) = tree.get(0) {
             if token.has_kind(TokenKind::Comma) {
                 return Ok(self.node_with_span(
@@ -289,9 +294,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        // @@Hack: here it might actually be a nested pattern in parenthesees. So we perform a slight
-        // transformation if the number of parsed patterns is only one. So essentially we handle the case
-        // where a pattern is wrapped in parentheses and so we just unwrap it.
+        // @@Hack: here it might actually be a nested pattern in parenthesees. So we
+        // perform a slight transformation if the number of parsed patterns is
+        // only one. So essentially we handle the case where a pattern is
+        // wrapped in parentheses and so we just unwrap it.
         let gen = self.from_stream(tree, parent_span);
 
         let mut elements = gen.parse_separated_fn(
@@ -313,7 +319,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Parse an entry within a tuple pattern which might contain an optional [Name] node.
+    /// Parse an entry within a tuple pattern which might contain an optional
+    /// [Name] node.
     pub(crate) fn parse_tuple_pattern_entry(&self) -> AstGenResult<AstNode<TuplePatternEntry>> {
         let start = self.next_location();
 
@@ -322,8 +329,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 kind: TokenKind::Ident(_),
                 ..
             }) => {
-                // Here if there is a '=', this means that there is a name attached to the entry within the
-                // tuple pattern...
+                // Here if there is a '=', this means that there is a name attached to the entry
+                // within the tuple pattern...
                 match self.peek_second() {
                     Some(token) if token.has_kind(TokenKind::Eq) => {
                         let name = self.parse_name()?;
@@ -353,13 +360,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Parse a spread operator from the current token tree. A spread operator can have an
-    /// optional name attached to the spread operator on the right hand-side.
+    /// Parse a spread operator from the current token tree. A spread operator
+    /// can have an optional name attached to the spread operator on the
+    /// right hand-side.
     ///
     /// ## Allowed locations
-    /// So the spread operator can only appear within either `list`, `tuple` patterns at the moment
-    /// which means that any other location will mark it as `invalid` in the current implementation.
-    ///
+    /// So the spread operator can only appear within either `list`, `tuple`
+    /// patterns at the moment which means that any other location will mark
+    /// it as `invalid` in the current implementation.
     pub(crate) fn parse_spread_pattern(&self) -> AstGenResult<SpreadPattern> {
         for k in 0..3 {
             self.parse_token_fast(TokenKind::Dot).ok_or_else(|| {
@@ -372,16 +380,17 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             })?;
         }
 
-        // Try and see if there is a identifier that is followed by the spread to try and
-        // bind the capture to a variable
+        // Try and see if there is a identifier that is followed by the spread to try
+        // and bind the capture to a variable
         let name = self.peek_resultant_fn(|| self.parse_name());
 
         Ok(SpreadPattern { name })
     }
 
-    /// Function to parse a [BindingPattern] without considering whether it might be part of a
-    /// constructor or any other form of pattern. This function also accounts for visibility or
-    /// mutability modifiers on the binding pattern.
+    /// Function to parse a [BindingPattern] without considering whether it
+    /// might be part of a constructor or any other form of pattern. This
+    /// function also accounts for visibility or mutability modifiers on the
+    /// binding pattern.
     fn parse_binding_pattern(&self) -> AstGenResult<Pattern> {
         let visibility = self.peek_resultant_fn(|| self.parse_visibility());
 
@@ -419,8 +428,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
-    /// Utility function to lookahead and see if it's possible to parse a singular pattern
-    /// from the current position in the token stream.
+    /// Utility function to lookahead and see if it's possible to parse a
+    /// singular pattern from the current position in the token stream.
     pub(crate) fn begins_pattern(&self) -> bool {
         let n_lookahead = match self.peek() {
             // Namespace, List, Tuple, etc.

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -1,5 +1,5 @@
-//! Self hosted hash parser, this function contains the implementations for `hash-ast`
-//! which provides a general interface to write a parser.
+//! Self hosted hash parser, this function contains the implementations for
+//! `hash-ast` which provides a general interface to write a parser.
 
 use std::{borrow::Cow, fs, path::PathBuf};
 

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -23,10 +23,7 @@ pub enum ParseSource {
 impl ParseSource {
     pub fn from_module(module_id: ModuleId, sources: &Sources) -> Self {
         let module = sources.get_module(module_id);
-        Self::Module {
-            module_id,
-            resolved_path: module.path().to_owned(),
-        }
+        Self::Module { module_id, resolved_path: module.path().to_owned() }
     }
     pub fn from_interactive(
         interactive_id: InteractiveId,
@@ -52,20 +49,19 @@ impl ParseSource {
 
     pub fn contents(&self) -> Result<Cow<str>, ParseError> {
         match self {
-            ParseSource::Module { resolved_path, .. } => Ok(Cow::Owned(
-                fs::read_to_string(&resolved_path).map_err(|_| {
+            ParseSource::Module { resolved_path, .. } => {
+                Ok(Cow::Owned(fs::read_to_string(&resolved_path).map_err(|_| {
                     let path = resolved_path.to_string_lossy();
                     ParseError::Import(ImportError {
                         src: None,
                         message: format!("Cannot read file: {}", path),
                         filename: resolved_path.to_owned(),
                     })
-                })?,
-            )),
-            ParseSource::Interactive {
-                interactive_contents,
-                ..
-            } => Ok(Cow::Borrowed(interactive_contents.as_str())),
+                })?))
+            }
+            ParseSource::Interactive { interactive_contents, .. } => {
+                Ok(Cow::Borrowed(interactive_contents.as_str()))
+            }
         }
     }
 

--- a/compiler/hash-pipeline/src/fs.rs
+++ b/compiler/hash-pipeline/src/fs.rs
@@ -23,9 +23,7 @@ pub struct ImportError {
 impl ImportError {
     pub fn create_report(&self) -> Report {
         let mut builder = ReportBuilder::new();
-        builder
-            .with_kind(ReportKind::Error)
-            .with_message("Failed to import");
+        builder.with_kind(ReportKind::Error).with_message("Failed to import");
 
         if let Some(src) = self.src {
             builder

--- a/compiler/hash-pipeline/src/fs.rs
+++ b/compiler/hash-pipeline/src/fs.rs
@@ -10,8 +10,8 @@ use std::{
 };
 use thiserror::Error;
 
-/// Import error is an abstraction to represent errors that are in relevance to IO
-/// operations rather than parsing operations.
+/// Import error is an abstraction to represent errors that are in relevance to
+/// IO operations rather than parsing operations.
 #[derive(Debug, Clone, Error)]
 #[error("Couldn't import module `{filename}`: {message}")]
 pub struct ImportError {
@@ -42,8 +42,8 @@ impl ImportError {
     }
 }
 
-/// The location of a build directory of this package, this used to resolve where the standard library
-/// is located at.
+/// The location of a build directory of this package, this used to resolve
+/// where the standard library is located at.
 static BUILD_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 /// Name of the prelude module
@@ -71,13 +71,15 @@ pub fn get_stdlib_modules(dir: impl AsRef<Path>) -> Vec<PathBuf> {
                     } else if path.is_file() {
                         let file_name = path.file_stem().unwrap();
 
-                        // Special case, don't add prelude to the module list since we don't want to allow
-                        // it to be imported under the normal standard library imports.
+                        // Special case, don't add prelude to the module list since we don't want to
+                        // allow it to be imported under the normal standard
+                        // library imports.
                         if file_name == PRELUDE {
                             continue;
                         }
 
-                        // This shouldn't happen but if there is a file which does not have a hash extension, we shouldn't add it
+                        // This shouldn't happen but if there is a file which does not have a hash
+                        // extension, we shouldn't add it
                         if path.extension().unwrap_or_default() != "hash" {
                             continue;
                         }
@@ -113,9 +115,9 @@ pub fn resolve_path(
     let work_dir = wd.canonicalize().unwrap();
     let raw_path = work_dir.join(path);
 
-    // If the provided path is a directory, we assume that the user is referencing an index
-    // module that is located within the given directory. This takes precedence over checking
-    // if a module is named that directory.
+    // If the provided path is a directory, we assume that the user is referencing
+    // an index module that is located within the given directory. This takes
+    // precedence over checking if a module is named that directory.
     // More info on this topic: https://hash-org.github.io/lang/modules.html#importing
     if raw_path.is_dir() {
         let idx_path = raw_path.join("index.hash");
@@ -139,9 +141,9 @@ pub fn resolve_path(
             src: location,
         })
     } else {
-        // we don't need to anything if the given raw_path already has a extension '.hash',
-        // since we don't disallow someone to import a module and reference the module with
-        // the name, like so...
+        // we don't need to anything if the given raw_path already has a extension
+        // '.hash', since we don't disallow someone to import a module and
+        // reference the module with the name, like so...
         //
         // > let lib = import("lib.hash");
         // same as...
@@ -153,7 +155,8 @@ pub fn resolve_path(
                 // add hash extension regardless and check if the path exists...
                 let raw_path_hash = raw_path.with_extension("hash");
 
-                // Only try to check this route if the provided file did not already have an extension
+                // Only try to check this route if the provided file did not already have an
+                // extension
                 if raw_path.extension().is_none() && raw_path_hash.exists() {
                     Ok(raw_path_hash)
                 } else {

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -1,9 +1,10 @@
-//! Hash Compiler pipeline implementation. The pipeline is a abstract representation
-//! of the compiler flow managing the compiling steps like parsing, typechecking, optimisation
-//! passes, etc. The pipeline is used to abstract away the idea of depending on specific
-//! implementations of the parser or typechecker and just use a common trait
-//! interface that can be used. This file also has definitions for how to access
-//! sources whether module or interactive.
+//! Hash Compiler pipeline implementation. The pipeline is a abstract
+//! representation of the compiler flow managing the compiling steps like
+//! parsing, typechecking, optimisation passes, etc. The pipeline is used to
+//! abstract away the idea of depending on specific implementations of the
+//! parser or typechecker and just use a common trait interface that can be
+//! used. This file also has definitions for how to access sources whether
+//! module or interactive.
 pub mod fs;
 pub mod settings;
 pub mod sources;
@@ -45,9 +46,10 @@ pub struct Compiler<'pool, P, D, S, C, V> {
     metrics: HashMap<CompilerMode, Duration>,
 }
 
-/// The [CompilerState] holds all the information and state of the compiler instance.
-/// Each stage of the compiler contains a `State` type parameter which the compiler stores
-/// so that incremental executions of the compiler are possible.
+/// The [CompilerState] holds all the information and state of the compiler
+/// instance. Each stage of the compiler contains a `State` type parameter which
+/// the compiler stores so that incremental executions of the compiler are
+/// possible.
 pub struct CompilerState<
     'c,
     'pool,
@@ -104,13 +106,14 @@ where
         }
     }
 
-    /// Create a compiler state to accompany with compiler execution. Internally, this
-    /// calls the [Tc] state making functions and saves it into the created
-    /// [CompilerState].
+    /// Create a compiler state to accompany with compiler execution.
+    /// Internally, this calls the [Tc] state making functions and saves it
+    /// into the created [CompilerState].
     pub fn create_state(&mut self) -> CompilerResult<CompilerState<'c, 'pool, D, S, C, V>> {
         let sources = Sources::new();
-        // let checker_interactive_state = self.checker.make_interactive_state(&mut checker_state)?;
-        // let checker_module_state = self.checker.make_module_state(&mut checker_state)?;
+        // let checker_interactive_state = self.checker.make_interactive_state(&mut
+        // checker_state)?; let checker_module_state =
+        // self.checker.make_module_state(&mut checker_state)?;
 
         let ds_state = self.desugarer.make_state()?;
         let semantic_analysis_state = self.semantic_analyser.make_state()?;
@@ -127,7 +130,8 @@ where
         })
     }
 
-    /// Function to report the collected metrics on the stages within the compiler.
+    /// Function to report the collected metrics on the stages within the
+    /// compiler.
     fn report_metrics(&self) {
         let mut total = Duration::new(0, 0);
 
@@ -156,7 +160,8 @@ where
     fn print_sources(&self, sources: &Sources, entry_point: SourceId) {
         match entry_point {
             SourceId::Interactive(id) => {
-                // If this is an interactive statement, we want to print the statement that was just parsed.
+                // If this is an interactive statement, we want to print the statement that was
+                // just parsed.
                 let source = sources.get_interactive_block(id);
 
                 let tree = AstTreeGenerator
@@ -166,7 +171,8 @@ where
                 println!("{}", TreeWriter::new(&tree));
             }
             SourceId::Module(_) => {
-                // If this is a module, we want to print all of the generated modules from the parsing stage
+                // If this is a module, we want to print all of the generated modules from the
+                // parsing stage
                 for (_, generated_module) in sources.iter_modules() {
                     let tree = AstTreeGenerator
                         .visit_module(&(), generated_module.node_ref())
@@ -263,11 +269,12 @@ where
     /// Function to invoke the typechecking stage for the entry point denoted by
     /// the passed [SourceId].
     ///
-    /// This function also expects the [CompilerSettings] for the current pass in order
-    /// to determine if it should output the result from the operation. This is only
-    /// relevant when the [SourceId] is interactive as it might be specified that the
-    /// pipeline output the type of the current expression. This directly comes from
-    /// a user using the `:t` mode in the REPL as so:
+    /// This function also expects the [CompilerSettings] for the current pass
+    /// in order to determine if it should output the result from the
+    /// operation. This is only relevant when the [SourceId] is interactive
+    /// as it might be specified that the pipeline output the type of the
+    /// current expression. This directly comes from a user using the `:t`
+    /// mode in the REPL as so:
     ///
     /// ```text
     /// >>> :t foo(3);
@@ -309,23 +316,24 @@ where
         Ok(())
     }
 
-    /// Helper function in order to check if the pipeline needs to terminate after
-    /// any stage on the condition that the [CompilerJobParams] specify that this
-    /// is the last stage, or if the previous stage had generated any errors that
-    /// are fatal and an abort is necessary.
+    /// Helper function in order to check if the pipeline needs to terminate
+    /// after any stage on the condition that the [CompilerJobParams]
+    /// specify that this is the last stage, or if the previous stage had
+    /// generated any errors that are fatal and an abort is necessary.
     fn maybe_terminate(
         &self,
         result: CompilerResult<()>,
         compiler_state: &mut CompilerState<'c, 'pool, D, S, C, V>,
         job_params: &CompilerJobParams,
-        // @@TODO(feds01): remove this parameter, it would be ideal that this parameter is stored within the compiler state
+        // @@TODO(feds01): remove this parameter, it would be ideal that this parameter is stored
+        // within the compiler state
         current_stage: CompilerMode,
     ) -> Result<(), ()> {
         if let Err(diagnostics) = result {
             compiler_state.diagnostics.extend(diagnostics.into_iter());
 
-            // Some diagnostics might not be errors and all just warnings, in this situation, we
-            // don't have to terminate execution
+            // Some diagnostics might not be errors and all just warnings, in this
+            // situation, we don't have to terminate execution
             if compiler_state.diagnostics.iter().any(|r| r.is_error()) {
                 return Err(());
             }
@@ -339,9 +347,10 @@ where
         Ok(())
     }
 
-    /// Run a particular job within the pipeline. This function handles both cases of either the
-    /// entry point being an [InteractiveId] or a [ModuleId]. The function deals with executing the
-    /// required stages in order as specified by the `job_parameters`
+    /// Run a particular job within the pipeline. This function handles both
+    /// cases of either the entry point being an [InteractiveId] or a
+    /// [ModuleId]. The function deals with executing the required stages in
+    /// order as specified by the `job_parameters`
     fn run_pipeline(
         &mut self,
         entry_point: SourceId,
@@ -408,8 +417,8 @@ where
             }
 
             // @@Hack: to prevent the compiler from printing this message when the pipeline
-            //         when it was instructed to terminate before all of the stages. For example,
-            //         if the compiler is just checking the source, then it will terminate early.
+            // when it was instructed to terminate before all of the stages. For example, if
+            // the compiler is just checking the source, then it will terminate early.
             if err_count != 0 || warn_count != 0 {
                 log::info!(
                     "compiler terminated with {err_count} error(s), and {warn_count} warning(s)."

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -164,9 +164,7 @@ where
                 // just parsed.
                 let source = sources.get_interactive_block(id);
 
-                let tree = AstTreeGenerator
-                    .visit_body_block(&(), source.node())
-                    .unwrap();
+                let tree = AstTreeGenerator.visit_body_block(&(), source.node()).unwrap();
 
                 println!("{}", TreeWriter::new(&tree));
             }
@@ -174,9 +172,8 @@ where
                 // If this is a module, we want to print all of the generated modules from the
                 // parsing stage
                 for (_, generated_module) in sources.iter_modules() {
-                    let tree = AstTreeGenerator
-                        .visit_module(&(), generated_module.node_ref())
-                        .unwrap();
+                    let tree =
+                        AstTreeGenerator.visit_module(&(), generated_module.node_ref()).unwrap();
 
                     println!(
                         "Tree for `{}`:\n{}",
@@ -221,10 +218,7 @@ where
         job_params: &CompilerJobParams,
     ) -> CompilerResult<()> {
         timed(
-            || {
-                self.desugarer
-                    .desugar(entry_point, sources, desugar_state, self.pool)
-            },
+            || self.desugarer.desugar(entry_point, sources, desugar_state, self.pool),
             log::Level::Debug,
             |time| {
                 self.metrics.insert(CompilerMode::DeSugar, time);
@@ -289,10 +283,7 @@ where
         match entry_point {
             SourceId::Interactive(id) => {
                 timed(
-                    || {
-                        self.checker
-                            .check_interactive(id, sources, checker_state, job_params)
-                    },
+                    || self.checker.check_interactive(id, sources, checker_state, job_params),
                     log::Level::Debug,
                     |time| {
                         self.metrics.insert(CompilerMode::Typecheck, time);
@@ -301,10 +292,7 @@ where
             }
             SourceId::Module(id) => {
                 timed(
-                    || {
-                        self.checker
-                            .check_module(id, sources, checker_state, job_params)
-                    },
+                    || self.checker.check_module(id, sources, checker_state, job_params),
                     log::Level::Debug,
                     |time| {
                         self.metrics.insert(CompilerMode::Typecheck, time);

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -21,10 +21,7 @@ pub struct CompilerSettings {
 
 impl CompilerSettings {
     pub fn new(display_metrics: bool, worker_count: usize) -> Self {
-        Self {
-            worker_count,
-            display_metrics,
-        }
+        Self { worker_count, display_metrics }
     }
 }
 
@@ -79,18 +76,12 @@ pub struct CompilerJobParams {
 
 impl CompilerJobParams {
     pub fn new(mode: CompilerMode, output_stage_result: bool) -> Self {
-        Self {
-            mode,
-            output_stage_result,
-        }
+        Self { mode, output_stage_result }
     }
 }
 
 impl Default for CompilerJobParams {
     fn default() -> Self {
-        Self {
-            mode: CompilerMode::Full,
-            output_stage_result: false,
-        }
+        Self { mode: CompilerMode::Full, output_stage_result: false }
     }
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -1,9 +1,10 @@
-//! Hash Compiler pipeline implementation. This file contains various structures and
-//! utilities representing settings and configurations that can be applied to the
-//! Compiler pipeline.
+//! Hash Compiler pipeline implementation. This file contains various structures
+//! and utilities representing settings and configurations that can be applied
+//! to the Compiler pipeline.
 use std::fmt::Display;
 
-/// Various settings that are present on the compiler pipeline when initially launching.
+/// Various settings that are present on the compiler pipeline when initially
+/// launching.
 #[derive(Debug, Clone, Copy)]
 pub struct CompilerSettings {
     /// Print metrics about each stage when the entire pipeline has completed.

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -19,10 +19,7 @@ pub struct InteractiveBlock {
 
 impl InteractiveBlock {
     pub fn new(contents: String) -> Self {
-        Self {
-            contents,
-            node: None,
-        }
+        Self { contents, node: None }
     }
 
     pub fn node(&self) -> ast::AstNodeRef<ast::BodyBlock> {
@@ -52,11 +49,7 @@ pub struct Module {
 
 impl Module {
     pub fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            contents: None,
-            node: None,
-        }
+        Self { path, contents: None, node: None }
     }
 
     pub fn path(&self) -> &Path {
@@ -188,10 +181,7 @@ impl Sources {
     }
 
     pub fn add_dependency(&mut self, source_id: SourceId, dependency: ModuleId) {
-        self.dependencies
-            .entry(source_id)
-            .or_insert_with(HashSet::new)
-            .insert(dependency);
+        self.dependencies.entry(source_id).or_insert_with(HashSet::new).insert(dependency);
     }
 }
 

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -1,6 +1,6 @@
-//! Hash Compiler pipeline traits. This file contains implementable interfaces that
-//! are used by the pipeline to run various stages that transform the provided sources
-//! into runnable/executable code.
+//! Hash Compiler pipeline traits. This file contains implementable interfaces
+//! that are used by the pipeline to run various stages that transform the
+//! provided sources into runnable/executable code.
 
 use hash_reporting::report::Report;
 use hash_source::{InteractiveId, ModuleId, SourceId};
@@ -9,12 +9,13 @@ use crate::{settings::CompilerJobParams, sources::Sources};
 
 pub type CompilerResult<T> = Result<T, Vec<Report>>;
 
-/// The [Parser] represents an abstract parser that can parse all aspects of the Hash programming
-/// language.
+/// The [Parser] represents an abstract parser that can parse all aspects of the
+/// Hash programming language.
 pub trait Parser<'pool> {
-    /// Given a [SourceId], parse the current job and append any parsed modules to the
-    /// provided sources parameter. On success, the function returns nothing and on
-    /// failure, the stage provides a generated diagnostics [Report].
+    /// Given a [SourceId], parse the current job and append any parsed modules
+    /// to the provided sources parameter. On success, the function returns
+    /// nothing and on failure, the stage provides a generated diagnostics
+    /// [Report].
     fn parse(
         &mut self,
         entry_point: SourceId,
@@ -23,8 +24,8 @@ pub trait Parser<'pool> {
     ) -> CompilerResult<()>;
 }
 
-/// The [Desugar] represents an abstract parser that can parse all aspects of the Hash programming
-/// language.
+/// The [Desugar] represents an abstract parser that can parse all aspects of
+/// the Hash programming language.
 pub trait Desugar<'pool> {
     type State;
 
@@ -41,11 +42,12 @@ pub trait Desugar<'pool> {
     ) -> CompilerResult<()>;
 }
 
-/// The [SemanticPass] represents a stage within the compiler that performs various
-/// verifications on the generated AST from the [Parser] and the [Desugar] stage. The
-/// details of the checks that this pass performs is available within the `hash-ast-passes`
-/// crate. However, overall the checks that this stage should perform will be detailed within
-/// the specification of the language.
+/// The [SemanticPass] represents a stage within the compiler that performs
+/// various verifications on the generated AST from the [Parser] and the
+/// [Desugar] stage. The details of the checks that this pass performs is
+/// available within the `hash-ast-passes` crate. However, overall the checks
+/// that this stage should perform will be detailed within the specification of
+/// the language.
 pub trait SemanticPass<'pool> {
     type State;
 
@@ -62,13 +64,14 @@ pub trait SemanticPass<'pool> {
     ) -> Result<(), Vec<Report>>;
 }
 
-/// The [Tc] represents an abstract type checker that implements all the specified
-/// typechecking methods and internally performs some kind of typechecking operations.
-/// The methods [Tc::check_module] and [Tc::check_interactive] will return
-/// a unit on success, or a generated diagnostic error report which can be displayed
-/// and printed by the user of the pipeline. Both functions modify the states of the
-/// checker and return them regardless of error, both states are considered to be the
-/// new states and should be set in the compiler pipeline.
+/// The [Tc] represents an abstract type checker that implements all the
+/// specified typechecking methods and internally performs some kind of
+/// typechecking operations. The methods [Tc::check_module] and
+/// [Tc::check_interactive] will return a unit on success, or a generated
+/// diagnostic error report which can be displayed and printed by the user of
+/// the pipeline. Both functions modify the states of the checker and return
+/// them regardless of error, both states are considered to be the new states
+/// and should be set in the compiler pipeline.
 pub trait Tc<'c> {
     /// The general [Tc] state. This is implementation specific to the
     /// typechecker that implements this trait. The pipeline should have no
@@ -78,9 +81,9 @@ pub trait Tc<'c> {
     /// Make the general [Tc::State].
     fn make_state(&mut self) -> CompilerResult<Self::State>;
 
-    /// Given a [InteractiveId], check the interactive statement with the specific rules
-    /// that are applied in interactive rules. The function accepts the previous [Tc]
-    /// state and previous [Tc::InteractiveState].
+    /// Given a [InteractiveId], check the interactive statement with the
+    /// specific rules that are applied in interactive rules. The function
+    /// accepts the previous [Tc] state and previous [Tc::InteractiveState].
     fn check_interactive<'pool>(
         &'pool mut self,
         interactive_id: InteractiveId,
@@ -89,8 +92,8 @@ pub trait Tc<'c> {
         job_params: &CompilerJobParams,
     ) -> CompilerResult<()>;
 
-    /// Given a [ModuleId], check the module. The function accepts the previous [Tc]
-    /// state and [Tc::ModuleState]
+    /// Given a [ModuleId], check the module. The function accepts the previous
+    /// [Tc] state and [Tc::ModuleState]
     fn check_module(
         &mut self,
         module_id: ModuleId,
@@ -102,8 +105,8 @@ pub trait Tc<'c> {
 
 /// The virtual machine trait
 pub trait VirtualMachine<'c> {
-    /// The general [VirtualMachine] state. This is implementation specific to the
-    /// VM that implements this trait. The pipeline should have no
+    /// The general [VirtualMachine] state. This is implementation specific to
+    /// the VM that implements this trait. The pipeline should have no
     /// dealings with the actual state, except saving it.
     type State;
 

--- a/compiler/hash-reporting/src/errors.rs
+++ b/compiler/hash-reporting/src/errors.rs
@@ -4,7 +4,8 @@ use thiserror::Error;
 
 use crate::highlight::{highlight, Colour, Modifier};
 
-/// Enum representing the variants of error that can occur when running an interactive session
+/// Enum representing the variants of error that can occur when running an
+/// interactive session
 #[derive(Error, Debug)]
 pub enum InteractiveCommandError {
     /// Encountering an unknown command.

--- a/compiler/hash-reporting/src/highlight.rs
+++ b/compiler/hash-reporting/src/highlight.rs
@@ -27,10 +27,7 @@ impl BitOr<Modifier> for Colour {
     type Output = Decoration;
 
     fn bitor(self, rhs: Modifier) -> Self::Output {
-        Decoration {
-            colour: self,
-            modifier: rhs,
-        }
+        Decoration { colour: self, modifier: rhs }
     }
 }
 
@@ -40,10 +37,7 @@ impl BitOr<Colour> for Modifier {
     type Output = Decoration;
 
     fn bitor(self, rhs: Colour) -> Self::Output {
-        Decoration {
-            colour: rhs,
-            modifier: self,
-        }
+        Decoration { colour: rhs, modifier: self }
     }
 }
 
@@ -95,11 +89,7 @@ pub struct Decoration {
 /// the Colour modifier and then the text modifier.
 impl Highlighter for Decoration {
     fn escape_code(&self) -> String {
-        self.colour
-            .escape_code()
-            .chars()
-            .chain(self.modifier.escape_code().chars())
-            .collect()
+        self.colour.escape_code().chars().chain(self.modifier.escape_code().chars()).collect()
     }
 }
 

--- a/compiler/hash-reporting/src/highlight.rs
+++ b/compiler/hash-reporting/src/highlight.rs
@@ -82,8 +82,8 @@ impl Highlighter for Modifier {
     }
 }
 
-/// Type that holds the union of a colour and a text modifier. This type is the resultant
-/// type when combining a text colour and a modifier.
+/// Type that holds the union of a colour and a text modifier. This type is the
+/// resultant type when combining a text colour and a modifier.
 pub struct Decoration {
     /// The colour of the decoration.
     pub colour: Colour,
@@ -91,8 +91,8 @@ pub struct Decoration {
     pub modifier: Modifier,
 }
 
-/// Implementation of the [Highlighter] trait for a Decoration. It first applies the
-/// Colour modifier and then the text modifier.
+/// Implementation of the [Highlighter] trait for a Decoration. It first applies
+/// the Colour modifier and then the text modifier.
 impl Highlighter for Decoration {
     fn escape_code(&self) -> String {
         self.colour
@@ -103,9 +103,9 @@ impl Highlighter for Decoration {
     }
 }
 
-/// General function to apply a highlighter on a string. This will call the provided
-/// [Highlighter] implementation and then apply it to the passed message, resetting the
-/// effect at the end of the message.
+/// General function to apply a highlighter on a string. This will call the
+/// provided [Highlighter] implementation and then apply it to the passed
+/// message, resetting the effect at the end of the message.
 pub fn highlight(highlighter: impl Highlighter, message: impl ToString) -> String {
     const RESET: &str = "\u{001b}[0m";
 

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -65,10 +65,7 @@ pub(crate) fn offset_col_row(offset: usize, source: &str, non_inclusive: bool) -
         };
 
         if range.contains(&offset) {
-            line_index = Some(ColRowOffset {
-                col: offset - bytes_skipped,
-                row: line_idx,
-            });
+            line_index = Some(ColRowOffset { col: offset - bytes_skipped, row: line_idx });
             break;
         }
 
@@ -120,15 +117,11 @@ impl ReportCodeBlock {
                 let source = modules.contents_by_id(source_id);
 
                 // Compute offset rows and columns from the provided span
-                let ColRowOffset {
-                    col: start_col,
-                    row: start_row,
-                } = offset_col_row(span.start(), source, true);
+                let ColRowOffset { col: start_col, row: start_row } =
+                    offset_col_row(span.start(), source, true);
 
-                let ColRowOffset {
-                    col: end_col,
-                    row: end_row,
-                } = offset_col_row(span.end(), source, false);
+                let ColRowOffset { col: end_col, row: end_row } =
+                    offset_col_row(span.end(), source, false);
 
                 let ColRowOffset { row: last_row, .. } =
                     offset_col_row(source.len(), source, false);
@@ -143,13 +136,8 @@ impl ReportCodeBlock {
                     .chars()
                     .count();
 
-                let info = ReportCodeBlockInfo {
-                    indent_width,
-                    start_col,
-                    start_row,
-                    end_col,
-                    end_row,
-                };
+                let info =
+                    ReportCodeBlockInfo { indent_width, start_col, start_row, end_col, end_row };
 
                 self.info.replace(Some(info));
                 info
@@ -167,9 +155,7 @@ impl ReportCodeBlock {
         let source_id = self.source_location.source_id;
         let source = modules.contents_by_id(source_id);
 
-        let ReportCodeBlockInfo {
-            start_row, end_row, ..
-        } = self.info(modules);
+        let ReportCodeBlockInfo { start_row, end_row, .. } = self.info(modules);
 
         let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
 
@@ -204,21 +190,11 @@ impl ReportCodeBlock {
     ) -> fmt::Result {
         let error_view = self.get_source_view(modules);
 
-        let ReportCodeBlockInfo {
-            start_row,
-            end_row,
-            start_col,
-            end_col,
-            ..
-        } = self.info(modules);
+        let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
 
         // Print each selected line with the line number
         for (index, line) in error_view {
-            let index_str = format!(
-                "{:>pad_width$}",
-                index + 1,
-                pad_width = longest_indent_width
-            );
+            let index_str = format!("{:>pad_width$}", index + 1, pad_width = longest_indent_width);
 
             let line_number = if (start_row..=end_row).contains(&index) {
                 highlight(report_kind.as_colour(), &index_str)
@@ -226,13 +202,7 @@ impl ReportCodeBlock {
                 index_str
             };
 
-            writeln!(
-                f,
-                "{} {}   {}",
-                line_number,
-                highlight(Colour::Blue, "|"),
-                line
-            )?;
+            writeln!(f, "{} {}   {}", line_number, highlight(Colour::Blue, "|"), line)?;
 
             if (start_row..=end_row).contains(&index) && !line.is_empty() {
                 let dashes: String = repeat(LINE_DIAGNOSTIC_MARKER)
@@ -303,13 +273,7 @@ impl ReportCodeBlock {
     ) -> fmt::Result {
         let error_view = self.get_source_view(modules);
 
-        let ReportCodeBlockInfo {
-            start_row,
-            end_row,
-            start_col,
-            end_col,
-            ..
-        } = self.info(modules);
+        let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
 
         // So here, we want to iterate over all of the line and on the starting line, we
         // want to draw an arrow from the left hand-side up until the beginning
@@ -318,11 +282,7 @@ impl ReportCodeBlock {
         // below the final line we want to draw an arrow leading up until
         // the end of the span.
         for (index, line) in error_view {
-            let index_str = format!(
-                "{:>pad_width$}",
-                index + 1,
-                pad_width = longest_indent_width
-            );
+            let index_str = format!("{:>pad_width$}", index + 1, pad_width = longest_indent_width);
 
             let line_number = if (start_row..=end_row).contains(&index) {
                 highlight(report_kind.as_colour(), &index_str)
@@ -352,10 +312,8 @@ impl ReportCodeBlock {
             // If this is th first row of the diagnostic span, then we want to draw an arrow
             // leading up to it
             if index == start_row {
-                let arrow: String = repeat('_')
-                    .take(start_col + 2)
-                    .chain(once(BLOCK_DIAGNOSTIC_MARKER))
-                    .collect();
+                let arrow: String =
+                    repeat('_').take(start_col + 2).chain(once(BLOCK_DIAGNOSTIC_MARKER)).collect();
 
                 writeln!(
                     f,
@@ -398,12 +356,7 @@ impl ReportCodeBlock {
         report_kind: ReportKind,
     ) -> fmt::Result {
         let source_id = self.source_location.source_id;
-        let ReportCodeBlockInfo {
-            start_row,
-            end_row,
-            start_col,
-            ..
-        } = self.info(modules);
+        let ReportCodeBlockInfo { start_row, end_row, start_col, .. } = self.info(modules);
 
         // Print the filename of the code block...
         writeln!(

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -55,9 +55,9 @@ pub(crate) fn offset_col_row(offset: usize, source: &str, non_inclusive: bool) -
         // One byte for the newline
         let skip_width = line.len() + 1;
 
-        // Here, we don't want an inclusive range because we don't want to get the last byte because
-        // that will always point to the newline character and this isn't necessary to be included
-        // when selecting a span for printing.
+        // Here, we don't want an inclusive range because we don't want to get the last
+        // byte because that will always point to the newline character and this
+        // isn't necessary to be included when selecting a span for printing.
         let range = if non_inclusive {
             bytes_skipped..bytes_skipped + skip_width
         } else {
@@ -86,9 +86,9 @@ pub(crate) fn offset_col_row(offset: usize, source: &str, non_inclusive: bool) -
 /// This function holds inner rules for calculating what the selected top
 /// and bottom buffer sizes should be.
 fn adjust_initial_span_size(span: usize) -> usize {
-    // @@Correctness: This is an arbitrary rule and should be decided upon more concretely. It's
-    //                even possible that we might not want to get any additional lines for even larger
-    //                spans
+    // @@Correctness: This is an arbitrary rule and should be decided upon more
+    // concretely. It's even possible that we might not want to get any additional
+    // lines for even larger spans
     match span {
         3..=4 => 2,
         5.. => 1,
@@ -157,8 +157,8 @@ impl ReportCodeBlock {
         }
     }
 
-    /// Function to extract the block of the code that will be used to display the span
-    /// of the diagnostic.
+    /// Function to extract the block of the code that will be used to display
+    /// the span of the diagnostic.
     fn get_source_view<'a, T: SourceMap>(
         &self,
         modules: &'a T,
@@ -181,9 +181,10 @@ impl ReportCodeBlock {
             .take(top_buffer + end_row - start_row + 1 + bottom_buffer)
     }
 
-    /// Function that performs the rendering of the `line` view for a diagnostic. In this mode,
-    /// only a single line is highlighted using the [LINE_DIAGNOSTIC_MARKER]. It will highlight
-    /// the entire span using this mode. Here is an example of a diagnostic using the `line`
+    /// Function that performs the rendering of the `line` view for a
+    /// diagnostic. In this mode, only a single line is highlighted using
+    /// the [LINE_DIAGNOSTIC_MARKER]. It will highlight the entire span
+    /// using this mode. Here is an example of a diagnostic using the `line`
     /// mode:
     ///
     /// ```text
@@ -191,7 +192,7 @@ impl ReportCodeBlock {
     /// --> ~/examples/weird.hash:1:1
     /// 1 |   a = "2";
     ///   |   ^^^^^^^ not allowed here
-    /// 2 |   
+    /// 2 |
     /// 3 |   // main := () => {
     /// ```
     fn render_line_view<T: SourceMap>(
@@ -268,29 +269,31 @@ impl ReportCodeBlock {
         Ok(())
     }
 
-    /// Function that performs the rendering of the `block` view for a diagnostic.
-    /// The `block` view works by drawing an initial arrow that points to the start
-    /// of the diagnostic span, and an arrow to the end of the span in the same
-    /// format (with a label at the end). The two arrows are connected by a vertical
-    /// connector on the left hand-side. Here is an example of the `block` mode:
+    /// Function that performs the rendering of the `block` view for a
+    /// diagnostic. The `block` view works by drawing an initial arrow that
+    /// points to the start of the diagnostic span, and an arrow to the end
+    /// of the span in the same format (with a label at the end). The two
+    /// arrows are connected by a vertical connector on the left hand-side.
+    /// Here is an example of the `block` mode:
     ///
     /// ```text
     /// error: non-declarative expressions are not allowed in `module` pattern
     ///   --> /Users/alex/Documents/hash-org/lang/examples/weird.hash:11:1
     ///  9 |    // };
-    /// 10 |    
+    /// 10 |
     /// 11 |    IoError = struct(
     ///    |  __-
     /// 12 | |      error: IoErrorType,
     /// 13 | |      message: str,
     /// 14 | |  );
     ///    | |___- not allowed here
-    /// 15 |    
+    /// 15 |
     /// 16 |    // Make this a test case:
     /// ```
     ///
-    /// As seen in this example, there are two arrows which look like `__-` and which
-    /// are connected by a vertical arrow on the left side of the span.
+    /// As seen in this example, there are two arrows which look like `__-` and
+    /// which are connected by a vertical arrow on the left side of the
+    /// span.
     fn render_block_view<T: SourceMap>(
         &self,
         f: &mut fmt::Formatter,
@@ -308,10 +311,11 @@ impl ReportCodeBlock {
             ..
         } = self.info(modules);
 
-        // So here, we want to iterate over all of the line and on the starting line, we want to
-        // draw an arrow from the left hand-side up until the beginning which then points up, on
-        // lines that are in the middle, we just want to draw a connecting character of the arrow,
-        // and finally on the line below the final line we want to draw an arrow leading up until
+        // So here, we want to iterate over all of the line and on the starting line, we
+        // want to draw an arrow from the left hand-side up until the beginning
+        // which then points up, on lines that are in the middle, we just want
+        // to draw a connecting character of the arrow, and finally on the line
+        // below the final line we want to draw an arrow leading up until
         // the end of the span.
         for (index, line) in error_view {
             let index_str = format!(
@@ -326,9 +330,10 @@ impl ReportCodeBlock {
                 index_str
             };
 
-            // Compute the connector, if the current index is within the diagnostic span, we also need
-            // to add a connector that connects the bottom and top spans by a vertical line to the left
-            // hand-side of the diagnostic span.
+            // Compute the connector, if the current index is within the diagnostic span, we
+            // also need to add a connector that connects the bottom and top
+            // spans by a vertical line to the left hand-side of the diagnostic
+            // span.
             let connector = if (start_row + 1..=end_row).contains(&index) {
                 DIAGNOSTIC_CONNECTING_CHAR
             } else {
@@ -344,7 +349,8 @@ impl ReportCodeBlock {
                 line
             )?;
 
-            // If this is th first row of the diagnostic span, then we want to draw an arrow leading up to it
+            // If this is th first row of the diagnostic span, then we want to draw an arrow
+            // leading up to it
             if index == start_row {
                 let arrow: String = repeat('_')
                     .take(start_col + 2)
@@ -360,8 +366,8 @@ impl ReportCodeBlock {
                 )?;
             }
 
-            // Now we perform the same operator for creating an arrow to join the end span, and of course
-            // we write the note at the end of the span.
+            // Now we perform the same operator for creating an arrow to join the end span,
+            // and of course we write the note at the end of the span.
             if index == end_row {
                 let arrow: String = once('|')
                     .chain(repeat('_').take(end_col + 2))
@@ -382,8 +388,8 @@ impl ReportCodeBlock {
         Ok(())
     }
 
-    /// Function to render the [ReportCodeBlock] using the provided [SourceLocation], message and
-    /// [ReportKind].
+    /// Function to render the [ReportCodeBlock] using the provided
+    /// [SourceLocation], message and [ReportKind].
     pub(crate) fn render<T: SourceMap>(
         &self,
         f: &mut fmt::Formatter,
@@ -416,9 +422,9 @@ impl ReportCodeBlock {
             )
         )?;
 
-        // Now we can determine whether we want to use the `block` or the `line` view. The
-        // block view is for displaying large spans for multiple lines, whilst the line view
-        // is for a single line span.
+        // Now we can determine whether we want to use the `block` or the `line` view.
+        // The block view is for displaying large spans for multiple lines,
+        // whilst the line view is for a single line span.
         if start_row == end_row {
             self.render_line_view(f, modules, longest_indent_width, report_kind)
         } else {

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -57,11 +57,7 @@ impl ReportKind {
 
 impl fmt::Display for ReportKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            highlight(self.as_colour() | Modifier::Bold, self.message())
-        )
+        write!(f, "{}", highlight(self.as_colour() | Modifier::Bold, self.message()))
     }
 }
 
@@ -94,10 +90,7 @@ pub struct ReportNote {
 
 impl ReportNote {
     pub fn new(label: ReportNoteKind, message: impl ToString) -> Self {
-        Self {
-            label,
-            message: message.to_string(),
-        }
+        Self { label, message: message.to_string() }
     }
 }
 
@@ -114,11 +107,7 @@ pub struct ReportCodeBlock {
 impl ReportCodeBlock {
     /// Create a new [ReportCodeBlock] from a [SourceLocation] and a message.
     pub fn new(source_location: SourceLocation, code_message: impl ToString) -> Self {
-        Self {
-            source_location,
-            code_message: code_message.to_string(),
-            info: Cell::new(None),
-        }
+        Self { source_location, code_message: code_message.to_string(), info: Cell::new(None) }
     }
 }
 

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -5,7 +5,8 @@ use crate::highlight::{highlight, Colour, Modifier};
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_source::location::SourceLocation;
 
-/// A data type representing a comment/message on a specific span in a code block.
+/// A data type representing a comment/message on a specific span in a code
+/// block.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ReportCodeBlockInfo {
     /// How many characters should be used for line numbers on the side.
@@ -20,13 +21,14 @@ pub struct ReportCodeBlockInfo {
     pub end_row: usize,
 }
 
-/// Enumeration describing the kind of [Report]; either being a warning, info or an
-/// error.
+/// Enumeration describing the kind of [Report]; either being a warning, info or
+/// an error.
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum ReportKind {
     /// The report is an error.
     Error,
-    /// The report is an informational diagnostic (likely for internal purposes).
+    /// The report is an informational diagnostic (likely for internal
+    /// purposes).
     Info,
     /// The report is a warning.
     Warning,
@@ -63,8 +65,8 @@ impl fmt::Display for ReportKind {
     }
 }
 
-/// The kind of [ReportNote], this is primarily used for rendering the label of the
-/// [ReportNote].
+/// The kind of [ReportNote], this is primarily used for rendering the label of
+/// the [ReportNote].
 #[derive(Debug, Clone)]
 pub enum ReportNoteKind {
     /// A help message or a suggestion.
@@ -82,7 +84,8 @@ impl fmt::Display for ReportNoteKind {
     }
 }
 
-/// Data type representing a report note which consists of a label and the message.
+/// Data type representing a report note which consists of a label and the
+/// message.
 #[derive(Debug, Clone)]
 pub struct ReportNote {
     pub label: ReportNoteKind,
@@ -98,9 +101,9 @@ impl ReportNote {
     }
 }
 
-/// Data structure representing an associated block of code with a report. The type
-/// contains the span of the block, the message associated with a block and optional
-/// [ReportCodeBlockInfo] which adds a message pointed to a code item.
+/// Data structure representing an associated block of code with a report. The
+/// type contains the span of the block, the message associated with a block and
+/// optional [ReportCodeBlockInfo] which adds a message pointed to a code item.
 #[derive(Debug, Clone)]
 pub struct ReportCodeBlock {
     pub source_location: SourceLocation,
@@ -119,16 +122,17 @@ impl ReportCodeBlock {
     }
 }
 
-/// Enumeration representing types of components of a [Report]. A [Report] can be made of
-/// either [ReportCodeBlock]s or [ReportNote]s.
+/// Enumeration representing types of components of a [Report]. A [Report] can
+/// be made of either [ReportCodeBlock]s or [ReportNote]s.
 #[derive(Debug, Clone)]
 pub enum ReportElement {
     CodeBlock(ReportCodeBlock),
     Note(ReportNote),
 }
 
-/// The report data type represents the entire report which might contain many [ReportElement]s. The
-/// report also contains a general [ReportKind] and a general message.
+/// The report data type represents the entire report which might contain many
+/// [ReportElement]s. The report also contains a general [ReportKind] and a
+/// general message.
 #[derive(Debug, Clone)]
 pub struct Report {
     /// The general kind of the report.
@@ -137,8 +141,8 @@ pub struct Report {
     pub message: String,
     /// An optional associated general error code with the report.
     pub error_code: Option<HashErrorCode>,
-    /// A vector of additional [ReportElement]s in order to add additional context
-    /// to errors.
+    /// A vector of additional [ReportElement]s in order to add additional
+    /// context to errors.
     pub contents: Vec<ReportElement>,
 }
 

--- a/compiler/hash-reporting/src/writer.rs
+++ b/compiler/hash-reporting/src/writer.rs
@@ -41,16 +41,12 @@ impl<T: SourceMap> fmt::Display for ReportWriter<'_, T> {
         )?;
 
         let longest_indent_width =
-            self.report
-                .contents
-                .iter()
-                .fold(0, |longest_indent_width, element| match element {
-                    ReportElement::CodeBlock(code_block) => code_block
-                        .info(self.sources)
-                        .indent_width
-                        .max(longest_indent_width),
-                    ReportElement::Note(_) => longest_indent_width,
-                });
+            self.report.contents.iter().fold(0, |longest_indent_width, element| match element {
+                ReportElement::CodeBlock(code_block) => {
+                    code_block.info(self.sources).indent_width.max(longest_indent_width)
+                }
+                ReportElement::Note(_) => longest_indent_width,
+            });
 
         let mut iter = self.report.contents.iter().peekable();
 

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -70,15 +70,16 @@ lazy_static! {
         CoreIdentifiers::from_ident_map(&IDENTIFIER_MAP);
 }
 
-/// Struct representing a globally accessible identifier map. The struct contains a identifier
-/// map and another map for reverse lookups.
+/// Struct representing a globally accessible identifier map. The struct
+/// contains a identifier map and another map for reverse lookups.
 #[derive(Debug, Default)]
 pub struct IdentifierMap<'c> {
     identifiers: DashMap<&'c str, Identifier, FnvBuildHasher>,
     reverse_lookup: DashMap<Identifier, &'c str, FnvBuildHasher>,
 }
 
-/// Holds some default identifiers in order to avoid map lookups when e.g. generating the AST.
+/// Holds some default identifiers in order to avoid map lookups when e.g.
+/// generating the AST.
 pub struct CoreIdentifiers {
     pub underscore: Identifier,
 }
@@ -120,7 +121,8 @@ impl<'c> IdentifierMap<'c> {
         }
     }
 
-    /// Function to lookup an identifier by an [Identifier] value in the identifier map.
+    /// Function to lookup an identifier by an [Identifier] value in the
+    /// identifier map.
     pub fn get_ident(&self, ident: Identifier) -> &'c str {
         self.reverse_lookup.get(&ident).unwrap().value()
     }

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -27,9 +27,7 @@ impl Display for Identifier {
 
 impl Debug for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Identifier")
-            .field(&IDENTIFIER_MAP.get_ident(*self).to_owned())
-            .finish()
+        f.debug_tuple("Identifier").field(&IDENTIFIER_MAP.get_ident(*self).to_owned()).finish()
     }
 }
 
@@ -87,19 +85,14 @@ pub struct CoreIdentifiers {
 impl CoreIdentifiers {
     /// Create the core identifiers inside the given [IdentifierMap].
     pub fn from_ident_map(ident_map: &IdentifierMap) -> Self {
-        Self {
-            underscore: ident_map.create_ident("_"),
-        }
+        Self { underscore: ident_map.create_ident("_") }
     }
 }
 
 impl<'c> IdentifierMap<'c> {
     /// Function to create a new identifier map instance.
     pub fn new() -> Self {
-        IdentifierMap {
-            identifiers: DashMap::default(),
-            reverse_lookup: DashMap::default(),
-        }
+        IdentifierMap { identifiers: DashMap::default(), reverse_lookup: DashMap::default() }
     }
 
     /// Function to create an identifier in the identifier map.
@@ -128,8 +121,6 @@ impl<'c> IdentifierMap<'c> {
     }
 
     pub fn get_path(&self, path: impl Iterator<Item = impl Borrow<Identifier>>) -> String {
-        path.map(|ident| self.get_ident(*ident.borrow()))
-            .collect::<Vec<&'_ str>>()
-            .join("::")
+        path.map(|ident| self.get_ident(*ident.borrow())).collect::<Vec<&'_ str>>().join("::")
     }
 }

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -5,8 +5,8 @@ use std::{convert::TryInto, fmt};
 
 /// Enum representing a location of a token within the source.
 ///
-/// The first element of the tuple represents the starting byte offset and the second element
-/// represents the ending byte offset.
+/// The first element of the tuple represents the starting byte offset and the
+/// second element represents the ending byte offset.
 #[derive(Debug, Eq, Hash, Clone, Copy, PartialEq)]
 pub struct Span(u32, u32);
 
@@ -22,10 +22,11 @@ impl Span {
         Span(start.try_into().unwrap(), end.try_into().unwrap())
     }
 
-    /// This function is used to join a [Span] to another [Span]. The assumption is made that the left hand-side
-    /// [Span] ends before the start of the right hand side [Span]. If that is the case, then a new location is
-    /// created with start pos of the lhs, and the end position of the rhs. If that is not the case, the
-    /// lhs span is returned.
+    /// This function is used to join a [Span] to another [Span]. The assumption
+    /// is made that the left hand-side [Span] ends before the start of the
+    /// right hand side [Span]. If that is the case, then a new location is
+    /// created with start pos of the lhs, and the end position of the rhs. If
+    /// that is not the case, the lhs span is returned.
     ///
     /// In essence, if this was the source stream:
     /// ```text
@@ -34,7 +35,8 @@ impl Span {
     /// --------------------------------------------------------------
     /// ```
     ///
-    /// Then the two locations are joined into one, otherwise the lhs is returned
+    /// Then the two locations are joined into one, otherwise the lhs is
+    /// returned
     #[must_use]
     pub fn join(&self, end: Self) -> Self {
         if self.end() <= end.start() {

--- a/compiler/hash-source/src/string.rs
+++ b/compiler/hash-source/src/string.rs
@@ -7,9 +7,10 @@ use lazy_static::lazy_static;
 
 use dashmap::DashMap;
 
-/// A map containing identifiers that essentially point to a string literal that has been parsed
-/// during the tokenisation process. This is so that we don't have to unnecessarily allocate a string
-/// multiple times even if it occurs within the source.
+/// A map containing identifiers that essentially point to a string literal that
+/// has been parsed during the tokenisation process. This is so that we don't
+/// have to unnecessarily allocate a string multiple times even if it occurs
+/// within the source.
 #[derive(Debug, Default)]
 pub struct StringLiteralMap {
     string_table: DashMap<StringLiteral, &'static str, FnvBuildHasher>,
@@ -29,7 +30,8 @@ impl Display for StringLiteral {
     }
 }
 
-// Utility methods for converting from a String to an StringLiteral and vice versa.
+// Utility methods for converting from a String to an StringLiteral and vice
+// versa.
 
 impl From<&str> for StringLiteral {
     fn from(string: &str) -> Self {
@@ -60,8 +62,8 @@ lazy_static! {
 }
 
 impl StringLiteralMap {
-    /// Add a new string to the map, this will add an additional entry even if the string is already
-    /// within the map.
+    /// Add a new string to the map, this will add an additional entry even if
+    /// the string is already within the map.
     pub fn create_string(&self, value: &str) -> StringLiteral {
         if let Some(key) = self.reverse_table.get(value) {
             *key

--- a/compiler/hash-token/src/delimiter.rs
+++ b/compiler/hash-token/src/delimiter.rs
@@ -1,8 +1,8 @@
 //! Hash Compiler token delimiter definitions.
 
-/// A [Delimiter] is a [super::TokenKind] is used to denote a separation or a nested token
-/// tree. The [Delimiter] does not contain the `<...>` because this conflicts with the
-/// binary operators '<' and '>'.
+/// A [Delimiter] is a [super::TokenKind] is used to denote a separation or a
+/// nested token tree. The [Delimiter] does not contain the `<...>` because this
+/// conflicts with the binary operators '<' and '>'.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Delimiter {
     /// '(' or ')'
@@ -52,8 +52,8 @@ impl Delimiter {
 }
 
 impl std::fmt::Display for Delimiter {
-    /// Display implementation for [Delimiter], it's always assumed that it's asking for
-    /// the right hand-side variant of the delimiter.
+    /// Display implementation for [Delimiter], it's always assumed that it's
+    /// asking for the right hand-side variant of the delimiter.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.right())
     }

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -301,19 +301,13 @@ impl TokenKindVector {
 
     #[inline(always)]
     pub fn begin_visibility() -> Self {
-        Self(vec![
-            TokenKind::Keyword(Keyword::Pub),
-            TokenKind::Keyword(Keyword::Priv),
-        ])
+        Self(vec![TokenKind::Keyword(Keyword::Pub), TokenKind::Keyword(Keyword::Priv)])
     }
 
     /// Tokens expected when the parser expects a collection of patterns to be
     /// present.
     pub fn begin_pattern_collection() -> Self {
-        Self(vec![
-            TokenKind::Delimiter(Delimiter::Paren, true),
-            TokenKind::Colon,
-        ])
+        Self(vec![TokenKind::Delimiter(Delimiter::Paren, true), TokenKind::Colon])
     }
 
     /// Tokens expected when a pattern begins in a match statement.

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -7,10 +7,10 @@ use delimiter::Delimiter;
 use hash_source::{identifier::Identifier, location::Span, string::StringLiteral};
 use keyword::Keyword;
 
-/// A Lexeme token that represents the smallest code unit of a hash source file. The
-/// token contains a kind which is elaborated by [TokenKind] and a [Span] in the
-/// source that is represented as a span. The span is the beginning byte offset, and the
-/// number of bytes for the said token.
+/// A Lexeme token that represents the smallest code unit of a hash source file.
+/// The token contains a kind which is elaborated by [TokenKind] and a [Span] in
+/// the source that is represented as a span. The span is the beginning byte
+/// offset, and the number of bytes for the said token.
 #[derive(Debug, PartialEq)]
 pub struct Token {
     /// The current token type.
@@ -62,7 +62,8 @@ impl std::fmt::Display for Token {
 }
 
 impl TokenKind {
-    /// Check if a [TokenKind] can be considered in a situation as a unary operator.
+    /// Check if a [TokenKind] can be considered in a situation as a unary
+    /// operator.
     pub fn is_unary_op(&self) -> bool {
         matches!(
             self,
@@ -80,8 +81,8 @@ impl TokenKind {
 
     /// Check if the current token can begin a pattern
 
-    /// Checks if the [TokenKind] must begin a block, as in the specified keywords that
-    /// follow a specific syntax, and must be statements.
+    /// Checks if the [TokenKind] must begin a block, as in the specified
+    /// keywords that follow a specific syntax, and must be statements.
     pub fn begins_block(&self) -> bool {
         matches!(
             self,
@@ -95,7 +96,8 @@ impl TokenKind {
         )
     }
 
-    /// Check if the [TokenKind] is a primitive literal; either a 'char', 'int', 'float' or a 'string'
+    /// Check if the [TokenKind] is a primitive literal; either a 'char', 'int',
+    /// 'float' or a 'string'
     pub fn is_literal(&self) -> bool {
         matches!(
             self,
@@ -109,8 +111,9 @@ impl TokenKind {
     }
 }
 
-/// An Atom represents all variants of a token that can be present in a source file. Atom token
-/// kinds can represent a single character, literal or an identifier.
+/// An Atom represents all variants of a token that can be present in a source
+/// file. Atom token kinds can represent a single character, literal or an
+/// identifier.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TokenKind {
     /// '='
@@ -174,19 +177,20 @@ pub enum TokenKind {
     /// Keyword
     Keyword(Keyword),
 
-    /// Delimiter: '(' '{', '[' and right hand-side variants, useful for error reporting and messages.
-    /// The boolean flag represents if the delimiter is left or right, If it's true, then it is the left
-    /// variant.
+    /// Delimiter: '(' '{', '[' and right hand-side variants, useful for error
+    /// reporting and messages. The boolean flag represents if the delimiter
+    /// is left or right, If it's true, then it is the left variant.
     Delimiter(Delimiter, bool),
 
-    /// A token that was unexpected by the lexer, e.g. a unicode symbol not within
-    /// string literal.
+    /// A token that was unexpected by the lexer, e.g. a unicode symbol not
+    /// within string literal.
     Unexpected(char),
 }
 
 impl TokenKind {
-    /// This function is used to create an error message representing when a token
-    /// was unexpectedly encountered or was expected in a particular context.
+    /// This function is used to create an error message representing when a
+    /// token was unexpectedly encountered or was expected in a particular
+    /// context.
     pub fn as_error_string(&self) -> String {
         match self {
             TokenKind::Unexpected(ch) => format!("an unknown character `{}`", ch),
@@ -253,16 +257,16 @@ impl std::fmt::Display for TokenKind {
     }
 }
 
-/// This is a wrapper around a vector of token atoms that can represent the expected
-/// tokens in a given context when transforming the token tree into and an AST.
-/// The wrapper exists because once again you cannot specify implementations for types
-/// that don't originate from the current crate.
+/// This is a wrapper around a vector of token atoms that can represent the
+/// expected tokens in a given context when transforming the token tree into and
+/// an AST. The wrapper exists because once again you cannot specify
+/// implementations for types that don't originate from the current crate.
 ///
-/// @@TODO(alex): Instead of using a [TokenKind], we should use an enum to custom
-/// variants or descriptors such as 'operator'. Instead of token atoms we can just
-/// the display representations of the token atoms. Or even better, we can use the
-/// [`ToString`] trait and just auto cast into a string, whilst holding a vector of
-/// strings.
+/// @@TODO(alex): Instead of using a [TokenKind], we should use an enum to
+/// custom variants or descriptors such as 'operator'. Instead of token atoms we
+/// can just the display representations of the token atoms. Or even better, we
+/// can use the [`ToString`] trait and just auto cast into a string, whilst
+/// holding a vector of strings.
 #[derive(Debug)]
 pub struct TokenKindVector(Vec<TokenKind>);
 
@@ -303,7 +307,8 @@ impl TokenKindVector {
         ])
     }
 
-    /// Tokens expected when the parser expects a collection of patterns to be present.
+    /// Tokens expected when the parser expects a collection of patterns to be
+    /// present.
     pub fn begin_pattern_collection() -> Self {
         Self(vec![
             TokenKind::Delimiter(Delimiter::Paren, true),

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -21,10 +21,11 @@ pub enum TcError {
     CannotUseValueAsTy { value: TermId },
     /// The given arguments do not match the length of the target parameters.
     MismatchingArgParamLength { args: Args, params: Params },
-    /// The parameter with the given name is not found in the given parameter list.
+    /// The parameter with the given name is not found in the given parameter
+    /// list.
     ParamNotFound { params: Params, name: Identifier },
-    /// There is a parameter (at the index `param_index_given_twice`) which is specified twice in
-    /// the given argument list.
+    /// There is a parameter (at the index `param_index_given_twice`) which is
+    /// specified twice in the given argument list.
     ParamGivenTwice {
         args: Args,
         params: Params,
@@ -41,11 +42,13 @@ pub enum TcError {
     UnresolvedVariable { name: Identifier },
     /// The given value does not support accessing (of the given name).
     UnsupportedAccess { name: Identifier, value: TermId },
-    /// The given value does not support namespace accessing (of the given name).
+    /// The given value does not support namespace accessing (of the given
+    /// name).
     UnsupportedNamespaceAccess { name: Identifier, value: TermId },
     /// The given value does not support property accessing (of the given name).
     UnsupportedPropertyAccess { name: Identifier, value: TermId },
-    /// The given type function cannot be applied to the given arguments, due to the given errors.
+    /// The given type function cannot be applied to the given arguments, due to
+    /// the given errors.
     InvalidTypeFunctionApplication {
         type_fn: TermId,
         args: Args,
@@ -59,8 +62,8 @@ pub enum TcError {
     InvalidTypeFunctionReturnType { return_ty: TermId },
     /// The given term cannot be used as a type function return value.
     InvalidTypeFunctionReturnValue { return_value: TermId },
-    /// The given merge term should only contain zero or one nominal elements, but it contains
-    /// more.
+    /// The given merge term should only contain zero or one nominal elements,
+    /// but it contains more.
     MergeShouldOnlyContainOneNominal {
         merge_term: TermId,
         nominal_term: TermId,
@@ -80,7 +83,8 @@ pub enum TcError {
     NeedMoreTypeAnnotationsToResolve { term_to_resolve: TermId },
     /// The given term cannot be instantiated at runtime.
     TermIsNotRuntimeInstantiable { term: TermId },
-    /// The given term cannot be used as the subject of a type function application.
+    /// The given term cannot be used as the subject of a type function
+    /// application.
     UnsupportedTypeFunctionApplication { subject_id: TermId },
     /// The given access operation results in more than one result.
     AmbiguousAccess { access: AccessTerm },

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -11,10 +11,7 @@ pub enum TcError {
     /// Cannot unify the two terms.
     CannotUnify { src: TermId, target: TermId },
     /// Cannot unify the two parameter lists.
-    CannotUnifyParams {
-        src_params: Params,
-        target_params: Params,
-    },
+    CannotUnifyParams { src_params: Params, target_params: Params },
     /// The given term should be a type function but it isn't.
     NotATypeFunction { term: TermId },
     /// The given value cannot be used as a type.
@@ -26,16 +23,9 @@ pub enum TcError {
     ParamNotFound { params: Params, name: Identifier },
     /// There is a parameter (at the index `param_index_given_twice`) which is
     /// specified twice in the given argument list.
-    ParamGivenTwice {
-        args: Args,
-        params: Params,
-        param_index_given_twice: usize,
-    },
+    ParamGivenTwice { args: Args, params: Params, param_index_given_twice: usize },
     /// It is invalid to use a positional argument after a named argument.
-    CannotUsePositionalArgAfterNamedArg {
-        args: Args,
-        problematic_arg_index: usize,
-    },
+    CannotUsePositionalArgAfterNamedArg { args: Args, problematic_arg_index: usize },
     /// The given name cannot be resolved in the given value.
     UnresolvedNameInValue { name: Identifier, value: TermId },
     /// The given variable cannot be resolved in the current context.
@@ -49,11 +39,7 @@ pub enum TcError {
     UnsupportedPropertyAccess { name: Identifier, value: TermId },
     /// The given type function cannot be applied to the given arguments, due to
     /// the given errors.
-    InvalidTypeFunctionApplication {
-        type_fn: TermId,
-        args: Args,
-        unification_errors: Vec<TcError>,
-    },
+    InvalidTypeFunctionApplication { type_fn: TermId, args: Args, unification_errors: Vec<TcError> },
     /// The given term cannot be used in a merge operation.
     InvalidElementOfMerge { term: TermId },
     /// The given term cannot be used as a type function parameter type.
@@ -70,15 +56,9 @@ pub enum TcError {
         second_nominal_term: TermId,
     },
     /// The given merge term should contain only level 1 terms.
-    MergeShouldBeLevel1 {
-        merge_term: TermId,
-        offending_term: TermId,
-    },
+    MergeShouldBeLevel1 { merge_term: TermId, offending_term: TermId },
     /// The given merge term should contain only level 2 terms.
-    MergeShouldBeLevel2 {
-        merge_term: TermId,
-        offending_term: TermId,
-    },
+    MergeShouldBeLevel2 { merge_term: TermId, offending_term: TermId },
     /// More type annotations are needed to resolve the given term.
     NeedMoreTypeAnnotationsToResolve { term_to_resolve: TermId },
     /// The given term cannot be instantiated at runtime.
@@ -89,8 +69,5 @@ pub enum TcError {
     /// The given access operation results in more than one result.
     AmbiguousAccess { access: AccessTerm },
     /// The given access operation does not resolve to a method.
-    InvalidPropertyAccessOfNonMethod {
-        subject: TermId,
-        property: Identifier,
-    },
+    InvalidPropertyAccessOfNonMethod { subject: TermId, property: Identifier },
 }

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -38,12 +38,7 @@ impl<'gs> TcFormatter<'gs> {
         for (i, param) in params.positional().iter().enumerate() {
             match param.name {
                 Some(param_name) => {
-                    write!(
-                        f,
-                        "{}: {}",
-                        param_name,
-                        param.ty.for_formatting(self.global_storage)
-                    )?;
+                    write!(f, "{}: {}", param_name, param.ty.for_formatting(self.global_storage))?;
                 }
                 None => {
                     self.fmt_term(f, param.ty, &Cell::new(false))?;
@@ -62,12 +57,7 @@ impl<'gs> TcFormatter<'gs> {
         for (i, arg) in args.positional().iter().enumerate() {
             match arg.name {
                 Some(arg_name) => {
-                    write!(
-                        f,
-                        "{} = {}",
-                        arg_name,
-                        arg.value.for_formatting(self.global_storage)
-                    )?;
+                    write!(f, "{} = {}", arg_name, arg.value.for_formatting(self.global_storage))?;
                 }
                 None => {
                     self.fmt_term(f, arg.value, &Cell::new(false))?;
@@ -104,11 +94,7 @@ impl<'gs> TcFormatter<'gs> {
         match term {
             Level0Term::Rt(ty_id) => {
                 is_atomic.set(true);
-                write!(
-                    f,
-                    "{{runtime value of type {}}}",
-                    ty_id.for_formatting(self.global_storage)
-                )
+                write!(f, "{{runtime value of type {}}}", ty_id.for_formatting(self.global_storage))
             }
             Level0Term::FnLit(fn_lit) => {
                 is_atomic.set(true);
@@ -326,12 +312,8 @@ impl<'gs> TcFormatter<'gs> {
     ) -> fmt::Result {
         is_atomic.set(true);
         match self.global_storage.nominal_def_store.get(nominal_def_id) {
-            NominalDef::Struct(StructDef {
-                name: Some(name), ..
-            })
-            | NominalDef::Enum(EnumDef {
-                name: Some(name), ..
-            }) => {
+            NominalDef::Struct(StructDef { name: Some(name), .. })
+            | NominalDef::Enum(EnumDef { name: Some(name), .. }) => {
                 write!(f, "{}", name)
             }
             // @@Future: we can actually print out the location of these definitions, which might
@@ -363,11 +345,7 @@ impl<'gs> TcFormatter<'gs> {
             None => match mod_def.origin {
                 ModDefOrigin::TrtImpl(trt_def_id) => {
                     is_atomic.set(false);
-                    write!(
-                        f,
-                        "impl {} {{..}}",
-                        trt_def_id.for_formatting(self.global_storage)
-                    )
+                    write!(f, "impl {} {{..}}", trt_def_id.for_formatting(self.global_storage))
                 }
                 ModDefOrigin::AnonImpl => {
                     is_atomic.set(false);
@@ -405,11 +383,7 @@ pub trait PrepareForFormatting: Sized {
         self,
         global_storage: &'gs GlobalStorage,
     ) -> ForFormatting<'gs, '_, Self> {
-        ForFormatting {
-            t: self,
-            global_storage,
-            is_atomic: None,
-        }
+        ForFormatting { t: self, global_storage, is_atomic: None }
     }
 
     /// Create a `ForFormatting<T>` given a `T`, and provide an out parameter
@@ -419,11 +393,7 @@ pub trait PrepareForFormatting: Sized {
         global_storage: &'gs GlobalStorage,
         is_atomic: &'a Cell<bool>,
     ) -> ForFormatting<'gs, 'a, Self> {
-        ForFormatting {
-            t: self,
-            global_storage,
-            is_atomic: Some(is_atomic),
-        }
+        ForFormatting { t: self, global_storage, is_atomic: Some(is_atomic) }
     }
 }
 

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -1,4 +1,5 @@
-//! Contains utilities to format types for displaying in error messages and debug output.
+//! Contains utilities to format types for displaying in error messages and
+//! debug output.
 use crate::storage::{
     primitives::{
         Args, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, ModDefId, ModDefOrigin,
@@ -12,10 +13,12 @@ use std::cell::Cell;
 
 /// Contains methods to format terms like types, traits, values etc.
 ///
-/// It needs access to [GlobalStorage] in order to resolve nested structures of types/traits/etc.
+/// It needs access to [GlobalStorage] in order to resolve nested structures of
+/// types/traits/etc.
 ///
-/// Some methods take an `is_atomic` parameter, which is an "out" parameter that is set to `true`
-/// when the output is atomic (i.e. does not need to be put in parentheses). For example:
+/// Some methods take an `is_atomic` parameter, which is an "out" parameter that
+/// is set to `true` when the output is atomic (i.e. does not need to be put in
+/// parentheses). For example:
 ///
 /// `(A, B, C)`: atomic
 /// `(A) -> B`: not atomic
@@ -78,8 +81,8 @@ impl<'gs> TcFormatter<'gs> {
         Ok(())
     }
 
-    /// Format the [TrtDef](crate::storage::primitives::TrtDef) indexed by the given [TrtDefId]
-    /// with the given formatter.
+    /// Format the [TrtDef](crate::storage::primitives::TrtDef) indexed by the
+    /// given [TrtDefId] with the given formatter.
     pub fn fmt_trt_def(&self, f: &mut fmt::Formatter, trt_def_id: TrtDefId) -> fmt::Result {
         match self.global_storage.trt_def_store.get(trt_def_id).name {
             Some(name) => {
@@ -202,7 +205,8 @@ impl<'gs> TcFormatter<'gs> {
         Ok(())
     }
 
-    /// Format the [Term] indexed by the given [TermId] with the given formatter.
+    /// Format the [Term] indexed by the given [TermId] with the given
+    /// formatter.
     pub fn fmt_term(
         &self,
         f: &mut fmt::Formatter,
@@ -342,7 +346,8 @@ impl<'gs> TcFormatter<'gs> {
         }
     }
 
-    /// Format a [ModDef](crate::storage::primitives::ModDef) indexed by the given [ModDefId].
+    /// Format a [ModDef](crate::storage::primitives::ModDef) indexed by the
+    /// given [ModDefId].
     pub fn fmt_mod_def(
         &self,
         f: &mut fmt::Formatter,
@@ -382,11 +387,11 @@ impl<'gs> TcFormatter<'gs> {
     }
 }
 
-/// Wraps a type `T` in a structure that contains information to be able to format `T` using
-/// [TcFormatter].
+/// Wraps a type `T` in a structure that contains information to be able to
+/// format `T` using [TcFormatter].
 ///
-/// This can wrap any type, but only types that have corresponding `fmt_*` methods in
-/// [TcFormatter] are useful with it.
+/// This can wrap any type, but only types that have corresponding `fmt_*`
+/// methods in [TcFormatter] are useful with it.
 pub struct ForFormatting<'gs, 'a, T> {
     pub t: T,
     pub global_storage: &'gs GlobalStorage,
@@ -407,8 +412,8 @@ pub trait PrepareForFormatting: Sized {
         }
     }
 
-    /// Create a `ForFormatting<T>` given a `T`, and provide an out parameter for the `is_atomic`
-    /// check.
+    /// Create a `ForFormatting<T>` given a `T`, and provide an out parameter
+    /// for the `is_atomic` check.
     fn for_formatting_with_atomic_flag<'gs, 'a>(
         self,
         global_storage: &'gs GlobalStorage,
@@ -427,7 +432,8 @@ impl PrepareForFormatting for TrtDefId {}
 impl PrepareForFormatting for ModDefId {}
 impl PrepareForFormatting for NominalDefId {}
 
-// Convenience implementations of Display for the types that implement PrepareForFormatting:
+// Convenience implementations of Display for the types that implement
+// PrepareForFormatting:
 
 impl fmt::Display for ForFormatting<'_, '_, TermId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -38,11 +38,7 @@ impl TcState {
         let mut global_storage = GlobalStorage::new();
         let core_defs = CoreDefs::new(&mut global_storage);
         let local_storage = LocalStorage::new(&mut global_storage);
-        Self {
-            global_storage,
-            core_defs,
-            prev_local_storage: local_storage,
-        }
+        Self { global_storage, core_defs, prev_local_storage: local_storage }
     }
 }
 
@@ -82,10 +78,7 @@ impl Tc<'_> for TcImpl {
             Ok(_) => Ok(()),
             Err(error) => {
                 // Turn the error into a report:
-                let err_with_storage = TcErrorWithStorage {
-                    error,
-                    storage: storage.storages(),
-                };
+                let err_with_storage = TcErrorWithStorage { error, storage: storage.storages() };
                 Err(err_with_storage.into())
             }
         }
@@ -115,10 +108,7 @@ impl Tc<'_> for TcImpl {
             Ok(_) => Ok(()),
             Err(error) => {
                 // Turn the error into a report:
-                let err_with_storage = TcErrorWithStorage {
-                    error,
-                    storage: storage.storages(),
-                };
+                let err_with_storage = TcErrorWithStorage { error, storage: storage.storages() };
                 Err(err_with_storage.into())
             }
         }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,7 +1,7 @@
 //! The Hash typechecker.
 //!
-//! This brings light to the world by ensuring the correctness of the crude and dangerous Hash
-//! program that is given as input to the compiler.
+//! This brings light to the world by ensuring the correctness of the crude and
+//! dangerous Hash program that is given as input to the compiler.
 //!
 //! @@Todo(kontheocharis): write docs about the stages of the typechecker.
 
@@ -66,8 +66,8 @@ impl Tc<'_> for TcImpl {
         state: &mut Self::State,
         _job_params: &hash_pipeline::settings::CompilerJobParams,
     ) -> CompilerResult<()> {
-        // Instantiate a visitor with the source and visit the source, using the previous local
-        // storage.
+        // Instantiate a visitor with the source and visit the source, using the
+        // previous local storage.
         let mut storage = StorageRefMut {
             global_storage: &mut state.global_storage,
             core_defs: &state.core_defs,

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -1,5 +1,5 @@
-//! Contains helper structures to create complex types and values without having to manually call
-//! the corresponding stores.
+//! Contains helper structures to create complex types and values without having
+//! to manually call the corresponding stores.
 use crate::storage::{
     primitives::{
         AccessOp, AccessTerm, AppSub, AppTyFn, Arg, Args, EnumDef, EnumVariant, EnumVariantValue,
@@ -13,7 +13,8 @@ use crate::storage::{
 use hash_source::identifier::Identifier;
 use std::cell::{Cell, RefCell};
 
-/// Helper to create various primitive constructions (from [crate::storage::primitives]).
+/// Helper to create various primitive constructions (from
+/// [crate::storage::primitives]).
 ///
 /// Optionally adds the constructions to a scope, if given.
 pub struct PrimitiveBuilder<'gs> {
@@ -37,7 +38,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a new [PrimitiveBuilder] with a given scope.
     ///
-    /// This adds every constructed item into the scope with their given names (if any).
+    /// This adds every constructed item into the scope with their given names
+    /// (if any).
     pub fn new_with_scope(gs: &'gs mut GlobalStorage, scope: ScopeId) -> Self {
         Self {
             gs: RefCell::new(gs),
@@ -75,7 +77,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.add_pub_member_to_scope(name, def_ty, def_value);
     }
 
-    /// Create a named module definition with the given name, members, and origin.
+    /// Create a named module definition with the given name, members, and
+    /// origin.
     ///
     /// This adds the name to the scope.
     pub fn create_named_mod_def(
@@ -98,7 +101,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_mod_def(Option::<Identifier>::None, origin, members, bound_vars)
     }
 
-    /// Create a module definition with the given optional name, members, and origin.
+    /// Create a module definition with the given optional name, members, and
+    /// origin.
     pub fn create_mod_def(
         &self,
         name: Option<impl Into<Identifier>>,
@@ -241,7 +245,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         }
     }
 
-    /// Create a [Term::Access] with the given subject and name, and namespace operator.
+    /// Create a [Term::Access] with the given subject and name, and namespace
+    /// operator.
     pub fn create_ns_access(&self, subject_id: TermId, name: impl Into<Identifier>) -> TermId {
         self.create_term(Term::Access(AccessTerm {
             subject: subject_id,
@@ -250,7 +255,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         }))
     }
 
-    /// Create a [Term::Access] with the given subject and name, and property operator.
+    /// Create a [Term::Access] with the given subject and name, and property
+    /// operator.
     pub fn create_prop_access(&self, subject_id: TermId, name: impl Into<Identifier>) -> TermId {
         self.create_term(Term::Access(AccessTerm {
             subject: subject_id,
@@ -330,7 +336,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Level0(Level0Term::Rt(ty_term_id)))
     }
 
-    /// Create a [Level0Term::FnLit] of the given function type and return value.
+    /// Create a [Level0Term::FnLit] of the given function type and return
+    /// value.
     pub fn create_fn_lit_term(&self, fn_ty: TermId, return_value: TermId) -> TermId {
         self.create_term(Term::Level0(Level0Term::FnLit(FnLit {
             fn_ty,
@@ -360,7 +367,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.gs.borrow_mut().term_store.create(term)
     }
 
-    /// Create a [Level1Term::Fn] term with the given parameters and return type.
+    /// Create a [Level1Term::Fn] term with the given parameters and return
+    /// type.
     pub fn create_fn_ty_term(
         &self,
         params: impl IntoIterator<Item = Param>,
@@ -382,8 +390,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.gs.borrow_mut().scope_store.create(scope)
     }
 
-    /// Create a [Scope] of kind [ScopeKind::Constant] from the given members, returning a
-    /// [ScopeId].
+    /// Create a [Scope] of kind [ScopeKind::Constant] from the given members,
+    /// returning a [ScopeId].
     pub fn create_constant_scope(&self, members: impl IntoIterator<Item = Member>) -> ScopeId {
         self.create_scope(Scope::new(ScopeKind::Constant, members))
     }
@@ -429,7 +437,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Level1(Level1Term::ModDef(mod_def_id)))
     }
 
-    /// Create a type function type term with the given name, parameters, and return type.
+    /// Create a type function type term with the given name, parameters, and
+    /// return type.
     pub fn create_ty_fn_ty_term(
         &self,
         params: impl IntoIterator<Item = Param>,
@@ -440,7 +449,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::TyFnTy(ty_fn))
     }
 
-    /// Create a nameless type function term with parameters, return type and value.
+    /// Create a nameless type function term with parameters, return type and
+    /// value.
     ///
     /// This adds the name to the scope.
     pub fn create_nameless_ty_fn_term(
@@ -452,7 +462,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_ty_fn_term(Option::<Identifier>::None, params, return_ty, return_value)
     }
 
-    /// Create a named type function term with parameters, return type and value.
+    /// Create a named type function term with parameters, return type and
+    /// value.
     ///
     /// This adds the name to the scope.
     pub fn create_named_ty_fn_term(
@@ -465,8 +476,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_ty_fn_term(Some(name), params, return_ty, return_value)
     }
 
-    /// Create a type function term with the given optional name, parameters, return type and
-    /// value.
+    /// Create a type function term with the given optional name, parameters,
+    /// return type and value.
     ///
     /// This adds the name to the scope.
     pub fn create_ty_fn_term(
@@ -496,7 +507,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         ty_fn_id
     }
 
-    /// Create a type function application, given type function value and arguments.
+    /// Create a type function application, given type function value and
+    /// arguments.
     pub fn create_app_ty_fn(
         &self,
         subject: TermId,
@@ -519,9 +531,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Unresolved(self.create_unresolved()))
     }
 
-    /// Create a substitution application term, given a substitution and inner term.
+    /// Create a substitution application term, given a substitution and inner
+    /// term.
     ///
-    /// If no elements exist in the substitution, returns the term itself without wrapping it.
+    /// If no elements exist in the substitution, returns the term itself
+    /// without wrapping it.
     pub fn create_app_sub_term(&self, sub: Sub, term: TermId) -> TermId {
         if sub.map().is_empty() {
             term
@@ -538,7 +552,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         }
     }
 
-    /// Create a type function application type, given type function value and arguments.
+    /// Create a type function application type, given type function value and
+    /// arguments.
     ///
     /// This calls [Self::create_app_ty_fn], so its conditions apply here.
     pub fn create_app_ty_fn_term(

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -30,10 +30,7 @@ pub struct PrimitiveBuilder<'gs> {
 impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a new [PrimitiveBuilder] with a given scope.
     pub fn new(gs: &'gs mut GlobalStorage) -> Self {
-        Self {
-            gs: RefCell::new(gs),
-            scope: Cell::new(None),
-        }
+        Self { gs: RefCell::new(gs), scope: Cell::new(None) }
     }
 
     /// Create a new [PrimitiveBuilder] with a given scope.
@@ -41,17 +38,12 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// This adds every constructed item into the scope with their given names
     /// (if any).
     pub fn new_with_scope(gs: &'gs mut GlobalStorage, scope: ScopeId) -> Self {
-        Self {
-            gs: RefCell::new(gs),
-            scope: Cell::new(Some(scope)),
-        }
+        Self { gs: RefCell::new(gs), scope: Cell::new(Some(scope)) }
     }
 
     /// Create a variable with the given name.
     pub fn create_var(&self, var_name: impl Into<Identifier>) -> Var {
-        Var {
-            name: var_name.into(),
-        }
+        Var { name: var_name.into() }
     }
 
     /// Create a variable with the given name, in the form of a [Term::Var].
@@ -128,15 +120,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         &self,
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> NominalDefId {
-        let def_id = self
-            .gs
-            .borrow_mut()
-            .nominal_def_store
-            .create(NominalDef::Struct(StructDef {
-                name: None,
-                fields: StructFields::Opaque,
-                bound_vars: bound_vars.into_iter().collect(),
-            }));
+        let def_id = self.gs.borrow_mut().nominal_def_store.create(NominalDef::Struct(StructDef {
+            name: None,
+            fields: StructFields::Opaque,
+            bound_vars: bound_vars.into_iter().collect(),
+        }));
         def_id
     }
 
@@ -149,15 +137,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> NominalDefId {
         let name = struct_name.into();
-        let def_id = self
-            .gs
-            .borrow_mut()
-            .nominal_def_store
-            .create(NominalDef::Struct(StructDef {
-                name: Some(name),
-                fields: StructFields::Opaque,
-                bound_vars: bound_vars.into_iter().collect(),
-            }));
+        let def_id = self.gs.borrow_mut().nominal_def_store.create(NominalDef::Struct(StructDef {
+            name: Some(name),
+            fields: StructFields::Opaque,
+            bound_vars: bound_vars.into_iter().collect(),
+        }));
         self.add_nominal_def_to_scope(name, def_id);
         def_id
     }
@@ -172,15 +156,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> NominalDefId {
         let name = struct_name.into();
-        let def_id = self
-            .gs
-            .borrow_mut()
-            .nominal_def_store
-            .create(NominalDef::Struct(StructDef {
-                name: Some(name),
-                fields: StructFields::Explicit(ParamList::new(fields.into_iter().collect())),
-                bound_vars: bound_vars.into_iter().collect(),
-            }));
+        let def_id = self.gs.borrow_mut().nominal_def_store.create(NominalDef::Struct(StructDef {
+            name: Some(name),
+            fields: StructFields::Explicit(ParamList::new(fields.into_iter().collect())),
+            bound_vars: bound_vars.into_iter().collect(),
+        }));
         self.add_nominal_def_to_scope(name, def_id);
         def_id
     }
@@ -203,10 +183,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
         name: impl Into<Identifier>,
         fields: impl IntoIterator<Item = Param>,
     ) -> EnumVariant {
-        EnumVariant {
-            name: name.into(),
-            fields: ParamList::new(fields.into_iter().collect()),
-        }
+        EnumVariant { name: name.into(), fields: ParamList::new(fields.into_iter().collect()) }
     }
 
     /// Create an enum with the given name and variants.
@@ -219,18 +196,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> NominalDefId {
         let name = enum_name.into();
-        let def_id = self
-            .gs
-            .borrow_mut()
-            .nominal_def_store
-            .create(NominalDef::Enum(EnumDef {
-                name: Some(name),
-                variants: variants
-                    .into_iter()
-                    .map(|variant| (variant.name, variant))
-                    .collect(),
-                bound_vars: bound_vars.into_iter().collect(),
-            }));
+        let def_id = self.gs.borrow_mut().nominal_def_store.create(NominalDef::Enum(EnumDef {
+            name: Some(name),
+            variants: variants.into_iter().map(|variant| (variant.name, variant)).collect(),
+            bound_vars: bound_vars.into_iter().collect(),
+        }));
         self.add_nominal_def_to_scope(name, def_id);
         def_id
     }
@@ -339,10 +309,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a [Level0Term::FnLit] of the given function type and return
     /// value.
     pub fn create_fn_lit_term(&self, fn_ty: TermId, return_value: TermId) -> TermId {
-        self.create_term(Term::Level0(Level0Term::FnLit(FnLit {
-            fn_ty,
-            return_value,
-        })))
+        self.create_term(Term::Level0(Level0Term::FnLit(FnLit { fn_ty, return_value })))
     }
 
     /// Create a [ParamList<T>] from the given set of items.
@@ -355,11 +322,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a parameter with the given name and type.
     pub fn create_param(&self, name: impl Into<Identifier>, ty: TermId) -> Param {
-        Param {
-            name: Some(name.into()),
-            ty,
-            default_value: None,
-        }
+        Param { name: Some(name.into()), ty, default_value: None }
     }
 
     /// Create a term with the given term value.
@@ -493,11 +456,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
             name,
             general_params: params.clone(),
             general_return_ty: return_ty,
-            cases: vec![TyFnCase {
-                params: params.clone(),
-                return_ty,
-                return_value,
-            }],
+            cases: vec![TyFnCase { params: params.clone(), return_ty, return_value }],
         };
         let ty_fn_id = self.create_term(Term::TyFn(ty_fn));
         let ty_fn_ty_id = self.create_term(Term::TyFnTy(TyFnTy { params, return_ty }));
@@ -514,10 +473,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
         subject: TermId,
         args: impl IntoIterator<Item = Arg>,
     ) -> AppTyFn {
-        AppTyFn {
-            args: Args::new(args.into_iter().collect()),
-            subject,
-        }
+        AppTyFn { args: Args::new(args.into_iter().collect()), subject }
     }
 
     /// Create a new unresolved term value, of type [Term::Unresolved].
@@ -546,10 +502,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create an argument with the given name and value.
     pub fn create_arg(&self, name: impl Into<Identifier>, value: TermId) -> Arg {
-        Arg {
-            name: Some(name.into()),
-            value,
-        }
+        Arg { name: Some(name.into()), value }
     }
 
     /// Create a type function application type, given type function value and

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -1,7 +1,8 @@
-//! Contains implementations of the main operations that the typechecker should be able to perform.
+//! Contains implementations of the main operations that the typechecker should
+//! be able to perform.
 //!
-//! Code from this module is to be used while traversing and typing the AST, in order to unify
-//! types and ensure correctness.
+//! Code from this module is to be used while traversing and typing the AST, in
+//! order to unify types and ensure correctness.
 use self::{
     building::PrimitiveBuilder, reader::PrimitiveReader, scope::ScopeResolver,
     simplify::Simplifier, substitute::Substituter, typing::Typer, unify::Unifier,
@@ -43,7 +44,8 @@ pub trait AccessToOpsMut: AccessToStorageMut {
         PrimitiveBuilder::new(self.global_storage_mut())
     }
 
-    /// Create an instance of [PrimitiveBuilder] from the global storage, with the given scope.
+    /// Create an instance of [PrimitiveBuilder] from the global storage, with
+    /// the given scope.
     ///
     /// See [PrimitiveBuilder] docs for more information.
     fn builder_with_scope(&mut self, scope: ScopeId) -> PrimitiveBuilder {

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 
 /// Pair the given parameters with the given arguments.
 ///
-/// This does not perform any typechecking, it simply matches parameters and arguments by
-/// position or name.
+/// This does not perform any typechecking, it simply matches parameters and
+/// arguments by position or name.
 pub fn pair_args_with_params<'p, 'a>(
     params: &'p Params,
     args: &'a Args,

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -1,4 +1,5 @@
-//! Contains helpers to read various things stored in [crate::storage] with ease.
+//! Contains helpers to read various things stored in [crate::storage] with
+//! ease.
 use hash_source::SourceId;
 
 use crate::storage::{
@@ -8,7 +9,8 @@ use crate::storage::{
     GlobalStorage,
 };
 
-/// Helper to read various primitive constructions (from [crate::storage::primitives]).
+/// Helper to read various primitive constructions (from
+/// [crate::storage::primitives]).
 pub struct PrimitiveReader<'gs> {
     gs: &'gs GlobalStorage,
 }
@@ -49,7 +51,8 @@ impl<'gs> PrimitiveReader<'gs> {
         self.gs.trt_def_store.get(trt_def_id)
     }
 
-    /// Get the module definition ID of the given source, if it has already been checked.
+    /// Get the module definition ID of the given source, if it has already been
+    /// checked.
     pub fn get_source_term(&self, source_id: SourceId) -> Option<ModDefId> {
         self.gs.checked_sources.source_type_id(source_id)
     }

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -38,10 +38,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         let new_args = args
             .positional()
             .iter()
-            .map(|arg| Arg {
-                name: arg.name,
-                value: self.apply_sub_to_term(sub, arg.value),
-            })
+            .map(|arg| Arg { name: arg.name, value: self.apply_sub_to_term(sub, arg.value) })
             .collect::<Vec<_>>();
         ParamList::new(new_args)
     }
@@ -55,9 +52,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             .map(|param| Param {
                 name: param.name,
                 ty: self.apply_sub_to_term(sub, param.ty),
-                default_value: param
-                    .default_value
-                    .map(|value| self.apply_sub_to_term(sub, value)),
+                default_value: param.default_value.map(|value| self.apply_sub_to_term(sub, value)),
             })
             .collect::<Vec<_>>();
         ParamList::new(new_params)
@@ -67,9 +62,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
     /// [Level3Term] with the substituted variables.
     pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TermId {
         match term {
-            Level3Term::TrtKind => self
-                .builder()
-                .create_term(Term::Level3(Level3Term::TrtKind)),
+            Level3Term::TrtKind => self.builder().create_term(Term::Level3(Level3Term::TrtKind)),
         }
     }
 
@@ -115,20 +108,18 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             Level1Term::Tuple(tuple_ty) => {
                 // Apply to all members
                 let subbed_members = self.apply_sub_to_params(sub, &tuple_ty.members);
-                self.builder()
-                    .create_term(Term::Level1(Level1Term::Tuple(TupleTy {
-                        members: subbed_members,
-                    })))
+                self.builder().create_term(Term::Level1(Level1Term::Tuple(TupleTy {
+                    members: subbed_members,
+                })))
             }
             Level1Term::Fn(fn_ty) => {
                 // Apply to parameters and return type
                 let subbed_params = self.apply_sub_to_params(sub, &fn_ty.params);
                 let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty);
-                self.builder()
-                    .create_term(Term::Level1(Level1Term::Fn(FnTy {
-                        params: subbed_params,
-                        return_ty: subbed_return_ty,
-                    })))
+                self.builder().create_term(Term::Level1(Level1Term::Fn(FnTy {
+                    params: subbed_params,
+                    return_ty: subbed_return_ty,
+                })))
             }
         }
     }
@@ -146,9 +137,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
                 // Here we add the substitution to the term using only vars in the enum
                 // definition.
                 let reader = self.reader();
-                let enum_def_vars = reader
-                    .get_nominal_def(enum_variant.enum_def_id)
-                    .bound_vars();
+                let enum_def_vars = reader.get_nominal_def(enum_variant.enum_def_id).bound_vars();
                 let selected_sub = sub.select(enum_def_vars);
                 let builder = self.builder();
                 builder.create_app_sub_term(
@@ -160,8 +149,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
                 // Apply to the function type and return value
                 let subbed_fn_ty = self.apply_sub_to_term(sub, fn_lit.fn_ty);
                 let subbed_return_value = self.apply_sub_to_term(sub, fn_lit.return_value);
-                self.builder()
-                    .create_fn_lit_term(subbed_fn_ty, subbed_return_value)
+                self.builder().create_fn_lit_term(subbed_fn_ty, subbed_return_value)
             }
         }
     }
@@ -199,8 +187,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             Term::Access(access) => {
                 // Just apply the substitution to the subject:
                 let subbed_subject_id = self.apply_sub_to_term(sub, access.subject);
-                self.builder()
-                    .create_ns_access(subbed_subject_id, access.name)
+                self.builder().create_ns_access(subbed_subject_id, access.name)
             }
             Term::Merge(terms) => {
                 // Apply the substitution to each element of the merge.
@@ -621,24 +608,15 @@ mod tests {
             .map(|x| storage_ref.builder().create_term(x.into()))
             .collect();
 
-        println!(
-            "{}",
-            subbed_target.for_formatting(storage_ref.global_storage())
-        );
+        println!("{}", subbed_target.for_formatting(storage_ref.global_storage()));
 
         print!("\nTarget free vars:\n");
         for target_free_var in &target_free_vars_list {
-            println!(
-                "{}",
-                target_free_var.for_formatting(storage_ref.global_storage())
-            );
+            println!("{}", target_free_var.for_formatting(storage_ref.global_storage()));
         }
         print!("\nInner free vars:\n");
         for inner_free_var in &inner_free_vars_list {
-            println!(
-                "{}",
-                inner_free_var.for_formatting(storage_ref.global_storage())
-            );
+            println!("{}", inner_free_var.for_formatting(storage_ref.global_storage()));
         }
 
         println!();

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -32,8 +32,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         Self { storage }
     }
 
-    /// Apply the given substitution to the given arguments, producing a new set of arguments
-    /// with the substituted variables.
+    /// Apply the given substitution to the given arguments, producing a new set
+    /// of arguments with the substituted variables.
     pub fn apply_sub_to_args(&mut self, sub: &Sub, args: &Args) -> Args {
         let new_args = args
             .positional()
@@ -46,8 +46,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         ParamList::new(new_args)
     }
 
-    /// Apply the given substitution to the given parameters, producing a new set of parameters
-    /// with the substituted variables.
+    /// Apply the given substitution to the given parameters, producing a new
+    /// set of parameters with the substituted variables.
     pub fn apply_sub_to_params(&mut self, sub: &Sub, params: &Params) -> Params {
         let new_params = params
             .positional()
@@ -63,8 +63,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         ParamList::new(new_params)
     }
 
-    /// Apply the given substitution to the given [Level3Term], producing a new [Level3Term] with
-    /// the substituted variables.
+    /// Apply the given substitution to the given [Level3Term], producing a new
+    /// [Level3Term] with the substituted variables.
     pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TermId {
         match term {
             Level3Term::TrtKind => self
@@ -73,12 +73,13 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Apply the given substitution to the given [Level2Term], producing a new [Level2Term] with
-    /// the substituted variables.
+    /// Apply the given substitution to the given [Level2Term], producing a new
+    /// [Level2Term] with the substituted variables.
     pub fn apply_sub_to_level2_term(&mut self, sub: &Sub, term: Level2Term) -> TermId {
         match term {
             Level2Term::Trt(trt_def_id) => {
-                // Here we add the substitution to the term using only vars in the trait definition.
+                // Here we add the substitution to the term using only vars in the trait
+                // definition.
                 let reader = self.reader();
                 let trt_def_vars = &reader.get_trt_def(trt_def_id).bound_vars;
                 let selected_sub = sub.select(trt_def_vars);
@@ -89,12 +90,13 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Apply the given substitution to the given [Level1Term], producing a new [Level1Term] with
-    /// the substituted variables.
+    /// Apply the given substitution to the given [Level1Term], producing a new
+    /// [Level1Term] with the substituted variables.
     pub fn apply_sub_to_level1_term(&mut self, sub: &Sub, term: Level1Term) -> TermId {
         match term {
             Level1Term::ModDef(mod_def_id) => {
-                // Here we add the substitution to the term using only vars in the mod definition.
+                // Here we add the substitution to the term using only vars in the mod
+                // definition.
                 let reader = self.reader();
                 let mod_def_vars = &reader.get_mod_def(mod_def_id).bound_vars;
                 let selected_sub = sub.select(mod_def_vars);
@@ -131,8 +133,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Apply the given substitution to the given [Level0Term], producing a new [Level0Term] with
-    /// the substituted variables.
+    /// Apply the given substitution to the given [Level0Term], producing a new
+    /// [Level0Term] with the substituted variables.
     pub fn apply_sub_to_level0_term(&mut self, sub: &Sub, term: Level0Term) -> TermId {
         match term {
             Level0Term::Rt(ty_term_id) => {
@@ -141,7 +143,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
                 self.builder().create_rt_term(subbed_ty_term_id)
             }
             Level0Term::EnumVariant(enum_variant) => {
-                // Here we add the substitution to the term using only vars in the enum definition.
+                // Here we add the substitution to the term using only vars in the enum
+                // definition.
                 let reader = self.reader();
                 let enum_def_vars = reader
                     .get_nominal_def(enum_variant.enum_def_id)
@@ -163,8 +166,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Apply the given substitution to the given [SubSubject], producing a new term with the
-    /// substituted result.
+    /// Apply the given substitution to the given [SubSubject], producing a new
+    /// term with the substituted result.
     pub fn apply_sub_to_subject(&mut self, sub: &Sub, subject: SubSubject) -> TermId {
         match sub.get_sub_for(subject) {
             Some(subbed_term_id) => subbed_term_id,
@@ -172,16 +175,18 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Apply the given substitution to the term indexed by the given [TermId], producing a new
-    /// term with the substituted variables.
+    /// Apply the given substitution to the term indexed by the given [TermId],
+    /// producing a new term with the substituted variables.
     ///
-    /// Sometimes, this will actually create a [Term::AppSub] somewhere inside the term tree, and
-    /// those are the leaf nodes of the substitution application. This will happen with `ModDef`,
-    /// `TrtDef`, `NominalDef`, and `EnumVariant`. This is so that when `AccessTerm` is resolved
-    /// for those types, the substitution is carried forward into the member term.
+    /// Sometimes, this will actually create a [Term::AppSub] somewhere inside
+    /// the term tree, and those are the leaf nodes of the substitution
+    /// application. This will happen with `ModDef`, `TrtDef`, `NominalDef`,
+    /// and `EnumVariant`. This is so that when `AccessTerm` is resolved for
+    /// those types, the substitution is carried forward into the member term.
     pub fn apply_sub_to_term(&mut self, sub: &Sub, term_id: TermId) -> TermId {
-        // @@Performance: here we copy a lot, maybe there is a way to avoid all this copying by
-        // first checking that the variables to be substituted actually exist in the term.
+        // @@Performance: here we copy a lot, maybe there is a way to avoid all this
+        // copying by first checking that the variables to be substituted
+        // actually exist in the term.
 
         let term = self.reader().get_term(term_id).clone();
         match term {
@@ -208,9 +213,10 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             Term::TyFn(ty_fn) => {
                 // Apply the substitution to the general parameters, return type, and each case.
                 //
-                // However, we first have to remove all the shadowed variables from the substitution:
-                // If we have T -> str, and <T> => List<T>, we don't wanna get <T> => List<str>
-                // because T is bound in the term, not free.
+                // However, we first have to remove all the shadowed variables from the
+                // substitution: If we have T -> str, and <T> => List<T>, we
+                // don't wanna get <T> => List<str> because T is bound in the
+                // term, not free.
                 let shadowed_sub = sub.filter(&ty_fn.general_params);
                 let subbed_general_params =
                     self.apply_sub_to_params(&shadowed_sub, &ty_fn.general_params);
@@ -255,8 +261,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             Term::AppSub(app_sub) => {
                 // @@Correctness: do we not want to unify substitutions here?
                 //
-                // Here, we have to substitute all X in * -> X pairs of the substitution, as well
-                // as the subject term itself.
+                // Here, we have to substitute all X in * -> X pairs of the substitution, as
+                // well as the subject term itself.
                 let subbed_sub = app_sub
                     .sub
                     .pairs()
@@ -276,7 +282,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables in the parameter default values and types to the given [HashSet].
+    /// Add the free variables in the parameter default values and types to the
+    /// given [HashSet].
     pub fn add_free_vars_in_params_to_set(
         &self,
         params: &Params,
@@ -291,8 +298,9 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Remove the free variables that exist in the given params as names, from the given
-    /// [HashSet], and add the free variables in the default values and types.
+    /// Remove the free variables that exist in the given params as names, from
+    /// the given [HashSet], and add the free variables in the default
+    /// values and types.
     ///
     /// This is to be used for type functions.
     pub fn add_and_remove_free_vars_in_params_from_set(
@@ -310,14 +318,16 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables that exist in the given args, to the given [HashSet].
+    /// Add the free variables that exist in the given args, to the given
+    /// [HashSet].
     pub fn add_free_vars_in_args_to_set(&self, args: &Args, result: &mut HashSet<SubSubject>) {
         for arg in args.positional() {
             self.add_free_vars_in_term_to_set(arg.value, result);
         }
     }
 
-    /// Add the free variables that exist in the given [Level0Term], to the given [HashSet].
+    /// Add the free variables that exist in the given [Level0Term], to the
+    /// given [HashSet].
     pub fn add_free_vars_in_level0_term_to_set(
         &self,
         term: &Level0Term,
@@ -338,7 +348,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables that exist in the given [Level1Term], to the given [HashSet].
+    /// Add the free variables that exist in the given [Level1Term], to the
+    /// given [HashSet].
     pub fn add_free_vars_in_level1_term_to_set(
         &self,
         term: &Level1Term,
@@ -346,8 +357,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
     ) {
         match term {
             Level1Term::ModDef(mod_def_id) => {
-                // Add the bound vars of the module (they are not bound because they are not behind
-                // a type function anymore).
+                // Add the bound vars of the module (they are not bound because they are not
+                // behind a type function anymore).
                 result.extend(
                     self.reader()
                         .get_mod_def(*mod_def_id)
@@ -358,8 +369,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
                 )
             }
             Level1Term::NominalDef(nominal_def_id) => {
-                // Add the bound vars of the nominal definition (they are not bound because they are not behind
-                // a type function anymore).
+                // Add the bound vars of the nominal definition (they are not bound because they
+                // are not behind a type function anymore).
                 result.extend(
                     self.reader()
                         .get_nominal_def(*nominal_def_id)
@@ -381,7 +392,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables that exist in the given [Level2Term], to the given [HashSet].
+    /// Add the free variables that exist in the given [Level2Term], to the
+    /// given [HashSet].
     pub fn add_free_vars_in_level2_term_to_set(
         &self,
         term: &Level2Term,
@@ -389,8 +401,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
     ) {
         match term {
             Level2Term::Trt(trt_def_id) => {
-                // Add the bound vars of the trait definition (they are not bound because they are not behind
-                // a type function anymore).
+                // Add the bound vars of the trait definition (they are not bound because they
+                // are not behind a type function anymore).
                 result.extend(
                     self.reader()
                         .get_trt_def(*trt_def_id)
@@ -404,7 +416,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables that exist in the given [Level3Term], to the given [HashSet].
+    /// Add the free variables that exist in the given [Level3Term], to the
+    /// given [HashSet].
     pub fn add_free_vars_in_level3_term_to_set(
         &self,
         term: &Level3Term,
@@ -415,9 +428,11 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Add the free variables that exist in the given term, to the given [HashSet].
+    /// Add the free variables that exist in the given term, to the given
+    /// [HashSet].
     ///
-    /// Free variables are either `Var` or `Unresolved`, and this function collects both.
+    /// Free variables are either `Var` or `Unresolved`, and this function
+    /// collects both.
     pub fn add_free_vars_in_term_to_set(&self, term_id: TermId, result: &mut HashSet<SubSubject>) {
         let reader = self.reader();
         let term = reader.get_term(term_id);
@@ -503,7 +518,8 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
 
     /// Get the set of free variables that exist in the given term.
     ///
-    /// Free variables are either `Var` or `Unresolved`, and this function collects both.
+    /// Free variables are either `Var` or `Unresolved`, and this function
+    /// collects both.
     pub fn get_free_vars_in_term(&self, term_id: TermId) -> HashSet<SubSubject> {
         let mut result = HashSet::new();
         self.add_free_vars_in_term_to_set(term_id, &mut result);
@@ -537,7 +553,8 @@ mod tests {
 
         let builder = storage_ref.builder();
 
-        // Visual testing for now, until term unification is implemented and we can actually write proper tests here:
+        // Visual testing for now, until term unification is implemented and we can
+        // actually write proper tests here:
         let hash_impl = builder.create_nameless_mod_def(
             ModDefOrigin::TrtImpl(builder.create_trt_term(core_defs.hash_trt)),
             builder.create_constant_scope([]),

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -57,9 +57,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                 match access_term.op {
                     // Only namespace is allowed by this point:
                     AccessOp::Namespace => {
-                        let ty_access_term = self
-                            .builder()
-                            .create_ns_access(ty_id_of_subject, access_term.name);
+                        let ty_access_term =
+                            self.builder().create_ns_access(ty_id_of_subject, access_term.name);
                         self.simplifier().potentially_simplify_term(ty_access_term)
                     }
                     AccessOp::Property => {
@@ -81,9 +80,7 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                             .unifier()
                             .unify_params_with_args(&ty_fn_ty.params, &app_ty_fn.args)?;
                         // Apply the substitution to the return type and use it as the result:
-                        Ok(self
-                            .substituter()
-                            .apply_sub_to_term(&sub, ty_fn_ty.return_ty))
+                        Ok(self.substituter().apply_sub_to_term(&sub, ty_fn_ty.return_ty))
                     }
                     _ => Err(TcError::UnsupportedTypeFunctionApplication {
                         subject_id: app_ty_fn.subject,
@@ -108,19 +105,15 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
             }
             Term::Merge(terms) => {
                 // The type of a merge is a merge of the inner terms:
-                let tys_of_terms: Vec<_> = terms
-                    .iter()
-                    .map(|term| self.ty_of_term(*term))
-                    .collect::<TcResult<_>>()?;
+                let tys_of_terms: Vec<_> =
+                    terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
             Term::AppSub(app_sub) => {
                 // The type of an AppSub is the type of the subject, with the substitution
                 // applied:
                 let ty_of_subject = self.ty_of_term(app_sub.term)?;
-                Ok(self
-                    .substituter()
-                    .apply_sub_to_term(&app_sub.sub, ty_of_subject))
+                Ok(self.substituter().apply_sub_to_term(&app_sub.sub, ty_of_subject))
             }
             Term::Unresolved(_) => {
                 // The type of an unresolved variable is unresolved:
@@ -171,9 +164,7 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                     }
                     Level0Term::EnumVariant(enum_variant) => {
                         // The type of an enum variant is the enum
-                        Ok(self
-                            .builder()
-                            .create_nominal_def_term(enum_variant.enum_def_id))
+                        Ok(self.builder().create_nominal_def_term(enum_variant.enum_def_id))
                     }
                 }
             }

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -35,16 +35,18 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
 
     /// Get the type of the given term, as another term.
     ///
-    /// First simplifies the term. If you already know you have a simplified term, you can use
-    /// [Self::ty_of_simplified_term].
+    /// First simplifies the term. If you already know you have a simplified
+    /// term, you can use [Self::ty_of_simplified_term].
     pub fn ty_of_term(&mut self, term_id: TermId) -> TcResult<TermId> {
         let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
         self.ty_of_simplified_term(simplified_term_id)
     }
 
-    /// Get the type of the given term, given that it is simplified, as another term.
+    /// Get the type of the given term, given that it is simplified, as another
+    /// term.
     ///
-    /// **Warning**: This might produce unexpected behaviour if the term is not simplified.
+    /// **Warning**: This might produce unexpected behaviour if the term is not
+    /// simplified.
     pub fn ty_of_simplified_term(&mut self, term_id: TermId) -> TcResult<TermId> {
         let term = self.reader().get_term(term_id).clone();
         match term {
@@ -93,7 +95,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                 Ok(self.builder().create_root_term())
             }
             Term::Var(var) => {
-                // The type of a variable can be found by looking at the scopes to its declaration:
+                // The type of a variable can be found by looking at the scopes to its
+                // declaration:
                 Ok(self.scope_resolver().resolve_name_in_scopes(var.name)?.ty)
             }
             Term::TyFn(ty_fn) => {
@@ -112,7 +115,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
             Term::AppSub(app_sub) => {
-                // The type of an AppSub is the type of the subject, with the substitution applied:
+                // The type of an AppSub is the type of the subject, with the substitution
+                // applied:
                 let ty_of_subject = self.ty_of_term(app_sub.term)?;
                 Ok(self
                     .substituter()
@@ -149,7 +153,8 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
                     }
                 }
                 Level1Term::NominalDef(_) | Level1Term::Tuple(_) | Level1Term::Fn(_) => {
-                    // The type of any nominal def, function type, or tuple type, is "RuntimeInstantiable":
+                    // The type of any nominal def, function type, or tuple type, is
+                    // "RuntimeInstantiable":
                     let rt_instantiable_def = self.core_defs().runtime_instantiable_trt;
                     Ok(self.builder().create_trt_term(rt_instantiable_def))
                 }

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -52,10 +52,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         // First split the domains into three parts: d0, d1 (not directly needed), and
         // the intersection (see second loop)
         let d0: HashSet<_> = dom_s0.difference(&dom_s1).copied().collect();
-        let t0 = Sub::from_pairs(
-            d0.iter()
-                .map(|&a| (a, substituter.apply_sub_to_subject(s0, a))),
-        );
+        let t0 = Sub::from_pairs(d0.iter().map(|&a| (a, substituter.apply_sub_to_subject(s0, a))));
 
         // Start with t0 and add terms for d1 one at a time, always producing well
         // formed substitutions
@@ -126,10 +123,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         // For each parameter, ensure it is the same:
         // @@Todo: handle default values.
         let mut cumulative_sub = Sub::empty();
-        let pairs = src_params
-            .positional()
-            .iter()
-            .zip(target_params.positional());
+        let pairs = src_params.positional().iter().zip(target_params.positional());
         for (src_param, target_param) in pairs {
             // Names match
             if src_param.name != target_param.name {
@@ -163,12 +157,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         let simplified_target = self.reader().get_term(simplified_target_id).clone();
 
         // Helper to return a unification error
-        let cannot_unify = || {
-            Err(TcError::CannotUnify {
-                src: src_id,
-                target: target_id,
-            })
-        };
+        let cannot_unify = || Err(TcError::CannotUnify { src: src_id, target: target_id });
 
         match (simplified_src, simplified_target) {
             // Unresolved
@@ -251,9 +240,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
             // Apply substitution:
             (Term::AppSub(src_app_sub), Term::AppSub(target_app_sub))
-                if self
-                    .validator()
-                    .subs_are_equivalent(&src_app_sub.sub, &target_app_sub.sub) =>
+                if self.validator().subs_are_equivalent(&src_app_sub.sub, &target_app_sub.sub) =>
             {
                 // Unify inner, then unify the resultant substitution with the ones given here:
                 let inner_sub = self.unify_terms(src_app_sub.term, target_app_sub.term)?;
@@ -305,9 +292,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                         self.unify_subs(&args_unified_sub, &subject_sub)
                     }
                     // If the subject is not a function type then application is invalid:
-                    _ => Err(TcError::UnsupportedTypeFunctionApplication {
-                        subject_id: subject,
-                    }),
+                    _ => Err(TcError::UnsupportedTypeFunctionApplication { subject_id: subject }),
                 }
             }
             (Term::AppTyFn(_), _) | (_, Term::AppTyFn(_)) => {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -38,27 +38,27 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
     /// Unify two substitutions to produce another substitution.
     ///
-    /// The resultant substitution contains all the information of the two source substitutions,
-    /// without any common free variables in their domains.
+    /// The resultant substitution contains all the information of the two
+    /// source substitutions, without any common free variables in their
+    /// domains.
     ///
     /// This implements the algorithm outlined in the paper:
     /// <https://www.researchgate.net/publication/221600544_On_the_Unification_of_Substitutions_in_Type_Interfaces>
-    ///
     pub fn unify_subs(&mut self, s0: &Sub, s1: &Sub) -> TcResult<Sub> {
         let dom_s0: HashSet<_> = s0.domain().collect();
         let dom_s1: HashSet<_> = s1.domain().collect();
         let mut substituter = self.substituter();
 
-        // First split the domains into three parts: d0, d1 (not directly needed), and the
-        // intersection (see second loop)
+        // First split the domains into three parts: d0, d1 (not directly needed), and
+        // the intersection (see second loop)
         let d0: HashSet<_> = dom_s0.difference(&dom_s1).copied().collect();
         let t0 = Sub::from_pairs(
             d0.iter()
                 .map(|&a| (a, substituter.apply_sub_to_subject(s0, a))),
         );
 
-        // Start with t0 and add terms for d1 one at a time, always producing well formed
-        // substitutions
+        // Start with t0 and add terms for d1 one at a time, always producing well
+        // formed substitutions
         let mut result = t0.clone();
         for (a, t) in t0.pairs() {
             // Remove elements of dom(result) from t, and remove a from result.
@@ -95,8 +95,9 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
     /// Unify the given parameters with the given arguments.
     ///
-    /// This is done by first getting the type of each argument, and unifying with the type of each
-    /// parameter. Then, a substitution is created from each parameter to each argument value.
+    /// This is done by first getting the type of each argument, and unifying
+    /// with the type of each parameter. Then, a substitution is created
+    /// from each parameter to each argument value.
     pub fn unify_params_with_args(&mut self, params: &Params, args: &Args) -> TcResult<Sub> {
         let pairs = pair_args_with_params(params, args)?;
         let mut cumulative_sub = Sub::empty();
@@ -147,7 +148,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
     /// Unify the two given terms, producing a substitution.
     ///
-    /// The relation between src and target is that src must be a subtype (or eq) of target.
+    /// The relation between src and target is that src must be a subtype (or
+    /// eq) of target.
     pub fn unify_terms(&mut self, src_id: TermId, target_id: TermId) -> TcResult<Sub> {
         // Shortcut: terms have the same ID:
         if src_id == target_id {
@@ -203,8 +205,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                 }
             }
             (Term::Merge(inner_src), _) => {
-                // Try to merge each individual term in source, with target. If any one succeeds,
-                // then the whole thing should succeed.
+                // Try to merge each individual term in source, with target. If any one
+                // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
                 for inner_src_id in inner_src {
                     match self.unify_terms(inner_src_id, target_id) {
@@ -232,7 +234,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                 self.unify_terms(src_access.subject, target_access.subject)
             }
             (Term::Access(_), _) | (_, Term::Access(_)) => {
-                // Since these cannot be simplified further, we don't know if they can be unified:
+                // Since these cannot be simplified further, we don't know if they can be
+                // unified:
                 cannot_unify()
             }
 
@@ -264,8 +267,8 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
             // Type functions:
             (Term::TyFn(_), _) | (_, Term::TyFn(_)) => {
-                // For now, type functions never unify, because unifying them would require a lot
-                // of work to match each of the cases.
+                // For now, type functions never unify, because unifying them would require a
+                // lot of work to match each of the cases.
                 //  @@Enhancement: in principle this is possible, though unclear if useful.
                 cannot_unify()
             }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -38,16 +38,16 @@ impl<'gs, 'ls, 'cd> AccessToStorageMut for Validator<'gs, 'ls, 'cd> {
     }
 }
 
-/// Used to communicate the result of a successful term validation, which produces the simplified
-/// term as well as its type.
+/// Used to communicate the result of a successful term validation, which
+/// produces the simplified term as well as its type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TermValidation {
     pub simplified_term_id: TermId,
     pub term_ty_id: TermId,
 }
 
-/// Helper type for [Validator::validate_merge_element], to keep track of the kind of the merge
-/// (whether it is level 2, level 1, or not known yet).
+/// Helper type for [Validator::validate_merge_element], to keep track of the
+/// kind of the merge (whether it is level 2, level 1, or not known yet).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MergeKind {
     Unknown,
@@ -75,14 +75,15 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
     /// Validate the nominal definition of the given [NominalDefId]
     pub fn validate_nominal_def(&mut self, _nominal_def_id: NominalDefId) -> TcResult<()> {
-        // Ensure all members have level 1 types/level 0 default values and the default values are
-        // of the given type.
+        // Ensure all members have level 1 types/level 0 default values and the default
+        // values are of the given type.
         todo!()
     }
 
-    /// Ensure the element `merge_element_term_id` of the merge with the given `merge_term_id` is
-    /// either level 2 (along with the merge being all level 2), or level 1 (along with the merge
-    /// being all level 1). Furthermore, if it is level 1, the merge should only have zero or one
+    /// Ensure the element `merge_element_term_id` of the merge with the given
+    /// `merge_term_id` is either level 2 (along with the merge being all
+    /// level 2), or level 1 (along with the merge being all level 1).
+    /// Furthermore, if it is level 1, the merge should only have zero or one
     /// nominal definition attached.
     fn validate_merge_element(
         &mut self,
@@ -180,17 +181,18 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         // Ensure the level of the term is valid:
         match merge_element_term {
             // Type function application, access, or variable:
-            // These should have already been simplified, so we only accept them if their type is level
-            // 3 and the merge is level 2, which means it is a level 2 term. Their type is level
-            // 2, we cannot be sure it won't have a duplicate nominal definition so we cannot
-            // accept it.
+            // These should have already been simplified, so we only accept them if their type is
+            // level 3 and the merge is level 2, which means it is a level 2 term. Their
+            // type is level 2, we cannot be sure it won't have a duplicate nominal
+            // definition so we cannot accept it.
             Term::AppTyFn(_) | Term::Access(_) | Term::Var(_) => {
                 let ty_id_of_term = self.typer().ty_of_term(merge_element_term_id)?;
                 let reader = self.reader();
                 let ty_of_term = reader.get_term(ty_id_of_term);
                 match ty_of_term {
                     Term::Level3(_) => {
-                        // If the type of the term is level 3, then we know that the merge should be level 2:
+                        // If the type of the term is level 3, then we know that the merge should be
+                        // level 2:
                         *merge_kind = ensure_merge_is_level2()?;
                         Ok(())
                     }
@@ -259,7 +261,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             if let Some(default_value) = param.default_value {
                 self.validate_term(default_value)?;
 
-                // Ensure the default value's type can be unified with the given type of the parameter:
+                // Ensure the default value's type can be unified with the given type of the
+                // parameter:
                 let ty_of_default_value = self.typer().ty_of_simplified_term(default_value)?;
                 let _ = self.unifier().unify_terms(ty_of_default_value, param.ty)?;
             }
@@ -279,7 +282,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
     /// Validate the given term for correctness.
     ///
-    /// Returns the simplified term, along with its type, which are computed during the validation.
+    /// Returns the simplified term, along with its type, which are computed
+    /// during the validation.
     pub fn validate_term(&mut self, term_id: TermId) -> TcResult<TermValidation> {
         // First, we try simplify the term:
         let simplified_term_id = self.simplifier().potentially_simplify_term(term_id)?;
@@ -374,8 +378,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                             let fn_return_value_validation =
                                 self.validate_term(fn_lit.return_value)?;
 
-                            // Ensure the return type of the function unifies with the type of the return
-                            // value:
+                            // Ensure the return type of the function unifies with the type of the
+                            // return value:
                             let _ = self.unifier().unify_terms(
                                 fn_return_value_validation.term_ty_id,
                                 fn_return_ty_validation.simplified_term_id,
@@ -399,8 +403,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
             // Access
             Term::Access(access_term) => {
-                // Validate the inner term; the access should already be valid since it passed the
-                // typing stage.
+                // Validate the inner term; the access should already be valid since it passed
+                // the typing stage.
                 self.validate_term(access_term.subject)?;
                 Ok(result)
             }
@@ -408,8 +412,9 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             // Substitution application:
             Term::AppSub(app_sub) => {
                 // @@Correctness: do we need to perform any sort of substitution validity check?
-                // maybe to try unify the substitution with itself to ensure it does not contradict
-                // itself? For example, if it contains cycles `T0 -> T1, T1 -> T0`.
+                // maybe to try unify the substitution with itself to ensure it does not
+                // contradict itself? For example, if it contains cycles `T0 ->
+                // T1, T1 -> T0`.
                 //
                 // For now, we just validate the inner term:
                 self.validate_term(app_sub.term)?;
@@ -492,8 +497,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             // Type function application:
             Term::AppTyFn(app_ty_fn) => {
                 // Since this could be typed, it means the application is valid in terms of
-                // unification of type function params with the arguments. Thus, all we need to do
-                // is validate individually the term and the arguments:
+                // unification of type function params with the arguments. Thus, all we need to
+                // do is validate individually the term and the arguments:
                 let app_ty_fn = app_ty_fn.clone();
                 self.validate_term(app_ty_fn.subject)?;
                 self.validate_args(&app_ty_fn.args)?;
@@ -508,7 +513,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
     /// Ensure that the given term is runtime instantiable.
     ///
-    /// Internally uses [Self::term_is_runtime_instantiable], check its docs for info.
+    /// Internally uses [Self::term_is_runtime_instantiable], check its docs for
+    /// info.
     pub fn ensure_term_is_runtime_instantiable(&mut self, term_id: TermId) -> TcResult<()> {
         if !(self.term_is_runtime_instantiable(term_id)?) {
             Err(TcError::TermIsNotRuntimeInstantiable { term: term_id })
@@ -517,11 +523,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Determine whether the given term is runtime instantiable, i.e. a level 1 term that can be
-    /// wrapped in an Rt(..).
+    /// Determine whether the given term is runtime instantiable, i.e. a level 1
+    /// term that can be wrapped in an Rt(..).
     ///
-    /// This is the condition for the term to be able to be used within tuple types, function
-    /// types, structs and enums.
+    /// This is the condition for the term to be able to be used within tuple
+    /// types, function types, structs and enums.
     ///
     /// *Note*: assumes the term has been simplified and validated.
     pub fn term_is_runtime_instantiable(&mut self, term_id: TermId) -> TcResult<bool> {
@@ -537,10 +543,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Determine if the given term can be used as the return value of a type function.
+    /// Determine if the given term can be used as the return value of a type
+    /// function.
     ///
-    /// This includes constant level 0 terms, level 1 terms, level 2 terms, and other type
-    /// functions.
+    /// This includes constant level 0 terms, level 1 terms, level 2 terms, and
+    /// other type functions.
     ///
     /// *Note*: assumes the term has been simplified and validated.
     pub fn term_can_be_used_as_ty_fn_return_value(&mut self, term_id: TermId) -> TcResult<bool> {
@@ -549,15 +556,16 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         if !(self.term_can_be_used_as_ty_fn_return_ty(term_ty_id)?) {
             return Ok(false);
         }
-        // If it passes the check, we just need to make sure that if it is a level 0 function, it
-        // is a function literal.
+        // If it passes the check, we just need to make sure that if it is a level 0
+        // function, it is a function literal.
         let reader = self.reader();
         let term = reader.get_term(term_id);
         match term {
             Term::Level0(level0_term) => {
                 match level0_term {
                     Level0Term::Rt(_) => {
-                        // Not any runtime value can be used here because it might produce side-effects.
+                        // Not any runtime value can be used here because it might produce
+                        // side-effects.
                         Ok(false)
                     }
                     Level0Term::FnLit(_) => {
@@ -575,10 +583,12 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Determine if the given term can be used as the return type of a type function.
+    /// Determine if the given term can be used as the return type of a type
+    /// function.
     ///
-    /// There are also additional restrictions on the kind of *value* that can be used for a type
-    /// function return, which are covered by [Self::term_can_be_used_as_ty_fn_return_value].
+    /// There are also additional restrictions on the kind of *value* that can
+    /// be used for a type function return, which are covered by
+    /// [Self::term_can_be_used_as_ty_fn_return_value].
     ///
     /// *Note*: assumes the term has been simplified and validated.
     pub fn term_can_be_used_as_ty_fn_return_ty(&mut self, term_id: TermId) -> TcResult<bool> {
@@ -629,10 +639,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         }
     }
 
-    /// Determine if the given term can be used as the parameter type of a type function.
+    /// Determine if the given term can be used as the parameter type of a type
+    /// function.
     ///
-    /// This extends to level 2, as well as type function types returning level 2 terms.
-    /// **Note**: assumes the term has been simplified.
+    /// This extends to level 2, as well as type function types returning level
+    /// 2 terms. **Note**: assumes the term has been simplified.
     ///
     /// @@Extension: we could allow level 3 terms as parameters too (TraitKind).
     pub fn term_can_be_used_as_ty_fn_param_ty(&mut self, term_id: TermId) -> TcResult<bool> {
@@ -695,10 +706,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
     /// Determine if the two given substitutions are equivalent.
     ///
-    /// That is, if for any term X, they produce the same result when applied to X
+    /// That is, if for any term X, they produce the same result when applied to
+    /// X
     ///
-    /// @@Correctness: This is not based on any accepted algorithm, and requires testing to ensure
-    /// its correctness.
+    /// @@Correctness: This is not based on any accepted algorithm, and requires
+    /// testing to ensure its correctness.
     pub fn subs_are_equivalent(&mut self, s0: &Sub, s1: &Sub) -> bool {
         // First we get the two substitutions as lists sorted by their domains:
         let mut s0_list = s0.pairs().collect::<Vec<_>>();
@@ -706,8 +718,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         s0_list.sort_by_key(|x| x.0);
         s1_list.sort_by_key(|x| x.0);
 
-        // Then for each pair, we ensure the domain elements are the same, and the range elements
-        // can be unified:
+        // Then for each pair, we ensure the domain elements are the same, and the range
+        // elements can be unified:
         for (s0_element, s1_element) in s0_list.iter().zip(&s1_list) {
             if s0_element.0 != s1_element.0 {
                 return false;

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -96,9 +96,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
         // Error helper:
         let invalid_merge_element = || -> TcResult<()> {
-            Err(TcError::InvalidElementOfMerge {
-                term: merge_element_term_id,
-            })
+            Err(TcError::InvalidElementOfMerge { term: merge_element_term_id })
         };
 
         // Helper to ensure that a merge is level 2, returns the updated MergeKind.
@@ -112,9 +110,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                     // Merge is already level 2, all good:
                     Ok(*merge_kind)
                 }
-                MergeKind::Level1 {
-                    nominal_attached: _,
-                } => {
+                MergeKind::Level1 { nominal_attached: _ } => {
                     // Merge was already specified to be level 1, error!
                     Err(TcError::MergeShouldBeLevel2 {
                         merge_term: merge_term_id,
@@ -129,9 +125,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             match (*merge_kind, checking_nominal) {
                 (MergeKind::Unknown, _) => {
                     // Now we know that the merge should be level 1
-                    Ok(MergeKind::Level1 {
-                        nominal_attached: checking_nominal,
-                    })
+                    Ok(MergeKind::Level1 { nominal_attached: checking_nominal })
                 }
                 (MergeKind::Level2, _) => {
                     // Merge was already specified to be level 2, error!
@@ -140,32 +134,18 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                         offending_term: merge_element_term_id,
                     })
                 }
-                (
-                    MergeKind::Level1 {
-                        nominal_attached: _,
-                    },
-                    None,
-                ) => {
+                (MergeKind::Level1 { nominal_attached: _ }, None) => {
                     // Merge is level 1; independently of whether a nominal is
                     // attached, this is fine because we are not checking a nominal.
                     Ok(*merge_kind)
                 }
-                (
-                    MergeKind::Level1 {
-                        nominal_attached: None,
-                    },
-                    Some(checking_nominal),
-                ) => {
+                (MergeKind::Level1 { nominal_attached: None }, Some(checking_nominal)) => {
                     // Merge is level 1 without a nominal and we are checking a nominal; we attach
                     // the nominal.
-                    Ok(MergeKind::Level1 {
-                        nominal_attached: Some(checking_nominal),
-                    })
+                    Ok(MergeKind::Level1 { nominal_attached: Some(checking_nominal) })
                 }
                 (
-                    MergeKind::Level1 {
-                        nominal_attached: Some(nominal_term_id),
-                    },
+                    MergeKind::Level1 { nominal_attached: Some(nominal_term_id) },
                     Some(checking_nominal),
                 ) => {
                     // A nominal has already been attached, error!
@@ -295,10 +275,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         let reader = self.reader();
 
         // Prepare the result of the validation:
-        let result = TermValidation {
-            simplified_term_id,
-            term_ty_id,
-        };
+        let result = TermValidation { simplified_term_id, term_ty_id };
 
         let term = reader.get_term(simplified_term_id);
         match term {
@@ -467,16 +444,12 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                     // Ensure the params are a subtype of the general params
                     // @@ErrorReporting: might be a bit ambiguous here, perhaps we should customise
                     // the message.
-                    let _ = self
-                        .unifier()
-                        .unify_params(&case.params, &ty_fn.general_params)?;
+                    let _ = self.unifier().unify_params(&case.params, &ty_fn.general_params)?;
 
                     // Ensure that the return type can be unified with the type of the return value:
                     // @@Safety: should be already simplified from above the match.
                     let return_value_ty = self.typer().ty_of_simplified_term(term_id)?;
-                    let _ = self
-                        .unifier()
-                        .unify_terms(case.return_ty, return_value_ty)?;
+                    let _ = self.unifier().unify_terms(case.return_ty, return_value_ty)?;
 
                     // Ensure the return value of each case is a subtype of the general return type.
                     let _ = self
@@ -623,9 +596,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             }
             Term::Unresolved(_) => {
                 // More type annotations are needed
-                Err(TcError::NeedMoreTypeAnnotationsToResolve {
-                    term_to_resolve: term_id,
-                })
+                Err(TcError::NeedMoreTypeAnnotationsToResolve { term_to_resolve: term_id })
             }
             // All level 2 and 3 terms are ok to use as return types
             Term::Level2(_) | Term::Level3(_) => Ok(true),
@@ -678,9 +649,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             }
             Term::Unresolved(_) => {
                 // More type annotations are needed
-                Err(TcError::NeedMoreTypeAnnotationsToResolve {
-                    term_to_resolve: term_id,
-                })
+                Err(TcError::NeedMoreTypeAnnotationsToResolve { term_to_resolve: term_id })
             }
             // All level 2 and 3 terms are ok to use as parameter types
             Term::Level2(_) | Term::Level3(_) => Ok(true),
@@ -726,14 +695,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             }
 
             // Unify bidirectionally
-            if self
-                .unifier()
-                .unify_terms(s0_element.1, s1_element.1)
-                .is_err()
-                || self
-                    .unifier()
-                    .unify_terms(s1_element.1, s0_element.1)
-                    .is_err()
+            if self.unifier().unify_terms(s0_element.1, s1_element.1).is_err()
+                || self.unifier().unify_terms(s1_element.1, s0_element.1).is_err()
             {
                 return false;
             }

--- a/compiler/hash-typecheck/src/reporting.rs
+++ b/compiler/hash-typecheck/src/reporting.rs
@@ -21,8 +21,6 @@ impl<'gs, 'ls, 'cd> AccessToStorage for TcErrorWithStorage<'gs, 'ls, 'cd> {
 impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Vec<Report> {
     fn from(err: TcErrorWithStorage<'gs, 'ls, 'cd>) -> Self {
         // @@Todo: actually implement this:
-        vec![ReportBuilder::new()
-            .with_message(format!("{:?}", err.error))
-            .build()]
+        vec![ReportBuilder::new().with_message(format!("{:?}", err.error)).build()]
     }
 }

--- a/compiler/hash-typecheck/src/reporting.rs
+++ b/compiler/hash-typecheck/src/reporting.rs
@@ -1,4 +1,5 @@
-//! Contains utilities to convert a [crate::error::TcError] into a [hash_reporting::report::Report].
+//! Contains utilities to convert a [crate::error::TcError] into a
+//! [hash_reporting::report::Report].
 use crate::{
     error::TcError,
     storage::{AccessToStorage, StorageRef},

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -66,10 +66,7 @@ impl CoreDefs {
         let char_ty = builder.create_opaque_struct_def("char", []);
         let bool_ty = builder.create_enum_def(
             "bool",
-            [
-                builder.create_enum_variant("true", []),
-                builder.create_enum_variant("false", []),
-            ],
+            [builder.create_enum_variant("true", []), builder.create_enum_variant("false", [])],
             [],
         );
 

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -1,9 +1,10 @@
 //! Contains all the core type and trait definitions of the language.
 //!
-//! These are accessed during the AST traversal in order to type certain language primitives (for
-//! example `if`-block subjects). This is because a lot of the "primitive" Hash types aren't
-//! actually primitives as far as the typechecker is concerned. This includes: integers, floats,
-//! characters, strings, lists, maps, references, etc.
+//! These are accessed during the AST traversal in order to type certain
+//! language primitives (for example `if`-block subjects). This is because a lot
+//! of the "primitive" Hash types aren't actually primitives as far as the
+//! typechecker is concerned. This includes: integers, floats, characters,
+//! strings, lists, maps, references, etc.
 use super::{
     primitives::{NominalDefId, TermId, TrtDefId},
     GlobalStorage,
@@ -37,13 +38,14 @@ pub struct CoreDefs {
 }
 
 impl CoreDefs {
-    /// Create the core language type and trait definitions in the given [GlobalStorage], and add
-    /// their symbols to the root scope.
+    /// Create the core language type and trait definitions in the given
+    /// [GlobalStorage], and add their symbols to the root scope.
     pub fn new(global_storage: &mut GlobalStorage) -> Self {
         // @@Safety: core defs have not been filled in global_storage, don't access
         // global_storage.core_defs()!
         //
-        // We use the root scope as the population scope, since these are the core definitions.
+        // We use the root scope as the population scope, since these are the core
+        // definitions.
         let builder = PrimitiveBuilder::new_with_scope(global_storage, global_storage.root_scope);
 
         // Primitive integers

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -1,10 +1,11 @@
-//! Structures relating to storing type information, symbol information, and other kinds of
-//! information managed by the typechecker.
+//! Structures relating to storing type information, symbol information, and
+//! other kinds of information managed by the typechecker.
 //!
-//! This information lives either in [LocalStorage] or [GlobalStorage], depending on if it is
-//! accessible from within a given source only, or accessible globally. For example, a stack
-//! variable will be in [LocalStorage] because it is only accessible from one file, whereas a
-//! type definition will be in [GlobalStorage] because it can be accessed from any file (with the
+//! This information lives either in [LocalStorage] or [GlobalStorage],
+//! depending on if it is accessible from within a given source only, or
+//! accessible globally. For example, a stack variable will be in [LocalStorage]
+//! because it is only accessible from one file, whereas a type definition will
+//! be in [GlobalStorage] because it can be accessed from any file (with the
 //! appropriate import).
 use self::{
     core::CoreDefs,
@@ -37,8 +38,9 @@ pub struct GlobalStorage {
     pub checked_sources: CheckedSources,
     /// Used to create the first scope when creating a LocalStorage.
     ///
-    /// This includes all the core language definitions; it shouldn't be directly queried, but
-    /// rather the [LocalStorage] scopes should be queried.
+    /// This includes all the core language definitions; it shouldn't be
+    /// directly queried, but rather the [LocalStorage] scopes should be
+    /// queried.
     pub root_scope: ScopeId,
 }
 
@@ -86,8 +88,8 @@ impl LocalStorage {
     }
 }
 
-/// A reference to the storage, which includes both local and global storage, as well as core
-/// definitions.
+/// A reference to the storage, which includes both local and global storage, as
+/// well as core definitions.
 #[derive(Debug, Clone, Copy)]
 pub struct StorageRef<'gs, 'ls, 'cd> {
     pub local_storage: &'ls LocalStorage,
@@ -95,8 +97,8 @@ pub struct StorageRef<'gs, 'ls, 'cd> {
     pub core_defs: &'cd CoreDefs,
 }
 
-/// A mutable reference to the storage, which includes both local and global storage, as well as
-/// core definitions.
+/// A mutable reference to the storage, which includes both local and global
+/// storage, as well as core definitions.
 #[derive(Debug)]
 pub struct StorageRefMut<'gs, 'ls, 'cd> {
     pub local_storage: &'ls mut LocalStorage,
@@ -104,8 +106,8 @@ pub struct StorageRefMut<'gs, 'ls, 'cd> {
     pub core_defs: &'cd CoreDefs,
 }
 
-/// Trait that provides convenient accessor methods to various parts of the storage given a path to
-/// a [StorageRef] object.
+/// Trait that provides convenient accessor methods to various parts of the
+/// storage given a path to a [StorageRef] object.
 pub trait AccessToStorage {
     fn storages(&self) -> StorageRef;
 
@@ -154,8 +156,8 @@ pub trait AccessToStorage {
     }
 }
 
-/// Trait that provides convenient mutable accessor methods to various parts of the storage given a
-/// path to a [StorageRefMut] object.
+/// Trait that provides convenient mutable accessor methods to various parts of
+/// the storage given a path to a [StorageRefMut] object.
 pub trait AccessToStorageMut: AccessToStorage {
     fn storages_mut(&mut self) -> StorageRefMut;
 

--- a/compiler/hash-typecheck/src/storage/mods.rs
+++ b/compiler/hash-typecheck/src/storage/mods.rs
@@ -1,4 +1,5 @@
-//! Contains structures to keep track of modules and information relating to them.
+//! Contains structures to keep track of modules and information relating to
+//! them.
 use super::primitives::{ModDef, ModDefId};
 use slotmap::SlotMap;
 
@@ -20,9 +21,9 @@ impl ModDefStore {
 
     /// Get a module by [ModDefId].
     ///
-    /// If the module is not found, this function will panic. However, this shouldn't happen
-    /// because the only way to acquire a module is to use [Self::create], and modules cannot be
-    /// deleted.
+    /// If the module is not found, this function will panic. However, this
+    /// shouldn't happen because the only way to acquire a module is to use
+    /// [Self::create], and modules cannot be deleted.
     pub fn get(&self, mod_def_id: ModDefId) -> &ModDef {
         self.data.get(mod_def_id).unwrap()
     }

--- a/compiler/hash-typecheck/src/storage/nominals.rs
+++ b/compiler/hash-typecheck/src/storage/nominals.rs
@@ -1,4 +1,5 @@
-//! Contains structures to keep track of nominal type definitions and information relating to them.
+//! Contains structures to keep track of nominal type definitions and
+//! information relating to them.
 use slotmap::SlotMap;
 
 use super::primitives::{NominalDef, NominalDefId};
@@ -21,9 +22,10 @@ impl NominalDefStore {
 
     /// Get a nominal type definition by [NominalDefId].
     ///
-    /// If the nominal type definition is not found, this function will panic. However, this
-    /// shouldn't happen because the only way to acquire a nominal type definition is to use
-    /// [Self::create], and nominal type definitions cannot be deleted.
+    /// If the nominal type definition is not found, this function will panic.
+    /// However, this shouldn't happen because the only way to acquire a
+    /// nominal type definition is to use [Self::create], and nominal type
+    /// definitions cannot be deleted.
     pub fn get(&self, nominal_def_id: NominalDefId) -> &NominalDef {
         self.data.get(nominal_def_id).unwrap()
     }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -58,21 +58,12 @@ pub struct Scope {
 impl Scope {
     /// Create an empty [Scope].
     pub fn empty(kind: ScopeKind) -> Self {
-        Self {
-            kind,
-            members: HashMap::new(),
-        }
+        Self { kind, members: HashMap::new() }
     }
 
     /// Create a new [Scope] from the given members.
     pub fn new(kind: ScopeKind, members: impl IntoIterator<Item = Member>) -> Self {
-        Self {
-            kind,
-            members: members
-                .into_iter()
-                .map(|member| (member.name, member))
-                .collect(),
-        }
+        Self { kind, members: members.into_iter().map(|member| (member.name, member)).collect() }
     }
 
     /// Add a member to the scope, overwriting any existing member with the same
@@ -595,12 +586,7 @@ impl Sub {
 
     /// Create a substitution from pairs of `(SubSubject, TermId)`.
     pub fn from_pairs(pairs: impl IntoIterator<Item = (impl Into<SubSubject>, TermId)>) -> Self {
-        Self {
-            data: pairs
-                .into_iter()
-                .map(|(from, to)| (from.into(), to))
-                .collect(),
-        }
+        Self { data: pairs.into_iter().map(|(from, to)| (from.into(), to)).collect() }
     }
 
     /// Get the substitution for the given [SubSubject], if any.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -1,4 +1,5 @@
-//! Contains type definitions that the rest of the storage and the general typechecker use.
+//! Contains type definitions that the rest of the storage and the general
+//! typechecker use.
 use hash_source::{identifier::Identifier, SourceId};
 use slotmap::new_key_type;
 use std::{
@@ -74,7 +75,8 @@ impl Scope {
         }
     }
 
-    /// Add a member to the scope, overwriting any existing member with the same name.
+    /// Add a member to the scope, overwriting any existing member with the same
+    /// name.
     pub fn add(&mut self, member: Member) {
         self.members.insert(member.name, member);
     }
@@ -85,8 +87,8 @@ impl Scope {
     }
 }
 
-/// Trait to be implemented by primitives which contain a `name` field that is an
-/// optional identifier.
+/// Trait to be implemented by primitives which contain a `name` field that is
+/// an optional identifier.
 pub trait GetNameOpt {
     /// Get the name of [Self], which should be an [Option<Identifier>].
     fn get_name_opt(&self) -> Option<Identifier>;
@@ -153,7 +155,8 @@ impl GetNameOpt for Arg {
 /// A list of arguments.
 pub type Args = ParamList<Arg>;
 
-/// A parameter, declaring a potentially named variable with a given type and default value.
+/// A parameter, declaring a potentially named variable with a given type and
+/// default value.
 #[derive(Debug, Clone, Hash)]
 pub struct Param {
     pub name: Option<Identifier>,
@@ -175,12 +178,12 @@ pub type Params = ParamList<Param>;
 /// Used to keep track of bound variables in definitions.
 pub type BoundVars = HashSet<Var>;
 
-/// The origin of a module: was it defined in a `mod` block, an anonymous `impl` block, or an
-/// `impl Trait` block?
+/// The origin of a module: was it defined in a `mod` block, an anonymous `impl`
+/// block, or an `impl Trait` block?
 #[derive(Debug, Clone, Copy, Hash)]
 pub enum ModDefOrigin {
-    /// Defined as a trait implementation (for the given term that should resolve to a trait
-    /// value).
+    /// Defined as a trait implementation (for the given term that should
+    /// resolve to a trait value).
     TrtImpl(TermId),
     /// Defined as an anonymous implementation.
     AnonImpl,
@@ -190,8 +193,8 @@ pub enum ModDefOrigin {
     Source(SourceId),
 }
 
-/// A module definition, which is of a given origin, has a binding name, and contains some constant
-/// members.
+/// A module definition, which is of a given origin, has a binding name, and
+/// contains some constant members.
 #[derive(Debug, Clone)]
 pub struct ModDef {
     pub name: Option<Identifier>,
@@ -207,8 +210,8 @@ pub enum StructFields {
     Explicit(Params),
     /// The struct does not have any accessible parameters.
     ///
-    /// This is used for core language definitions that will be filled in later in the compiler
-    /// pipeline.
+    /// This is used for core language definitions that will be filled in later
+    /// in the compiler pipeline.
     Opaque,
 }
 
@@ -287,12 +290,12 @@ pub struct FnTy {
 
 /// A type function type.
 ///
-/// A type function is a compile-time function that works on types. Type function return values
-/// can be level 0, level 1 or level 2. It has a general set of "base" parameters and return
-/// type.
+/// A type function is a compile-time function that works on types. Type
+/// function return values can be level 0, level 1 or level 2. It has a general
+/// set of "base" parameters and return type.
 ///
-/// These are refined in the `cases` field, which provides conditional values for the return
-/// value of the function, based on what the arguments are.
+/// These are refined in the `cases` field, which provides conditional values
+/// for the return value of the function, based on what the arguments are.
 ///
 /// For example, consider:
 ///
@@ -336,25 +339,27 @@ pub struct FnTy {
 /// }
 /// ```
 ///
-/// At any point, the resolved type of `Dog<T>` is the merged type of the return type of each case
-/// which matches `T`. In other words, cases are not short-circuiting; they are all evaluated and
-/// then combined.
+/// At any point, the resolved type of `Dog<T>` is the merged type of the return
+/// type of each case which matches `T`. In other words, cases are not
+/// short-circuiting; they are all evaluated and then combined.
 ///
-/// The `general_return_ty` field is always a supertype of the return type of each case.
+/// The `general_return_ty` field is always a supertype of the return type of
+/// each case.
 #[derive(Debug, Clone)]
 pub struct TyFn {
-    /// An optional name for the type function, if it is directly assigned to a binding.
+    /// An optional name for the type function, if it is directly assigned to a
+    /// binding.
     pub name: Option<Identifier>,
     pub general_params: Params,
     pub general_return_ty: TermId,
     pub cases: Vec<TyFnCase>,
 }
 
-/// Represents a case in a type function, for some subset of its `general_params`, to some specific
-/// return type and refined return value.
+/// Represents a case in a type function, for some subset of its
+/// `general_params`, to some specific return type and refined return value.
 ///
-/// The `value` property of each [Param] in the `params` field represents types which have been
-/// set, for example:
+/// The `value` property of each [Param] in the `params` field represents types
+/// which have been set, for example:
 ///
 /// ```ignore
 /// Dog<str> ~= impl Conv<str> {
@@ -376,9 +381,9 @@ pub struct TyFn {
 ///     ])
 /// ```
 ///
-/// The case's `return_ty` must always be able to unify with the target `general_return_ty`,
-/// and the type parameters should be able to each unify with the target `general_params`, of the
-/// parent [TyFn].
+/// The case's `return_ty` must always be able to unify with the target
+/// `general_return_ty`, and the type parameters should be able to each unify
+/// with the target `general_params`, of the parent [TyFn].
 #[derive(Debug, Clone)]
 pub struct TyFnCase {
     pub params: Params,
@@ -402,12 +407,13 @@ pub struct Var {
 
 /// The action of applying a set of arguments to a type function.
 ///
-/// This essentially creates a lambda calculus within the Hash type system, which allows it to
-/// express arbitrary programs.
+/// This essentially creates a lambda calculus within the Hash type system,
+/// which allows it to express arbitrary programs.
 ///
-/// When this type is unified with another type, the function is applied by first instantiating
-/// its return value over its type parameters, and then unifying the instantiated type parameters
-/// with the given type arguments of the function (the `args` field).
+/// When this type is unified with another type, the function is applied by
+/// first instantiating its return value over its type parameters, and then
+/// unifying the instantiated type parameters with the given type arguments of
+/// the function (the `args` field).
 #[derive(Debug, Clone)]
 pub struct AppTyFn {
     pub subject: TermId,
@@ -433,8 +439,8 @@ pub struct TyFnTy {
     pub return_ty: TermId,
 }
 
-/// An enum variant value, consisting of a [NominalDefId] pointing to an enum, as well as the
-/// variant of the enum in the form of an [Identifier].
+/// An enum variant value, consisting of a [NominalDefId] pointing to an enum,
+/// as well as the variant of the enum in the form of an [Identifier].
 ///
 /// Has a level 0 type.
 #[derive(Debug, Clone, Copy)]
@@ -456,7 +462,8 @@ pub enum AccessOp {
     Property,
 }
 
-/// An access term, which is of the form X::Y, where X is a term and Y is an identifier.
+/// An access term, which is of the form X::Y, where X is a term and Y is an
+/// identifier.
 ///
 /// Has level N where N is the level of the Y property of X.
 #[derive(Debug, Clone)]
@@ -478,31 +485,32 @@ pub enum Level3Term {
 
 /// A level 2 term.
 ///
-/// Type of: types, for example: `struct(..)`, `enum(..)`, `mod {..}`, `impl {..}`.
-/// Value of: traits, for example `trait(..)`.
+/// Type of: types, for example: `struct(..)`, `enum(..)`, `mod {..}`, `impl
+/// {..}`. Value of: traits, for example `trait(..)`.
 #[derive(Debug, Clone)]
 pub enum Level2Term {
     // ---- Level 2 ---- the term that is a return term of trait(..)
     /// A trait term.
     Trt(TrtDefId),
-    /// Basically a trait term that all types implement, i.e. the trait that is a supertrait to
-    /// all other traits.
+    /// Basically a trait term that all types implement, i.e. the trait that is
+    /// a supertrait to all other traits.
     AnyTy,
 }
 
 /// A level 1 term.
 ///
 /// Type of: values, for example: `3`, `"test"`, `[1, 2, 3]`, `Dog(name="Bob")`.
-/// Value of: types, for example `struct(..)`, `enum(..)`, `mod {..}`, `(a: A) -> B` etc.
+/// Value of: types, for example `struct(..)`, `enum(..)`, `mod {..}`, `(a: A)
+/// -> B` etc.
 #[derive(Debug, Clone)]
 pub enum Level1Term {
     /// Modules or impls.
     ///
-    /// Modules and trait implementations, as well as anonymous implementations, are treated as
-    /// types, but do not have instance values.
+    /// Modules and trait implementations, as well as anonymous implementations,
+    /// are treated as types, but do not have instance values.
     ///
-    /// Information about the origin of each module definition can be found in its corresponding
-    /// [ModDef] struct.
+    /// Information about the origin of each module definition can be found in
+    /// its corresponding [ModDef] struct.
     ModDef(ModDefId),
 
     /// A nominal type definition, either a struct or an enum.
@@ -515,7 +523,8 @@ pub enum Level1Term {
     Fn(FnTy),
 }
 
-/// Represents a function literal, with a function type, as well as a return value.
+/// Represents a function literal, with a function type, as well as a return
+/// value.
 #[derive(Debug, Clone, Copy)]
 pub struct FnLit {
     pub fn_ty: TermId,
@@ -566,7 +575,8 @@ impl From<SubSubject> for Term {
     }
 }
 
-/// A substitution containing pairs of `(SubSubject, TermId)` to be applied to a term.
+/// A substitution containing pairs of `(SubSubject, TermId)` to be applied to a
+/// term.
 #[derive(Debug, Default, Clone)]
 pub struct Sub {
     data: HashMap<SubSubject, TermId>,
@@ -598,7 +608,8 @@ impl Sub {
         self.data.get(&subject).copied()
     }
 
-    /// Get all the subjects (i.e. the domain) of the substitution as an iterator.
+    /// Get all the subjects (i.e. the domain) of the substitution as an
+    /// iterator.
     pub fn domain(&self) -> impl Iterator<Item = SubSubject> + '_ {
         self.data.keys().copied()
     }
@@ -625,14 +636,14 @@ impl Sub {
 
     /// Extend the substitution with pairs from the given one.
     ///
-    /// This is a naive implementation which does not perform any unification. For substitution
-    /// unification, see the `crate::ops::unify` module.
+    /// This is a naive implementation which does not perform any unification.
+    /// For substitution unification, see the `crate::ops::unify` module.
     pub fn extend(&mut self, other: &Sub) {
         self.data.extend(other.pairs());
     }
 
-    /// Create a new substitution equivalent to this one but selecting only the pairs which are not
-    /// shadowed by the given [Params].
+    /// Create a new substitution equivalent to this one but selecting only the
+    /// pairs which are not shadowed by the given [Params].
     pub fn filter(&self, params: &Params) -> Self {
         Self {
             data: self
@@ -652,8 +663,8 @@ impl Sub {
         }
     }
 
-    /// Create a new substitution equivalent to this one but selecting only the given [BoundVars]
-    /// as subjects.
+    /// Create a new substitution equivalent to this one but selecting only the
+    /// given [BoundVars] as subjects.
     pub fn select(&self, bound_vars: &BoundVars) -> Self {
         Self {
             data: self
@@ -690,14 +701,17 @@ pub enum Term {
     /// Is level N, where N is the level of the resultant access.
     Access(AccessTerm),
 
-    /// A type-level variable, with some type that is stored in the current scope.
+    /// A type-level variable, with some type that is stored in the current
+    /// scope.
     ///
-    /// Is level N-1, where N is the level of the type of the variable in the context
+    /// Is level N-1, where N is the level of the type of the variable in the
+    /// context
     Var(Var),
 
     /// Merge of multiple terms.
     ///
-    /// Inner types must have the same level. Merging is also idempotent, associative, and commutative.
+    /// Inner types must have the same level. Merging is also idempotent,
+    /// associative, and commutative.
     ///
     /// Is level N, where N is the level of the inner types.
     Merge(Vec<TermId>),
@@ -719,7 +733,8 @@ pub enum Term {
 
     /// Substitution application.
     ///
-    /// Is level N, where N is the level of the inner term after the substitution has been applied.
+    /// Is level N, where N is the level of the inner term after the
+    /// substitution has been applied.
     AppSub(AppSub),
 
     /// Not yet resolved.
@@ -739,8 +754,8 @@ pub enum Term {
     /// A level 0 term.
     Level0(Level0Term),
 
-    /// The only level 4 term, which is the "endpoint" of the typing hierarchy. This is the type of
-    /// "TraitKind" and "TyFnTy".
+    /// The only level 4 term, which is the "endpoint" of the typing hierarchy.
+    /// This is the type of "TraitKind" and "TyFnTy".
     Root,
 }
 
@@ -774,9 +789,9 @@ new_key_type! {
 /// The ID of a [UnresolvedTerm], separate from its [TermId], stored in
 /// [super::terms::TermStore].
 ///
-/// This needs to be separate from [TermId] so that if a type is copied (and new IDs are
-/// generated for its members) the identity of the unknown variables remains the same as in the
-/// original type.
+/// This needs to be separate from [TermId] so that if a type is copied (and new
+/// IDs are generated for its members) the identity of the unknown variables
+/// remains the same as in the original type.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct ResolutionId(pub(super) usize);
 

--- a/compiler/hash-typecheck/src/storage/scope.rs
+++ b/compiler/hash-typecheck/src/storage/scope.rs
@@ -48,16 +48,12 @@ pub struct ScopeStack {
 impl ScopeStack {
     /// Create a [ScopeStack] from a single scope.
     pub fn singular(scope_id: ScopeId) -> Self {
-        Self {
-            scopes: vec![scope_id],
-        }
+        Self { scopes: vec![scope_id] }
     }
 
     /// Create a [ScopeStack] from a collection of scopes.
     pub fn many(scopes: impl IntoIterator<Item = ScopeId>) -> Self {
-        Self {
-            scopes: scopes.into_iter().collect(),
-        }
+        Self { scopes: scopes.into_iter().collect() }
     }
 
     /// Append a scope to the stack.

--- a/compiler/hash-typecheck/src/storage/scope.rs
+++ b/compiler/hash-typecheck/src/storage/scope.rs
@@ -1,5 +1,5 @@
-//! Contains structures that store information about the scopes in a given module, as well as the
-//! symbols in each scope.
+//! Contains structures that store information about the scopes in a given
+//! module, as well as the symbols in each scope.
 use super::primitives::{Scope, ScopeId};
 use slotmap::SlotMap;
 
@@ -23,8 +23,9 @@ impl ScopeStore {
 
     /// Get a scope by [ScopeId].
     ///
-    /// If the scope is not found, this function will panic. However, this shouldn't happen because
-    /// the only way to acquire a scope is to use [Self::create], and scopes cannot be deleted.
+    /// If the scope is not found, this function will panic. However, this
+    /// shouldn't happen because the only way to acquire a scope is to use
+    /// [Self::create], and scopes cannot be deleted.
     pub fn get(&self, ty_id: ScopeId) -> &Scope {
         self.data.get(ty_id).unwrap()
     }
@@ -37,7 +38,8 @@ impl ScopeStore {
     }
 }
 
-/// Stores a collection of scopes, used from within [LocalStorage](crate::storage::LocalStorage).
+/// Stores a collection of scopes, used from within
+/// [LocalStorage](crate::storage::LocalStorage).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeStack {
     scopes: Vec<ScopeId>,

--- a/compiler/hash-typecheck/src/storage/sources.rs
+++ b/compiler/hash-typecheck/src/storage/sources.rs
@@ -3,7 +3,8 @@ use super::primitives::ModDefId;
 use hash_source::SourceId;
 use std::collections::HashMap;
 
-/// Contains a record of all the sources which have been typechecked, and maps them to [ModDefId]s.
+/// Contains a record of all the sources which have been typechecked, and maps
+/// them to [ModDefId]s.
 #[derive(Debug, Default)]
 pub struct CheckedSources {
     data: HashMap<SourceId, ModDefId>,

--- a/compiler/hash-typecheck/src/storage/terms.rs
+++ b/compiler/hash-typecheck/src/storage/terms.rs
@@ -14,9 +14,10 @@ pub struct TermStore {
     /// Keeps track of the last ID used for unresolved terms.
     /// This will be incremented every time a [Term::Unresolved] is created.
     ///
-    /// @@Future: In the future, resolution IDs can be used to implement a pointer-based unknown
-    /// term resolution, where substitutions correspond to mutating terms rather than creating
-    /// whole new ones. This could greatly improve performance.
+    /// @@Future: In the future, resolution IDs can be used to implement a
+    /// pointer-based unknown term resolution, where substitutions
+    /// correspond to mutating terms rather than creating whole new ones.
+    /// This could greatly improve performance.
     last_resolution_id: Cell<usize>,
 }
 
@@ -32,9 +33,9 @@ impl TermStore {
 
     /// Get a term by [TermId].
     ///
-    /// If the term is not found, this function will panic. However, this shouldn't happen
-    /// because the only way to acquire a term is to use [Self::create], and terms cannot be
-    /// deleted.
+    /// If the term is not found, this function will panic. However, this
+    /// shouldn't happen because the only way to acquire a term is to use
+    /// [Self::create], and terms cannot be deleted.
     pub fn get(&self, term_id: TermId) -> &Term {
         self.data.get(term_id).unwrap()
     }
@@ -48,7 +49,8 @@ impl TermStore {
 
     /// Get a new [ResolutionId] for a new [Term::Unresolved].
     ///
-    /// This shouldn't be directly used in inference code, rather call the appropriate
+    /// This shouldn't be directly used in inference code, rather call the
+    /// appropriate
     /// [PrimitiveBuilder](crate::ops::building::PrimitiveBuilder) function.
     pub fn new_resolution_id(&self) -> ResolutionId {
         let new_id = self.last_resolution_id.get() + 1;
@@ -59,9 +61,10 @@ impl TermStore {
 
 /// Stores the source location of terms in the AST tree.
 ///
-/// Not every term is guaranteed to have an attached location, but if it does it will be stored
-/// here. Note that term locations are on the [TermId]-level, not on the [Term]-level. So two
-/// identical [Term]s with different [TermId]s can have separate location attachments.
+/// Not every term is guaranteed to have an attached location, but if it does it
+/// will be stored here. Note that term locations are on the [TermId]-level, not
+/// on the [Term]-level. So two identical [Term]s with different [TermId]s can
+/// have separate location attachments.
 #[derive(Debug, Default)]
 pub struct TermLocations {
     data: SecondaryMap<TermId, SourceLocation>,
@@ -79,7 +82,8 @@ impl TermLocations {
 
     /// Attach a location to the term with the given [TermId].
     ///
-    /// This will overwrite any previous location attachment for this specific term.
+    /// This will overwrite any previous location attachment for this specific
+    /// term.
     pub fn add_location(&mut self, id: TermId, location: SourceLocation) {
         self.data.insert(id, location);
     }

--- a/compiler/hash-typecheck/src/storage/trts.rs
+++ b/compiler/hash-typecheck/src/storage/trts.rs
@@ -1,4 +1,5 @@
-//! Contains structures to keep track of traits and information relating to them.
+//! Contains structures to keep track of traits and information relating to
+//! them.
 use super::primitives::{TrtDef, TrtDefId};
 use slotmap::SlotMap;
 
@@ -20,8 +21,9 @@ impl TrtDefStore {
 
     /// Get a trait by [TrtDefId].
     ///
-    /// If the trait is not found, this function will panic. However, this shouldn't happen because
-    /// the only way to acquire a trait is to use [Self::create], and traits cannot be deleted.
+    /// If the trait is not found, this function will panic. However, this
+    /// shouldn't happen because the only way to acquire a trait is to use
+    /// [Self::create], and traits cannot be deleted.
     pub fn get(&self, trt_def_id: TrtDefId) -> &TrtDef {
         self.data.get(trt_def_id).unwrap()
     }

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -40,11 +40,7 @@ impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
         source_id: SourceId,
         sources: &'src Sources,
     ) -> Self {
-        TcVisitor {
-            storage,
-            source_id,
-            sources,
-        }
+        TcVisitor { storage, source_id, sources }
     }
 
     /// Visits the source passed in as an argument to [Self::new], and returns

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1,4 +1,5 @@
-//! Contains functions to traverse the AST and add types to it, while checking it for correctness.
+//! Contains functions to traverse the AST and add types to it, while checking
+//! it for correctness.
 
 use hash_ast::visitor;
 use hash_pipeline::sources::Sources;
@@ -32,7 +33,8 @@ impl<'gs, 'ls, 'cd, 'src> AccessToStorageMut for TcVisitor<'gs, 'ls, 'cd, 'src> 
 }
 
 impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
-    /// Create a new [TcVisitor] with the given state, traversing the given source from [Sources].
+    /// Create a new [TcVisitor] with the given state, traversing the given
+    /// source from [Sources].
     pub fn new_in_source(
         storage: StorageRefMut<'gs, 'ls, 'cd>,
         source_id: SourceId,
@@ -45,8 +47,8 @@ impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
         }
     }
 
-    /// Visits the source passed in as an argument to [Self::new], and returns the term of the
-    /// module that corresponds to the source.
+    /// Visits the source passed in as an argument to [Self::new], and returns
+    /// the term of the module that corresponds to the source.
     pub fn visit_source(&mut self) -> TcResult<TermId> {
         // @@Todo: implement this
         Ok(self.builder().create_unresolved_term())

--- a/compiler/hash-utils/src/printing.rs
+++ b/compiler/hash-utils/src/printing.rs
@@ -1,12 +1,14 @@
 //! Hash utilities for printing various data structures that might be used for
-//! debugging purposes or for creating human readable error messages when reporting
-//! errors.
+//! debugging purposes or for creating human readable error messages when
+//! reporting errors.
 use std::fmt;
 
-/// This is used within error messages, so it is formatted in a pretty way to display the expected token kinds
-/// after a particular token. This is useful for constructing re-usable error messages that might appear in multiple
-/// places when parsing. We use conjunctives to display multiple variants together, so they are readable. If the
-/// length of the vector kind is one, we don't use conjunctives to glue kinds together.
+/// This is used within error messages, so it is formatted in a pretty way to
+/// display the expected token kinds after a particular token. This is useful
+/// for constructing re-usable error messages that might appear in multiple
+/// places when parsing. We use conjunctives to display multiple variants
+/// together, so they are readable. If the length of the vector kind is one, we
+/// don't use conjunctives to glue kinds together.
 pub struct SequenceDisplay<'a, T: 'a>(pub &'a [T]);
 
 impl<'a, T: fmt::Display + 'a> fmt::Display for SequenceDisplay<'a, T> {

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -11,18 +11,12 @@ pub struct TreeNode {
 impl TreeNode {
     /// Create a leaf node with the given label.
     pub fn leaf(label: impl Into<Cow<'static, str>>) -> Self {
-        Self {
-            label: label.into(),
-            children: vec![],
-        }
+        Self { label: label.into(), children: vec![] }
     }
 
     /// Create a branch node with the given children.
     pub fn branch(label: impl Into<Cow<'static, str>>, children: Vec<TreeNode>) -> Self {
-        Self {
-            label: label.into(),
-            children,
-        }
+        Self { label: label.into(), children }
     }
 }
 
@@ -56,10 +50,7 @@ impl TreeWriterConfig {
     /// Draw trees using Unicode box drawing characters and longer child
     /// prefixes.
     pub fn unicode_long() -> Self {
-        Self {
-            child_prefix: "──".into(),
-            ..Self::unicode()
-        }
+        Self { child_prefix: "──".into(), ..Self::unicode() }
     }
 
     /// Draw trees using ASCII characters.
@@ -109,11 +100,7 @@ impl<'t, 'cfg> TreeWriter<'t, 'cfg> {
     /// Create a new [TreeWriter] with the given [TreeNode] and configuration
     /// [TreeWriterConfig].
     pub fn new_with_config(tree: &'t TreeNode, config: TreeWriterConfig) -> Self {
-        Self {
-            tree,
-            pad: String::new(),
-            config: Cow::Owned(config),
-        }
+        Self { tree, pad: String::new(), config: Cow::Owned(config) }
     }
 
     fn is_last(&self, child_index: usize) -> bool {
@@ -130,18 +117,9 @@ impl<'t, 'cfg> TreeWriter<'t, 'cfg> {
         let extra_pad =
             iter::repeat(self.config.pad).take(self.config.child_prefix.chars().count());
 
-        let new_pad = self
-            .pad
-            .chars()
-            .chain(vertical_line_or_pad)
-            .chain(extra_pad)
-            .collect();
+        let new_pad = self.pad.chars().chain(vertical_line_or_pad).chain(extra_pad).collect();
 
-        TreeWriter {
-            tree: child,
-            pad: new_pad,
-            config: Cow::Borrowed(self.config.as_ref()),
-        }
+        TreeWriter { tree: child, pad: new_pad, config: Cow::Borrowed(self.config.as_ref()) }
     }
 }
 
@@ -158,11 +136,7 @@ impl fmt::Display for TreeWriter<'_, '_> {
 
             let child_writer = self.next_depth(child, index);
 
-            write!(
-                f,
-                "{}{}{}{}",
-                self.pad, pipe_char, self.config.child_prefix, child_writer,
-            )?;
+            write!(f, "{}{}{}{}", self.pad, pipe_char, self.config.child_prefix, child_writer,)?;
         }
 
         Ok(())

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -53,7 +53,8 @@ impl TreeWriterConfig {
         }
     }
 
-    /// Draw trees using Unicode box drawing characters and longer child prefixes.
+    /// Draw trees using Unicode box drawing characters and longer child
+    /// prefixes.
     pub fn unicode_long() -> Self {
         Self {
             child_prefix: "──".into(),
@@ -99,12 +100,14 @@ pub struct TreeWriter<'t, 'cfg> {
 }
 
 impl<'t, 'cfg> TreeWriter<'t, 'cfg> {
-    /// Create a new [TreeWriter] with the given [TreeNode] and default configuration.
+    /// Create a new [TreeWriter] with the given [TreeNode] and default
+    /// configuration.
     pub fn new(tree: &'t TreeNode) -> Self {
         Self::new_with_config(tree, TreeWriterConfig::default())
     }
 
-    /// Create a new [TreeWriter] with the given [TreeNode] and configuration [TreeWriterConfig].
+    /// Create a new [TreeWriter] with the given [TreeNode] and configuration
+    /// [TreeWriterConfig].
     pub fn new_with_config(tree: &'t TreeNode, config: TreeWriterConfig) -> Self {
         Self {
             tree,

--- a/compiler/hash-utils/testing-macros/src/lib.rs
+++ b/compiler/hash-utils/testing-macros/src/lib.rs
@@ -119,10 +119,11 @@ fn read_dir(
 
 /// Generate test cases based on a directory structure.
 ///
-/// Test cases are generated based on a given test folder path (see `TEST_DIR` below). Each
-/// generated test corresponds to the full path of each "wanted" (see `TEST_PATTERN` below) leaf
-/// node of the test folder structure, converted to snake case. For example, for a file path
-/// `number_tests/is_valid_number.hash`, a test function named `test_number_tests_is_valid_number`
+/// Test cases are generated based on a given test folder path (see `TEST_DIR`
+/// below). Each generated test corresponds to the full path of each "wanted"
+/// (see `TEST_PATTERN` below) leaf node of the test folder structure, converted
+/// to snake case. For example, for a file path `number_tests/is_valid_number.
+/// hash`, a test function named `test_number_tests_is_valid_number`
 /// will be generated.
 ///
 /// The format of this macro is as follows:
@@ -130,26 +131,32 @@ fn read_dir(
 /// generate_tests!(TEST_DIR, TEST_PATTERN, TEST_FN);
 /// ```
 ///
-/// - `TEST_DIR` must be a string literal path, relative to the file in which the macro is invoked,
-/// which is the root directory of the test folder structure (whose name is not included in the
-/// test function names).
+/// - `TEST_DIR` must be a string literal path, relative to the file in which
+///   the macro is invoked,
+/// which is the root directory of the test folder structure (whose name is not
+/// included in the test function names).
 ///
-/// - `TEST_PATTERN` must be a string literal regular expression, which should match some leaf node
-/// of the test folder structure. The generator will stop generating sub-tests for a subfolder once
-/// any file in that subfolder matches `TEST_PATTERN`. For example, if the test folder structure is
-/// such that some test folder `test_foo/` contains files `case.hash` and `output`, specifying
-/// either of `"output"` or `"case.hash"` as `TEST_PATTERN` will result in a test case being
-/// generated for `test_foo`, but no further (i.e. not `test_foo_output` or `test_foo_case_hash`).
+/// - `TEST_PATTERN` must be a string literal regular expression, which should
+///   match some leaf node
+/// of the test folder structure. The generator will stop generating sub-tests
+/// for a subfolder once any file in that subfolder matches `TEST_PATTERN`. For
+/// example, if the test folder structure is such that some test folder
+/// `test_foo/` contains files `case.hash` and `output`, specifying either of `"
+/// output"` or `"case.hash"` as `TEST_PATTERN` will result in a test case being
+/// generated for `test_foo`, but no further (i.e. not `test_foo_output` or
+/// `test_foo_case_hash`).
 ///
-/// - `FN_PREFIX` is a unique prefix for the generated function in case the macro is used more than once
-/// in a single file for generating more than one test file with a potentially different internal test
-/// logic. The prefix must be a specified string literal, leaving it empty will generate the normal
-/// test name.
+/// - `FN_PREFIX` is a unique prefix for the generated function in case the
+///   macro is used more than once
+/// in a single file for generating more than one test file with a potentially
+/// different internal test logic. The prefix must be a specified string
+/// literal, leaving it empty will generate the normal test name.
 ///
-/// - `TEST_FN` must be an expression of type [`TestingFn`](hash_utils::testing::TestingFn). Every
+/// - `TEST_FN` must be an expression of type
+///   [`TestingFn`](hash_utils::testing::TestingFn). Every
 /// generated test case body will invoke this function with the appropriate
-/// [`TestingInput`](hash_utils::testing::TestingInput). Within this function, the actual test
-/// logic should be written.
+/// [`TestingInput`](hash_utils::testing::TestingInput). Within this function,
+/// the actual test logic should be written.
 #[proc_macro]
 pub fn generate_tests(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as GenerateTestsInput);

--- a/compiler/hash-utils/testing-macros/src/lib.rs
+++ b/compiler/hash-utils/testing-macros/src/lib.rs
@@ -82,12 +82,7 @@ fn read_dir(
         let entry = entry?;
         let path = entry.path();
 
-        let entry_snake_name = path
-            .file_stem()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_case(Case::Snake);
+        let entry_snake_name = path.file_stem().unwrap().to_str().unwrap().to_case(Case::Snake);
         let snake_name: String = base_name
             .into_iter()
             .chain(iter::once(entry_snake_name.as_str()))
@@ -166,13 +161,7 @@ pub fn generate_tests(input: TokenStream) -> TokenStream {
     let call_site = Span::call_site();
 
     let file_path = fs::canonicalize(
-        call_site
-            .source_file()
-            .path()
-            .parent()
-            .unwrap()
-            .to_owned()
-            .join(test_path),
+        call_site.source_file().path().parent().unwrap().to_owned().join(test_path),
     )
     .unwrap();
 

--- a/compiler/hash-vm/src/bytecode.rs
+++ b/compiler/hash-vm/src/bytecode.rs
@@ -373,23 +373,26 @@ pub enum Instruction {
     Jmp {
         location: Register,
     },
-    /// Jump if the comparison value yields a '> zero', or in other words the right is greater than left
+    /// Jump if the comparison value yields a '> zero', or in other words the
+    /// right is greater than left
     JmpPos {
         l1: Register,
         location: Register,
     },
-    /// Jump if the comparison value yields a '< zero', or in other words the left is greater than right
+    /// Jump if the comparison value yields a '< zero', or in other words the
+    /// left is greater than right
     JmpNeg {
         l1: Register,
         location: Register,
     },
-    /// Jump if the comparison yields a 'zero', or in other words the left and right are equal
+    /// Jump if the comparison yields a 'zero', or in other words the left and
+    /// right are equal
     JmpZero {
         l1: Register,
         location: Register,
     },
-    /// Compare both values and store the result in `l1`. This will return either a one, zero or negative
-    /// one.
+    /// Compare both values and store the result in `l1`. This will return
+    /// either a one, zero or negative one.
     Cmp {
         l1: Register,
         l2: Register,

--- a/compiler/hash-vm/src/error.rs
+++ b/compiler/hash-vm/src/error.rs
@@ -20,11 +20,7 @@ impl fmt::Display for StackAccessKind {
 
 #[derive(Debug)]
 pub enum RuntimeError {
-    StackViolationAccess {
-        kind: StackAccessKind,
-        size: u8,
-        total: usize,
-    },
+    StackViolationAccess { kind: StackAccessKind, size: u8, total: usize },
 }
 
 pub type RuntimeResult<T> = Result<T, RuntimeError>;

--- a/compiler/hash-vm/src/heap.rs
+++ b/compiler/hash-vm/src/heap.rs
@@ -18,8 +18,7 @@ impl Heap {
     pub fn allocate(&mut self, size: u64) -> Pointer {
         let offset = self.values.len();
 
-        self.values
-            .extend(iter::repeat(0).take(size.try_into().unwrap()));
+        self.values.extend(iter::repeat(0).take(size.try_into().unwrap()));
 
         Pointer(offset.try_into().unwrap())
     }

--- a/compiler/hash-vm/src/register.rs
+++ b/compiler/hash-vm/src/register.rs
@@ -35,8 +35,8 @@ impl Default for RegisterSet {
 }
 
 ///
-/// This is how {get|set}_register{32|16|8} access the entire register. The functions access
-/// the lower X-bytes like so:
+/// This is how {get|set}_register{32|16|8} access the entire register. The
+/// functions access the lower X-bytes like so:
 ///
 /// Register
 /// XXXXXXXX
@@ -53,19 +53,20 @@ impl Default for RegisterSet {
 ///        ^
 ///     get_register8
 ///       
-///
 impl RegisterSet {
     /// Function to get a [Register] within the [RegisterSet].
     pub fn get_register_8b(&self, register: Register) -> &[u8; 8] {
         &self.registers[register.0 as usize]
     }
 
-    /// Function to get a lower four bytes of a [Register] within the [RegisterSet].
+    /// Function to get a lower four bytes of a [Register] within the
+    /// [RegisterSet].
     pub fn get_register_4b(&self, register: Register) -> &[u8; 4] {
         self.registers[register.0 as usize][4..].try_into().unwrap()
     }
 
-    /// Function to get a lower two bytes of a [Register] within the [RegisterSet].
+    /// Function to get a lower two bytes of a [Register] within the
+    /// [RegisterSet].
     pub fn get_register_2b(&self, register: Register) -> &[u8; 2] {
         self.registers[register.0 as usize][6..].try_into().unwrap()
     }
@@ -81,13 +82,15 @@ impl RegisterSet {
         reg.copy_from_slice(value);
     }
 
-    /// Function to set the lower four bytes of a [Register] within the [RegisterSet].
+    /// Function to set the lower four bytes of a [Register] within the
+    /// [RegisterSet].
     pub fn set_register_4b(&mut self, register: Register, value: &[u8; 4]) {
         let reg = self.get_register_mut(register);
         reg[4..].copy_from_slice(value);
     }
 
-    /// Function to set the lower two bytes of a [Register] within the [RegisterSet].
+    /// Function to set the lower two bytes of a [Register] within the
+    /// [RegisterSet].
     pub fn set_register_2b(&mut self, register: Register, value: &[u8; 2]) {
         let reg = self.get_register_mut(register);
         reg[6..].copy_from_slice(value);
@@ -99,7 +102,8 @@ impl RegisterSet {
         reg[7] = value[0];
     }
 
-    /// Function to get a mutable reference to a  [Register] within the [RegisterSet].
+    /// Function to get a mutable reference to a  [Register] within the
+    /// [RegisterSet].
     fn get_register_mut(&mut self, register: Register) -> &mut [u8; 8] {
         self.registers.get_mut(register.0 as usize).unwrap()
     }

--- a/compiler/hash-vm/src/register.rs
+++ b/compiler/hash-vm/src/register.rs
@@ -28,9 +28,7 @@ pub struct RegisterSet {
 
 impl Default for RegisterSet {
     fn default() -> Self {
-        Self {
-            registers: [[0; 8]; 256],
-        }
+        Self { registers: [[0; 8]; 256] }
     }
 }
 

--- a/compiler/hash-vm/src/stack.rs
+++ b/compiler/hash-vm/src/stack.rs
@@ -16,10 +16,7 @@ pub struct Stack {
 impl Stack {
     /// Create a new stack
     pub fn new(size: usize) -> Self {
-        Stack {
-            data: vec![0; size],
-            stack_pointer: 0,
-        }
+        Stack { data: vec![0; size], stack_pointer: 0 }
     }
 
     /// Method that verifies that a particular call to modify the stack storage
@@ -40,9 +37,7 @@ impl Stack {
     pub fn pop8(&mut self) -> RuntimeResult<&[u8; 1]> {
         self.verify_access(StackAccessKind::Pop, 1)?;
 
-        let value = (&self.data[(self.stack_pointer - 1)..self.stack_pointer])
-            .try_into()
-            .unwrap();
+        let value = (&self.data[(self.stack_pointer - 1)..self.stack_pointer]).try_into().unwrap();
         self.stack_pointer -= 1;
 
         Ok(value)
@@ -52,9 +47,7 @@ impl Stack {
     pub fn pop16(&mut self) -> RuntimeResult<&[u8; 2]> {
         self.verify_access(StackAccessKind::Pop, 2)?;
 
-        let value = (&self.data[(self.stack_pointer - 2)..self.stack_pointer])
-            .try_into()
-            .unwrap();
+        let value = (&self.data[(self.stack_pointer - 2)..self.stack_pointer]).try_into().unwrap();
         self.stack_pointer -= 2;
 
         Ok(value)
@@ -63,9 +56,7 @@ impl Stack {
     pub fn pop32(&mut self) -> RuntimeResult<&[u8; 4]> {
         self.verify_access(StackAccessKind::Pop, 4)?;
 
-        let value = (&self.data[(self.stack_pointer - 4)..self.stack_pointer])
-            .try_into()
-            .unwrap();
+        let value = (&self.data[(self.stack_pointer - 4)..self.stack_pointer]).try_into().unwrap();
         self.stack_pointer -= 4;
 
         Ok(value)
@@ -75,9 +66,7 @@ impl Stack {
     pub fn pop64(&mut self) -> RuntimeResult<&[u8; 8]> {
         self.verify_access(StackAccessKind::Pop, 8)?;
 
-        let value = (&self.data[(self.stack_pointer - 8)..self.stack_pointer])
-            .try_into()
-            .unwrap();
+        let value = (&self.data[(self.stack_pointer - 8)..self.stack_pointer]).try_into().unwrap();
         self.stack_pointer -= 8;
 
         Ok(value)
@@ -87,10 +76,7 @@ impl Stack {
     pub fn push8(&mut self, value: &[u8; 1]) -> RuntimeResult<()> {
         self.verify_access(StackAccessKind::Push, 1)?;
 
-        self.data.splice(
-            self.stack_pointer..(self.stack_pointer + 1),
-            value.iter().copied(),
-        );
+        self.data.splice(self.stack_pointer..(self.stack_pointer + 1), value.iter().copied());
         self.stack_pointer += 1;
         Ok(())
     }
@@ -99,10 +85,7 @@ impl Stack {
     pub fn push16(&mut self, value: &[u8; 2]) -> RuntimeResult<()> {
         self.verify_access(StackAccessKind::Push, 2)?;
 
-        self.data.splice(
-            self.stack_pointer..(self.stack_pointer + 2),
-            value.iter().copied(),
-        );
+        self.data.splice(self.stack_pointer..(self.stack_pointer + 2), value.iter().copied());
         self.stack_pointer += 2;
         Ok(())
     }
@@ -111,10 +94,7 @@ impl Stack {
     pub fn push32(&mut self, value: &[u8; 4]) -> RuntimeResult<()> {
         self.verify_access(StackAccessKind::Push, 4)?;
 
-        self.data.splice(
-            self.stack_pointer..(self.stack_pointer + 4),
-            value.iter().copied(),
-        );
+        self.data.splice(self.stack_pointer..(self.stack_pointer + 4), value.iter().copied());
         self.stack_pointer += 4;
         Ok(())
     }
@@ -123,10 +103,7 @@ impl Stack {
     pub fn push64(&mut self, value: &[u8; 8]) -> RuntimeResult<()> {
         self.verify_access(StackAccessKind::Push, 8)?;
 
-        self.data.splice(
-            self.stack_pointer..(self.stack_pointer + 8),
-            value.iter().copied(),
-        );
+        self.data.splice(self.stack_pointer..(self.stack_pointer + 8), value.iter().copied());
         self.stack_pointer += 8;
         Ok(())
     }

--- a/compiler/hash-vm/src/stack.rs
+++ b/compiler/hash-vm/src/stack.rs
@@ -6,8 +6,8 @@ use crate::error::{RuntimeError, RuntimeResult, StackAccessKind};
 /// program.
 #[derive(Debug)]
 pub struct Stack {
-    /// The actual internal data of the stack. Once created, the stack size cannot
-    /// be modified.
+    /// The actual internal data of the stack. Once created, the stack size
+    /// cannot be modified.
     data: Vec<u8>,
     /// The internal representation of where the stack offset is located at.
     stack_pointer: usize,

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -390,8 +390,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_b(l1, &r1.wrapping_div(r2).to_be_bytes());
+                        self.registers.set_register_b(l1, &r1.wrapping_div(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -406,8 +405,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_b(l1, &r1.wrapping_mul(r2).to_be_bytes());
+                        self.registers.set_register_b(l1, &r1.wrapping_mul(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -422,8 +420,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_2b(l1, &r1.wrapping_mul(r2).to_be_bytes());
+                        self.registers.set_register_2b(l1, &r1.wrapping_mul(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -438,8 +435,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_2b(l1, &r1.wrapping_mul(r2).to_be_bytes());
+                        self.registers.set_register_2b(l1, &r1.wrapping_mul(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -454,8 +450,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_4b(l1, &r1.wrapping_div(r2).to_be_bytes());
+                        self.registers.set_register_4b(l1, &r1.wrapping_div(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -470,8 +465,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_4b(l1, &r1.wrapping_mul(r2).to_be_bytes());
+                        self.registers.set_register_4b(l1, &r1.wrapping_mul(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -486,8 +480,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_8b(l1, &r1.wrapping_div(r2).to_be_bytes());
+                        self.registers.set_register_8b(l1, &r1.wrapping_div(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -502,8 +495,7 @@ impl Interpreter {
                         self.flags.overflow.set(false);
                     }
                     None => {
-                        self.registers
-                            .set_register_8b(l1, &r1.wrapping_mul(r2).to_be_bytes());
+                        self.registers.set_register_8b(l1, &r1.wrapping_mul(r2).to_be_bytes());
                         self.flags.overflow.set(true);
                     }
                 }
@@ -664,15 +656,13 @@ impl Interpreter {
                 let r1 = self.registers.get_register_f32(l1);
                 let r2 = self.registers.get_register_f32(l2);
 
-                self.registers
-                    .set_register_4b(l1, &r1.powf(r2).to_be_bytes());
+                self.registers.set_register_4b(l1, &r1.powf(r2).to_be_bytes());
             }
             Instruction::PowF64 { l1, l2 } => {
                 let r1 = self.registers.get_register_f64(l1);
                 let r2 = self.registers.get_register_f64(l2);
 
-                self.registers
-                    .set_register_8b(l1, &r1.powf(r2).to_be_bytes());
+                self.registers.set_register_8b(l1, &r1.powf(r2).to_be_bytes());
             }
             Instruction::Shl8 { l1, l2 } => {
                 let r1 = self.registers.get_register8(l1);
@@ -816,18 +806,11 @@ impl Interpreter {
             Instruction::Call { func } => {
                 // Save the ip onto the stack
                 self.stack.push64(
-                    &self
-                        .registers
-                        .get_register64(Register::INSTRUCTION_POINTER)
-                        .to_be_bytes(),
+                    &self.registers.get_register64(Register::INSTRUCTION_POINTER).to_be_bytes(),
                 )?;
                 // Save the bp onto the stack
-                self.stack.push64(
-                    &self
-                        .registers
-                        .get_register64(Register::BASE_POINTER)
-                        .to_be_bytes(),
-                )?;
+                self.stack
+                    .push64(&self.registers.get_register64(Register::BASE_POINTER).to_be_bytes())?;
 
                 // Set the new bp as the stack pointer
                 self.registers.set_register64(
@@ -868,16 +851,12 @@ impl Interpreter {
 
     /// Gets the current instruction pointer of the VM.
     pub fn get_instruction_pointer(&self) -> usize {
-        self.registers
-            .get_register64(Register::INSTRUCTION_POINTER)
-            .try_into()
-            .unwrap()
+        self.registers.get_register64(Register::INSTRUCTION_POINTER).try_into().unwrap()
     }
 
     /// Sets the current instruction pointer of the VM.
     pub fn set_instruction_pointer(&mut self, value: usize) {
-        self.registers
-            .set_register64(Register::INSTRUCTION_POINTER, value.try_into().unwrap());
+        self.registers.set_register64(Register::INSTRUCTION_POINTER, value.try_into().unwrap());
     }
 
     pub fn set_program(&mut self, program: Vec<Instruction>) {

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -42,22 +42,24 @@ pub struct InterpreterFlags {
     pub comparison: Cell<i64>,
 }
 
-/// The [Interpreter] is a structure representing the current execution context of the program. It
-/// contains the program stack, heap, instruction vector, registers, etc.
-///
+/// The [Interpreter] is a structure representing the current execution context
+/// of the program. It contains the program stack, heap, instruction vector,
+/// registers, etc.
 #[derive(Debug)]
 pub struct Interpreter {
-    /// The Interpreter stack holds the current execution context of the function. This is
-    /// very similar to the way that the x86 architecture handles the flag.
+    /// The Interpreter stack holds the current execution context of the
+    /// function. This is very similar to the way that the x86 architecture
+    /// handles the flag.
     stack: Stack,
-    /// Interpreter flags represent the result of some operation that has occurred
+    /// Interpreter flags represent the result of some operation that has
+    /// occurred
     flags: InterpreterFlags,
     /// A vector of [Instruction]s representing the program that it will run
     instructions: Vec<Instruction>,
     /// We have 256 [Register]s available to the interpreter at any time
     registers: RegisterSet,
-    // /// The interpreter [Heap] containing heap allocated values that are not contained on the stack
-    // heap: Heap,
+    // /// The interpreter [Heap] containing heap allocated values that are not contained on the
+    // stack heap: Heap,
 }
 
 impl Interpreter {
@@ -734,8 +736,8 @@ impl Interpreter {
             Instruction::JmpPos { l1, location } => {
                 let r1 = i64::from_be_bytes(*self.registers.get_register_8b(l1));
 
-                // Arbitrarily jump to the specified location in the register if the comparison value is less
-                // than zero or in other words, negative...
+                // Arbitrarily jump to the specified location in the register if the comparison
+                // value is less than zero or in other words, negative...
                 if r1 > 0 {
                     let value = self.registers.get_register64(location).try_into().unwrap();
                     self.set_instruction_pointer(value);
@@ -744,8 +746,8 @@ impl Interpreter {
             Instruction::JmpNeg { l1, location } => {
                 let r1 = i64::from_be_bytes(*self.registers.get_register_8b(l1));
 
-                // Arbitrarily jump to the specified location in the register if the comparison value is less
-                // than zero or in other words, negative...
+                // Arbitrarily jump to the specified location in the register if the comparison
+                // value is less than zero or in other words, negative...
                 if r1 < 0 {
                     let value = self.registers.get_register64(location).try_into().unwrap();
                     self.set_instruction_pointer(value);
@@ -754,8 +756,8 @@ impl Interpreter {
             Instruction::JmpZero { l1, location } => {
                 let r1 = i64::from_be_bytes(*self.registers.get_register_8b(l1));
 
-                // Arbitrarily jump to the specified location in the register if the comparison value is less
-                // than zero or in other words, negative...
+                // Arbitrarily jump to the specified location in the register if the comparison
+                // value is less than zero or in other words, negative...
                 if r1 == 0 {
                     let value = self.registers.get_register64(location).try_into().unwrap();
                     self.set_instruction_pointer(value);
@@ -894,13 +896,15 @@ impl Interpreter {
         let ip = self.get_instruction_pointer();
 
         while ip < self.instructions.len() {
-            // Ok, now we need to run the current instruction, so we pass it into the run_next_instruction,
-            // it's possible that the the next instruction will jump or invoke some kind of exit condition in
-            // the VM, therefore we have to check after each invocation of the instruction if we can proceed
+            // Ok, now we need to run the current instruction, so we pass it into the
+            // run_next_instruction, it's possible that the the next instruction
+            // will jump or invoke some kind of exit condition in
+            // the VM, therefore we have to check after each invocation of the instruction
+            // if we can proceed
             self.run_next_instruction()?;
 
-            // TODO: we probably need to refactor this out into a function as the 'done' state will become
-            //       significantly more complicated...
+            // TODO: we probably need to refactor this out into a function as the 'done'
+            // state will become       significantly more complicated...
             if ip == self.instructions.len() - 1 {
                 return Ok(());
             }

--- a/compiler/hash-vm/tests/vm.rs
+++ b/compiler/hash-vm/tests/vm.rs
@@ -1,7 +1,9 @@
 //! Hash Compiler VM tests.
 use hash_vm::{
-    bytecode::Instruction, bytecode_builder::BytecodeBuilder, register::Register, vm::Interpreter,
-    vm::InterpreterOptions,
+    bytecode::Instruction,
+    bytecode_builder::BytecodeBuilder,
+    register::Register,
+    vm::{Interpreter, InterpreterOptions},
 };
 
 #[test]

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -2,9 +2,9 @@
 
 use clap::Parser as ClapParser;
 
-/// CompilerOptions is a structural representation of what arguments the compiler
-/// can take when running. Compiler options are well documented on the wiki page:
-/// <https://hash-org.github.io/hash-arxiv/interpreter-options.html>
+/// CompilerOptions is a structural representation of what arguments the
+/// compiler can take when running. Compiler options are well documented on the
+/// wiki page: <https://hash-org.github.io/hash-arxiv/interpreter-options.html>
 #[derive(ClapParser)]
 #[clap(
     name = "Hash Interpreter",

--- a/compiler/hash/src/crash_handler.rs
+++ b/compiler/hash/src/crash_handler.rs
@@ -40,11 +40,7 @@ pub(crate) fn panic_handler(info: &PanicInfo) {
 
         // Print backtrace and thread name if available
         if let Some(name) = thread::current().name() {
-            let _ = writeln!(
-                &mut stdout,
-                "Backtrace for thread \"{}\":\n{:?}",
-                name, backtrace
-            );
+            let _ = writeln!(&mut stdout, "Backtrace for thread \"{}\":\n{:?}", name, backtrace);
         } else {
             let _ = writeln!(&mut stdout, "Backtrace:\n{:?}", backtrace);
         }

--- a/compiler/hash/src/crash_handler.rs
+++ b/compiler/hash/src/crash_handler.rs
@@ -1,15 +1,14 @@
 //! Hash Compiler crash handler
 use backtrace::Backtrace;
-use std::panic::PanicInfo;
-use std::process::exit;
-use std::{io::Write, sync::atomic, thread};
+use std::{io::Write, panic::PanicInfo, process::exit, sync::atomic, thread};
 
 const BUG_REPORT_MSG: &str = "This is an compiler bug, please file a bug report at";
 const BUG_REPORT_URI: &str =
     "https://github.com/hash-org/lang/issues?labels=bug&template=bug_report";
 
 pub(crate) fn panic_handler(info: &PanicInfo) {
-    // keep track to ensure that we only panic once and multiple threads can exit gracefully!
+    // keep track to ensure that we only panic once and multiple threads can exit
+    // gracefully!
     static PANIC_ONCE: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
     if !PANIC_ONCE.swap(true, atomic::Ordering::SeqCst) {

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -21,9 +21,7 @@ use hash_typecheck::TcImpl;
 use hash_vm::vm::{Interpreter, InterpreterOptions};
 use log::LevelFilter;
 use logger::CompilerLogger;
-use std::num::NonZeroUsize;
-use std::panic;
-use std::{env, fs};
+use std::{env, fs, num::NonZeroUsize, panic};
 
 use crate::{
     args::{AstGenMode, CheckMode, CompilerOptions, DeSugarMode, IrGenMode, SubCmd},
@@ -90,8 +88,9 @@ fn main() {
     let vm = Interpreter::new(InterpreterOptions::new(opts.stack_size));
     let compiler_settings = CompilerSettings::new(opts.debug, worker_count);
 
-    // We need at least 2 workers for the parsing loop in order so that the job queue can run
-    // within a worker and any other jobs can run inside another worker or workers.
+    // We need at least 2 workers for the parsing loop in order so that the job
+    // queue can run within a worker and any other jobs can run inside another
+    // worker or workers.
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(worker_count + 1)
         .thread_name(|id| format!("compiler-worker-{}", id))

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -97,15 +97,8 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut compiler = Compiler::new(
-        parser,
-        desugarer,
-        semnatic_analyser,
-        checker,
-        vm,
-        &pool,
-        compiler_settings,
-    );
+    let mut compiler =
+        Compiler::new(parser, desugarer, semnatic_analyser, checker, vm, &pool, compiler_settings);
     let mut compiler_state = compiler.create_state().unwrap();
 
     execute(|| {
@@ -116,10 +109,7 @@ fn main() {
                 let filename = resolve_path(fs::canonicalize(&path)?, current_dir, None);
 
                 if let Err(err) = filename {
-                    println!(
-                        "{}",
-                        ReportWriter::new(err.create_report(), &compiler_state.sources)
-                    );
+                    println!("{}", ReportWriter::new(err.create_report(), &compiler_state.sources));
 
                     return Ok(());
                 };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+use_small_heuristics = "Max"
+format_code_in_doc_comments = true
 wrap_comments = true
 imports_granularity = "Crate"
 use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
-single_line_if_else_max_width = 92
+wrap_comments = true
+imports_granularity = "Crate"
+use_field_init_shorthand = true

--- a/tests/parser/tests/test_runner.rs
+++ b/tests/parser/tests/test_runner.rs
@@ -17,8 +17,8 @@ use regex::Regex;
 /// Whether or not the UI tests should re-generate the output.
 const REGENERATE_OUTPUT: bool = false;
 
-/// This is the ANSI Regular expression matcher. This will match all the specified
-/// ANSI escape codes that are used by the [`hash_reporting`] crate.
+/// This is the ANSI Regular expression matcher. This will match all the
+/// specified ANSI escape codes that are used by the [`hash_reporting`] crate.
 const ANSI_RE: &str = r"[\x1b\x9b]\[[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]";
 
 lazy_static! {
@@ -108,8 +108,8 @@ fn handle_test(input: TestingInput) {
     if should_fail {
         handle_failure_case(input, result, sources).unwrap();
     } else {
-        // Check whether the result fails or not, depending on if the file_path begins with
-        // 'should_fail'...
+        // Check whether the result fails or not, depending on if the file_path begins
+        // with 'should_fail'...
         assert!(result.is_ok(), "parsing file failed: {:?}", content_path);
     }
 }

--- a/tests/parser/tests/test_runner.rs
+++ b/tests/parser/tests/test_runner.rs
@@ -37,11 +37,7 @@ fn handle_failure_case(
     let content_path = input.path.join("case.hash");
 
     // Verify that the parser failed to parse this file
-    assert!(
-        result.is_err(),
-        "parsing file: {:?} did not fail",
-        content_path
-    );
+    assert!(result.is_err(), "parsing file: {:?} did not fail", content_path);
 
     let diagnostics = result.unwrap_err();
     let contents = diagnostics
@@ -55,9 +51,7 @@ fn handle_failure_case(
 
     // Replace the directory by `$DIR`
     let dir_regex = Regex::new(input.path.as_path().to_str().unwrap()).unwrap();
-    let report_contents = dir_regex
-        .replace_all(report_contents.as_ref(), r"$$DIR")
-        .to_string();
+    let report_contents = dir_regex.replace_all(report_contents.as_ref(), r"$$DIR").to_string();
 
     // We want to load the `.stderr` file and verify that the contents of the
     // file match to the created report. If the `.stderr` file does not exist


### PR DESCRIPTION
This should hopefully lead to a more consistent code appearance, and shorter import lists.