### PR TITLE
TC: Implement traversal of function types, reference types, infer type

### DIFF
--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -746,6 +746,16 @@ impl AstVisitor for SemanticAnalyser {
         Ok(())
     }
 
+    type RefKindRet = ();
+
+    fn visit_ref_kind(
+        &mut self,
+        _: &Self::Ctx,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::RefKind>,
+    ) -> Result<Self::RefKindRet, Self::Error> {
+        Ok(())
+    }
+
     type DeclarationRet = ();
 
     fn visit_declaration(

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -297,7 +297,7 @@ pub struct NamedType {
 }
 
 /// Reference kind representing either a raw reference or a normal reference.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RefKind {
     /// Raw reference type
     Raw,

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -358,6 +358,7 @@ pub struct MapType {
 /// The function type.
 #[derive(Debug, PartialEq)]
 pub struct FnType {
+    // @@Todo: rename this to parameters
     pub args: AstNodes<NamedFieldTypeEntry>,
     pub return_ty: AstNode<Type>,
 }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -369,7 +369,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::RefType>,
     ) -> Result<Self::RefTypeRet, Self::Error> {
-        let walk::RefType { inner, mutability } = walk::walk_ref_type(self, ctx, node)?;
+        let walk::RefType { inner, mutability, .. } = walk::walk_ref_type(self, ctx, node)?;
 
         let label = if node.kind.as_ref().map_or(false, |t| *t.body() == ast::RefKind::Raw) {
             "raw_ref"
@@ -383,6 +383,15 @@ impl AstVisitor for AstTreeGenerator {
                 .chain(mutability.map(|t| TreeNode::branch("mutability", vec![t])))
                 .collect(),
         ))
+    }
+
+    type RefKindRet = ();
+    fn visit_ref_kind(
+        &mut self,
+        _: &Self::Ctx,
+        _: ast::AstNodeRef<ast::RefKind>,
+    ) -> Result<Self::RefKindRet, Self::Error> {
+        Ok(())
     }
 
     type MergedTypeRet = TreeNode;

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -1,6 +1,7 @@
 //! Contains helper structures to create complex types and values without having
 //! to manually call the corresponding stores.
 use crate::storage::{
+    location::LocationTarget,
     primitives::{
         AccessOp, AccessTerm, AppSub, AppTyFn, Arg, ArgsId, EnumDef, EnumVariant, EnumVariantValue,
         FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Member, MemberData, ModDef,
@@ -545,8 +546,16 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::AppTyFn(app_ty_fn))
     }
 
-    /// Add a [SourceLocation] to a [Term].
-    pub fn add_location_to_term(&self, subject: TermId, location: SourceLocation) {
-        self.gs.borrow_mut().location_store.add_location_to_target(subject, location);
+    /// Add a [SourceLocation] to a [LocationTarget].
+    ///
+    /// This is added so that locations can be added without having to destroy
+    /// the current builder first (because it has mutable access to
+    /// [GlobalStorage]).
+    pub fn add_location_to_target(
+        &self,
+        target: impl Into<LocationTarget>,
+        location: SourceLocation,
+    ) {
+        self.gs.borrow_mut().location_store.add_location_to_target(target, location);
     }
 }

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -524,6 +524,30 @@ impl<'gs, 'ls, 'cd> Substituter<'gs, 'ls, 'cd> {
         }
     }
 
+    /// Add the free variables that exist in the given [Sub], to the
+    /// given [HashSet].
+    pub fn add_free_vars_in_sub_to_set(&self, sub: &Sub, result: &mut HashSet<SubSubject>) {
+        // Add all the variables in the range, minus the variables in the domain:
+        for r in sub.range() {
+            self.add_free_vars_in_term_to_set(r, result);
+        }
+        let mut domain_vars = HashSet::new();
+        for d in sub.range() {
+            self.add_free_vars_in_term_to_set(d, &mut domain_vars);
+        }
+        // Remove all the variables in domain_vars:
+        for d in domain_vars {
+            result.remove(&d);
+        }
+    }
+
+    /// Get the free variables that exist in the given [Sub].
+    pub fn get_free_vars_in_sub(&self, sub: &Sub) -> HashSet<SubSubject> {
+        let mut result = HashSet::new();
+        self.add_free_vars_in_sub_to_set(sub, &mut result);
+        result
+    }
+
     /// Get the set of free variables that exist in the given term.
     ///
     /// Free variables are either `Var` or `Unresolved`, and this function

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -39,7 +39,20 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         Self { storage }
     }
 
-    /// Unify two substitutions to produce another substitution.
+    /// Get the super-substitution of the two substitutions.
+    ///
+    /// Equivalent to first unifying `U(s0, s1)` and then applying `s1` or `s0`.
+    pub(crate) fn get_super_sub(&mut self, s0: &Sub, s1: &Sub) -> TcResult<Sub> {
+        let fv_s1 = self.substituter().get_free_vars_in_sub(s1);
+        let dom_s0: HashSet<_> = s0.domain().collect();
+        if fv_s1.intersection(&dom_s0).next().is_some() {
+            panic!("Super-sub is not well formed!");
+        }
+        Ok(self.unify_subs(s0, s1)?.with_extension(s0))
+    }
+
+    /// Unify two substitutions to produce another substitution which is the
+    /// unifier of the two.
     ///
     /// The resultant substitution contains all the information of the two
     /// source substitutions, without any common free variables in their
@@ -55,12 +68,14 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         // First split the domains into three parts: d0, d1 (not directly needed), and
         // the intersection (see second loop)
         let d0: HashSet<_> = dom_s0.difference(&dom_s1).copied().collect();
+        let d1: HashSet<_> = dom_s1.difference(&dom_s0).copied().collect();
         let t0 = Sub::from_pairs(d0.iter().map(|&a| (a, substituter.apply_sub_to_subject(s0, a))));
+        let t1 = Sub::from_pairs(d1.iter().map(|&a| (a, substituter.apply_sub_to_subject(s1, a))));
 
         // Start with t0 and add terms for d1 one at a time, always producing well
         // formed substitutions
-        let mut result = t0.clone();
-        for (a, t) in t0.pairs() {
+        let mut result = t0;
+        for (a, t) in t1.pairs() {
             // Remove elements of dom(result) from t, and remove a from result.
             let subbed_t = substituter.apply_sub_to_term(&result, t);
             if substituter.get_free_vars_in_term(subbed_t).contains(&a) {
@@ -113,7 +128,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
         for (param, arg) in pairs.into_iter() {
             let ty_of_arg = self.typer().ty_of_term(arg.value)?;
             let sub = self.unify_terms(ty_of_arg, param.ty)?;
-            cumulative_sub = self.unify_subs(&cumulative_sub, &sub)?;
+            cumulative_sub = self.get_super_sub(&cumulative_sub, &sub)?;
         }
         Ok(cumulative_sub)
     }
@@ -159,7 +174,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
             let ty_sub = self.unify_terms(src_param.ty, target_param.ty)?;
 
             // Add to cumulative substitution
-            cumulative_sub = self.unify_subs(&cumulative_sub, &ty_sub)?;
+            cumulative_sub = self.get_super_sub(&cumulative_sub, &ty_sub)?;
         }
 
         // Return the cumulative substitution of all the parameter types:
@@ -321,7 +336,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
 
                         // Unify all the created substitutions
                         let args_unified_sub = self.unify_subs(&args_src_sub, &args_target_sub)?;
-                        self.unify_subs(&args_unified_sub, &subject_sub)
+                        Ok(self.get_super_sub(&args_unified_sub, &subject_sub)?)
                     }
                     // If the subject is not a function type then application is invalid:
                     _ => Err(TcError::UnsupportedTypeFunctionApplication { subject_id: subject }),
@@ -425,7 +440,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                             self.unify_terms(src_fn_ty.return_ty, target_fn_ty.return_ty)?;
 
                         // Merge the subs
-                        self.unify_subs(&params_sub, &return_sub)
+                        Ok(self.get_super_sub(&params_sub, &return_sub)?)
                     }
                     // Mismatching level 1 term variants do not unify:
                     _ => cannot_unify(),

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -31,7 +31,9 @@ pub struct CoreDefs {
     pub char_ty: NominalDefId,
     pub bool_ty: NominalDefId,
     pub reference_ty_fn: TermId,
+    pub reference_mut_ty_fn: TermId,
     pub raw_reference_ty_fn: TermId,
+    pub raw_reference_mut_ty_fn: TermId,
     pub hash_trt: TrtDefId,
     pub eq_trt: TrtDefId,
     pub runtime_instantiable_trt: TrtDefId,
@@ -94,8 +96,30 @@ impl CoreDefs {
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
         );
+        let reference_mut_ty_fn = builder.create_ty_fn_term(
+            Some("RefMut"),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TyFn,
+            ),
+            builder.create_any_ty_term(),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
+        );
         let raw_reference_ty_fn = builder.create_ty_fn_term(
             Some("RawRef"),
+            builder.create_params(
+                [builder.create_param("T", builder.create_any_ty_term())],
+                ParamOrigin::TyFn,
+            ),
+            builder.create_any_ty_term(),
+            builder.create_nominal_def_term(
+                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+            ),
+        );
+        let raw_reference_mut_ty_fn = builder.create_ty_fn_term(
+            Some("RawRefMut"),
             builder.create_params(
                 [builder.create_param("T", builder.create_any_ty_term())],
                 ParamOrigin::TyFn,
@@ -215,7 +239,9 @@ impl CoreDefs {
             char_ty,
             bool_ty,
             reference_ty_fn,
+            raw_reference_mut_ty_fn,
             raw_reference_ty_fn,
+            reference_mut_ty_fn,
             hash_trt,
             eq_trt,
             runtime_instantiable_trt,

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -720,6 +720,12 @@ impl Sub {
         self.data.insert(subject, term);
     }
 
+    /// Extend the substitution with pairs from the given one, consuming self.
+    pub fn with_extension(mut self, other: &Sub) -> Self {
+        self.extend(other);
+        self
+    }
+
     /// Extend the substitution with pairs from the given one.
     ///
     /// This is a naive implementation which does not perform any unification.

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -364,7 +364,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::FnType>,
     ) -> Result<Self::FnTypeRet, Self::Error> {
         let walk::FnType { args, return_ty } = walk::walk_function_type(self, ctx, node)?;
-        let params = self.builder().create_params(args);
+        let params = self.builder().create_params(args, ParamOrigin::Fn);
 
         // Add all the locations to the parameters:
         for (index, param) in node.args.iter().enumerate() {


### PR DESCRIPTION
This PR implements traversal of function types and reference types. It also adds a `kind` field to the `RefKind` struct in the AST visitor, which was missing. Furthermore, it treats the `_` type as an infer-type, which means it gets assigned an unresolved term.

This PR also fixes a bug with substitutions. It seems the paper that is referenced for substitution unification has a typo, in that it writes T0 instead of T1 in a specific step. At least this is the assumption :D. Substitutions seem to work correctly now. Also, substitution merging is fixed to use a combination of merging and unification.

Closes #343, closes #342. Does not address #327 yet, contrary to the branch name, because this change is deemed too big to be done in one PR.