### PR TITLE
TC: implement reporting for remaining members of `TcError`

### DIFF
--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -113,7 +113,9 @@ impl From<AnalysisError> for Report {
                     )));
             }
             AnalysisErrorKind::AmbiguousPatternFieldOrder { origin } => {
-                builder.with_message(format!("Ambiguous field order in `{}` pattern", origin));
+                builder
+                    .with_error_code(HashErrorCode::AmbiguousFieldOrder)
+                    .with_message(format!("Ambiguous field order in `{}` pattern", origin));
 
                 builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                     err.location,

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -35,4 +35,5 @@ error_codes! {
     // Errors in regard to parameter lists
     ParameterLengthMismatch = 25,
     ParameterNameMismatch = 26,
+    ParameterInUse = 29,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -6,19 +6,20 @@ error_codes! {
     UsingContinueOutsideLoop = 3,
     UsingReturnOutsideFunction = 4,
     // 5: un-used
+
+    // Name spacing and symbol errors
     UnresolvedSymbol = 6,
-    TryingToNamespaceType = 7,
-    TryingToNamespaceVariable = 8,
-    SymbolIsNotAType = 9,
-    SymbolIsNotAVariable = 10,
-    SymbolIsNotATrait = 11,
-    SymbolIsNotAEnum = 12,
+    UnsupportedAccess = 8,
+    UnsupportedNamespaceAccess = 9,
+    UnsupportedPropertyAccess = 10,
+
 
     UnresolvedStructField = 15,
     InvalidPropertyAccess = 16,
     ExpectingBooleanInCondition = 17,
     MissingStructField = 18,
-    BoundRequiresStrictlyTypeVars = 19,
+
+
     // 20: un-used
     TraitDefinitionNotFound = 21,
     NoMatchingTraitImplementations = 24,

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -14,9 +14,10 @@ error_codes! {
     UnsupportedNamespaceAccess = 12,
     UnsupportedPropertyAccess = 13,
     AmbiguousAccess = 14,
-    UnresolvedStructField = 15,
+    UnresolvedNameInValue = 15,
     InvalidPropertyAccess = 16,
     MissingStructField = 17,
+    UninitialisedMember = 18,
 
     // Type errors
     TypeMismatch = 20,
@@ -26,6 +27,7 @@ error_codes! {
     ValueCannotBeUsedAsType = 24,
     NonRuntimeInstantiable = 25,
     UnsupportedTypeFunctionApplication = 26,
+    TypeIsNotTrait = 27,
 
     // Errors in regard to parameter lists
     ParameterLengthMismatch = 35,
@@ -38,4 +40,6 @@ error_codes! {
     MultipleNominals = 51,
     TraitDefinitionNotFound = 52,
     NoMatchingTraitImplementations = 53,
+    InvalidPropertyAccessOfNonMethod = 54,
+    TraitImplMissingMember = 55,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -36,4 +36,5 @@ error_codes! {
     ParameterLengthMismatch = 25,
     ParameterNameMismatch = 26,
     ParameterInUse = 29,
+    AmbiguousFieldOrder = 30,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -38,4 +38,5 @@ error_codes! {
 
     // traits
     InvalidMergeElement = 50,
+    MultipleNominals = 51,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -26,10 +26,7 @@ error_codes! {
 
     // Type errors
     TypeMismatch = 1,
-    TypeIsNotStruct = 13,
-    TypeIsNotEnum = 14,
-    TypeAnnotationNotAllowedInTraitImpl = 22,
-    TypeArgumentLengthMismatch = 23,
+    DisallowedType = 22,
     TypeIsNotTypeFunction = 27,
     ValueCannotBeUsedAsType = 28,
 
@@ -38,4 +35,7 @@ error_codes! {
     ParameterNameMismatch = 26,
     ParameterInUse = 29,
     AmbiguousFieldOrder = 30,
+
+    // traits
+    InvalidMergeElement = 50,
 }

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -2,41 +2,40 @@
 
 error_codes! {
     // Semantic errors
+    ExpectingBooleanInCondition = 1,
     UsingBreakOutsideLoop = 2,
     UsingContinueOutsideLoop = 3,
     UsingReturnOutsideFunction = 4,
     // 5: un-used
 
     // Name spacing and symbol errors
-    UnresolvedSymbol = 6,
-    UnsupportedAccess = 8,
-    UnsupportedNamespaceAccess = 9,
-    UnsupportedPropertyAccess = 10,
-
-
+    UnresolvedSymbol = 10,
+    UnsupportedAccess = 11,
+    UnsupportedNamespaceAccess = 12,
+    UnsupportedPropertyAccess = 13,
+    AmbiguousAccess = 14,
     UnresolvedStructField = 15,
     InvalidPropertyAccess = 16,
-    ExpectingBooleanInCondition = 17,
-    MissingStructField = 18,
-
-
-    // 20: un-used
-    TraitDefinitionNotFound = 21,
-    NoMatchingTraitImplementations = 24,
+    MissingStructField = 17,
 
     // Type errors
-    TypeMismatch = 1,
-    DisallowedType = 22,
-    TypeIsNotTypeFunction = 27,
-    ValueCannotBeUsedAsType = 28,
+    TypeMismatch = 20,
+    DisallowedType = 21,
+    UnresolvedType = 22,
+    TypeIsNotTypeFunction = 23,
+    ValueCannotBeUsedAsType = 24,
+    NonRuntimeInstantiable = 25,
+    UnsupportedTypeFunctionApplication = 26,
 
     // Errors in regard to parameter lists
-    ParameterLengthMismatch = 25,
-    ParameterNameMismatch = 26,
-    ParameterInUse = 29,
-    AmbiguousFieldOrder = 30,
+    ParameterLengthMismatch = 35,
+    ParameterNameMismatch = 36,
+    ParameterInUse = 37,
+    AmbiguousFieldOrder = 38,
 
     // traits
     InvalidMergeElement = 50,
     MultipleNominals = 51,
+    TraitDefinitionNotFound = 52,
+    NoMatchingTraitImplementations = 53,
 }

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -23,6 +23,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let decl = match self.begins_pattern() {
             true => {
                 let pat = self.parse_singular_pattern()?;
+
                 self.parse_token(TokenKind::Colon)?;
 
                 let decl = self.parse_declaration(pat)?;

--- a/compiler/hash-parser/src/parser/pattern.rs
+++ b/compiler/hash-parser/src/parser/pattern.rs
@@ -429,6 +429,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             _ => return false,
         };
 
+        // Ensure that double colons `::` aren't followed which doesn't necessarily
+        // imply that this is a declaration
         matches!(self.peek_nth(n_lookahead), Some(token) if token.has_kind(TokenKind::Colon))
+            && matches!(self.peek_nth(n_lookahead + 1), Some(token) if !token.has_kind(TokenKind::Colon))
     }
 }

--- a/compiler/hash-parser/src/parser/pattern.rs
+++ b/compiler/hash-parser/src/parser/pattern.rs
@@ -248,12 +248,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     }
 
     /// Parse a [Pattern::Tuple] from the token vector. A tuple pattern consists
-    /// of nested patterns within parenthesees which might also have an
+    /// of nested patterns within parentheses which might also have an
     /// optional named fields.
     ///
     /// If only a singular pattern is parsed and it doesn't have a name, then
     /// the function will assume that this is not a tuple pattern and simply
-    /// a pattern wrapped within parenthesees.
+    /// a pattern wrapped within parentheses.
     pub(crate) fn parse_tuple_pattern(
         &self,
         tree: &'stream [Token],
@@ -270,7 +270,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             }
         }
 
-        // @@Hack: here it might actually be a nested pattern in parenthesees. So we
+        // @@Hack: here it might actually be a nested pattern in parentheses. So we
         // perform a slight transformation if the number of parsed patterns is
         // only one. So essentially we handle the case where a pattern is
         // wrapped in parentheses and so we just unwrap it.

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -3,7 +3,10 @@
 use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, TermId, TyFnCase};
 use hash_source::identifier::Identifier;
 
-use super::params::{ParamListKind, ParamUnificationErrorReason};
+use super::{
+    params::{ParamListKind, ParamUnificationErrorReason},
+    symbol::NameFieldOrigin,
+};
 
 /// Convenient type alias for a result with a [TcError] as the error type.
 pub type TcResult<T> = Result<T, TcError>;
@@ -38,7 +41,7 @@ pub enum TcError {
     /// It is invalid to use a positional argument after a named argument.
     AmbiguousArgumentOrdering { param_kind: ParamListKind, index: usize },
     /// The given name cannot be resolved in the given value.
-    UnresolvedNameInValue { name: Identifier, value: TermId },
+    UnresolvedNameInValue { name: Identifier, origin: NameFieldOrigin, value: TermId },
     /// The given variable cannot be resolved in the current context.
     UnresolvedVariable { name: Identifier, value: TermId },
     /// The given value does not support accessing (of the given name).
@@ -92,10 +95,12 @@ pub enum TcError {
     /// @@ErrorReporting: add span of member.
     UninitialisedMemberNotAllowed { member_ty: TermId },
     /// Cannot implement something that isn't a trait.
-    CannotImplementNonTrait { supposed_trait_term: TermId },
+    CannotImplementNonTrait { term: TermId },
     /// The trait implementation `trt_impl_term_id` is missing the member
     /// `trt_def_missing_member_id` from the trait `trt_def_term_id`.
-    TraitImplementationMissingMember {
+    ///
+    /// @@ErrorReporting: identify all missing members
+    TraitImplMissingMember {
         trt_impl_term_id: TermId,
         trt_def_term_id: TermId,
         // @@ErrorReporting: Ideally we want to be able to identify whole members rather than just

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -68,8 +68,10 @@ pub enum TcError {
     /// but it contains more.
     MergeShouldOnlyContainOneNominal {
         merge_term: TermId,
-        nominal_term: TermId,
-        second_nominal_term: TermId,
+        /// The first term
+        initial_term: TermId,
+        /// Secondary nominal term
+        offending_term: TermId,
     },
     /// The given merge term should contain only level 1 terms.
     MergeShouldBeLevel1 { merge_term: TermId, offending_term: TermId },

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -57,7 +57,7 @@ pub enum TcError {
         unification_errors: Vec<TcError>,
     },
     /// The given term cannot be used in a merge operation.
-    InvalidElementOfMerge { term: TermId },
+    InvalidMergeElement { term: TermId },
     /// The given term cannot be used as a type function parameter type.
     InvalidTypeFunctionParameterType { param_ty: TermId },
     /// The given term cannot be used as a type function return type.

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -1,6 +1,6 @@
 //! Error-related data structures for errors that occur during typechecking.
 
-use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, TermId};
+use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, TermId, TyFnCase};
 use hash_source::identifier::Identifier;
 
 use super::params::{ParamListKind, ParamUnificationErrorReason};
@@ -52,6 +52,7 @@ pub enum TcError {
     /// the given errors.
     InvalidTypeFunctionApplication {
         type_fn: TermId,
+        cases: Vec<TyFnCase>,
         args: ArgsId,
         unification_errors: Vec<TcError>,
     },

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -78,7 +78,7 @@ pub enum TcError {
     /// The given merge term should contain only level 2 terms.
     MergeShouldBeLevel2 { merge_term: TermId, offending_term: TermId },
     /// More type annotations are needed to resolve the given term.
-    NeedMoreTypeAnnotationsToResolve { term_to_resolve: TermId },
+    NeedMoreTypeAnnotationsToResolve { term: TermId },
     /// The given term cannot be instantiated at runtime.
     TermIsNotRuntimeInstantiable { term: TermId },
     /// The given term cannot be used as the subject of a type function

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -85,7 +85,7 @@ pub enum TcError {
     /// application.
     UnsupportedTypeFunctionApplication { subject_id: TermId },
     /// The given access operation results in more than one result.
-    AmbiguousAccess { access: AccessTerm },
+    AmbiguousAccess { access: AccessTerm, results: Vec<TermId> },
     /// The given access operation does not resolve to a method.
     InvalidPropertyAccessOfNonMethod { subject: TermId, property: Identifier },
     /// The given member requires an initialisation in the current scope.

--- a/compiler/hash-typecheck/src/diagnostics/mod.rs
+++ b/compiler/hash-typecheck/src/diagnostics/mod.rs
@@ -4,3 +4,4 @@
 pub mod error;
 pub mod params;
 pub mod reporting;
+pub mod symbol;

--- a/compiler/hash-typecheck/src/diagnostics/mod.rs
+++ b/compiler/hash-typecheck/src/diagnostics/mod.rs
@@ -1,0 +1,6 @@
+//! Module file for diagnostic creation and reporting within the typechecking
+//! crate.
+
+pub mod error;
+pub mod params;
+pub mod reporting;

--- a/compiler/hash-typecheck/src/diagnostics/params.rs
+++ b/compiler/hash-typecheck/src/diagnostics/params.rs
@@ -1,0 +1,65 @@
+//! Error-related data structures for errors that in regards to parameters and
+//! arguments within any type that uses parameters.
+
+use std::fmt::Display;
+
+use hash_source::location::SourceLocation;
+
+use crate::storage::{
+    location::LocationStore,
+    primitives::{ArgsId, ParamOrigin, ParamsId},
+    GlobalStorage,
+};
+
+/// Particular reason why parameters couldn't be unified, either argument
+/// length mis-match or that a name mismatched between the two given parameters.
+#[derive(Debug, Clone, Copy)]
+pub enum ParamUnificationErrorReason {
+    /// The provided and expected parameter lengths mismatched.
+    LengthMismatch,
+    /// A name mismatch of the parameters occurred at the particular
+    /// index.
+    NameMismatch(usize),
+}
+
+/// This type is used to represent a `source` of where
+/// a [TcError::ParamGivenTwice] occurs. It can either occur
+/// in an argument list, or it can occur within a parameter list.
+/// The reporting logic is the same, with the minor wording difference.
+#[derive(Debug, Clone)]
+pub enum ParamListKind {
+    Params(ParamsId),
+    Args(ArgsId),
+}
+
+impl ParamListKind {
+    /// Convert a [ParamListKind] into a [SourceLocation] by looking up the
+    /// inner id within the [LocationStore].
+    pub(crate) fn to_location(
+        &self,
+        index: usize,
+        store: &LocationStore,
+    ) -> Option<SourceLocation> {
+        match self {
+            ParamListKind::Params(id) => store.get_location((*id, index)),
+            ParamListKind::Args(id) => store.get_location((*id, index)),
+        }
+    }
+
+    /// Get the [ParamOrigin] from the [ParamListKind]
+    pub(crate) fn origin(&self, store: &GlobalStorage) -> ParamOrigin {
+        match self {
+            ParamListKind::Params(id) => store.params_store.get(*id).origin(),
+            ParamListKind::Args(id) => store.args_store.get(*id).origin(),
+        }
+    }
+}
+
+impl Display for ParamListKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParamListKind::Params(_) => write!(f, "fields"),
+            ParamListKind::Args(_) => write!(f, "arguments"),
+        }
+    }
+}

--- a/compiler/hash-typecheck/src/diagnostics/params.rs
+++ b/compiler/hash-typecheck/src/diagnostics/params.rs
@@ -23,7 +23,7 @@ pub enum ParamUnificationErrorReason {
 }
 
 /// This type is used to represent a `source` of where
-/// a [TcError::ParamGivenTwice] occurs. It can either occur
+/// a [super::TcError::ParamGivenTwice] occurs. It can either occur
 /// in an argument list, or it can occur within a parameter list.
 /// The reporting logic is the same, with the minor wording difference.
 #[derive(Debug, Clone)]

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -547,6 +547,47 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                     )));
                 }
             }
+
+            TcError::MergeShouldBeLevel1 { merge_term, offending_term } => {
+                let location = err.location_store().get_location(merge_term).unwrap();
+
+                let offender = err.term_store().get(*offending_term);
+                let offender_location = err.location_store().get_location(offending_term).unwrap();
+
+                builder
+                    .with_error_code(HashErrorCode::DisallowedType)
+                    .with_message(
+                        "this merge declaration should only contain a level-1 terms".to_string(),
+                    )
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "in this merge declaration",
+                    )))
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        offender_location,
+                        format!("this term is of {} and not level-1", offender.get_term_level()),
+                    )));
+            }
+            TcError::MergeShouldBeLevel2 { merge_term, offending_term } => {
+                let location = err.location_store().get_location(merge_term).unwrap();
+
+                let offender = err.term_store().get(*offending_term);
+                let offender_location = err.location_store().get_location(offending_term).unwrap();
+
+                builder
+                    .with_error_code(HashErrorCode::DisallowedType)
+                    .with_message(
+                        "this merge declaration should only contain a level-2 terms".to_string(),
+                    )
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "in this merge declaration",
+                    )))
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        offender_location,
+                        format!("this term is of {} and not level-2", offender.get_term_level()),
+                    )));
+            }
             _ => {
                 // @@Temporary
                 builder.with_message(format!("not yet pretty error: {:#?}", err.error));

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -351,6 +351,61 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Vec<Report> {
                     )));
                 }
             }
+            TcError::UnsupportedAccess { name, value } => {
+                builder
+                    .with_error_code(HashErrorCode::UnsupportedAccess)
+                    .with_message("unsupported access");
+
+                if let Some(location) = err.location_store().get_location(value) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "`{}` cannot be accessed using with the name `{}`",
+                            value.for_formatting(err.global_storage()),
+                            name
+                        ),
+                    )));
+                }
+            }
+            TcError::UnsupportedNamespaceAccess { name, value } => {
+                builder.with_error_code(HashErrorCode::UnsupportedNamespaceAccess).with_message(
+                    format!(
+                        "unsupported namespace access, `{}` cannot be namespaced",
+                        value.for_formatting(err.global_storage())
+                    ),
+                );
+
+                if let Some(location) = err.location_store().get_location(value) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "`{}` cannot be namespaced using with the name `{}`",
+                            value.for_formatting(err.global_storage()),
+                            name
+                        ),
+                    )));
+                }
+            }
+
+            TcError::UnsupportedPropertyAccess { name, value } => {
+                builder.with_error_code(HashErrorCode::UnsupportedPropertyAccess).with_message(
+                    format!(
+                        "unsupported property access for type `{}`",
+                        value.for_formatting(err.global_storage())
+                    ),
+                );
+
+                if let Some(location) = err.location_store().get_location(value) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "The property `{}` cannot be accessed from `{}`, it does not support property. accessing",
+                            name,
+                            value.for_formatting(err.global_storage()),
+                        ),
+                    )));
+                }
+            }
             _ => {
                 // @@Temporary
                 builder.with_message(format!("not yet pretty error: {:#?}", err.error));

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -516,6 +516,37 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                     )));
                 }
             }
+            TcError::MergeShouldOnlyContainOneNominal {
+                merge_term,
+                initial_term,
+                offending_term,
+            } => {
+                builder.with_error_code(HashErrorCode::DisallowedType).with_message(
+                    "merge declarations should only contain a single nominal term".to_string(),
+                );
+
+                if let Some(location) = err.location_store().get_location(initial_term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "the merge declaration has an initial nominal term here",
+                    )));
+                }
+
+                if let Some(location) = err.location_store().get_location(offending_term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "...and the second nominal term use occurs here",
+                    )));
+                }
+
+                // Add the location of the actual merge for annotation
+                if let Some(location) = err.location_store().get_location(merge_term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "within this merge term",
+                    )));
+                }
+            }
             _ => {
                 // @@Temporary
                 builder.with_message(format!("not yet pretty error: {:#?}", err.error));

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -1,7 +1,11 @@
-//! Contains utilities to convert a [crate::error::TcError] into a
+//! Contains utilities to convert a [super::error::TcError] into a
 //! [hash_reporting::report::Report].
+
+use super::{
+    error::TcError,
+    params::{ParamListKind, ParamUnificationErrorReason},
+};
 use crate::{
-    error::{ParamListKind, ParamUnificationErrorReason, TcError},
     fmt::PrepareForFormatting,
     storage::{
         primitives::{Arg, Param},
@@ -331,6 +335,19 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Vec<Report> {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         "un-named parameters cannot appear after named parameters",
+                    )));
+                }
+            }
+            TcError::UnresolvedVariable { name, value } => {
+                builder.with_error_code(HashErrorCode::UnresolvedSymbol).with_message(format!(
+                    "variable `{}` is not defined in the current scope",
+                    name
+                ));
+
+                if let Some(location) = err.location_store().get_location(value) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "variable not defined in the current scope",
                     )));
                 }
             }

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -446,6 +446,76 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
 
                 // @@Todo(feds01): Now we need to merge the reports:
             }
+            TcError::InvalidMergeElement { term } => {
+                builder
+                    .with_error_code(HashErrorCode::InvalidMergeElement)
+                    .with_message("invalid element within a merge declaration");
+
+                if let Some(location) = err.location_store().get_location(term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "cannot use the type `{}` within a merge declaration",
+                            term.for_formatting(err.global_storage()),
+                        ),
+                    )));
+
+                    // @@Todo(feds01): add more helpful information about why
+                    // this particular type cannot be
+                    // used within this position
+                }
+            }
+            TcError::InvalidTypeFunctionParameterType { param_ty } => {
+                builder
+                    .with_error_code(HashErrorCode::DisallowedType)
+                    .with_message("invalid function parameter type".to_string());
+
+                if let Some(location) = err.location_store().get_location(param_ty) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "cannot use the type `{}` within as the type of a function parameter",
+                            param_ty.for_formatting(err.global_storage()),
+                        ),
+                    )));
+                }
+            }
+            TcError::InvalidTypeFunctionReturnType { return_ty } => {
+                builder
+                    .with_error_code(HashErrorCode::DisallowedType)
+                    .with_message("invalid function return type".to_string());
+
+                if let Some(location) = err.location_store().get_location(return_ty) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "cannot use the type `{}` as the return type of a function",
+                            return_ty.for_formatting(err.global_storage()),
+                        ),
+                    )));
+                }
+            }
+            TcError::InvalidTypeFunctionReturnValue { return_value } => {
+                builder
+                    .with_error_code(HashErrorCode::DisallowedType)
+                    .with_message("invalid type of function return value".to_string());
+
+                if let Some(location) = err.location_store().get_location(return_value) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "this can't be used as the return of the function",
+                    )));
+
+                    // @@Todo(feds01): more information about why this is disallowed
+                    builder.add_element(ReportElement::Note(ReportNote::new(
+                        ReportNoteKind::Note,
+                        format!(
+                            "the type of the return value `{}` which is disallowed",
+                            return_value.for_formatting(err.global_storage()),
+                        ),
+                    )));
+                }
+            }
             _ => {
                 // @@Temporary
                 builder.with_message(format!("not yet pretty error: {:#?}", err.error));

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -581,7 +581,10 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                     )))
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         offender_location,
-                        format!("this term is of {} and not level-1", offender.get_term_level()),
+                        format!(
+                            "this term is of {} and not level-1",
+                            offender.get_term_level(err.term_store())
+                        ),
                     )));
             }
             TcError::MergeShouldBeLevel2 { merge_term, offending_term } => {
@@ -601,7 +604,10 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                     )))
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         offender_location,
-                        format!("this term is of {} and not level-2", offender.get_term_level()),
+                        format!(
+                            "this term is of {} and not level-2",
+                            offender.get_term_level(err.term_store())
+                        ),
                     )));
             }
             TcError::NeedMoreTypeAnnotationsToResolve { term } => {

--- a/compiler/hash-typecheck/src/diagnostics/symbol.rs
+++ b/compiler/hash-typecheck/src/diagnostics/symbol.rs
@@ -1,0 +1,63 @@
+//! Error-related data structures for errors that in regards to symbols
+//! and symbols within error variants.
+
+use std::fmt::Display;
+
+use crate::storage::{
+    primitives::{Level0Term, Level1Term, Term},
+    terms::TermStore,
+};
+
+/// An enum representing the origin of a named field access.
+/// This is used to provide additional contextual information
+/// when the validator fails to find a named field within
+/// an enumeration or similar kind of [Term]. The error that
+/// the validator generates with this value in mind is
+/// [super::error::TcError::UnresolvedNameInValue].
+#[derive(Debug, Clone)]
+pub enum NameFieldOrigin {
+    /// Enum nominal definition
+    Enum,
+    /// Inner variant of an enum
+    EnumVariant,
+    /// Impl or module block, unclear which it is but it shouldn't matter.
+    Mod,
+    /// Tuple parent subject
+    Tuple,
+}
+
+impl NameFieldOrigin {
+    /// Utility function to convert a [Term] into a [NameFieldOrigin].
+    ///
+    /// This assumes that the provided term does yield a [NameFieldOrigin]
+    /// and any other variant of term will cause the function to *panic*.
+    pub fn new_from_term(term: &Term, store: &TermStore) -> Self {
+        let term_from_level_1 = |t: &Level1Term| match t {
+            Level1Term::ModDef(_) => Self::Mod,
+            Level1Term::NominalDef(_) => Self::Enum,
+            Level1Term::Tuple(_) => Self::Tuple,
+            Level1Term::Fn(_) => unreachable!(),
+        };
+
+        match term {
+            Term::Level1(inner) => term_from_level_1(inner),
+            Term::Level0(Level0Term::Rt(inner)) => {
+                // we can extract the inner type since it's
+                // known that this should be a level-1 term
+                NameFieldOrigin::new_from_term(store.get(*inner), store)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Display for NameFieldOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NameFieldOrigin::Enum => write!(f, "enum"),
+            NameFieldOrigin::EnumVariant => write!(f, "enum variant"),
+            NameFieldOrigin::Mod => write!(f, "impl block"),
+            NameFieldOrigin::Tuple => write!(f, "tuple"),
+        }
+    }
+}

--- a/compiler/hash-typecheck/src/diagnostics/symbol.rs
+++ b/compiler/hash-typecheck/src/diagnostics/symbol.rs
@@ -4,7 +4,7 @@
 use std::fmt::Display;
 
 use crate::storage::{
-    primitives::{Level0Term, Level1Term, Term},
+    primitives::{AppSub, Level0Term, Level1Term, Term},
     terms::TermStore,
 };
 
@@ -45,6 +45,9 @@ impl NameFieldOrigin {
                 // we can extract the inner type since it's
                 // known that this should be a level-1 term
                 NameFieldOrigin::from_term(store.get(*inner), store)
+            }
+            Term::AppSub(AppSub { term, .. }) => {
+                NameFieldOrigin::from_term(store.get(*term), store)
             }
             _ => panic!(
                 "`NameFieldOrigin::from_term` should only be used on level-1 or level-0 terms"

--- a/compiler/hash-typecheck/src/diagnostics/symbol.rs
+++ b/compiler/hash-typecheck/src/diagnostics/symbol.rs
@@ -31,12 +31,12 @@ impl NameFieldOrigin {
     ///
     /// This assumes that the provided term does yield a [NameFieldOrigin]
     /// and any other variant of term will cause the function to *panic*.
-    pub fn new_from_term(term: &Term, store: &TermStore) -> Self {
+    pub fn from_term(term: &Term, store: &TermStore) -> Self {
         let term_from_level_1 = |t: &Level1Term| match t {
             Level1Term::ModDef(_) => Self::Mod,
             Level1Term::NominalDef(_) => Self::Enum,
             Level1Term::Tuple(_) => Self::Tuple,
-            Level1Term::Fn(_) => unreachable!(),
+            Level1Term::Fn(_) => panic!("`NameFieldOrigin::from_term` hit fn literal type"),
         };
 
         match term {
@@ -44,9 +44,11 @@ impl NameFieldOrigin {
             Term::Level0(Level0Term::Rt(inner)) => {
                 // we can extract the inner type since it's
                 // known that this should be a level-1 term
-                NameFieldOrigin::new_from_term(store.get(*inner), store)
+                NameFieldOrigin::from_term(store.get(*inner), store)
             }
-            _ => unreachable!(),
+            _ => panic!(
+                "`NameFieldOrigin::from_term` should only be used on level-1 or level-0 terms"
+            ),
         }
     }
 }

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -18,7 +18,7 @@ pub enum ParamUnificationErrorReason {
     NameMismatch(usize),
 }
 
-// / This enum describes the origin kind of the subject that a parameter
+/// This enum describes the origin kind of the subject that a parameter
 /// unification occurred on.
 #[derive(Debug, Clone, Copy)]
 pub enum ParamUnificationOrigin {
@@ -35,6 +35,16 @@ impl Display for ParamUnificationOrigin {
             ParamUnificationOrigin::TypeFunction => write!(f, "type function"),
         }
     }
+}
+
+/// This type is used to represent a `source` of where
+/// a [TcError::ParamGivenTwice] occurs. It can either occur
+/// in an argument list, or it can occur within a parameter list.
+/// The reporting logic is the same, with the minor wording difference.
+#[derive(Debug, Clone)]
+pub enum ParameterListOrigin {
+    Params(ParamsId),
+    Args(ArgsId),
 }
 
 /// An error that occurs during typechecking.
@@ -62,11 +72,11 @@ pub enum TcError {
     /// The parameter with the given name is not found in the given parameter
     /// list.
     ParamNotFound { params: ParamsId, name: Identifier },
-    /// There is a parameter (at the index `param_index_given_twice`) which is
+    /// There is a argument or parameter (at the index) which is
     /// specified twice in the given argument list.
-    ParamGivenTwice { args: ArgsId, params: ParamsId, param_index_given_twice: usize },
+    ParamGivenTwice { origin: ParameterListOrigin, index: usize },
     /// It is invalid to use a positional argument after a named argument.
-    CannotUsePositionalArgAfterNamedArg { args: ArgsId, problematic_arg_index: usize },
+    CannotUsePositionalArgAfterNamedArg { origin: ParameterListOrigin, index: usize },
     /// The given name cannot be resolved in the given value.
     UnresolvedNameInValue { name: Identifier, value: TermId },
     /// The given variable cannot be resolved in the current context.

--- a/compiler/hash-typecheck/src/error.rs
+++ b/compiler/hash-typecheck/src/error.rs
@@ -1,8 +1,12 @@
 //! Error-related data structures for errors that occur during typechecking.
 use std::fmt::Display;
 
-use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, TermId};
-use hash_source::identifier::Identifier;
+use crate::storage::{
+    location::LocationStore,
+    primitives::{AccessTerm, ArgsId, ParamOrigin, ParamsId, TermId},
+    GlobalStorage,
+};
+use hash_source::{identifier::Identifier, location::SourceLocation};
 
 /// Convenient type alias for a result with a [TcError] as the error type.
 pub type TcResult<T> = Result<T, TcError>;
@@ -18,33 +22,46 @@ pub enum ParamUnificationErrorReason {
     NameMismatch(usize),
 }
 
-/// This enum describes the origin kind of the subject that a parameter
-/// unification occurred on.
-#[derive(Debug, Clone, Copy)]
-pub enum ParamUnificationOrigin {
-    Tuple,
-    Function,
-    TypeFunction,
-}
-
-impl Display for ParamUnificationOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParamUnificationOrigin::Tuple => write!(f, "tuple"),
-            ParamUnificationOrigin::Function => write!(f, "function"),
-            ParamUnificationOrigin::TypeFunction => write!(f, "type function"),
-        }
-    }
-}
-
 /// This type is used to represent a `source` of where
 /// a [TcError::ParamGivenTwice] occurs. It can either occur
 /// in an argument list, or it can occur within a parameter list.
 /// The reporting logic is the same, with the minor wording difference.
 #[derive(Debug, Clone)]
-pub enum ParameterListOrigin {
+pub enum ParamListKind {
     Params(ParamsId),
     Args(ArgsId),
+}
+
+impl ParamListKind {
+    /// Convert a [ParamListKind] into a [SourceLocation] by looking up the
+    /// inner id within the [LocationStore].
+    pub(crate) fn to_location(
+        &self,
+        index: usize,
+        store: &LocationStore,
+    ) -> Option<SourceLocation> {
+        match self {
+            ParamListKind::Params(id) => store.get_location((*id, index)),
+            ParamListKind::Args(id) => store.get_location((*id, index)),
+        }
+    }
+
+    /// Get the [ParamOrigin] from the [ParamListKind]
+    pub(crate) fn origin(&self, store: &GlobalStorage) -> ParamOrigin {
+        match self {
+            ParamListKind::Params(id) => store.params_store.get(*id).origin(),
+            ParamListKind::Args(id) => store.args_store.get(*id).origin(),
+        }
+    }
+}
+
+impl Display for ParamListKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParamListKind::Params(_) => write!(f, "fields"),
+            ParamListKind::Args(_) => write!(f, "arguments"),
+        }
+    }
 }
 
 /// An error that occurs during typechecking.
@@ -60,7 +77,6 @@ pub enum TcError {
         target_params_id: ParamsId,
         src: TermId,
         target: TermId,
-        origin: ParamUnificationOrigin,
         reason: ParamUnificationErrorReason,
     },
     /// The given term should be a type function but it isn't.
@@ -74,9 +90,9 @@ pub enum TcError {
     ParamNotFound { params: ParamsId, name: Identifier },
     /// There is a argument or parameter (at the index) which is
     /// specified twice in the given argument list.
-    ParamGivenTwice { origin: ParameterListOrigin, index: usize },
+    ParamGivenTwice { param_kind: ParamListKind, index: usize },
     /// It is invalid to use a positional argument after a named argument.
-    CannotUsePositionalArgAfterNamedArg { origin: ParameterListOrigin, index: usize },
+    AmbiguousArgumentOrdering { param_kind: ParamListKind, index: usize },
     /// The given name cannot be resolved in the given value.
     UnresolvedNameInValue { name: Identifier, value: TermId },
     /// The given variable cannot be resolved in the current context.

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -109,6 +109,7 @@ impl Tc<'_> for TcImpl {
             hash_source::SourceId::Module(module_id),
             sources,
         );
+
         match tc_visitor.visit_source() {
             Ok(_) => Ok(()),
             Err(error) => {

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -84,7 +84,7 @@ impl Tc<'_> for TcImpl {
             Err(error) => {
                 // Turn the error into a report:
                 let err_with_storage = TcErrorWithStorage { error, storage: storage.storages() };
-                Err(err_with_storage.into())
+                Err(vec![err_with_storage.into()])
             }
         }
     }
@@ -114,7 +114,7 @@ impl Tc<'_> for TcImpl {
             Err(error) => {
                 // Turn the error into a report:
                 let err_with_storage = TcErrorWithStorage { error, storage: storage.storages() };
-                Err(err_with_storage.into())
+                Err(vec![err_with_storage.into()])
             }
         }
     }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -5,11 +5,10 @@
 //!
 //! @@Todo(kontheocharis): write docs about the stages of the typechecker.
 
-#![allow(dead_code)] // @@Temporary
 #![feature(generic_associated_types)]
 
+use diagnostics::reporting::TcErrorWithStorage;
 use hash_pipeline::{traits::Tc, CompilerResult};
-use reporting::TcErrorWithStorage;
 use storage::{
     core::CoreDefs, AccessToStorage, AccessToStorageMut, GlobalStorage, LocalStorage, StorageRefMut,
 };
@@ -17,10 +16,9 @@ use traverse::TcVisitor;
 
 use crate::fmt::PrepareForFormatting;
 
-pub mod error;
+pub mod diagnostics;
 pub mod fmt;
 pub mod ops;
-pub mod reporting;
 pub mod storage;
 pub mod traverse;
 

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -1,7 +1,10 @@
 //! Operations related to handling parameters.
+
 use crate::{
-    error::{TcError, TcResult},
-    storage::primitives::{Arg, Args, ArgsId, Param, Params, ParamsId, TermId},
+    error::{ParameterListOrigin, TcError, TcResult},
+    storage::primitives::{
+        Arg, Args, ArgsId, GetNameOpt, Param, ParamList, Params, ParamsId, TermId,
+    },
 };
 use std::collections::HashSet;
 
@@ -32,6 +35,8 @@ pub(crate) fn pair_args_with_params<'p, 'a>(
         });
     }
 
+    let origin = ParameterListOrigin::Args(args_id);
+
     // Keep track of the first non-positional argument
     let mut done_positional = false;
     for (i, arg) in args.positional().iter().enumerate() {
@@ -41,13 +46,9 @@ pub(crate) fn pair_args_with_params<'p, 'a>(
                 done_positional = true;
                 match params.get_by_name(arg_name) {
                     Some((param_i, param)) => {
-                        if params_used.contains(&i) {
+                        if params_used.contains(&param_i) {
                             // Ensure not already used
-                            return Err(TcError::ParamGivenTwice {
-                                args: args_id,
-                                params: params_id,
-                                param_index_given_twice: param_i,
-                            });
+                            return Err(TcError::ParamGivenTwice { origin, index: param_i });
                         } else {
                             params_used.insert(param_i);
                             result.push((param, arg));
@@ -62,17 +63,10 @@ pub(crate) fn pair_args_with_params<'p, 'a>(
                 // Positional argument
                 if done_positional {
                     // Using positional args after named args is an error
-                    return Err(TcError::CannotUsePositionalArgAfterNamedArg {
-                        args: args_id,
-                        problematic_arg_index: i,
-                    });
+                    return Err(TcError::CannotUsePositionalArgAfterNamedArg { origin, index: i });
                 } else if params_used.contains(&i) {
                     // Ensure not already used
-                    return Err(TcError::ParamGivenTwice {
-                        args: args_id,
-                        params: params_id,
-                        param_index_given_twice: i,
-                    });
+                    return Err(TcError::ParamGivenTwice { origin, index: i });
                 } else {
                     params_used.insert(i);
                     result.push((params.positional().get(i).unwrap(), arg));
@@ -82,4 +76,53 @@ pub(crate) fn pair_args_with_params<'p, 'a>(
     }
 
     Ok(result)
+}
+
+/// Verify that a [ParamList<T>] adheres to the standard rules of ordering for
+/// named fields. The two rules that must hold within the parameter list are:
+///
+/// - Named parameters cannot be used more than once.
+///
+/// - Un-named parameters must not be used after named ones.
+///
+/// This does not perform any typechecking, it simply checks that the given
+/// [ParamList] follows the described rules. This function works for either
+/// parameters or arguments, and hence why it accepts a [ParameterListOrigin]
+/// in order to preserve context in the event of an error.
+pub(crate) fn validate_param_list_ordering<'p, T: Clone + GetNameOpt>(
+    params: &'p ParamList<T>,
+    origin: ParameterListOrigin,
+) -> TcResult<()> {
+    // Keep track of used params to ensure no parameter is given twice.
+    let mut params_used = HashSet::new();
+
+    // Keep track of when positional parameters are in use
+    let mut done_positional = false;
+
+    for (index, param) in params.positional().iter().enumerate() {
+        // If the parameter has a name, verify that it is only being used once
+        match param.get_name_opt() {
+            Some(name) => {
+                done_positional = true;
+
+                // If we have found the index in our set, that means that it must
+                // of already been used and therefore it should trigger an error
+                if let Some((found_index, _)) = params.get_by_name(name) {
+                    if params_used.contains(&found_index) {
+                        return Err(TcError::ParamGivenTwice { origin, index });
+                    } else {
+                        params_used.insert(found_index);
+                    }
+                }
+            }
+            None => {
+                // Using positional args after named args is an error
+                if done_positional {
+                    return Err(TcError::CannotUsePositionalArgAfterNamedArg { origin, index });
+                }
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -1,7 +1,10 @@
 //! Operations related to handling parameters.
 
 use crate::{
-    error::{ParamListKind, TcError, TcResult},
+    diagnostics::{
+        error::{TcError, TcResult},
+        params::ParamListKind,
+    },
     storage::primitives::{
         Arg, Args, ArgsId, GetNameOpt, Param, ParamList, Params, ParamsId, TermId,
     },

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -2,28 +2,44 @@
 
 use super::AccessToOps;
 use crate::{
-    error::{TcError, TcResult},
-    storage::{primitives::Member, AccessToStorage, StorageRef},
+    diagnostics::error::{TcError, TcResult},
+    storage::{
+        primitives::{Member, TermId},
+        AccessToStorage, StorageRef,
+    },
 };
 use hash_source::identifier::Identifier;
 
 /// Contains actions related to variable resolution.
 pub struct ScopeResolver<'gs, 'ls, 'cd> {
+    /// Inner storage for global, local and core definitions.
     storage: StorageRef<'gs, 'ls, 'cd>,
 }
 
 impl<'gs, 'ls, 'cd> AccessToStorage for ScopeResolver<'gs, 'ls, 'cd> {
+    /// Get the inner storage for resolving.
     fn storages(&self) -> StorageRef {
         self.storage.storages()
     }
 }
 
 impl<'gs, 'ls, 'cd> ScopeResolver<'gs, 'ls, 'cd> {
+    /// Create a new [ScopeResolver].
     pub fn new(storage: StorageRef<'gs, 'ls, 'cd>) -> Self {
         Self { storage }
     }
 
-    pub(crate) fn resolve_name_in_scopes(&self, name: Identifier) -> TcResult<Member> {
+    /// Function used to resolve a particular [Identifier] within the scope. If
+    /// the variable is found, then the [Member] of the scope is returned.
+    ///
+    /// The [TermId] is used in order to give more information about the
+    /// location of the variable in the event that the variable could not be
+    /// found in the current scope.
+    pub(crate) fn resolve_name_in_scopes(
+        &self,
+        name: Identifier,
+        term: TermId,
+    ) -> TcResult<Member> {
         // Here, we have to look in the scopes:
         for scope_id in self.scopes().iter_up() {
             match self.reader().get_scope(scope_id).get(name) {
@@ -33,7 +49,8 @@ impl<'gs, 'ls, 'cd> ScopeResolver<'gs, 'ls, 'cd> {
                 None => continue,
             }
         }
+
         // Name was not found, error:
-        Err(TcError::UnresolvedVariable { name })
+        Err(TcError::UnresolvedVariable { name, value: term })
     }
 }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1,7 +1,7 @@
 //! Contains functionality to simplify terms into more concrete terms.
 use super::{substitute::Substituter, unify::Unifier, AccessToOps, AccessToOpsMut};
 use crate::{
-    error::{TcError, TcResult},
+    diagnostics::error::{TcError, TcResult},
     storage::{
         primitives::{
             AccessOp, AccessTerm, AppTyFn, Arg, ArgsId, FnLit, FnTy, Level0Term, Level1Term,
@@ -815,7 +815,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
             Term::Var(var) => {
                 // First resolve the name:
                 let maybe_resolved_term_id =
-                    self.scope_resolver().resolve_name_in_scopes(var.name)?.data.value();
+                    self.scope_resolver().resolve_name_in_scopes(var.name, term_id)?.data.value();
                 // Try to simplify it
                 if let Some(resolved_term_id) = maybe_resolved_term_id {
                     Ok(Some(self.potentially_simplify_term(resolved_term_id)?))

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -435,7 +435,10 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     // We only got a single result, so we can use it:
                     [single_result] => Ok(Some(*single_result)),
                     // Got multiple results, which is ambiguous:
-                    _ => Err(TcError::AmbiguousAccess { access: access_term.clone() }),
+                    results => Err(TcError::AmbiguousAccess {
+                        access: access_term.clone(),
+                        results: results.to_vec(),
+                    }),
                 }
             }
             Term::AppSub(app_sub) => {

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -492,6 +492,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
         let cannot_apply = || -> TcResult<Option<TermId>> {
             Err(TcError::UnsupportedTypeFunctionApplication { subject_id: simplified_subject_id })
         };
+
         match simplified_subject {
             Term::TyFn(ty_fn) => {
                 // Keep track of encountered errors so that if no cases match, we can return all
@@ -533,6 +534,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     // If we have no results, we have to return an error:
                     Err(TcError::InvalidTypeFunctionApplication {
                         type_fn: simplified_subject_id,
+                        cases: ty_fn.cases,
                         args: apply_ty_fn.args,
                         unification_errors: errors,
                     })

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -277,10 +277,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                         value: access_term.subject,
                         // @@Hack: this feels a bit hacky and there should be an easier
                         // way to yield the origin rather than inspecting the term.
-                        origin: NameFieldOrigin::new_from_term(
-                            &Term::Level0(*term),
-                            self.term_store(),
-                        ),
+                        origin: NameFieldOrigin::from_term(&Term::Level0(*term), self.term_store()),
                     }),
                 }
             }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -138,7 +138,7 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                 Ok(builder.create_fn_ty_term(
                     builder.create_params(
                         subbed_params.into_positional().into_iter().skip(1),
-                        ParamOrigin::Function,
+                        ParamOrigin::Fn,
                     ),
                     fn_ty.return_ty,
                 ))
@@ -955,7 +955,7 @@ mod test_super {
             core_defs.reference_ty_fn,
             builder.create_args(
                 [builder.create_arg("T", builder.create_var_term("Self"))],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
         );
         let dog_def = builder.create_struct_def(
@@ -977,7 +977,7 @@ mod test_super {
                     builder.create_fn_ty_term(
                         builder.create_params(
                             [builder.create_param("value", builder.create_var_term("Self"))],
-                            ParamOrigin::Function,
+                            ParamOrigin::Fn,
                         ),
                         builder.create_nominal_def_term(core_defs.u64_ty),
                     ),
@@ -985,7 +985,7 @@ mod test_super {
                         builder.create_fn_ty_term(
                             builder.create_params(
                                 [builder.create_param("value", builder.create_var_term("Self"))],
-                                ParamOrigin::Function,
+                                ParamOrigin::Fn,
                             ),
                             builder.create_nominal_def_term(core_defs.u64_ty),
                         ),

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -572,7 +572,7 @@ mod tests {
         let inner = builder.create_nameless_ty_fn_term(
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_app_ty_fn_term(
@@ -582,14 +582,14 @@ mod tests {
                         builder.create_arg("T", builder.create_var_term("T")),
                         builder.create_arg("X", builder.create_mod_def_term(hash_impl)),
                     ],
-                    ParamOrigin::TypeFunction,
+                    ParamOrigin::TyFn,
                 ),
             ),
         );
         let target = builder.create_ty_fn_ty_term(
             builder.create_params(
                 [builder.create_param("U", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_fn_ty_term(
                 builder.create_params(
@@ -601,12 +601,12 @@ mod tests {
                                 core_defs.list_ty_fn,
                                 builder.create_args(
                                     [builder.create_arg("T", inner)],
-                                    ParamOrigin::TypeFunction,
+                                    ParamOrigin::TyFn,
                                 ),
                             ),
                         ),
                     ],
-                    ParamOrigin::Function,
+                    ParamOrigin::Fn,
                 ),
                 builder.create_var_term("T"),
             ),
@@ -626,7 +626,7 @@ mod tests {
                         builder.create_arg("K", builder.create_nominal_def_term(core_defs.str_ty)),
                         builder.create_arg("V", builder.create_nominal_def_term(core_defs.u64_ty)),
                     ],
-                    ParamOrigin::TypeFunction,
+                    ParamOrigin::TyFn,
                 ),
             ),
         )]);

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -43,7 +43,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             .map(|arg| Arg { name: arg.name, value: self.apply_sub_to_term(sub, arg.value) })
             .collect::<Vec<_>>();
 
-        self.builder().create_args(new_args)
+        self.builder().create_args(new_args, args.origin())
     }
 
     /// Apply the given substitution to the given parameters, producing a new
@@ -61,7 +61,7 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
             })
             .collect::<Vec<_>>();
 
-        self.builder().create_params(new_params)
+        self.builder().create_params(new_params, params.origin())
     }
 
     /// Apply the given substitution to the given [Level3Term], producing a new
@@ -543,7 +543,7 @@ mod tests {
         ops::AccessToOpsMut,
         storage::{
             core::CoreDefs,
-            primitives::{ModDefOrigin, Sub},
+            primitives::{ModDefOrigin, ParamOrigin, Sub},
             AccessToStorage, AccessToStorageMut, GlobalStorage, LocalStorage, StorageRefMut,
         },
     };
@@ -570,29 +570,44 @@ mod tests {
         );
 
         let inner = builder.create_nameless_ty_fn_term(
-            builder.create_params([builder.create_param("T", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_app_ty_fn_term(
                 core_defs.set_ty_fn,
-                builder.create_args([
-                    builder.create_arg("T", builder.create_var_term("T")),
-                    builder.create_arg("X", builder.create_mod_def_term(hash_impl)),
-                ]),
+                builder.create_args(
+                    [
+                        builder.create_arg("T", builder.create_var_term("T")),
+                        builder.create_arg("X", builder.create_mod_def_term(hash_impl)),
+                    ],
+                    ParamOrigin::TypeFunction,
+                ),
             ),
         );
         let target = builder.create_ty_fn_ty_term(
-            builder.create_params([builder.create_param("U", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("U", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_fn_ty_term(
-                builder.create_params([
-                    builder.create_param("foo", builder.create_unresolved_term()),
-                    builder.create_param(
-                        "bar",
-                        builder.create_app_ty_fn_term(
-                            core_defs.list_ty_fn,
-                            builder.create_args([builder.create_arg("T", inner)]),
+                builder.create_params(
+                    [
+                        builder.create_param("foo", builder.create_unresolved_term()),
+                        builder.create_param(
+                            "bar",
+                            builder.create_app_ty_fn_term(
+                                core_defs.list_ty_fn,
+                                builder.create_args(
+                                    [builder.create_arg("T", inner)],
+                                    ParamOrigin::TypeFunction,
+                                ),
+                            ),
                         ),
-                    ),
-                ]),
+                    ],
+                    ParamOrigin::Function,
+                ),
                 builder.create_var_term("T"),
             ),
         );
@@ -606,10 +621,13 @@ mod tests {
             builder.create_var("T"),
             builder.create_app_ty_fn_term(
                 core_defs.map_ty_fn,
-                builder.create_args([
-                    builder.create_arg("K", builder.create_nominal_def_term(core_defs.str_ty)),
-                    builder.create_arg("V", builder.create_nominal_def_term(core_defs.u64_ty)),
-                ]),
+                builder.create_args(
+                    [
+                        builder.create_arg("K", builder.create_nominal_def_term(core_defs.str_ty)),
+                        builder.create_arg("V", builder.create_nominal_def_term(core_defs.u64_ty)),
+                    ],
+                    ParamOrigin::TypeFunction,
+                ),
             ),
         )]);
 

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -1,6 +1,6 @@
 //! Contains operations to get the type of a term.
 use crate::{
-    error::{TcError, TcResult},
+    diagnostics::error::{TcError, TcResult},
     storage::{
         primitives::{
             AccessOp, Level0Term, Level1Term, Level2Term, Level3Term, MemberData, ModDefOrigin,
@@ -128,7 +128,7 @@ impl<'gs, 'ls, 'cd> Typer<'gs, 'ls, 'cd> {
             Term::Var(var) => {
                 // The type of a variable can be found by looking at the scopes to its
                 // declaration:
-                let var_member = self.scope_resolver().resolve_name_in_scopes(var.name)?;
+                let var_member = self.scope_resolver().resolve_name_in_scopes(var.name, term_id)?;
                 Ok(self.infer_member_data(var_member.data)?.ty)
             }
             Term::TyFn(ty_fn) => {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -1,7 +1,7 @@
 //! Utilities related to type unification and substitution.
 use super::{params::pair_args_with_params, AccessToOps, AccessToOpsMut};
 use crate::{
-    error::{ParamUnificationErrorReason, ParamUnificationOrigin, TcError, TcResult},
+    error::{ParamUnificationErrorReason, TcError, TcResult},
     storage::{
         primitives::{
             ArgsId, Level0Term, Level1Term, Level2Term, Level3Term, ParamsId, Sub, Term, TermId,
@@ -124,7 +124,6 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         target_params_id: ParamsId,
         src_id: TermId,
         target_id: TermId,
-        origin: ParamUnificationOrigin,
     ) -> TcResult<Sub> {
         let src_params = self.params_store().get(src_params_id).clone();
         let target_params = self.params_store().get(target_params_id).clone();
@@ -134,7 +133,6 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                 src_params_id,
                 target_params_id,
                 reason,
-                origin,
                 src: src_id,
                 target: target_id,
             })
@@ -342,7 +340,6 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                     src_ty_fn_ty.params,
                     src_id,
                     target_id,
-                    ParamUnificationOrigin::TypeFunction,
                 )?;
 
                 let return_sub =
@@ -410,13 +407,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                     }
                     // Tuples unify if all their members unify:
                     (Level1Term::Tuple(src_tuple), Level1Term::Tuple(target_tuple)) => self
-                        .unify_params(
-                            src_tuple.members,
-                            target_tuple.members,
-                            src_id,
-                            target_id,
-                            ParamUnificationOrigin::Tuple,
-                        ),
+                        .unify_params(src_tuple.members, target_tuple.members, src_id, target_id),
                     // Tuples unify if their parameters and return unify:
                     (Level1Term::Fn(src_fn_ty), Level1Term::Fn(target_fn_ty)) => {
                         // Once again, params need to be unified inversely.
@@ -425,7 +416,6 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                             src_fn_ty.params,
                             target_id,
                             src_id,
-                            ParamUnificationOrigin::Function,
                         )?;
 
                         let return_sub =

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -1,7 +1,10 @@
 //! Utilities related to type unification and substitution.
 use super::{params::pair_args_with_params, AccessToOps, AccessToOpsMut};
 use crate::{
-    error::{ParamUnificationErrorReason, TcError, TcResult},
+    diagnostics::{
+        error::{TcError, TcResult},
+        params::ParamUnificationErrorReason,
+    },
     storage::{
         primitives::{
             ArgsId, Level0Term, Level1Term, Level2Term, Level3Term, ParamsId, Sub, Term, TermId,

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -246,7 +246,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                         let _ =
                             self.unifier().unify_terms(scope_member_data.ty, trt_member_ty_subbed);
                     } else {
-                        return Err(TcError::TraitImplementationMissingMember {
+                        return Err(TcError::TraitImplMissingMember {
                             trt_def_term_id,
                             trt_impl_term_id: scope_originating_term_id,
                             trt_def_missing_member_term_id: trt_member_data.ty,
@@ -258,9 +258,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                 // that are not in the trait definition?
                 Ok(())
             }
-            _ => Err(TcError::CannotImplementNonTrait {
-                supposed_trait_term: simplified_trt_def_term_id,
-            }),
+            _ => Err(TcError::CannotImplementNonTrait { term: simplified_trt_def_term_id }),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -12,10 +12,11 @@ use crate::{
     ops::params::validate_param_list_ordering,
     storage::{
         primitives::{
-            ArgsId, FnTy, Level0Term, Level1Term, Level2Term, MemberData, ModDefId, ModDefOrigin,
-            Mutability, NominalDefId, ParamsId, Scope, ScopeId, ScopeKind, Sub, Term, TermId,
-            TrtDefId,
+            AppSub, ArgsId, FnTy, Level0Term, Level1Term, Level2Term, MemberData, ModDefId,
+            ModDefOrigin, Mutability, NominalDefId, ParamsId, Scope, ScopeId, ScopeKind, Sub, Term,
+            TermId, TrtDefId,
         },
+        terms::TermStore,
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
 };
@@ -55,17 +56,16 @@ impl Term {
     /// Compute the level of the term. This is a primitive computation
     /// and does not attempt to compute the true level of the [Term]
     /// by looking at the inner children of the [Term].
-    pub fn get_term_level(&self) -> TermLevel {
+    pub fn get_term_level(&self, store: &TermStore) -> TermLevel {
+        // @@Todo(feds01): implement the other variants by recursing into them.
         match self {
             Term::Access(_)
             | Term::Var(_)
             | Term::Merge(_)
             | Term::TyFn(_)
             | Term::TyFnTy(_)
-            | Term::AppTyFn(_)
-            | Term::AppSub(_) => {
-                todo!()
-            }
+            | Term::AppTyFn(_) => TermLevel::Unknown,
+            Term::AppSub(AppSub { term, .. }) => store.get(*term).get_term_level(store),
             Term::Unresolved(_) => TermLevel::Unknown,
             Term::Root => TermLevel::Level4,
             Term::Level3(_) => TermLevel::Level3,

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -277,7 +277,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
 
         // Error helper:
         let invalid_merge_element = || -> TcResult<()> {
-            Err(TcError::InvalidElementOfMerge { term: merge_element_term_id })
+            Err(TcError::InvalidMergeElement { term: merge_element_term_id })
         };
 
         // Helper to ensure that a merge is level 2, returns the updated MergeKind.

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -1,8 +1,12 @@
 //! Contains utilities to validate terms.
+#![allow(dead_code)]
 
 use super::{AccessToOps, AccessToOpsMut};
 use crate::{
-    error::{ParamListKind, TcError, TcResult},
+    diagnostics::{
+        error::{TcError, TcResult},
+        params::ParamListKind,
+    },
     ops::params::validate_param_list_ordering,
     storage::{
         primitives::{

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -2,7 +2,7 @@
 
 use super::{AccessToOps, AccessToOpsMut};
 use crate::{
-    error::{ParamUnificationOrigin, ParameterListOrigin, TcError, TcResult},
+    error::{ParamListKind, TcError, TcResult},
     ops::params::validate_param_list_ordering,
     storage::{
         primitives::{
@@ -419,7 +419,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
     /// **Note**: Requires that the parameters have already been simplified.
     pub(crate) fn validate_params(&mut self, params_id: ParamsId) -> TcResult<()> {
         let params = self.params_store().get(params_id).clone();
-        validate_param_list_ordering(&params, ParameterListOrigin::Params(params_id))?;
+        validate_param_list_ordering(&params, ParamListKind::Params(params_id))?;
 
         for param in params.positional() {
             self.validate_term(param.ty)?;
@@ -647,7 +647,6 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                         ty_fn.general_params,
                         case.return_ty,
                         term_id,
-                        ParamUnificationOrigin::TypeFunction,
                     )?;
 
                     // Ensure that the return type can be unified with the type of the return value:

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -34,8 +34,8 @@ pub enum TermLevel {
     Level2,
     /// Level 3 terms
     Level3,
-    /// Still unknown
-    LevelN,
+    /// Level 4 terms, specifically [Term::Root]
+    Level4,
 }
 
 impl Display for TermLevel {
@@ -46,7 +46,7 @@ impl Display for TermLevel {
             TermLevel::Level1 => write!(f, "level-1"),
             TermLevel::Level2 => write!(f, "level-2"),
             TermLevel::Level3 => write!(f, "level-3"),
-            TermLevel::LevelN => write!(f, "level-n"),
+            TermLevel::Level4 => write!(f, "level-4"),
         }
     }
 }
@@ -63,9 +63,11 @@ impl Term {
             | Term::TyFn(_)
             | Term::TyFnTy(_)
             | Term::AppTyFn(_)
-            | Term::AppSub(_)
-            | Term::Root => TermLevel::LevelN,
+            | Term::AppSub(_) => {
+                todo!()
+            }
             Term::Unresolved(_) => TermLevel::Unknown,
+            Term::Root => TermLevel::Level4,
             Term::Level3(_) => TermLevel::Level3,
             Term::Level2(_) => TermLevel::Level2,
             Term::Level1(_) => TermLevel::Level1,

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -34,7 +34,7 @@ pub enum TermLevel {
     Level2,
     /// Level 3 terms
     Level3,
-    /// Higher order levels
+    /// Still unknown
     LevelN,
 }
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -332,8 +332,8 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                     // A nominal has already been attached, error!
                     Err(TcError::MergeShouldOnlyContainOneNominal {
                         merge_term: merge_term_id,
-                        nominal_term: nominal_term_id,
-                        second_nominal_term: checking_nominal,
+                        initial_term: nominal_term_id,
+                        offending_term: checking_nominal,
                     })
                 }
             }

--- a/compiler/hash-typecheck/src/reporting.rs
+++ b/compiler/hash-typecheck/src/reporting.rs
@@ -87,7 +87,7 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Vec<Report> {
                                 format!(
                                     "this {} expects `{}` arguments.",
                                     origin,
-                                    target.for_formatting(err.global_storage()),
+                                    target_params.len(),
                                 ),
                             )));
                         }

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -83,7 +83,7 @@ impl CoreDefs {
             Some("Ref"),
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
@@ -94,7 +94,7 @@ impl CoreDefs {
             Some("RawRef"),
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
@@ -114,7 +114,7 @@ impl CoreDefs {
                     builder.create_fn_ty_term(
                         builder.create_params(
                             [builder.create_param("value", builder.create_var_term("Self"))],
-                            ParamOrigin::Function,
+                            ParamOrigin::Fn,
                         ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
@@ -134,7 +134,7 @@ impl CoreDefs {
                                 builder.create_param("a", builder.create_var_term("Self")),
                                 builder.create_param("b", builder.create_var_term("Self")),
                             ],
-                            ParamOrigin::Function,
+                            ParamOrigin::Fn,
                         ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
@@ -151,7 +151,7 @@ impl CoreDefs {
             Some("List"),
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
@@ -163,7 +163,7 @@ impl CoreDefs {
             Some("Set"),
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
@@ -184,7 +184,7 @@ impl CoreDefs {
                     ),
                     builder.create_param("V", builder.create_any_ty_term()),
                 ],
-                ParamOrigin::TypeFunction,
+                ParamOrigin::TyFn,
             ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def([

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -6,7 +6,7 @@
 //! typechecker is concerned. This includes: integers, floats, characters,
 //! strings, lists, maps, references, etc.
 use super::{
-    primitives::{NominalDefId, TermId, TrtDefId},
+    primitives::{NominalDefId, ParamOrigin, TermId, TrtDefId},
     GlobalStorage,
 };
 use crate::ops::building::PrimitiveBuilder;
@@ -67,8 +67,10 @@ impl CoreDefs {
         let bool_ty = builder.create_enum_def(
             "bool",
             [
-                builder.create_enum_variant("true", builder.create_params([])),
-                builder.create_enum_variant("false", builder.create_params([])),
+                builder
+                    .create_enum_variant("true", builder.create_params([], ParamOrigin::Unknown)),
+                builder
+                    .create_enum_variant("false", builder.create_params([], ParamOrigin::Unknown)),
             ],
             [],
         );
@@ -79,7 +81,10 @@ impl CoreDefs {
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
             Some("Ref"),
-            builder.create_params([builder.create_param("T", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
@@ -87,7 +92,10 @@ impl CoreDefs {
         );
         let raw_reference_ty_fn = builder.create_ty_fn_term(
             Some("RawRef"),
-            builder.create_params([builder.create_param("T", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
@@ -104,9 +112,10 @@ impl CoreDefs {
                 builder.create_uninitialised_pub_member(
                     "hash",
                     builder.create_fn_ty_term(
-                        builder.create_params([
-                            builder.create_param("value", builder.create_var_term("Self"))
-                        ]),
+                        builder.create_params(
+                            [builder.create_param("value", builder.create_var_term("Self"))],
+                            ParamOrigin::Function,
+                        ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
                 ),
@@ -120,10 +129,13 @@ impl CoreDefs {
                 builder.create_uninitialised_pub_member(
                     "eq",
                     builder.create_fn_ty_term(
-                        builder.create_params([
-                            builder.create_param("a", builder.create_var_term("Self")),
-                            builder.create_param("b", builder.create_var_term("Self")),
-                        ]),
+                        builder.create_params(
+                            [
+                                builder.create_param("a", builder.create_var_term("Self")),
+                                builder.create_param("b", builder.create_var_term("Self")),
+                            ],
+                            ParamOrigin::Function,
+                        ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
                 ),
@@ -137,7 +149,10 @@ impl CoreDefs {
         // Collection types
         let list_ty_fn = builder.create_ty_fn_term(
             Some("List"),
-            builder.create_params([builder.create_param("T", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
@@ -146,7 +161,10 @@ impl CoreDefs {
 
         let set_ty_fn = builder.create_ty_fn_term(
             Some("Set"),
-            builder.create_params([builder.create_param("T", builder.create_any_ty_term())]),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
@@ -155,16 +173,19 @@ impl CoreDefs {
 
         let map_ty_fn = builder.create_ty_fn_term(
             Some("Map"),
-            builder.create_params([
-                builder.create_param(
-                    "K",
-                    builder.create_merge_term([
-                        builder.create_trt_term(hash_trt),
-                        builder.create_trt_term(eq_trt),
-                    ]),
-                ),
-                builder.create_param("V", builder.create_any_ty_term()),
-            ]),
+            builder.create_params(
+                [
+                    builder.create_param(
+                        "K",
+                        builder.create_merge_term([
+                            builder.create_trt_term(hash_trt),
+                            builder.create_trt_term(eq_trt),
+                        ]),
+                    ),
+                    builder.create_param("V", builder.create_any_ty_term()),
+                ],
+                ParamOrigin::TypeFunction,
+            ),
             builder.create_any_ty_term(),
             builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def([
                 builder.create_var("K"),

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -67,10 +67,14 @@ impl CoreDefs {
         let bool_ty = builder.create_enum_def(
             "bool",
             [
-                builder
-                    .create_enum_variant("true", builder.create_params([], ParamOrigin::Unknown)),
-                builder
-                    .create_enum_variant("false", builder.create_params([], ParamOrigin::Unknown)),
+                builder.create_enum_variant(
+                    "true",
+                    builder.create_params([], ParamOrigin::EnumVariant),
+                ),
+                builder.create_enum_variant(
+                    "false",
+                    builder.create_params([], ParamOrigin::EnumVariant),
+                ),
             ],
             [],
         );

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -144,6 +144,7 @@ pub enum ParamOrigin {
     Struct,
     Fn,
     TyFn,
+    EnumVariant,
 }
 
 impl Display for ParamOrigin {
@@ -154,6 +155,7 @@ impl Display for ParamOrigin {
             ParamOrigin::Struct => write!(f, "struct"),
             ParamOrigin::Fn => write!(f, "function"),
             ParamOrigin::TyFn => write!(f, "type function"),
+            ParamOrigin::EnumVariant => write!(f, "enum variant"),
         }
     }
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -142,8 +142,8 @@ pub enum ParamOrigin {
     Unknown,
     Tuple,
     Struct,
-    Function,
-    TypeFunction,
+    Fn,
+    TyFn,
 }
 
 impl Display for ParamOrigin {
@@ -152,8 +152,8 @@ impl Display for ParamOrigin {
             ParamOrigin::Unknown => write!(f, "unknown"),
             ParamOrigin::Tuple => write!(f, "tuple"),
             ParamOrigin::Struct => write!(f, "struct"),
-            ParamOrigin::Function => write!(f, "function"),
-            ParamOrigin::TypeFunction => write!(f, "type function"),
+            ParamOrigin::Fn => write!(f, "function"),
+            ParamOrigin::TyFn => write!(f, "type function"),
         }
     }
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -593,7 +593,7 @@ pub enum Level2Term {
 /// -> B` etc.
 #[derive(Debug, Clone)]
 pub enum Level1Term {
-    /// Modules or impls.
+    /// Modules or impl blocks.
     ///
     /// Modules and trait implementations, as well as anonymous implementations,
     /// are treated as types, but do not have instance values.
@@ -624,7 +624,7 @@ pub struct FnLit {
 ///
 /// Type of: nothing.
 /// Value of: values, for example `3`, `Result::Ok(3)`, etc.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Level0Term {
     /// A runtime value, has some Level 1 term as type (the inner data).
     Rt(TermId),

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -542,6 +542,15 @@ pub enum AccessOp {
     Property,
 }
 
+impl Display for AccessOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AccessOp::Namespace => write!(f, "namespace member"),
+            AccessOp::Property => write!(f, "property"),
+        }
+    }
+}
+
 /// An access term, which is of the form X::Y, where X is a term and Y is an
 /// identifier.
 ///

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -2,7 +2,7 @@
 //! it for correctness.
 
 use crate::{
-    error::{TcError, TcResult},
+    diagnostics::error::{TcError, TcResult},
     ops::{validate::TermValidation, AccessToOpsMut},
     storage::{
         primitives::{Member, MemberData, Mutability, Param, ParamOrigin, Sub, TermId, Visibility},
@@ -191,6 +191,11 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::VariableExpr>,
     ) -> Result<Self::VariableExprRet, Self::Error> {
         let walk::VariableExpr { name, .. } = walk::walk_variable_expr(self, ctx, node)?;
+
+        // We need to add the location to the term
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(name, location);
+
         let TermValidation { simplified_term_id, .. } = self.validator().validate_term(name)?;
         Ok(simplified_term_id)
     }

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -554,7 +554,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let builder = self.builder();
         let list_ty = builder.create_app_ty_fn_term(
             list_inner_ty,
-            builder.create_args([builder.create_arg("T", shared_term)], ParamOrigin::TypeFunction),
+            builder.create_args([builder.create_arg("T", shared_term)], ParamOrigin::TyFn),
         );
 
         let term = self.builder().create_rt_term(list_ty);
@@ -749,8 +749,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let return_value = self.substituter().apply_sub_to_term(&body_sub, fn_body);
         let return_ty = self.substituter().apply_sub_to_term(&body_sub, return_ty_or_unresolved);
-        let params_potentially_unresolved =
-            self.builder().create_params(args, ParamOrigin::Function);
+        let params_potentially_unresolved = self.builder().create_params(args, ParamOrigin::Fn);
         let params =
             self.substituter().apply_sub_to_params(&body_sub, params_potentially_unresolved);
 

--- a/tests/parser/tests/cases/should_fail/malformed_access_name/case.stderr
+++ b/tests/parser/tests/cases/should_fail/malformed_access_name/case.stderr
@@ -2,4 +2,4 @@ error: Failed to parse
  --> $DIR/case.hash:1:5
 1 |   a::b:c()
   |       ^ here
-  = note: Unexpectedly encountered a `:`.
+  = note: Expected an operator. Consider adding either a '.', '=', or ';'.


### PR DESCRIPTION
This PR adds implementations for reporting all of the remaining error variants.

closes #300 