### PR TITLE
TC: Implement simplification of function calls

### DIFF
--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -34,6 +34,7 @@ error_codes! {
     ParameterNameMismatch = 36,
     ParameterInUse = 37,
     AmbiguousFieldOrder = 38,
+    InvalidFunctionCallSubject = 39,
 
     // traits
     InvalidMergeElement = 50,

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -89,6 +89,8 @@ pub enum TcError {
     UnsupportedTypeFunctionApplication { subject_id: TermId },
     /// The given access operation results in more than one result.
     AmbiguousAccess { access: AccessTerm, results: Vec<TermId> },
+    /// Cannot use this as a function call subject.
+    InvalidFunctionCallSubject { term: TermId },
     /// The given access operation does not resolve to a method.
     InvalidPropertyAccessOfNonMethod { subject: TermId, property: Identifier },
     /// The given member requires an initialisation in the current scope.

--- a/compiler/hash-typecheck/src/diagnostics/macros.rs
+++ b/compiler/hash-typecheck/src/diagnostics/macros.rs
@@ -117,6 +117,6 @@ pub macro tc_panic_on_many {
         }
     },
     ($terms: expr, $storage:expr, $fmt: expr, $($arg:tt)*) => {
-        tc_panic_on_many!($terms, $storage, format!($fmt, $($arg)*));
+        tc_panic_on_many!($terms, $storage, format!($fmt, $($arg)*))
     }
 }

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -768,6 +768,19 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     )));
                 }
             }
+            TcError::InvalidFunctionCallSubject { term } => {
+                builder.with_error_code(HashErrorCode::TypeIsNotTrait).with_message(format!(
+                    "cannot use `{}` as a function call subject",
+                    term.for_formatting(err.global_storage())
+                ));
+
+                if let Some(location) = err.location_store().get_location(term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "this cannot be called because it's not function-like",
+                    )));
+                }
+            }
         };
 
         builder.build()

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -213,6 +213,12 @@ impl<'gs> TcFormatter<'gs> {
                     enum_variant.enum_def_id.for_formatting(self.global_storage)
                 )
             }
+            Level0Term::FnCall(fn_call) => {
+                opts.is_atomic.set(true);
+                self.fmt_term_as_single(f, fn_call.subject, TcFormatOpts::default())?;
+                write!(f, "({})", fn_call.args.for_formatting(self.global_storage))?;
+                Ok(())
+            }
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -4,8 +4,8 @@ use crate::storage::{
     location::LocationTarget,
     primitives::{
         AccessOp, AccessTerm, AppSub, AppTyFn, Arg, ArgsId, EnumDef, EnumVariant, EnumVariantValue,
-        FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Member, MemberData, ModDef,
-        ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList,
+        FnCall, FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Member, MemberData,
+        ModDef, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList,
         ParamOrigin, ParamsId, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term,
         TermId, TrtDef, TrtDefId, TupleTy, TyFn, TyFnCase, TyFnTy, UnresolvedTerm, Var, Visibility,
     },
@@ -337,6 +337,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// value.
     pub fn create_fn_lit_term(&self, fn_ty: TermId, return_value: TermId) -> TermId {
         self.create_term(Term::Level0(Level0Term::FnLit(FnLit { fn_ty, return_value })))
+    }
+
+    /// Create a [Level0Term::FnCall] term with the given subject and arguments.
+    pub fn create_fn_call_term(&self, subject: TermId, args: ArgsId) -> TermId {
+        self.create_term(Term::Level0(Level0Term::FnCall(FnCall { subject, args })))
     }
 
     /// Create a parameter with the given name and type.

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -158,16 +158,13 @@ impl<'gs> PrimitiveBuilder<'gs> {
     pub fn create_struct_def(
         &self,
         struct_name: impl Into<Identifier>,
-        fields: impl IntoIterator<Item = Param>,
+        fields: ParamsId,
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> NominalDefId {
         let name = struct_name.into();
         let def_id = self.gs.borrow_mut().nominal_def_store.create(NominalDef::Struct(StructDef {
             name: Some(name),
-            fields: StructFields::Explicit(ParamList::new(
-                fields.into_iter().collect(),
-                ParamOrigin::Struct,
-            )),
+            fields: StructFields::Explicit(fields),
             bound_vars: bound_vars.into_iter().collect(),
         }));
         self.add_nominal_def_to_scope(name, def_id);

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -663,14 +663,16 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     }
                 }
             }
-            Term::AppSub(_) => {
+            Term::AppSub(app_sub) => {
                 // Recurse to inner and then apply sub
-                todo!()
+                let app_sub = app_sub.clone();
+                let inner_fn_ty = self.use_term_as_fn_call_subject(app_sub.term)?;
+                Ok(self.substituter().apply_sub_to_fn_ty(&app_sub.sub, inner_fn_ty))
             }
             Term::Unresolved(_) => {
                 // @@Future: Here maybe create a function type with unknown args and return?
                 // For now error:
-                todo!()
+                cannot_use_as_fn_call_subject()
             }
             Term::Level1(_) => {
                 // Ensure it is a struct def

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -313,7 +313,9 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                             None => name_not_found(access_term, NameFieldOrigin::EnumVariant),
                         }
                     }
-                    NominalDef::Struct(_) => unreachable!("Got struct def ID in enum variant!"),
+                    NominalDef::Struct(_) => {
+                        tc_panic!(originating_term, self, "Got struct def ID in enum variant!")
+                    }
                 }
             }
             Level0Term::FnLit(_) => does_not_support_access(access_term),

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -357,9 +357,10 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 self.add_free_vars_in_term_to_set(fn_lit.fn_ty, result);
                 self.add_free_vars_in_term_to_set(fn_lit.return_value, result);
             }
-            Level0Term::FnCall(_) => {
+            Level0Term::FnCall(fn_call) => {
                 // Forward to subject and args:
-                todo!()
+                self.add_free_vars_in_term_to_set(fn_call.subject, result);
+                self.add_free_vars_in_args_to_set(fn_call.args, result);
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -64,6 +64,15 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
         self.builder().create_params(new_params, params.origin())
     }
 
+    /// Apply the given substitution to the given [FnTy], producing a new
+    /// [FnTy] with the substituted variables.
+    pub fn apply_sub_to_fn_ty(&mut self, sub: &Sub, fn_ty: FnTy) -> FnTy {
+        // Apply to parameters and return type
+        let subbed_params = self.apply_sub_to_params(sub, fn_ty.params);
+        let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty);
+        FnTy { params: subbed_params, return_ty: subbed_return_ty }
+    }
+
     /// Apply the given substitution to the given [Level3Term], producing a new
     /// [Level3Term] with the substituted variables.
     pub fn apply_sub_to_level3_term(&mut self, _: &Sub, term: Level3Term) -> TermId {
@@ -120,12 +129,8 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
             }
             Level1Term::Fn(fn_ty) => {
                 // Apply to parameters and return type
-                let subbed_params = self.apply_sub_to_params(sub, fn_ty.params);
-                let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty);
-                self.builder().create_term(Term::Level1(Level1Term::Fn(FnTy {
-                    params: subbed_params,
-                    return_ty: subbed_return_ty,
-                })))
+                let subbed_fn_ty = self.apply_sub_to_fn_ty(sub, fn_ty);
+                self.builder().create_term(Term::Level1(Level1Term::Fn(subbed_fn_ty)))
             }
         }
     }
@@ -157,9 +162,11 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 let subbed_return_value = self.apply_sub_to_term(sub, fn_lit.return_value);
                 self.builder().create_fn_lit_term(subbed_fn_ty, subbed_return_value)
             }
-            Level0Term::FnCall(_) => {
+            Level0Term::FnCall(fn_call) => {
                 // Apply to subject and args
-                todo!()
+                let subbed_subject = self.apply_sub_to_term(sub, fn_call.subject);
+                let subbed_args = self.apply_sub_to_args(sub, fn_call.args);
+                self.builder().create_fn_call_term(subbed_subject, subbed_args)
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -157,6 +157,10 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 let subbed_return_value = self.apply_sub_to_term(sub, fn_lit.return_value);
                 self.builder().create_fn_lit_term(subbed_fn_ty, subbed_return_value)
             }
+            Level0Term::FnCall(_) => {
+                // Apply to subject and args
+                todo!()
+            }
         }
     }
 
@@ -352,6 +356,10 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 // Forward to fn type and return value
                 self.add_free_vars_in_term_to_set(fn_lit.fn_ty, result);
                 self.add_free_vars_in_term_to_set(fn_lit.return_value, result);
+            }
+            Level0Term::FnCall(_) => {
+                // Forward to subject and args:
+                todo!()
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -207,6 +207,9 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                         // The type of an enum variant is the enum
                         Ok(self.builder().create_nominal_def_term(enum_variant.enum_def_id))
                     }
+                    Level0Term::FnCall(_) => {
+                        tc_panic!(term_id, self, "Function call should have been simplified away!")
+                    }
                 }
             }
             // The type of root is root

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 
-use super::{AccessToOps, AccessToOpsMut};
+use super::{unify::UnifyParamsWithArgsMode, AccessToOps, AccessToOpsMut};
 
 /// Can resolve the type of a given term, as another term.
 pub struct Typer<'gs, 'ls, 'cd, 's> {
@@ -119,6 +119,7 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                             ty_fn_ty.params,
                             app_ty_fn.args,
                             ty_id_of_subject,
+                            UnifyParamsWithArgsMode::SubstituteParamNamesForArgValues,
                         )?;
                         // Apply the substitution to the return type and use it as the result:
                         Ok(self.substituter().apply_sub_to_term(&sub, ty_fn_ty.return_ty))
@@ -208,7 +209,7 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                         Ok(self.builder().create_nominal_def_term(enum_variant.enum_def_id))
                     }
                     Level0Term::FnCall(_) => {
-                        tc_panic!(term_id, self, "Function call should have been simplified away!")
+                        tc_panic!(term_id, self, "Function call should have been simplified away when trying to get the type of the term!")
                     }
                 }
             }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -7,7 +7,7 @@ use super::{AccessToOps, AccessToOpsMut};
 use crate::{
     diagnostics::{
         error::{TcError, TcResult},
-        macros::tc_panic,
+        macros::{tc_panic, tc_panic_on_many},
         params::ParamListKind,
     },
     ops::params::validate_param_list_ordering,
@@ -453,7 +453,11 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             Term::Root => invalid_merge_element(),
             // This should have been flattened already:
             Term::Merge(_) => {
-                unreachable!("Merge term should have already been flattened")
+                tc_panic_on_many!(
+                    [merge_element_term_id, merge_term_id],
+                    self,
+                    "Merge term should have already been flattened"
+                )
             }
         }
     }
@@ -873,7 +877,11 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             }
             Term::Level0(_) | Term::TyFn(_) => {
                 // This should never happen
-                unreachable!("Found type function definition or level 0 term in type position!")
+                tc_panic!(
+                    term_id,
+                    self,
+                    "Found type function definition or level 0 term in type position!"
+                )
             }
             Term::TyFnTy(_) => {
                 // All good, basically curried type function:
@@ -926,7 +934,11 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             }
             Term::Level0(_) | Term::TyFn(_) => {
                 // This should never happen
-                unreachable!("Found type function definition or level 0 term in type position!")
+                tc_panic!(
+                    term_id,
+                    self,
+                    "Found type function definition or level 0 term in type position!"
+                )
             }
             Term::TyFnTy(ty_fn_ty) => {
                 // Type function types are okay to use if their return types can be used here:

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -618,6 +618,13 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     // name. Furthermore, there are no inner terms to validate.
                     Ok(result)
                 }
+                Level0Term::FnCall(_) => {
+                    tc_panic!(
+                        simplified_term_id,
+                        self,
+                        "Function call in validation should have been simplified!"
+                    )
+                }
             },
 
             // Access
@@ -821,6 +828,13 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                         // @@PotentiallyAllow: Enum variants also do not produce side effects, so
                         // why wouldn't they be allowed? Is there a use case for this?
                         Ok(false)
+                    }
+                    Level0Term::FnCall(_) => {
+                        tc_panic!(
+                        term_id,
+                        self,
+                        "Function call in checking for type function return validity should have been simplified!"
+                    )
                     }
                 }
             }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -543,7 +543,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             Term::Level1(level1_term) => match level1_term {
                 Level1Term::Tuple(tuple_ty) => {
                     // Validate each parameter
-                    let tuple_ty = tuple_ty.clone();
+                    let tuple_ty = *tuple_ty;
                     self.validate_params(tuple_ty.members)?;
 
                     let members = self.params_store().get(tuple_ty.members).clone();
@@ -556,7 +556,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 }
                 Level1Term::Fn(fn_ty) => {
                     // Validate parameters and return type
-                    let fn_ty = fn_ty.clone();
+                    let fn_ty = *fn_ty;
                     self.validate_params(fn_ty.params)?;
                     self.validate_term(fn_ty.return_ty)?;
 
@@ -969,7 +969,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
         let reader = self.reader();
         let term = reader.get_term(simplified_term_id);
         match term {
-            Term::Level1(Level1Term::Fn(fn_ty)) => Ok(Some(fn_ty.clone())),
+            Term::Level1(Level1Term::Fn(fn_ty)) => Ok(Some(*fn_ty)),
             _ => Ok(None),
         }
     }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -308,7 +308,7 @@ pub struct StructDef {
 /// An enum variant, containing a variant name and a set of fields.
 ///
 /// Structurally the same as a struct.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct EnumVariant {
     pub name: Identifier,
     pub fields: ParamsId,
@@ -356,7 +356,7 @@ impl NominalDef {
 }
 
 /// A tuple type, containing parameters as members.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TupleTy {
     pub members: ParamsId,
 }
@@ -364,7 +364,7 @@ pub struct TupleTy {
 /// A function type, with a set of input parameters and a return type.
 ///
 /// All the parameter types and return type must be level 0
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct FnTy {
     pub params: ParamsId,
     pub return_ty: TermId,

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -289,7 +289,7 @@ pub struct ModDef {
 #[derive(Debug, Clone)]
 pub enum StructFields {
     /// An explicit set of fields, as a set of parameters.
-    Explicit(Params),
+    Explicit(ParamsId),
     /// The struct does not have any accessible parameters.
     ///
     /// This is used for core language definitions that will be filled in later

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -614,6 +614,15 @@ pub enum Level1Term {
     Fn(FnTy),
 }
 
+// Represents a function call, with a level 0 subject and level 0 arguments.
+//
+// The subject must be either a `Rt(Fn(..))`, or an `FnLit(..)`.
+#[derive(Debug, Clone, Copy)]
+pub struct FnCall {
+    pub subject: TermId,
+    pub args: ArgsId,
+}
+
 /// Represents a function literal, with a function type, as well as a return
 /// value.
 #[derive(Debug, Clone, Copy)]
@@ -630,6 +639,9 @@ pub struct FnLit {
 pub enum Level0Term {
     /// A runtime value, has some Level 1 term as type (the inner data).
     Rt(TermId),
+
+    /// A function call.
+    FnCall(FnCall),
 
     /// A function literal.
     FnLit(FnLit),


### PR DESCRIPTION
This PR adds `FnCall` as a new level 0 term, which should make traversal of function calls trivial. Works towards #328. Supports, constructors, enum variants, and functions.