### PR TITLE
TC: Implement validation of traits and modules

### DIFF
--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -73,4 +73,15 @@ pub enum TcError {
     /// The given member requires an initialisation in the current scope.
     /// @@ErrorReporting: add span of member.
     UninitialisedMemberNotAllowed { member_ty: TermId },
+    /// Cannot implement something that isn't a trait.
+    CannotImplementNonTrait { supposed_trait_term: TermId },
+    /// The trait implementation `trt_impl_term_id` is missing the member
+    /// `trt_def_missing_member_id` from the trait `trt_def_term_id`.
+    TraitImplementationMissingMember {
+        trt_impl_term_id: TermId,
+        trt_def_term_id: TermId,
+        // @@ErrorReporting: Ideally we want to be able to identify whole members rather than just
+        // "terms".
+        trt_def_missing_member_term_id: TermId,
+    },
 }

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -70,4 +70,7 @@ pub enum TcError {
     AmbiguousAccess { access: AccessTerm },
     /// The given access operation does not resolve to a method.
     InvalidPropertyAccessOfNonMethod { subject: TermId, property: Identifier },
+    /// The given member requires an initialisation in the current scope.
+    /// @@ErrorReporting: add span of member.
+    UninitialisedMemberNotAllowed { member_ty: TermId },
 }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -3,10 +3,10 @@
 use crate::storage::{
     primitives::{
         AccessOp, AccessTerm, AppSub, AppTyFn, Arg, Args, EnumDef, EnumVariant, EnumVariantValue,
-        FnLit, FnTy, GetNameOpt, Level0Term, Level1Term, Level2Term, Level3Term, Member, ModDef,
-        ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList, Scope,
-        ScopeId, ScopeKind, StructDef, StructFields, Sub, Term, TermId, TrtDef, TrtDefId, TupleTy,
-        TyFn, TyFnCase, TyFnTy, UnresolvedTerm, Var, Visibility,
+        FnLit, FnTy, GetNameOpt, Level0Term, Level1Term, Level2Term, Level3Term, Member,
+        MemberData, ModDef, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param,
+        ParamList, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term, TermId, TrtDef,
+        TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, UnresolvedTerm, Var, Visibility,
     },
     GlobalStorage,
 };
@@ -244,19 +244,21 @@ impl<'gs> PrimitiveBuilder<'gs> {
     ) -> Member {
         Member {
             name: name.into(),
-            ty,
-            value: Some(value),
+            data: MemberData::InitialisedWithTy { ty, value },
             visibility: Visibility::Public,
             mutability: Mutability::Immutable,
         }
     }
 
     /// Create a public member with the given name, type and unset value.
-    pub fn create_unset_pub_member(&self, name: impl Into<Identifier>, ty: TermId) -> Member {
+    pub fn create_uninitialised_pub_member(
+        &self,
+        name: impl Into<Identifier>,
+        ty: TermId,
+    ) -> Member {
         Member {
             name: name.into(),
-            ty,
-            value: None,
+            data: MemberData::Uninitialised { ty },
             visibility: Visibility::Public,
             mutability: Mutability::Immutable,
         }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1,4 +1,8 @@
 //! Contains functionality to simplify terms into more concrete terms.
+
+// @@Remove
+#![allow(unused)]
+
 use super::{substitute::Substituter, unify::Unifier, AccessToOps, AccessToOpsMut};
 use crate::{
     error::{TcError, TcResult},
@@ -148,7 +152,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
 
                 // Apply the substitution on the parameters and return type:
                 let subbed_params = self.substituter().apply_sub_to_params(&sub, &fn_ty.params);
-                let subbed_return_ty = self.substituter().apply_sub_to_term(&sub, fn_ty.return_ty);
+                let _subbed_return_ty = self.substituter().apply_sub_to_term(&sub, fn_ty.return_ty);
 
                 // Return the substituted type without the first parameter:
                 Ok(self.builder().create_fn_ty_term(
@@ -355,7 +359,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                 let reader = self.reader();
                 let nominal_def = reader.get_nominal_def(*nominal_def_id);
                 match nominal_def {
-                    NominalDef::Struct(struct_def) => {
+                    NominalDef::Struct(_struct_def) => {
                         // Struct type access is not valid.
                         does_not_support_access(access_term)
                     }
@@ -377,7 +381,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     }
                 }
             }
-            Level1Term::Tuple(tuple_ty) => does_not_support_access(access_term),
+            Level1Term::Tuple(_tuple_ty) => does_not_support_access(access_term),
             Level1Term::Fn(_) => does_not_support_access(access_term),
         }
     }
@@ -420,7 +424,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
     /// [AccessTerm].
     fn apply_access_to_level3_term(
         &mut self,
-        term: &Level3Term,
+        _term: &Level3Term,
         access_term: &AccessTerm,
     ) -> TcResult<Option<TermId>> {
         does_not_support_access(access_term)
@@ -895,7 +899,7 @@ mod test_super {
 
     fn get_storages() -> (GlobalStorage, LocalStorage, CoreDefs) {
         let mut global_storage = GlobalStorage::new();
-        let mut local_storage = LocalStorage::new(&mut global_storage);
+        let local_storage = LocalStorage::new(&mut global_storage);
         let core_defs = CoreDefs::new(&mut global_storage);
         (global_storage, local_storage, core_defs)
     }
@@ -912,7 +916,7 @@ mod test_super {
         let builder = storage_ref.builder();
 
         // Handy shorthand for &Self type
-        let ref_self_ty = builder.create_app_ty_fn_term(
+        let _ref_self_ty = builder.create_app_ty_fn_term(
             core_defs.reference_ty_fn,
             [builder.create_arg("T", builder.create_var_term("Self"))],
         );

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -63,9 +63,7 @@ fn does_not_support_ns_access(access_term: &AccessTerm) -> TcResult<()> {
 // Helper for [Simplifier::apply_access_term] erroring for name not found in
 // value:
 fn name_not_found<T>(access_term: &AccessTerm) -> TcResult<T> {
-    {
-        Err(TcError::UnresolvedNameInValue { name: access_term.name, value: access_term.subject })
-    }
+    Err(TcError::UnresolvedNameInValue { name: access_term.name, value: access_term.subject })
 }
 
 impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1,16 +1,12 @@
 //! Contains functionality to simplify terms into more concrete terms.
-
-// @@Remove
-#![allow(unused)]
-
 use super::{substitute::Substituter, unify::Unifier, AccessToOps, AccessToOpsMut};
 use crate::{
     error::{TcError, TcResult},
     storage::{
         primitives::{
             AccessOp, AccessTerm, AppTyFn, Arg, Args, FnLit, FnTy, Level0Term, Level1Term,
-            Level2Term, Level3Term, Member, NominalDef, Param, Params, ScopeId, StructFields, Term,
-            TermId, TupleTy, TyFn, TyFnCase, TyFnTy,
+            Level2Term, Level3Term, NominalDef, Param, Params, StructFields, Term, TermId, TupleTy,
+            TyFn, TyFnCase, TyFnTy,
         },
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
@@ -85,44 +81,6 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
     /// Convenience method to get a [Substituter].
     fn substituter(&mut self) -> Substituter {
         Substituter::new(self.storages_mut())
-    }
-
-    /// Resolve the given name in the scope with the given [ScopeId],
-    /// originating from the given value.
-    ///
-    /// Returns the resolved member, or errors if no such member was found.
-    fn resolve_name_member_in_scope(
-        &self,
-        name: Identifier,
-        scope: ScopeId,
-        value: TermId,
-    ) -> TcResult<Member> {
-        match self.reader().get_scope(scope).get(name) {
-            Some(member) => Ok(member),
-            None => {
-                // Member not found!
-                Err(TcError::UnresolvedNameInValue { name, value })
-            }
-        }
-    }
-
-    /// Resolve the given name in the scope with the given [ScopeId],
-    /// originating from the given value.
-    ///
-    /// Returns [Some] if the member can be resolved with a value, [None] if it
-    /// cannot because it has no value yet.
-    fn resolve_name_in_scope(
-        &self,
-        name: Identifier,
-        scope: ScopeId,
-        value: TermId,
-    ) -> TcResult<Option<TermId>> {
-        match self.resolve_name_member_in_scope(name, scope, value)?.data.value() {
-            // Member found and has value, return it!
-            Some(value) => Ok(Some(value)),
-            // Cannot simplify yet, because the member does not have a defined value:
-            None => Ok(None),
-        }
     }
 
     /// Convert an accessed type (or any other type for that matter) along with
@@ -490,7 +448,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
             // @@Enhancement: maybe we can allow this and add it to some hints context of the
             // variable.
             Term::Unresolved(_) => does_not_support_access(access_term),
-            Term::Access(_) | Term::Var(_) | Term::AppTyFn(_) | Term::Unresolved(_) => {
+            Term::Access(_) | Term::Var(_) | Term::AppTyFn(_) => {
                 // We cannot perform any accessing here:
                 Ok(None)
             }

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -29,10 +29,8 @@ impl<'gs, 'ls, 'cd> AccessToStorageMut for Typer<'gs, 'ls, 'cd> {
     }
 }
 
-/// Helper to store an member with inferred type and possibly a value.
-///
-/// If the original member does not have a type, then it is inferred from the
-/// value.
+/// A version of [MemberData] where the type has been inferred if it was not
+/// given in the member definition.
 #[derive(Debug, Clone, Copy)]
 pub struct InferredMemberData {
     pub ty: TermId,

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -165,7 +165,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
             Term::AppSub(app_sub) => {
                 let app_sub = app_sub.clone();
                 // Recurse to inner term
-                let unified_sub = self.unifier().unify_subs(&trt_sub, &app_sub.sub)?;
+                let unified_sub = self.unifier().unify_subs(trt_sub, &app_sub.sub)?;
                 self.ensure_scope_implements_trait(
                     app_sub.term,
                     &unified_sub,
@@ -190,7 +190,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
                         // Apply the substitution to the trait member first:
                         let trt_member_ty_subbed =
-                            self.substituter().apply_sub_to_term(&trt_sub, trt_member_data.ty);
+                            self.substituter().apply_sub_to_term(trt_sub, trt_member_data.ty);
 
                         // Unify the types of the scope member and the substituted trait member:
                         let _ =
@@ -244,10 +244,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
     }
 
     /// Validate the trait definition of the given [TrtDefId]
-    pub fn validate_trt_def(&mut self, _trt_def_id: TrtDefId) -> TcResult<()> {
-        // Ensure Self exists?
+    pub fn validate_trt_def(&mut self, trt_def_id: TrtDefId) -> TcResult<()> {
         // @@Design: do we allow traits without self?
-        todo!()
+        let reader = self.reader();
+        let trt_def = reader.get_trt_def(trt_def_id);
+        self.validate_constant_scope(trt_def.members, true, SelfMode::Required)
     }
 
     /// Validate the nominal definition of the given [NominalDefId]

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -60,7 +60,6 @@ enum MergeKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(unused)] // @@Todo: remove
 enum SelfMode {
-    NotAllowed,
     Allowed,
     Required,
 }
@@ -78,7 +77,6 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         &mut self,
         scope_id: ScopeId,
         allow_uninitialised: bool,
-        _self_mode: SelfMode,
     ) -> TcResult<()> {
         // @@Design: when do we insert each member into the scope? As we go or all at
         // once? For now, we insert as we go.
@@ -228,7 +226,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
         // Validate all members:
         // Bound vars should already be in scope.
-        self.validate_constant_scope(mod_def_members, false, SelfMode::Allowed)?;
+        self.validate_constant_scope(mod_def_members, false)?;
 
         // Ensure if it is a trait impl it implements all the trait members.
         if let ModDefOrigin::TrtImpl(trt_def_term_id) = mod_def_origin {
@@ -248,7 +246,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         // @@Design: do we allow traits without self?
         let reader = self.reader();
         let trt_def = reader.get_trt_def(trt_def_id);
-        self.validate_constant_scope(trt_def.members, true, SelfMode::Required)
+        self.validate_constant_scope(trt_def.members, true)
     }
 
     /// Validate the nominal definition of the given [NominalDefId]

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -91,7 +91,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
         for member in scope.iter() {
             // This should have been checked in semantic analysis:
             assert!(
-                member.mutability == Mutability::Mutable,
+                member.mutability != Mutability::Mutable,
                 "Found mutable member in constant scope!"
             );
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -62,14 +62,15 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
     /// Validate the members of the given constant scope.
     ///
-    /// Allows uninitialised members in the scope if `allow_uninitialised` is true.
+    /// Allows uninitialised members in the scope if `allow_uninitialised` is
+    /// true.
     fn validate_constant_scope(
         &mut self,
         scope_id: ScopeId,
         allow_uninitialised: bool,
     ) -> TcResult<()> {
-        // @@Design: when do we insert each member into the scope? As we go or all at once?
-        // For now, we insert as we go.
+        // @@Design: when do we insert each member into the scope? As we go or all at
+        // once? For now, we insert as we go.
 
         // Enter the progressive scope:
         let progressive_scope = Scope::new(ScopeKind::Constant, []);
@@ -96,24 +97,22 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                 MemberData::InitialisedWithTy { ty, value } => {
                     // Validate the term, the type, and unify them.
                     let TermValidation { term_ty_id, .. } = self.validate_term(value)?;
-                    let TermValidation {
-                        simplified_term_id: simplified_ty_id,
-                        ..
-                    } = self.validate_term(ty)?;
+                    let TermValidation { simplified_term_id: simplified_ty_id, .. } =
+                        self.validate_term(ty)?;
                     let _ = self.unifier().unify_terms(term_ty_id, simplified_ty_id)?;
                 }
                 MemberData::InitialisedWithInferredTy { value } => {
                     // Validate the term, and the type
                     let TermValidation { term_ty_id, .. } = self.validate_term(value)?;
-                    // @@PotentiallyRedundant: is this necessary? shouldn't this be an invariant already?
+                    // @@PotentiallyRedundant: is this necessary? shouldn't this be an invariant
+                    // already?
                     self.validate_term(term_ty_id)?;
                 }
             }
 
-            // Now add the member to the progressive scope so that next members can access it.
-            self.scope_store_mut()
-                .get_mut(progressive_scope_id)
-                .add(member);
+            // Now add the member to the progressive scope so that next members can access
+            // it.
+            self.scope_store_mut().get_mut(progressive_scope_id).add(member);
         }
 
         // Leave the progressive scope:

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -97,8 +97,8 @@ impl CoreDefs {
         let hash_trt = builder.create_trt_def(
             "Hash",
             [
-                builder.create_unset_pub_member("Self", builder.create_any_ty_term()),
-                builder.create_unset_pub_member(
+                builder.create_uninitialised_pub_member("Self", builder.create_any_ty_term()),
+                builder.create_uninitialised_pub_member(
                     "hash",
                     builder.create_fn_ty_term(
                         [builder.create_param("value", builder.create_var_term("Self"))],
@@ -111,8 +111,8 @@ impl CoreDefs {
         let eq_trt = builder.create_trt_def(
             "Eq",
             [
-                builder.create_unset_pub_member("Self", builder.create_any_ty_term()),
-                builder.create_unset_pub_member(
+                builder.create_uninitialised_pub_member("Self", builder.create_any_ty_term()),
+                builder.create_uninitialised_pub_member(
                     "eq",
                     builder.create_fn_ty_term(
                         [


### PR DESCRIPTION
This PR implements the validation of traits and modules. This consists of validating each member of a trait/mod/impl, and ensuring that an `impl X` definition implements `X` correctly. After this PR, #312 needs to be tackled, as well as traversal (concurrently).

Closes #304.