### PR TITLE
TC: Implement traversal of type functions

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -376,7 +376,7 @@ pub struct TypeFunctionParam {
 /// A type function e.g. `<T = u32, E: Conv ~ Eq> -> Result<T, E>`
 #[derive(Debug, PartialEq)]
 pub struct TypeFunction {
-    pub args: AstNodes<TypeFunctionParam>,
+    pub params: AstNodes<TypeFunctionParam>,
     pub return_ty: AstNode<Type>,
 }
 
@@ -726,6 +726,7 @@ pub struct TypeFunctionDefParam {
 
     /// The argument bounds.
     pub ty: Option<AstNode<Type>>,
+    // @@Todo: missing default value
 }
 
 /// A declaration, e.g. `x := 3;`.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -443,7 +443,8 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunction>,
     ) -> Result<Self::TypeFunctionRet, Self::Error> {
-        let walk::TypeFunction { args, return_ty } = walk::walk_type_function(self, ctx, node)?;
+        let walk::TypeFunction { params: args, return_ty } =
+            walk::walk_type_function(self, ctx, node)?;
 
         let return_child = TreeNode::branch("return", vec![return_ty]);
 
@@ -1020,7 +1021,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionDef>,
     ) -> Result<Self::TypeFunctionDefRet, Self::Error> {
-        let walk::TypeFunctionDef { args, return_ty, expression } =
+        let walk::TypeFunctionDef { params: args, return_ty, expression } =
             walk::walk_type_function_def(self, ctx, node)?;
 
         Ok(TreeNode::branch(
@@ -1038,7 +1039,7 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionDefParam>,
     ) -> Result<Self::TypeFunctionDefArgRet, Self::Error> {
-        let walk::TypeFunctionDefArg { name, ty } =
+        let walk::TypeFunctionDefParam { name, ty } =
             walk::walk_type_function_def_param(self, ctx, node)?;
 
         Ok(TreeNode::branch("param", iter::once(name).chain(ty).collect()))

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -2463,7 +2463,7 @@ pub mod walk {
     }
 
     pub struct TypeFunction<V: AstVisitor> {
-        pub args: V::CollectionContainer<V::TypeFunctionParamRet>,
+        pub params: V::CollectionContainer<V::TypeFunctionParamRet>,
         pub return_ty: V::TypeRet,
     }
 
@@ -2473,9 +2473,9 @@ pub mod walk {
         node: ast::AstNodeRef<ast::TypeFunction>,
     ) -> Result<TypeFunction<V>, V::Error> {
         Ok(TypeFunction {
-            args: V::try_collect_items(
+            params: V::try_collect_items(
                 ctx,
-                node.args.iter().map(|a| visitor.visit_type_function_param(ctx, a.ast_ref())),
+                node.params.iter().map(|a| visitor.visit_type_function_param(ctx, a.ast_ref())),
             )?,
             return_ty: visitor.visit_type(ctx, node.return_ty.ast_ref())?,
         })
@@ -3062,7 +3062,7 @@ pub mod walk {
     }
 
     pub struct TypeFunctionDef<V: AstVisitor> {
-        pub args: V::CollectionContainer<V::TypeFunctionDefArgRet>,
+        pub params: V::CollectionContainer<V::TypeFunctionDefArgRet>,
         pub return_ty: Option<V::TypeRet>,
         pub expression: V::ExpressionRet,
     }
@@ -3073,7 +3073,7 @@ pub mod walk {
         node: ast::AstNodeRef<ast::TypeFunctionDef>,
     ) -> Result<TypeFunctionDef<V>, V::Error> {
         Ok(TypeFunctionDef {
-            args: V::try_collect_items(
+            params: V::try_collect_items(
                 ctx,
                 node.params.iter().map(|t| visitor.visit_type_function_def_param(ctx, t.ast_ref())),
             )?,
@@ -3086,7 +3086,7 @@ pub mod walk {
         })
     }
 
-    pub struct TypeFunctionDefArg<V: AstVisitor> {
+    pub struct TypeFunctionDefParam<V: AstVisitor> {
         pub name: V::NameRet,
         pub ty: Option<V::TypeRet>,
     }
@@ -3095,8 +3095,8 @@ pub mod walk {
         visitor: &mut V,
         ctx: &V::Ctx,
         node: ast::AstNodeRef<ast::TypeFunctionDefParam>,
-    ) -> Result<TypeFunctionDefArg<V>, V::Error> {
-        Ok(TypeFunctionDefArg {
+    ) -> Result<TypeFunctionDefParam<V>, V::Error> {
+        Ok(TypeFunctionDefParam {
             name: visitor.visit_name(ctx, node.name.ast_ref())?,
             ty: node
                 .ty
@@ -4237,7 +4237,7 @@ pub mod walk_mut {
         Ok(TypeFunction {
             args: V::try_collect_items(
                 ctx,
-                node.args
+                node.params
                     .iter_mut()
                     .map(|a| visitor.visit_type_function_param(ctx, a.ast_ref_mut())),
             )?,

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -316,7 +316,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let return_ty = self.parse_type()?;
 
         Ok(Type::TypeFunction(TypeFunction {
-            args: AstNodes::new(args, Some(arg_span)),
+            params: AstNodes::new(args, Some(arg_span)),
             return_ty,
         }))
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -218,7 +218,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
     ///
     /// All other methods call this one to actually add members to the scope.
     pub fn add_pub_member_to_scope(&self, name: impl Into<Identifier>, ty: TermId, value: TermId) {
-        let member = self.create_pub_member(name, ty, value);
+        let member = self.create_constant_member(name, ty, value, Visibility::Public);
         if let Some(scope) = self.scope.get() {
             self.gs.borrow_mut().scope_store.get_mut(scope).add(member);
         }
@@ -261,30 +261,32 @@ impl<'gs> PrimitiveBuilder<'gs> {
     }
 
     /// Create a public member with the given name, type and value.
-    pub fn create_pub_member(
+    pub fn create_constant_member(
         &self,
         name: impl Into<Identifier>,
         ty: TermId,
         value: TermId,
+        visibility: Visibility,
     ) -> Member {
         Member {
             name: name.into(),
             data: MemberData::InitialisedWithTy { ty, value },
-            visibility: Visibility::Public,
+            visibility,
             mutability: Mutability::Immutable,
         }
     }
 
     /// Create a public member with the given name, type and unset value.
-    pub fn create_uninitialised_pub_member(
+    pub fn create_uninitialised_constant_member(
         &self,
         name: impl Into<Identifier>,
         ty: TermId,
+        visibility: Visibility,
     ) -> Member {
         Member {
             name: name.into(),
             data: MemberData::Uninitialised { ty },
-            visibility: Visibility::Public,
+            visibility,
             mutability: Mutability::Immutable,
         }
     }

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -27,11 +27,6 @@ pub trait AccessToOps: AccessToStorage {
     fn reader(&self) -> PrimitiveReader {
         PrimitiveReader::new(self.global_storage())
     }
-
-    /// Create an instance of [ScopeResolver].
-    fn scope_resolver(&self) -> ScopeResolver {
-        ScopeResolver::new(self.storages())
-    }
 }
 
 impl<T: AccessToStorage> AccessToOps for T {}
@@ -75,6 +70,11 @@ pub trait AccessToOpsMut: AccessToStorageMut {
     /// Create an instance of [Validator].
     fn validator(&mut self) -> Validator {
         Validator::new(self.storages_mut())
+    }
+
+    /// Create an instance of [ScopeResolver].
+    fn scope_resolver(&mut self) -> ScopeResolver {
+        ScopeResolver::new(self.storages_mut())
     }
 }
 

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -94,10 +94,9 @@ impl<'gs, 'ls, 'cd> ScopeResolver<'gs, 'ls, 'cd> {
         let builder = self.builder();
         let param_scope =
             builder.create_constant_scope(params.positional().iter().filter_map(|param| {
-                Some(builder.create_constant_member(
+                Some(builder.create_uninitialised_constant_member(
                     param.name?,
                     param.ty,
-                    builder.create_rt_term(param.ty),
                     Visibility::Private,
                 ))
             }));

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -841,7 +841,10 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
 
                 // Simplify general params and return
                 let simplified_general_params = self.simplify_params(ty_fn.general_params)?;
+
+                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn.general_params);
                 let simplified_general_return_ty = self.simplify_term(ty_fn.general_return_ty)?;
+                self.scopes_mut().pop_the_scope(param_scope);
 
                 // Simplify each of the cases
                 let simplified_cases: Vec<_> = ty_fn
@@ -849,8 +852,12 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                     .iter()
                     .map(|case| {
                         let simplified_params = self.simplify_params(case.params)?;
+
+                        let param_scope = self.scope_resolver().enter_ty_param_scope(case.params);
                         let simplified_return_ty = self.simplify_term(case.return_ty)?;
                         let simplified_return_value = self.simplify_term(case.return_value)?;
+                        self.scopes_mut().pop_the_scope(param_scope);
+
                         // A case is simplified if any of its constituents is simplified:
                         match (&simplified_params, simplified_return_ty, simplified_return_value) {
                             (None, None, None) => Ok(None),
@@ -890,7 +897,11 @@ impl<'gs, 'ls, 'cd> Simplifier<'gs, 'ls, 'cd> {
                 // Simplify params and return, and if either is simplified, the whole term is
                 // simplified.
                 let simplified_params = self.simplify_params(ty_fn_ty.params)?;
+
+                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn_ty.params);
                 let simplified_return_ty = self.simplify_term(ty_fn_ty.return_ty)?;
+                self.scopes_mut().pop_the_scope(param_scope);
+
                 match (&simplified_params, simplified_return_ty) {
                     (None, None) => Ok(None),
                     _ => Ok(Some(self.builder().create_term(Term::TyFnTy(TyFnTy {

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -926,7 +926,11 @@ mod test_super {
     use super::*;
     use crate::{
         fmt::PrepareForFormatting,
-        storage::{core::CoreDefs, primitives::ModDefOrigin, GlobalStorage, LocalStorage},
+        storage::{
+            core::CoreDefs,
+            primitives::{ModDefOrigin, Visibility},
+            GlobalStorage, LocalStorage,
+        },
     };
 
     fn get_storages() -> (GlobalStorage, LocalStorage, CoreDefs) {
@@ -964,12 +968,13 @@ mod test_super {
         let hash_impl = builder.create_nameless_mod_def(
             ModDefOrigin::TrtImpl(builder.create_trt_term(core_defs.hash_trt)),
             builder.create_constant_scope([
-                builder.create_pub_member(
+                builder.create_constant_member(
                     "Self",
                     builder.create_any_ty_term(),
                     builder.create_nominal_def_term(dog_def),
+                    Visibility::Public,
                 ),
-                builder.create_pub_member(
+                builder.create_constant_member(
                     "hash",
                     builder.create_fn_ty_term(
                         builder.create_params(
@@ -988,6 +993,7 @@ mod test_super {
                         ),
                         builder.create_rt_term(builder.create_nominal_def_term(core_defs.u64_ty)),
                     ),
+                    Visibility::Public,
                 ),
             ]),
             [],

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -6,7 +6,7 @@
 //! typechecker is concerned. This includes: integers, floats, characters,
 //! strings, lists, maps, references, etc.
 use super::{
-    primitives::{NominalDefId, ParamOrigin, TermId, TrtDefId},
+    primitives::{NominalDefId, ParamOrigin, TermId, TrtDefId, Visibility},
     GlobalStorage,
 };
 use crate::ops::building::PrimitiveBuilder;
@@ -136,8 +136,12 @@ impl CoreDefs {
         let hash_trt = builder.create_trt_def(
             "Hash",
             [
-                builder.create_uninitialised_pub_member("Self", builder.create_any_ty_term()),
-                builder.create_uninitialised_pub_member(
+                builder.create_uninitialised_constant_member(
+                    "Self",
+                    builder.create_any_ty_term(),
+                    Visibility::Public,
+                ),
+                builder.create_uninitialised_constant_member(
                     "hash",
                     builder.create_fn_ty_term(
                         builder.create_params(
@@ -146,6 +150,7 @@ impl CoreDefs {
                         ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
+                    Visibility::Public,
                 ),
             ],
             [],
@@ -153,8 +158,12 @@ impl CoreDefs {
         let eq_trt = builder.create_trt_def(
             "Eq",
             [
-                builder.create_uninitialised_pub_member("Self", builder.create_any_ty_term()),
-                builder.create_uninitialised_pub_member(
+                builder.create_uninitialised_constant_member(
+                    "Self",
+                    builder.create_any_ty_term(),
+                    Visibility::Public,
+                ),
+                builder.create_uninitialised_constant_member(
                     "eq",
                     builder.create_fn_ty_term(
                         builder.create_params(
@@ -166,6 +175,7 @@ impl CoreDefs {
                         ),
                         builder.create_nominal_def_term(u64_ty),
                     ),
+                    Visibility::Public,
                 ),
             ],
             [],

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -7,6 +7,8 @@
 //! because it is only accessible from one file, whereas a type definition will
 //! be in [GlobalStorage] because it can be accessed from any file (with the
 //! appropriate import).
+use crate::fmt::{ForFormatting, PrepareForFormatting};
+
 use self::{
     arguments::ArgsStore,
     core::CoreDefs,
@@ -177,6 +179,15 @@ pub trait AccessToStorage {
 
     fn scopes(&self) -> &ScopeStack {
         &self.local_storage().scopes
+    }
+
+    /// Create a [ForFormatting] for the given `T` and [GlobalStorage] from
+    /// self.
+    fn for_fmt<T>(&self, t: T) -> ForFormatting<T>
+    where
+        T: PrepareForFormatting,
+    {
+        t.for_formatting(self.global_storage())
     }
 }
 


### PR DESCRIPTION
This PR implements AST traversal and typechecking of type functions and type function types. It also fixes the previous implementation of validation/simplification for type functions, to enter parameter scope before validating the return type and value.

Closes #341.