### PR TITLE
parser: fix over eager token skipping in `parse_type_function`

### DIFF
--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -270,9 +270,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         // only be fired when the next token is a an `<`
         debug_assert!(matches!(self.next_token(), Some(Token { kind: TokenKind::Lt, .. })));
 
-        self.skip_token();
         let mut arg_span = self.current_location();
-
         let mut args = vec![];
 
         loop {
@@ -280,7 +278,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             let name = self.parse_name()?;
 
             let bound = match self.parse_token_fast(TokenKind::Colon) {
-                Some(_) => Some(self.parse_type()?),
+                Some(_) => match self.peek() {
+                    // Don't try and parse a type if an '=' is followed straight after
+                    Some(tok) if tok.has_kind(TokenKind::Eq) => None,
+                    _ => Some(self.parse_type()?),
+                },
                 None => None,
             };
 

--- a/tests/parser/tests/cases/should_pass/type_function_types/case.hash
+++ b/tests/parser/tests/cases/should_pass/type_function_types/case.hash
@@ -1,0 +1,7 @@
+// Various ways of declaring a type functiont type!
+x: <T: Type> -> Type;
+x: <T> -> Type;
+x: <T, Q> -> Type;
+x: <T = i32> -> Type;
+x: <T := i32> -> Type;
+x: <T : i32 = i32> -> Type;


### PR DESCRIPTION
closes #345