### PR TITLE
AST+TC: fix todos within the AST and add basic location information during tc traversal

### DIFF
--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -918,14 +918,14 @@ impl AstVisitorMut for AstDesugaring {
         Ok(())
     }
 
-    type FunctionDefArgRet = ();
+    type FunctionDefParamRet = ();
 
-    fn visit_function_def_arg(
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error> {
-        let _ = walk_mut::walk_function_def_arg(self, ctx, node);
+        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error> {
+        let _ = walk_mut::walk_function_def_param(self, ctx, node);
         Ok(())
     }
 
@@ -1286,10 +1286,10 @@ impl AstVisitorMut for AstDesugaring {
 
     type TypeFunctionDefArgRet = ();
 
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         _: &Self::Ctx,
-        _: hash_ast::ast::AstNodeRefMut<hash_ast::ast::TypeFunctionDefArg>,
+        _: hash_ast::ast::AstNodeRefMut<hash_ast::ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
         Ok(())
     }

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -191,7 +191,6 @@ fn desugar_for_loop_block(node: Block, parent_span: Span) -> Block {
                     subject: AstNode::new(
                         Expression::new(ExpressionKind::Variable(VariableExpr {
                             name: make_access_name("next"),
-                            type_args: ast_nodes![],
                         })),
                         iter_span,
                     ),

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -525,14 +525,14 @@ impl AstVisitor for SemanticAnalyser {
         Ok(())
     }
 
-    type FunctionDefArgRet = ();
+    type FunctionDefParamRet = ();
 
-    fn visit_function_def_arg(
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error> {
-        let _ = walk::walk_function_def_arg(self, ctx, node);
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error> {
+        let _ = walk::walk_function_def_param(self, ctx, node);
         Ok(())
     }
 
@@ -913,10 +913,10 @@ impl AstVisitor for SemanticAnalyser {
 
     type TypeFunctionDefArgRet = ();
 
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         _: &Self::Ctx,
-        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TypeFunctionDefArg>,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
         Ok(())
     }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1273,11 +1273,6 @@ pub struct Import {
 pub struct VariableExpr {
     /// The name of the variable.
     pub name: AstNode<AccessName>,
-    /// Any type arguments of the variable. Only valid for traits.
-    ///
-    /// @@Todo(@feds01): Shouldn't be here, it should be a TypeFunctionCall if
-    /// there are arguments.
-    pub type_args: AstNodes<NamedFieldTypeEntry>,
 }
 
 /// A reference expression with a flag denoting whether it is a raw ref or not

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -710,7 +710,7 @@ impl Display for Mutability {
 #[derive(Debug, PartialEq)]
 pub struct TypeFunctionDef {
     /// The type arguments of the function.
-    pub args: AstNodes<TypeFunctionDefArg>,
+    pub params: AstNodes<TypeFunctionDefParam>,
     /// Optional return type of the type function
     pub return_ty: Option<AstNode<Type>>,
     /// The body of the type function,
@@ -719,7 +719,7 @@ pub struct TypeFunctionDef {
 
 /// An argument within a type function
 #[derive(Debug, PartialEq)]
-pub struct TypeFunctionDefArg {
+pub struct TypeFunctionDefParam {
     /// The name of the argument
     pub name: AstNode<Name>,
 
@@ -1180,12 +1180,9 @@ impl Block {
     }
 }
 
-/// A function definition argument.
-///
-/// @@Naming,@@Todo(@feds01): Rename "Arg" to "Param", to be in-line with TC
-/// terminology.
+/// A function definition parameter.
 #[derive(Debug, PartialEq)]
-pub struct FunctionDefArg {
+pub struct FunctionDefParam {
     /// The name of the argument.
     pub name: AstNode<Name>,
     /// The type of the argument, if any.
@@ -1201,8 +1198,8 @@ pub struct FunctionDefArg {
 /// A function definition.
 #[derive(Debug, PartialEq)]
 pub struct FunctionDef {
-    /// The arguments of the function definition.
-    pub args: AstNodes<FunctionDefArg>,
+    /// The parameters of the function definition.
+    pub params: AstNodes<FunctionDefParam>,
     /// The return type of the function definition.
     ///
     /// Will be inferred if [None].

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -426,7 +426,7 @@ impl AstVisitor for AstTreeGenerator {
             walk::walk_type_function_param(self, ctx, node)?;
 
         Ok(TreeNode::branch(
-            "arg",
+            "param",
             iter::once(TreeNode::branch("name", vec![name]))
                 .chain(bound.map(|t| TreeNode::branch("type", vec![t])))
                 .chain(default.map(|d| TreeNode::branch("default", vec![d])))
@@ -589,16 +589,16 @@ impl AstVisitor for AstTreeGenerator {
         ))
     }
 
-    type FunctionDefArgRet = TreeNode;
-    fn visit_function_def_arg(
+    type FunctionDefParamRet = TreeNode;
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error> {
-        let walk::FunctionDefArg { name, ty, default } =
-            walk::walk_function_def_arg(self, ctx, node)?;
+        node: ast::AstNodeRef<ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error> {
+        let walk::FunctionDefParam { name, ty, default } =
+            walk::walk_function_def_param(self, ctx, node)?;
         Ok(TreeNode::branch(
-            "arg",
+            "param",
             iter::once(TreeNode::branch("name", vec![name]))
                 .chain(ty.map(|t| TreeNode::branch("type", vec![t])))
                 .chain(default.map(|d| TreeNode::branch("default", vec![d])))
@@ -1030,15 +1030,15 @@ impl AstVisitor for AstTreeGenerator {
     }
 
     type TypeFunctionDefArgRet = TreeNode;
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypeFunctionDefArg>,
+        node: ast::AstNodeRef<ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
         let walk::TypeFunctionDefArg { name, ty } =
-            walk::walk_type_function_def_arg(self, ctx, node)?;
+            walk::walk_type_function_def_param(self, ctx, node)?;
 
-        Ok(TreeNode::branch("arg", iter::once(name).chain(ty).collect()))
+        Ok(TreeNode::branch("param", iter::once(name).chain(ty).collect()))
     }
 
     type ConstructorPatternRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -85,15 +85,9 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::VariableExpr>,
     ) -> Result<Self::VariableExprRet, Self::Error> {
-        let walk::VariableExpr { name, type_args } = walk::walk_variable_expr(self, ctx, node)?;
+        let walk::VariableExpr { name } = walk::walk_variable_expr(self, ctx, node)?;
 
-        let mut children = vec![TreeNode::leaf(labelled("named", name.label, "\""))];
-
-        if !type_args.is_empty() {
-            children.extend(iter::once(TreeNode::branch("type_args", type_args)));
-        }
-
-        Ok(TreeNode::branch("variable", children))
+        Ok(TreeNode::branch("variable", vec![TreeNode::leaf(labelled("named", name.label, "\""))]))
     }
 
     type DirectiveExprRet = TreeNode;

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -329,12 +329,12 @@ pub trait AstVisitor: Sized {
         node: ast::AstNodeRef<ast::FunctionDef>,
     ) -> Result<Self::FunctionDefRet, Self::Error>;
 
-    type FunctionDefArgRet;
-    fn visit_function_def_arg(
+    type FunctionDefParamRet;
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error>;
+        node: ast::AstNodeRef<ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error>;
 
     type BlockRet;
     fn visit_block(
@@ -554,10 +554,10 @@ pub trait AstVisitor: Sized {
     ) -> Result<Self::TypeFunctionDefRet, Self::Error>;
 
     type TypeFunctionDefArgRet;
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::TypeFunctionDefArg>,
+        node: ast::AstNodeRef<ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error>;
 
     type ConstructorPatternRet;
@@ -1036,12 +1036,12 @@ pub trait AstVisitorMut: Sized {
         node: ast::AstNodeRefMut<ast::FunctionDef>,
     ) -> Result<Self::FunctionDefRet, Self::Error>;
 
-    type FunctionDefArgRet;
-    fn visit_function_def_arg(
+    type FunctionDefParamRet;
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error>;
+        node: ast::AstNodeRefMut<ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error>;
 
     type BlockRet;
     fn visit_block(
@@ -1261,10 +1261,10 @@ pub trait AstVisitorMut: Sized {
     ) -> Result<Self::TypeFunctionDefRet, Self::Error>;
 
     type TypeFunctionDefArgRet;
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::TypeFunctionDefArg>,
+        node: ast::AstNodeRefMut<ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error>;
 
     type ConstructorPatternRet;
@@ -1435,18 +1435,18 @@ pub trait AstVisitorMut: Sized {
 pub mod walk {
     use super::{ast, AstVisitor};
 
-    pub struct FunctionDefArg<V: AstVisitor> {
+    pub struct FunctionDefParam<V: AstVisitor> {
         pub name: V::NameRet,
         pub ty: Option<V::TypeRet>,
         pub default: Option<V::ExpressionRet>,
     }
 
-    pub fn walk_function_def_arg<V: AstVisitor>(
+    pub fn walk_function_def_param<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::FunctionDefArg>,
-    ) -> Result<FunctionDefArg<V>, V::Error> {
-        Ok(FunctionDefArg {
+        node: ast::AstNodeRef<ast::FunctionDefParam>,
+    ) -> Result<FunctionDefParam<V>, V::Error> {
+        Ok(FunctionDefParam {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
             ty: node.ty.as_ref().map(|t| visitor.visit_type(ctx, t.ast_ref())).transpose()?,
             default: node
@@ -1458,7 +1458,7 @@ pub mod walk {
     }
 
     pub struct FunctionDef<V: AstVisitor> {
-        pub args: V::CollectionContainer<V::FunctionDefArgRet>,
+        pub args: V::CollectionContainer<V::FunctionDefParamRet>,
         pub return_ty: Option<V::TypeRet>,
         pub fn_body: V::ExpressionRet,
     }
@@ -1471,7 +1471,7 @@ pub mod walk {
         Ok(FunctionDef {
             args: V::try_collect_items(
                 ctx,
-                node.args.iter().map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref())),
+                node.params.iter().map(|a| visitor.visit_function_def_param(ctx, a.ast_ref())),
             )?,
             return_ty: node
                 .return_ty
@@ -3069,7 +3069,7 @@ pub mod walk {
         Ok(TypeFunctionDef {
             args: V::try_collect_items(
                 ctx,
-                node.args.iter().map(|t| visitor.visit_type_function_def_arg(ctx, t.ast_ref())),
+                node.params.iter().map(|t| visitor.visit_type_function_def_param(ctx, t.ast_ref())),
             )?,
             return_ty: node
                 .return_ty
@@ -3085,10 +3085,10 @@ pub mod walk {
         pub ty: Option<V::TypeRet>,
     }
 
-    pub fn walk_type_function_def_arg<V: AstVisitor>(
+    pub fn walk_type_function_def_param<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::TypeFunctionDefArg>,
+        node: ast::AstNodeRef<ast::TypeFunctionDefParam>,
     ) -> Result<TypeFunctionDefArg<V>, V::Error> {
         Ok(TypeFunctionDefArg {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
@@ -3165,10 +3165,10 @@ pub mod walk_mut {
         pub default: Option<V::ExpressionRet>,
     }
 
-    pub fn walk_function_def_arg<V: AstVisitorMut>(
+    pub fn walk_function_def_param<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::FunctionDefArg>,
+        mut node: ast::AstNodeRefMut<ast::FunctionDefParam>,
     ) -> Result<FunctionDefArg<V>, V::Error> {
         Ok(FunctionDefArg {
             name: visitor.visit_name(ctx, node.name.ast_ref_mut())?,
@@ -3182,7 +3182,7 @@ pub mod walk_mut {
     }
 
     pub struct FunctionDef<V: AstVisitorMut> {
-        pub args: V::CollectionContainer<V::FunctionDefArgRet>,
+        pub params: V::CollectionContainer<V::FunctionDefParamRet>,
         pub return_ty: Option<V::TypeRet>,
         pub fn_body: V::ExpressionRet,
     }
@@ -3193,9 +3193,11 @@ pub mod walk_mut {
         mut node: ast::AstNodeRefMut<ast::FunctionDef>,
     ) -> Result<FunctionDef<V>, V::Error> {
         Ok(FunctionDef {
-            args: V::try_collect_items(
+            params: V::try_collect_items(
                 ctx,
-                node.args.iter_mut().map(|a| visitor.visit_function_def_arg(ctx, a.ast_ref_mut())),
+                node.params
+                    .iter_mut()
+                    .map(|a| visitor.visit_function_def_param(ctx, a.ast_ref_mut())),
             )?,
             return_ty: node
                 .return_ty
@@ -4870,7 +4872,7 @@ pub mod walk_mut {
     }
 
     pub struct TypeFunctionDef<V: AstVisitorMut> {
-        pub args: V::CollectionContainer<V::TypeFunctionDefArgRet>,
+        pub params: V::CollectionContainer<V::TypeFunctionDefArgRet>,
         pub return_ty: Option<V::TypeRet>,
         pub expression: V::ExpressionRet,
     }
@@ -4881,11 +4883,11 @@ pub mod walk_mut {
         mut node: ast::AstNodeRefMut<ast::TypeFunctionDef>,
     ) -> Result<TypeFunctionDef<V>, V::Error> {
         Ok(TypeFunctionDef {
-            args: V::try_collect_items(
+            params: V::try_collect_items(
                 ctx,
-                node.args
+                node.params
                     .iter_mut()
-                    .map(|t| visitor.visit_type_function_def_arg(ctx, t.ast_ref_mut())),
+                    .map(|t| visitor.visit_type_function_def_param(ctx, t.ast_ref_mut())),
             )?,
             return_ty: node
                 .return_ty
@@ -4896,17 +4898,17 @@ pub mod walk_mut {
         })
     }
 
-    pub struct TypeFunctionDefArg<V: AstVisitorMut> {
+    pub struct TypeFunctionDefParam<V: AstVisitorMut> {
         pub name: V::NameRet,
         pub ty: Option<V::TypeRet>,
     }
 
-    pub fn walk_type_function_def_arg<V: AstVisitorMut>(
+    pub fn walk_type_function_def_param<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::TypeFunctionDefArg>,
-    ) -> Result<TypeFunctionDefArg<V>, V::Error> {
-        Ok(TypeFunctionDefArg {
+        mut node: ast::AstNodeRefMut<ast::TypeFunctionDefParam>,
+    ) -> Result<TypeFunctionDefParam<V>, V::Error> {
+        Ok(TypeFunctionDefParam {
             name: visitor.visit_name(ctx, node.name.ast_ref_mut())?,
             ty: node
                 .ty

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -1677,7 +1677,6 @@ pub mod walk {
 
     pub struct VariableExpr<V: AstVisitor> {
         pub name: V::AccessNameRet,
-        pub type_args: V::CollectionContainer<V::NamedFieldTypeRet>,
     }
 
     pub fn walk_variable_expr<V: AstVisitor>(
@@ -1685,13 +1684,7 @@ pub mod walk {
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::VariableExpr>,
     ) -> Result<VariableExpr<V>, V::Error> {
-        Ok(VariableExpr {
-            name: visitor.visit_access_name(ctx, node.name.ast_ref())?,
-            type_args: V::try_collect_items(
-                ctx,
-                node.type_args.iter().map(|t| visitor.visit_named_field_type(ctx, t.ast_ref())),
-            )?,
-        })
+        Ok(VariableExpr { name: visitor.visit_access_name(ctx, node.name.ast_ref())? })
     }
 
     pub struct DirectiveExpr<V: AstVisitor> {
@@ -3406,7 +3399,6 @@ pub mod walk_mut {
 
     pub struct VariableExpr<V: AstVisitorMut> {
         pub name: V::AccessNameRet,
-        pub type_args: V::CollectionContainer<V::NamedFieldTypeRet>,
     }
 
     pub fn walk_variable_expr<V: AstVisitorMut>(
@@ -3414,15 +3406,7 @@ pub mod walk_mut {
         ctx: &V::Ctx,
         mut node: ast::AstNodeRefMut<ast::VariableExpr>,
     ) -> Result<VariableExpr<V>, V::Error> {
-        Ok(VariableExpr {
-            name: visitor.visit_access_name(ctx, node.name.ast_ref_mut())?,
-            type_args: V::try_collect_items(
-                ctx,
-                node.type_args
-                    .iter_mut()
-                    .map(|t| visitor.visit_named_field_type(ctx, t.ast_ref_mut())),
-            )?,
-        })
+        Ok(VariableExpr { name: visitor.visit_access_name(ctx, node.name.ast_ref_mut())? })
     }
 
     pub struct DirectiveExpr<V: AstVisitorMut> {

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -9,7 +9,7 @@ use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a [StructDef]. The keyword `struct` begins the construct and is
-    /// followed by parenthesees with inner struct fields defined.
+    /// followed by parentheses with inner struct fields defined.
     pub fn parse_struct_def(&self) -> AstGenResult<StructDef> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Struct)));
 
@@ -89,7 +89,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// level on expressions such as struct, enum, function, and trait
     /// definitions.
     pub fn parse_type_function_def(&self) -> AstGenResult<TypeFunctionDef> {
-        let mut args = AstNodes::empty();
+        let mut params = AstNodes::empty();
 
         // We can't do this because the parse_separated_fn() function expects a token
         // tree and not the while tree:
@@ -101,8 +101,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         //
         // And so instead we do this:
         //
-        while let Some(arg) = self.peek_resultant_fn(|| self.parse_type_function_def_arg()) {
-            args.nodes.push(arg);
+        while let Some(param) = self.peek_resultant_fn(|| self.parse_type_function_def_arg()) {
+            params.nodes.push(param);
 
             match self.peek() {
                 Some(token) if token.has_kind(TokenKind::Comma) => {
@@ -132,20 +132,20 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.parse_arrow()?;
         let expr = self.parse_expression_with_precedence(0)?;
 
-        Ok(TypeFunctionDef { args, return_ty, expr })
+        Ok(TypeFunctionDef { params, return_ty, expr })
     }
 
     // Parse a [TypeFunctionDefArg] which consists the name of the argument and then
     // any specified bounds on the argument which are essentially types that are
     // separated by a `~`
-    fn parse_type_function_def_arg(&self) -> AstGenResult<AstNode<TypeFunctionDefArg>> {
+    fn parse_type_function_def_arg(&self) -> AstGenResult<AstNode<TypeFunctionDefParam>> {
         let start = self.current_location();
         let name = self.parse_name()?;
 
         // Now it's followed by a colon
         let ty = self.parse_token_fast(TokenKind::Colon).map(|_| self.parse_type()).transpose()?;
 
-        Ok(self.node_with_joined_span(TypeFunctionDefArg { name, ty }, &start))
+        Ok(self.node_with_joined_span(TypeFunctionDefParam { name, ty }, &start))
     }
 
     /// Parse a [TraitDef]. A [TraitDef] is essentially a block prefixed with

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -111,13 +111,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             kind if kind.is_literal() => self.parse_literal(),
             TokenKind::Ident(ident) => {
                 let start = self.node_with_span(*ident, token.span);
-
-                self.node_with_joined_span(
-                    Expression::new(ExpressionKind::Variable(
-                        self.parse_variable_expression(Some(start))?,
-                    )),
-                    &token.span,
-                )
+                self.parse_variable_or_type_fn_call(Some(start))?
             }
             TokenKind::Lt => self.node_with_joined_span(
                 Expression::new(ExpressionKind::TypeFunctionDef(self.parse_type_function_def()?)),
@@ -292,10 +286,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         self.parse_singular_expression(subject)
     }
 
-    fn parse_variable_expression(
+    fn parse_variable_or_type_fn_call(
         &self,
         start: Option<AstNode<Identifier>>,
-    ) -> AstGenResult<VariableExpr> {
+    ) -> AstGenResult<AstNode<Expression>> {
         let name = match start {
             Some(node) => self.parse_access_name(node)?,
             None => match self.peek() {
@@ -312,18 +306,39 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             },
         };
 
+        let name_span = name.span();
+
         // @@Speed: so here we want to be efficient about type_args, we'll just try to
         // see if the next token atom is a 'Lt' rather than using parse_token_atom
         // because it throws an error essentially and thus allocates a stupid amount
         // of strings which at the end of the day aren't even used...
-        let type_args = match self.peek() {
-            Some(token) if token.has_kind(TokenKind::Lt) => self
-                .peek_resultant_fn(|| self.parse_type_args(false))
-                .unwrap_or_else(AstNodes::empty),
-            _ => AstNodes::empty(),
-        };
-
-        Ok(VariableExpr { name, type_args })
+        match self.peek() {
+            Some(token) if token.has_kind(TokenKind::Lt) => {
+                match self.peek_resultant_fn(|| self.parse_type_args(false)) {
+                    Some(args) => Ok(self.node_with_joined_span(
+                        Expression::new(ExpressionKind::Type(TypeExpr(
+                            self.node_with_joined_span(
+                                Type::TypeFunctionCall(TypeFunctionCall {
+                                    subject: self
+                                        .node_with_span(Type::Named(NamedType { name }), name_span),
+                                    args,
+                                }),
+                                &name_span,
+                            ),
+                        ))),
+                        &name_span,
+                    )),
+                    None => Ok(self.node_with_joined_span(
+                        Expression::new(ExpressionKind::Variable(VariableExpr { name })),
+                        &name_span,
+                    )),
+                }
+            }
+            _ => Ok(self.node_with_joined_span(
+                Expression::new(ExpressionKind::Variable(VariableExpr { name })),
+                &name_span,
+            )),
+        }
     }
 
     /// Parse an expression whilst taking into account binary precedence
@@ -463,7 +478,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                                 &start,
                             );
                         }
-                        ExpressionKind::Variable(VariableExpr { name, type_args: _ }) => {
+                        ExpressionKind::Variable(VariableExpr { name }) => {
                             // @@Cleanup: This produces an AstNode<AccessName> whereas we just want
                             // the single name...
                             let ident = name.body().path[0].body();
@@ -808,29 +823,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Parse an single name or a function call that is applied on the left hand
     /// side expression. Infix calls and name are only separated by infix
-    /// calls having parenthesees at the end of the name.
+    /// calls having parentheses at the end of the name.
     pub(crate) fn parse_name_or_infix_call(&self) -> AstGenResult<AstNode<Expression>> {
         debug_assert!(self.current_token().has_kind(TokenKind::Dot));
 
-        let start = self.current_location();
-
         match &self.next_token() {
             Some(Token { kind: TokenKind::Ident(id), span: id_span }) => {
-                let type_args = self
-                    .peek_resultant_fn(|| self.parse_type_args(false))
-                    .unwrap_or_else(AstNodes::empty);
-
-                // create the subject of the call
-                let subject = self.node_with_span(
-                    Expression::new(ExpressionKind::Variable(VariableExpr {
-                        name: self.node_with_span(
-                            AccessName { path: ast_nodes![self.node_with_span(*id, *id_span)] },
-                            *id_span,
-                        ),
-                        type_args,
-                    })),
-                    start.join(self.current_location()),
-                );
+                let subject =
+                    self.parse_variable_or_type_fn_call(Some(self.node_with_span(*id, *id_span)))?;
 
                 match self.peek() {
                     Some(Token { kind: TokenKind::Tree(Delimiter::Paren, tree_index), span }) => {
@@ -900,7 +900,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let entry = gen.parse_tuple_literal_entry()?;
 
         // In the special case where this is just an expression that is wrapped within
-        // parenthesees, we can check that the 'name' and 'ty' parameters are
+        // parentheses, we can check that the 'name' and 'ty' parameters are
         // set to `None` and that there are no extra tokens that are left within
         // the token tree...
         if entry.ty.is_none() && entry.name.is_none() && !gen.has_token() {

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -938,7 +938,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Parse a function definition argument, which is made of an identifier and
     /// a function type.
-    pub(crate) fn parse_function_def_arg(&self) -> AstGenResult<AstNode<FunctionDefArg>> {
+    pub(crate) fn parse_function_def_param(&self) -> AstGenResult<AstNode<FunctionDefParam>> {
         let name = self.parse_name()?;
         let name_span = name.span();
 
@@ -958,7 +958,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             _ => None,
         };
 
-        Ok(self.node_with_joined_span(FunctionDefArg { name, ty, default }, &name_span))
+        Ok(self.node_with_joined_span(FunctionDefParam { name, ty, default }, &name_span))
     }
 
     /// Parse a function literal. Function literals are essentially definitions
@@ -970,9 +970,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     ) -> AstGenResult<AstNode<Expression>> {
         let start = self.current_location();
 
-        // parse function definition arguments.
-        let args = gen.parse_separated_fn(
-            || gen.parse_function_def_arg(),
+        // parse function definition parameters.
+        let params = gen.parse_separated_fn(
+            || gen.parse_function_def_param(),
             || gen.parse_token(TokenKind::Comma),
         )?;
 
@@ -990,7 +990,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         };
 
         Ok(self.node_with_joined_span(
-            Expression::new(ExpressionKind::FunctionDef(FunctionDef { args, return_ty, fn_body })),
+            Expression::new(ExpressionKind::FunctionDef(FunctionDef {
+                params,
+                return_ty,
+                fn_body,
+            })),
             &start,
         ))
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     },
     GlobalStorage,
 };
-use hash_source::identifier::Identifier;
+use hash_source::{identifier::Identifier, location::SourceLocation};
 use std::cell::{Cell, RefCell};
 
 /// Helper to create various primitive constructions (from
@@ -31,6 +31,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a new [PrimitiveBuilder] with a given scope.
     pub fn new(gs: &'gs mut GlobalStorage) -> Self {
         Self { gs: RefCell::new(gs), scope: Cell::new(None) }
+    }
+
+    /// Release [Self], returning the original [GlobalStorage].
+    pub fn release(self) -> &'gs mut GlobalStorage {
+        self.gs.into_inner()
     }
 
     /// Create a new [PrimitiveBuilder] with a given scope.
@@ -530,8 +535,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::AppTyFn(app_ty_fn))
     }
 
-    /// Release [Self], returning the original [GlobalStorage].
-    pub fn release(self) -> &'gs mut GlobalStorage {
-        self.gs.into_inner()
+    /// Add a [SourceLocation] to a [Term].
+    pub fn add_location_to(&self, subject: TermId, location: SourceLocation) {
+        self.gs.borrow_mut().location_store.add_location_to_target(subject.into(), location);
     }
 }

--- a/compiler/hash-typecheck/src/reporting.rs
+++ b/compiler/hash-typecheck/src/reporting.rs
@@ -48,7 +48,7 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Vec<Report> {
                     )));
                 }
 
-                if let Some(location) = err.location_store().get_location((*src).into()) {
+                if let Some(location) = err.location_store().get_location(src.into()) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         format!(

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -525,9 +525,9 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionDef>,
     ) -> Result<Self::FunctionDefRet, Self::Error> {
         let args: Vec<_> = node
-            .args
+            .params
             .iter()
-            .map(|a| self.visit_function_def_arg(ctx, a.ast_ref()))
+            .map(|a| self.visit_function_def_param(ctx, a.ast_ref()))
             .collect::<TcResult<_>>()?;
         let return_ty =
             node.return_ty.as_ref().map(|t| self.visit_type(ctx, t.ast_ref())).transpose()?;
@@ -558,14 +558,14 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         Ok(builder.create_fn_lit_term(builder.create_fn_ty_term(params, return_ty), return_value))
     }
 
-    type FunctionDefArgRet = Param;
-    fn visit_function_def_arg(
+    type FunctionDefParamRet = Param;
+    fn visit_function_def_param(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionDefArg>,
-    ) -> Result<Self::FunctionDefArgRet, Self::Error> {
-        let walk::FunctionDefArg { name, default, ty } =
-            walk::walk_function_def_arg(self, ctx, node)?;
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FunctionDefParam>,
+    ) -> Result<Self::FunctionDefParamRet, Self::Error> {
+        let walk::FunctionDefParam { name, default, ty } =
+            walk::walk_function_def_param(self, ctx, node)?;
 
         let ty_or_unresolved = self.builder().or_unresolved_term(ty);
         let value_or_unresolved = self.builder().or_unresolved_term(default);
@@ -902,10 +902,10 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     type TypeFunctionDefArgRet = TermId;
 
-    fn visit_type_function_def_arg(
+    fn visit_type_function_def_param(
         &mut self,
         _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::TypeFunctionDefArg>,
+        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
         todo!()
     }


### PR DESCRIPTION
This patch fixes the two outstanding todos within `ast.rs`:
- `VariableExpr` should not have `type_args` on it and any expression which is an `AccessName` followed by type arguments should be parsed as a `TypeFunctionCall`.
- rename `FunctionDefArg` and friends to `FunctionDefParam`

This patch also adds basic information about term locations during traversal, which has led to the first error report within typechecking to be rendered with locations!