### PR TITLE
TC: Traverse merge types and type function calls

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -388,6 +388,7 @@ pub struct TypeFunction {
 #[derive(Debug, PartialEq)]
 pub struct TypeFunctionCall {
     pub subject: AstNode<Type>,
+    // @@Todo: This should probably not use `NamedFieldTypeEntry`.
     pub args: AstNodes<NamedFieldTypeEntry>,
 }
 

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -241,12 +241,12 @@ impl<T> AstNodes<T> {
 impl<T> Deref for AstNodes<T> {
     type Target = [AstNode<T>];
     fn deref(&self) -> &Self::Target {
-        &*self.nodes
+        &self.nodes
     }
 }
 impl<T> DerefMut for AstNodes<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.nodes
+        &mut self.nodes
     }
 }
 

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -208,7 +208,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         match self.stream.get(offset) {
             Some(token) => token.span,
-            None => (*self.stream.last().unwrap()).span,
+            None => self.stream.last().unwrap().span,
         }
     }
 

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -573,7 +573,7 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                 builder
                     .with_error_code(HashErrorCode::DisallowedType)
                     .with_message(
-                        "this merge declaration should only contain a level-1 terms".to_string(),
+                        "this merge declaration should only contain level-1 terms".to_string(),
                     )
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
@@ -596,7 +596,7 @@ impl<'gs, 'ls, 'cd> From<TcErrorWithStorage<'gs, 'ls, 'cd>> for Report {
                 builder
                     .with_error_code(HashErrorCode::DisallowedType)
                     .with_message(
-                        "this merge declaration should only contain a level-2 terms".to_string(),
+                        "this merge declaration should only contain level-2 terms".to_string(),
                     )
                     .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -218,7 +218,7 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
             }
 
             // Merging:
-            (Term::Merge(_), Term::Merge(inner_target)) => {
+            (_, Term::Merge(inner_target)) => {
                 // Try to merge source with each individual term in target. If all succeed,
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
@@ -232,13 +232,6 @@ impl<'gs, 'ls, 'cd> Unifier<'gs, 'ls, 'cd> {
                     }
                 }
                 Ok(subs)
-            }
-            (_, Term::Merge(inner_target)) => {
-                // This is only valid if the merge has one element and unifies with source
-                match inner_target.as_slice() {
-                    [inner_target_id] => self.unify_terms(src_id, *inner_target_id),
-                    _ => cannot_unify(),
-                }
             }
             (Term::Merge(inner_src), _) => {
                 // Try to merge each individual term in source, with target. If any one

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -438,17 +438,11 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                     *merge_kind = ensure_merge_is_level1(None)?;
                     Ok(())
                 }
-                // Nominals:
-                Level1Term::NominalDef(_) => {
-                    // Checking a nominal:
+                // Nominals, tuples, functions:
+                Level1Term::NominalDef(_) | Level1Term::Tuple(_) | Level1Term::Fn(_) => {
                     *merge_kind = ensure_merge_is_level1(Some(merge_element_term_id))?;
                     Ok(())
                 }
-                // Cannot attach a tuple to a merge
-                // @@Design: can we possibly allow this?
-                Level1Term::Tuple(_) => invalid_merge_element(),
-                // Cannot attach a function type to a merge
-                Level1Term::Fn(_) => invalid_merge_element(),
             },
             // Type functions are not allowed
             Term::TyFn(_) | Term::TyFnTy(_) => invalid_merge_element(),

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -340,7 +340,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                 }
                 MergeKind::Level1 { nominal_attached: _ } => {
                     // Merge was already specified to be level 1, error!
-                    Err(TcError::MergeShouldBeLevel2 {
+                    Err(TcError::MergeShouldBeLevel1 {
                         merge_term: merge_term_id,
                         offending_term: merge_element_term_id,
                     })
@@ -357,7 +357,7 @@ impl<'gs, 'ls, 'cd> Validator<'gs, 'ls, 'cd> {
                 }
                 (MergeKind::Level2, _) => {
                     // Merge was already specified to be level 2, error!
-                    Err(TcError::MergeShouldBeLevel1 {
+                    Err(TcError::MergeShouldBeLevel2 {
                         merge_term: merge_term_id,
                         offending_term: merge_element_term_id,
                     })

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -30,6 +30,7 @@ pub struct CoreDefs {
     pub f64_ty: NominalDefId,
     pub char_ty: NominalDefId,
     pub bool_ty: NominalDefId,
+    pub any_ty: TermId,
     pub reference_ty_fn: TermId,
     pub reference_mut_ty_fn: TermId,
     pub raw_reference_ty_fn: TermId,
@@ -83,6 +84,10 @@ impl CoreDefs {
 
         // String
         let str_ty = builder.create_opaque_struct_def("str", []);
+
+        // Any type
+        let any_ty = builder.create_any_ty_term();
+        builder.add_pub_member_to_scope("Type", builder.create_trt_kind_term(), any_ty);
 
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
@@ -248,6 +253,7 @@ impl CoreDefs {
             f64_ty,
             char_ty,
             bool_ty,
+            any_ty,
             reference_ty_fn,
             raw_reference_mut_ty_fn,
             raw_reference_ty_fn,

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -503,10 +503,18 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     fn visit_merged_type(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergedType>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergedType>,
     ) -> Result<Self::MergedTypeRet, Self::Error> {
-        todo!()
+        let walk::MergedType(elements) = walk::walk_merged_type(self, ctx, node)?;
+
+        let merge_term = self.builder().create_merge_term(elements);
+
+        // Add location
+        let merge_term_location = self.source_location(node.span());
+        self.builder().add_location_to_target(merge_term, merge_term_location);
+
+        Ok(self.validator().validate_term(merge_term)?.simplified_term_id)
     }
 
     type TypeFunctionDefRet = TermId;

--- a/compiler/hash-vm/src/stack.rs
+++ b/compiler/hash-vm/src/stack.rs
@@ -37,7 +37,7 @@ impl Stack {
     pub fn pop8(&mut self) -> RuntimeResult<&[u8; 1]> {
         self.verify_access(StackAccessKind::Pop, 1)?;
 
-        let value = (&self.data[(self.stack_pointer - 1)..self.stack_pointer]).try_into().unwrap();
+        let value = self.data[(self.stack_pointer - 1)..self.stack_pointer].try_into().unwrap();
         self.stack_pointer -= 1;
 
         Ok(value)
@@ -47,7 +47,7 @@ impl Stack {
     pub fn pop16(&mut self) -> RuntimeResult<&[u8; 2]> {
         self.verify_access(StackAccessKind::Pop, 2)?;
 
-        let value = (&self.data[(self.stack_pointer - 2)..self.stack_pointer]).try_into().unwrap();
+        let value = self.data[(self.stack_pointer - 2)..self.stack_pointer].try_into().unwrap();
         self.stack_pointer -= 2;
 
         Ok(value)
@@ -56,7 +56,7 @@ impl Stack {
     pub fn pop32(&mut self) -> RuntimeResult<&[u8; 4]> {
         self.verify_access(StackAccessKind::Pop, 4)?;
 
-        let value = (&self.data[(self.stack_pointer - 4)..self.stack_pointer]).try_into().unwrap();
+        let value = self.data[(self.stack_pointer - 4)..self.stack_pointer].try_into().unwrap();
         self.stack_pointer -= 4;
 
         Ok(value)
@@ -66,7 +66,7 @@ impl Stack {
     pub fn pop64(&mut self) -> RuntimeResult<&[u8; 8]> {
         self.verify_access(StackAccessKind::Pop, 8)?;
 
-        let value = (&self.data[(self.stack_pointer - 8)..self.stack_pointer]).try_into().unwrap();
+        let value = self.data[(self.stack_pointer - 8)..self.stack_pointer].try_into().unwrap();
         self.stack_pointer -= 8;
 
         Ok(value)


### PR DESCRIPTION
This PR implements traversal of merge types and type function calls, completing the bulk of the basic type traversal (minus definitions like structs, enums).

Closes #327.