### PR TITLE
Tc: implement traversal for more expressions and types

### DIFF
--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1093,10 +1093,16 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     fn visit_loop_block(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::LoopBlock>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::LoopBlock>,
     ) -> Result<Self::LoopBlockRet, Self::Error> {
-        todo!()
+        let walk::LoopBlock(term) = walk::walk_loop_block(self, ctx, node)?;
+
+        // Add the location of the type as the whole block
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(term, location);
+
+        Ok(term)
     }
 
     type ForLoopBlockRet = TermId;
@@ -1208,10 +1214,16 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     fn visit_return_statement(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::ReturnStatement>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ReturnStatement>,
     ) -> Result<Self::ReturnStatementRet, Self::Error> {
-        todo!()
+        let walk::ReturnStatement(inner_ty) = walk::walk_return_statement(self, ctx, node)?;
+        let ret_ty = inner_ty.unwrap_or_else(|| self.builder().create_void_ty_term());
+
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(ret_ty, location);
+
+        Ok(ret_ty)
     }
 
     type BreakStatementRet = TermId;
@@ -1219,9 +1231,14 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
     fn visit_break_statement(
         &mut self,
         _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::BreakStatement>,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::BreakStatement>,
     ) -> Result<Self::BreakStatementRet, Self::Error> {
-        todo!()
+        let void_ty = self.builder().create_void_ty_term();
+
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(void_ty, location);
+
+        Ok(void_ty)
     }
 
     type ContinueStatementRet = TermId;
@@ -1229,9 +1246,14 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
     fn visit_continue_statement(
         &mut self,
         _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::ContinueStatement>,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ContinueStatement>,
     ) -> Result<Self::ContinueStatementRet, Self::Error> {
-        todo!()
+        let void_ty = self.builder().create_void_ty_term();
+
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(void_ty, location);
+
+        Ok(void_ty)
     }
 
     type VisibilityRet = Visibility;

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -359,6 +359,9 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         // Attempt to unify this with a `Ref<T>` to see if the `inner_ty` can
         // be dereferenced. If that fails, then try to unify with `RefMut<T>`
+        //
+        // @@Todo(feds01): Add a custom error type that says the desired type cannot be
+        // dereferenced
         let result = self
             .unifier()
             .unify_terms(inner_ty, ap_ref_ty)

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -678,30 +678,75 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     fn visit_list_type(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::ListType>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ListType>,
     ) -> Result<Self::ListTypeRet, Self::Error> {
-        todo!()
+        let walk::ListType { inner } = walk::walk_list_type(self, ctx, node)?;
+
+        let inner_ty = self.core_defs().list_ty_fn;
+        let builder = self.builder();
+
+        let list_ty = builder.create_app_ty_fn_term(
+            inner_ty,
+            builder.create_args([builder.create_arg("T", inner)], ParamOrigin::TyFn),
+        );
+
+        // Add the location to the type
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(list_ty, location);
+
+        Ok(list_ty)
     }
 
     type SetTypeRet = TermId;
 
     fn visit_set_type(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::SetType>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::SetType>,
     ) -> Result<Self::SetTypeRet, Self::Error> {
-        todo!()
+        let walk::SetType { inner } = walk::walk_set_type(self, ctx, node)?;
+
+        let inner_ty = self.core_defs().set_ty_fn;
+        let builder = self.builder();
+
+        let set_ty = builder.create_app_ty_fn_term(
+            inner_ty,
+            builder.create_args([builder.create_arg("T", inner)], ParamOrigin::TyFn),
+        );
+
+        // Add the location to the type
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(set_ty, location);
+
+        Ok(set_ty)
     }
 
     type MapTypeRet = TermId;
 
     fn visit_map_type(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::MapType>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MapType>,
     ) -> Result<Self::MapTypeRet, Self::Error> {
-        todo!()
+        let walk::MapType { key, value } = walk::walk_map_type(self, ctx, node)?;
+
+        let inner_ty = self.core_defs().map_ty_fn;
+        let builder = self.builder();
+
+        let map_ty = builder.create_app_ty_fn_term(
+            inner_ty,
+            builder.create_args(
+                [builder.create_arg("K", key), builder.create_arg("V", value)],
+                ParamOrigin::TyFn,
+            ),
+        );
+
+        // Add the location to the type
+        let location = self.source_location(node.span());
+        self.location_store_mut().add_location_to_target(map_ty, location);
+
+        Ok(map_ty)
     }
 
     type MapLiteralRet = TermId;

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1189,14 +1189,17 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         todo!()
     }
 
-    type VisibilityRet = TermId;
+    type VisibilityRet = Visibility;
 
     fn visit_visibility_modifier(
         &mut self,
         _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::Visibility>,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Visibility>,
     ) -> Result<Self::VisibilityRet, Self::Error> {
-        todo!()
+        Ok(match node.body() {
+            hash_ast::ast::Visibility::Public => Visibility::Public,
+            hash_ast::ast::Visibility::Private => Visibility::Private,
+        })
     }
 
     type MutabilityRet = Mutability;


### PR DESCRIPTION
This patch implements the following traversal methods:

- `loop` blocks, 
- `continue`, `break`, and `return` expressions
-  `deref`, `ref` expressions
- scaffold implementation for `unsafe` and `directive` expressions
- `map`, `set`, `list` type traversals

closes #327
closes #333