### PR TITLE
Add pre-commit hook for format/lint/test, and remove build step from CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,50 +2,43 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build_and_test:
-    name: Unit, Style, and Lint Testing
+    name: Test, clippy, and format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-      - name: Install Rust Nightly
+      - name: Install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
-      - name: Cargo Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --verbose
-      - name: Cargo Test
+      - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --verbose
-      - name: Cargo Doc
+      - name: Generate documentation
         uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --all --verbose
-      - name: Cargo Clippy
+      - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all -- -D warnings
-      - name: Cargo Fmt
+      - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,7 @@ name = "hash"
 version = "0.1.0"
 dependencies = [
  "backtrace",
+ "cargo-husky",
  "clap",
  "hash-alloc",
  "hash-ast-desugaring",

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -795,26 +795,22 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     // No simplification occurred:
                     (None, None) if simplified_cases.iter().all(|x| x.is_none()) => Ok(None),
                     // Otherwise, build the simplified type function:
-                    _ => {
-                        Ok(Some(self.builder().create_term(
-                            Term::TyFn(
-                                TyFn {
-                                    name: ty_fn.name,
-                                    general_params: simplified_general_params
-                                        .unwrap_or(ty_fn.general_params),
-                                    general_return_ty: simplified_general_return_ty
-                                        .unwrap_or(ty_fn.general_return_ty),
-                                    cases: simplified_cases
-                                        .into_iter()
-                                        .zip(ty_fn.cases.into_iter())
-                                        .map(|(simplified_case, old_case)| {
-                                            simplified_case.unwrap_or(old_case)
-                                        })
-                                        .collect(),
-                                },
-                            ),
-                        )))
-                    }
+                    _ => Ok(Some(
+                        self.builder().create_term(Term::TyFn(TyFn {
+                            name: ty_fn.name,
+                            general_params: simplified_general_params
+                                .unwrap_or(ty_fn.general_params),
+                            general_return_ty: simplified_general_return_ty
+                                .unwrap_or(ty_fn.general_return_ty),
+                            cases: simplified_cases
+                                .into_iter()
+                                .zip(ty_fn.cases.into_iter())
+                                .map(|(simplified_case, old_case)| {
+                                    simplified_case.unwrap_or(old_case)
+                                })
+                                .collect(),
+                        })),
+                    )),
                 }
             }
             Term::TyFnTy(ty_fn_ty) => {

--- a/compiler/hash/Cargo.toml
+++ b/compiler/hash/Cargo.toml
@@ -15,21 +15,32 @@ clap = { version = "3.0.0", features = ["derive"] }
 profiling = "1.0.6"
 tracy-client = "0.13.2"
 
-hash-parser = {path = "../hash-parser" }
-hash-alloc = {path = "../hash-alloc" }
-hash-interactive = {path = "../hash-interactive" } 
-hash-reporting = {path = "../hash-reporting" }
-hash-pipeline = {path = "../hash-pipeline" }
+hash-parser = { path = "../hash-parser" }
+hash-alloc = { path = "../hash-alloc" }
+hash-interactive = { path = "../hash-interactive" }
+hash-reporting = { path = "../hash-reporting" }
+hash-pipeline = { path = "../hash-pipeline" }
 
 # Various stages that the pipeline interfaces with
 hash-ast-desugaring = { path = "../hash-ast-desugaring" }
 hash-ast-passes = { path = "../hash-ast-passes" }
-hash-typecheck = {path = "../hash-typecheck" }
-hash-vm = {path = "../hash-vm" }
-hash-source = {path = "../hash-source" }
+hash-typecheck = { path = "../hash-typecheck" }
+hash-vm = { path = "../hash-vm" }
+hash-source = { path = "../hash-source" }
 
 [features]
 profile-with-tracy = ["profiling/profile-with-tracy"]
 
 # Enable this flag to run tracy profiling
 # default = ["profile-with-tracy"]
+
+[dev-dependencies.cargo-husky]
+version = "1.5"
+default-features = false
+features = [
+  "precommit-hook",
+  "run-for-all",
+  "run-cargo-test",
+  "run-cargo-fmt",
+  "run-cargo-clippy",
+]


### PR DESCRIPTION
- The pre-commit hook (powered by [`cargo-husky`](https://github.com/rhysd/cargo-husky)) should lead to fewer "Fix {formatting,clippy,tests}" commits.
- The build step was removed from CI because CI takes a very long time and building doesn't check for anything more than what `cargo clippy` does.

Closes #316.