### PR TITLE
TC: Introduce unions and the "never" type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "hash-reporting",
  "hash-source",
  "hash-utils",
+ "itertools",
  "slotmap",
 ]
 
@@ -608,6 +609,15 @@ checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -43,4 +43,5 @@ error_codes! {
     NoMatchingTraitImplementations = 53,
     InvalidPropertyAccessOfNonMethod = 54,
     TraitImplMissingMember = 55,
+    InvalidUnionElement = 56,
 }

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 [dependencies]
 slotmap = "1.0"
 dashmap = "5.1"
+itertools = "0.10"
 
 hash-ast = { path = "../hash-ast" }
 hash-source = { path = "../hash-source" }
 hash-utils = { path = "../hash-utils" }
 hash-alloc = { path = "../hash-alloc" }
-hash-reporting = {path = "../hash-reporting" }
-hash-pipeline = {path = "../hash-pipeline" }
-hash-error-codes = {path = "../hash-error-codes" }
+hash-reporting = { path = "../hash-reporting" }
+hash-pipeline = { path = "../hash-pipeline" }
+hash-error-codes = { path = "../hash-error-codes" }

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -61,6 +61,8 @@ pub enum TcError {
     },
     /// The given term cannot be used in a merge operation.
     InvalidMergeElement { term: TermId },
+    /// The given term cannot be used in a union operation.
+    InvalidUnionElement { term: TermId },
     /// The given term cannot be used as a type function parameter type.
     InvalidTypeFunctionParameterType { param_ty: TermId },
     /// The given term cannot be used as a type function return type.

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -481,6 +481,25 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     // used within this position
                 }
             }
+            TcError::InvalidUnionElement { term } => {
+                builder
+                    .with_error_code(HashErrorCode::InvalidUnionElement)
+                    .with_message("invalid element within a union");
+
+                if let Some(location) = err.location_store().get_location(term) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "cannot use the type `{}` within a union",
+                            term.for_formatting(err.global_storage()),
+                        ),
+                    )));
+
+                    // @@Todo(feds01): add more helpful information about why
+                    // this particular type cannot be
+                    // used within this position
+                }
+            }
             TcError::InvalidTypeFunctionParameterType { param_ty } => {
                 builder
                     .with_error_code(HashErrorCode::DisallowedType)

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -496,8 +496,8 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     )));
 
                     // @@Todo(feds01): add more helpful information about why
-                    // this particular type cannot be
-                    // used within this position
+                    // this particular type cannot be used
+                    // within this position
                 }
             }
             TcError::InvalidTypeFunctionParameterType { param_ty } => {

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -263,7 +263,7 @@ impl<'gs> TcFormatter<'gs> {
         match term {
             Level2Term::Trt(trt_def_id) => self.fmt_trt_def(f, *trt_def_id, opts),
             Level2Term::AnyTy => {
-                write!(f, "Type")
+                write!(f, "AnyType")
             }
         }
     }

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -328,6 +328,16 @@ impl<'gs> TcFormatter<'gs> {
                 }
                 Ok(())
             }
+            Term::Union(terms) => {
+                opts.is_atomic.set(false);
+                for (i, term_id) in terms.iter().enumerate() {
+                    self.fmt_term_as_single(f, *term_id, opts.clone())?;
+                    if i != terms.len() - 1 {
+                        write!(f, " | ")?;
+                    }
+                }
+                Ok(())
+            }
             Term::TyFn(ty_fn) => {
                 match ty_fn.name {
                     Some(name) if !opts.expand => {

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -329,14 +329,20 @@ impl<'gs> TcFormatter<'gs> {
                 Ok(())
             }
             Term::Union(terms) => {
-                opts.is_atomic.set(false);
-                for (i, term_id) in terms.iter().enumerate() {
-                    self.fmt_term_as_single(f, *term_id, opts.clone())?;
-                    if i != terms.len() - 1 {
-                        write!(f, " | ")?;
+                if terms.is_empty() {
+                    opts.is_atomic.set(true);
+                    write!(f, "never")?;
+                    Ok(())
+                } else {
+                    opts.is_atomic.set(false);
+                    for (i, term_id) in terms.iter().enumerate() {
+                        self.fmt_term_as_single(f, *term_id, opts.clone())?;
+                        if i != terms.len() - 1 {
+                            write!(f, " | ")?;
+                        }
                     }
+                    Ok(())
                 }
-                Ok(())
             }
             Term::TyFn(ty_fn) => {
                 match ty_fn.name {

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -3,7 +3,7 @@
 //! This brings light to the world by ensuring the correctness of the crude and
 //! dangerous Hash program that is given as input to the compiler.
 //!
-//! @@Todo(kontheocharis): write docs about the stages of the typechecker.
+//! @@Docs(kontheocharis): write docs about the stages of the typechecker.
 
 #![feature(generic_associated_types, decl_macro)]
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! @@Docs(kontheocharis): write docs about the stages of the typechecker.
 
-#![feature(generic_associated_types, decl_macro)]
+#![feature(generic_associated_types, decl_macro, slice_pattern, option_result_contains)]
 
 use diagnostics::reporting::TcErrorWithStorage;
 use hash_pipeline::{traits::Tc, CompilerResult};

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -326,6 +326,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         })))
     }
 
+    /// Create the never type term: [Term::Union] with no members.
+    pub fn create_never_ty_term(&self) -> TermId {
+        self.create_term(Term::Union(vec![]))
+    }
+
     /// Create a tuple type term [Level1Term::Tuple].
     pub fn create_tuple_ty_term(&self, members: ParamsId) -> TermId {
         self.create_term(Term::Level1(Level1Term::Tuple(TupleTy { members })))

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -314,6 +314,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Merge(terms.into_iter().collect()))
     }
 
+    /// Create a term [Term::Union] with the given inner terms.
+    pub fn create_union_term(&self, terms: impl IntoIterator<Item = TermId>) -> TermId {
+        self.create_term(Term::Union(terms.into_iter().collect()))
+    }
+
     /// Create the void type term: [Level1Term::Tuple] with no members.
     pub fn create_void_ty_term(&self) -> TermId {
         self.create_term(Term::Level1(Level1Term::Tuple(TupleTy {

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -326,8 +326,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
         })))
     }
 
-    /// Create the never type term: [Term::Union] with no members.
-    pub fn create_never_ty_term(&self) -> TermId {
+    /// Create the never term: [Term::Union] with no members.
+    pub fn create_never_term(&self) -> TermId {
         self.create_term(Term::Union(vec![]))
     }
 

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -22,6 +22,7 @@ use crate::{
     },
 };
 use hash_source::identifier::Identifier;
+use itertools::Itertools;
 
 /// Can perform simplification on terms.
 pub struct Simplifier<'gs, 'ls, 'cd, 's> {
@@ -980,17 +981,76 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
     /// - Flattening nests: B ^ (C ^ D) becomes B ^ C ^ D
     /// - Simplifying inner terms:
     ///  (<T> => (str, T))<i32> ^ C becomes (str, i32) ^ C
+    /// - Distributivity: @@Todo, @@Enhancement
     ///
     /// This is to be used for merge and union types.
     pub fn simplify_algebraic_term_list(
         &mut self,
-        _term_list: &[TermId],
+        term_list: &[TermId],
+        is_nested: impl Fn(&Term) -> Option<Vec<TermId>>,
     ) -> TcResult<Option<Vec<TermId>>> {
-        // @@Todo: we also need a function for unions and a function for merges for
-        // their specific properties (and we need to decide whether to have CNF or DNF
-        // as the simplified default---do we distribute unions over merges or merges
-        // over unions?)
-        todo!()
+        let mut simplified_once = false;
+
+        // Flatten nests (associativity);
+        // Also simplify inner terms
+        let flattened = term_list
+            .iter()
+            .copied()
+            .map(|term_id| {
+                // Check if the term is a nested list, and if so flatten it:
+                let simplified_term_id = self
+                    .simplifier()
+                    .simplify_term(term_id)?
+                    .map(|x| {
+                        simplified_once = true;
+                        x
+                    })
+                    .unwrap_or(term_id);
+                let reader = self.reader();
+                let term = reader.get_term(simplified_term_id);
+                match is_nested(term) {
+                    // It is a merge, flatten it (this also means the merge has been
+                    // simplified):
+                    Some(terms) => {
+                        simplified_once = true;
+                        Ok(terms)
+                    }
+                    // Not a merge, just return a single-element vector:
+                    _ => Ok(vec![simplified_term_id]),
+                }
+            })
+            .try_fold(vec![], |mut all_terms, nested_terms| {
+                // Combine all the nested terms
+                all_terms.extend(nested_terms?);
+                Ok(all_terms)
+            })?;
+
+        // Merge equal terms (idempotency)
+        let mut merged: Vec<_> = flattened.into_iter().map(Some).collect();
+        for terms in term_list.iter().enumerate().combinations(2) {
+            match terms.as_slice() {
+                [(first_idx, &first), (second_idx, &second)] => {
+                    // Try to merge the two terms if they are the same:
+                    if self.unifier().terms_are_equal(first, second) {
+                        simplified_once = true;
+                        merged[*first_idx] = Some(first);
+                        merged[*second_idx] = None;
+                    } else {
+                        merged[*first_idx] = Some(first);
+                        merged[*second_idx] = Some(second);
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+        let result: Vec<_> = merged.into_iter().flatten().collect();
+
+        // Only return if it has been simplified
+        if simplified_once {
+            Ok(None)
+        } else {
+            Ok(Some(result))
+        }
     }
 
     /// Simplify the given term, if possible.
@@ -1001,63 +1061,18 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
         // @@Performance: we can cache the result of the simplification in a hashmap.
         let value = self.reader().get_term(term_id).clone();
         let new_term = match value {
-            Term::Merge(inner) => {
-                // Simplify each element of the merge:
-
-                // Shortcut if it is a single element:
-                if inner.len() == 1 {
-                    self.simplify_term(inner[0])
-                } else {
-                    // Keep track of if any terms have been simplified.
-                    let mut simplified_once = false;
-                    let inner = inner;
-                    let inner_simplified = inner
-                        .iter()
-                        .copied()
-                        .map(|term_id| {
-                            // Simplify the current term:
-                            let simplified_term_id =
-                                self.simplify_term(term_id)?.map(|simplified_term_id| {
-                                    simplified_once = true;
-                                    simplified_term_id
-                                });
-
-                            // Check if the simplified term is a merge, and if so flatten it:
-                            let reader = self.reader();
-                            let simplified_term =
-                                reader.get_term(simplified_term_id.unwrap_or(term_id));
-                            match simplified_term {
-                                // It is a merge, flatten it (this also means the merge has been
-                                // simplified):
-                                Term::Merge(terms) => {
-                                    simplified_once = true;
-                                    Ok(terms.clone())
-                                }
-                                // Not a merge, just return a single-element vector:
-                                _ => Ok(vec![simplified_term_id.unwrap_or(term_id)]),
-                            }
-                        })
-                        .try_fold(vec![], |mut all_terms, nested_terms| {
-                            // Combine all the nested terms
-                            all_terms.extend(nested_terms?);
-                            Ok(all_terms)
-                        })?;
-
-                    // @@Enhancement: here we can also collapse degenerate elements
-
-                    if simplified_once {
-                        // If any of them have been simplified, create a new term
-                        Ok(Some(self.builder().create_merge_term(inner_simplified)))
-                    } else {
-                        // No simplification occurred
-                        Ok(None)
-                    }
-                }
-            }
-            Term::Union(_) => {
-                // @@Todo
-                todo!()
-            }
+            Term::Merge(inner) => Ok(self
+                .simplify_algebraic_term_list(&inner, |term| match term {
+                    Term::Merge(terms) => Some(terms.clone()),
+                    _ => None,
+                })?
+                .map(|result| self.builder().create_merge_term(result))),
+            Term::Union(inner) => Ok(self
+                .simplify_algebraic_term_list(&inner, |term| match term {
+                    Term::Union(terms) => Some(terms.clone()),
+                    _ => None,
+                })?
+                .map(|result| self.builder().create_merge_term(result))),
             Term::AppSub(apply_sub) => Ok(Some(
                 // @@Performance: add Option<_> to the substituter to return
                 // terms which don't have the variables in them.

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1033,11 +1033,11 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     // Try to merge the two terms if they are the same:
                     if self.unifier().terms_are_equal(first, second) {
                         simplified_once = true;
-                        merged[*first_idx] = Some(first);
+                        merged[*first_idx] = merged[*first_idx].map(|_| first);
                         merged[*second_idx] = None;
                     } else {
-                        merged[*first_idx] = Some(first);
-                        merged[*second_idx] = Some(second);
+                        merged[*first_idx] = merged[*first_idx].map(|_| first);
+                        merged[*second_idx] = merged[*second_idx].map(|_| second);
                     }
                 }
                 _ => unreachable!(),
@@ -1046,7 +1046,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
         let result: Vec<_> = merged.into_iter().flatten().collect();
 
         // Only return if it has been simplified
-        if simplified_once {
+        if !simplified_once {
             Ok(None)
         } else {
             Ok(Some(result))

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -973,6 +973,26 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
         }
     }
 
+    /// Simplify the given set of terms by performing the following operations
+    /// (where ^ is the separator of the list):
+    ///
+    /// - Applying idempotency: B ^ B ^ C becomes B ^ C
+    /// - Flattening nests: B ^ (C ^ D) becomes B ^ C ^ D
+    /// - Simplifying inner terms:
+    ///  (<T> => (str, T))<i32> ^ C becomes (str, i32) ^ C
+    ///
+    /// This is to be used for merge and union types.
+    pub fn simplify_algebraic_term_list(
+        &mut self,
+        _term_list: &[TermId],
+    ) -> TcResult<Option<Vec<TermId>>> {
+        // @@Todo: we also need a function for unions and a function for merges for
+        // their specific properties (and we need to decide whether to have CNF or DNF
+        // as the simplified default---do we distribute unions over merges or merges
+        // over unions?)
+        todo!()
+    }
+
     /// Simplify the given term, if possible.
     ///
     /// This does not perform all validity checks, some are performed by
@@ -1034,8 +1054,10 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     }
                 }
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
+            Term::Union(_) => {
+                // @@Todo
+                todo!()
+            }
             Term::AppSub(apply_sub) => Ok(Some(
                 // @@Performance: add Option<_> to the substituter to return
                 // terms which don't have the variables in them.

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1072,7 +1072,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     Term::Union(terms) => Some(terms.clone()),
                     _ => None,
                 })?
-                .map(|result| self.builder().create_merge_term(result))),
+                .map(|result| self.builder().create_union_term(result))),
             Term::AppSub(apply_sub) => Ok(Some(
                 // @@Performance: add Option<_> to the substituter to return
                 // terms which don't have the variables in them.

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -215,8 +215,14 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                     .collect::<Vec<_>>();
                 self.builder().create_term(Term::Merge(terms))
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
+            Term::Union(terms) => {
+                // Apply the substitution to each element of the union.
+                let terms = terms
+                    .into_iter()
+                    .map(|term| self.apply_sub_to_term(sub, term))
+                    .collect::<Vec<_>>();
+                self.builder().create_term(Term::Union(terms))
+            }
             Term::TyFn(ty_fn) => {
                 // Apply the substitution to the general parameters, return type, and each case.
                 //

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -215,6 +215,8 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                     .collect::<Vec<_>>();
                 self.builder().create_term(Term::Merge(terms))
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
             Term::TyFn(ty_fn) => {
                 // Apply the substitution to the general parameters, return type, and each case.
                 //
@@ -480,6 +482,8 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                     self.add_free_vars_in_term_to_set(*inner_term_id, result);
                 }
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
             Term::TyFn(ty_fn) => {
                 // Add the vars in the subjects and return:
                 self.add_free_vars_in_term_to_set(ty_fn.general_return_ty, result);

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -488,8 +488,12 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                     self.add_free_vars_in_term_to_set(*inner_term_id, result);
                 }
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
+            Term::Union(terms) => {
+                // Free vars in each term:
+                for inner_term_id in terms {
+                    self.add_free_vars_in_term_to_set(*inner_term_id, result);
+                }
+            }
             Term::TyFn(ty_fn) => {
                 // Add the vars in the subjects and return:
                 self.add_free_vars_in_term_to_set(ty_fn.general_return_ty, result);

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -151,6 +151,8 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                     terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
             Term::AppSub(app_sub) => {
                 // The type of an AppSub is the type of the subject, with the substitution
                 // applied:

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -151,8 +151,12 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                     terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
+            Term::Union(terms) => {
+                // The type of a union is a union of the inner terms:
+                let tys_of_terms: Vec<_> =
+                    terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
+                Ok(self.builder().create_union_term(tys_of_terms))
+            }
             Term::AppSub(app_sub) => {
                 // The type of an AppSub is the type of the subject, with the substitution
                 // applied:

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -151,11 +151,11 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                     terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
-            Term::Union(terms) => {
-                // The type of a union is a union of the inner terms:
-                let tys_of_terms: Vec<_> =
-                    terms.iter().map(|term| self.ty_of_term(*term)).collect::<TcResult<_>>()?;
-                Ok(self.builder().create_union_term(tys_of_terms))
+            Term::Union(_) => {
+                // The type of a union is "RuntimeInstantiable":
+                // @@Future: relax this
+                let rt_instantiable_def = self.core_defs().runtime_instantiable_trt;
+                Ok(self.builder().create_trt_term(rt_instantiable_def))
             }
             Term::AppSub(app_sub) => {
                 // The type of an AppSub is the type of the subject, with the substitution

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -290,7 +290,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
                 for inner_target_id in inner_target {
-                    match self.unify_terms(inner_target_id, target_id) {
+                    match self.unify_terms(src_id, inner_target_id) {
                         Ok(result) => {
                             return Ok(result);
                         }
@@ -311,7 +311,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
                 for inner_src_id in inner_src {
-                    match self.unify_terms(src_id, inner_src_id) {
+                    match self.unify_terms(inner_src_id, target_id) {
                         Ok(result) => {
                             subs = self.unify_subs(&subs, &result)?;
                             continue;

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -252,7 +252,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
                 for inner_target_id in inner_target {
-                    match self.unify_terms(src_id, inner_target_id) {
+                    match self.unify_terms(simplified_src_id, inner_target_id) {
                         Ok(result) => {
                             subs = self.unify_subs(&subs, &result)?;
                             continue;
@@ -267,7 +267,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
                 for inner_src_id in inner_src {
-                    match self.unify_terms(inner_src_id, target_id) {
+                    match self.unify_terms(inner_src_id, simplified_target_id) {
                         Ok(result) => {
                             return Ok(result);
                         }
@@ -290,7 +290,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
                 for inner_target_id in inner_target {
-                    match self.unify_terms(src_id, inner_target_id) {
+                    match self.unify_terms(simplified_src_id, inner_target_id) {
                         Ok(result) => {
                             return Ok(result);
                         }
@@ -311,7 +311,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
                 for inner_src_id in inner_src {
-                    match self.unify_terms(inner_src_id, target_id) {
+                    match self.unify_terms(inner_src_id, simplified_target_id) {
                         Ok(result) => {
                             subs = self.unify_subs(&subs, &result)?;
                             continue;

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -210,6 +210,12 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
         Ok(cumulative_sub)
     }
 
+    /// Terms are equal if they unify both ways without any substitutions.
+    pub(crate) fn terms_are_equal(&mut self, a: TermId, b: TermId) -> bool {
+        self.unify_terms(a, b).contains(&Sub::empty())
+            && self.unify_terms(b, a).contains(&Sub::empty())
+    }
+
     /// Unify the two given terms, producing a substitution.
     ///
     /// The relation between src and target is that src must be a subtype (or

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -268,14 +268,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 let mut first_error = None;
                 for inner_src_id in inner_src {
                     match self.unify_terms(inner_src_id, simplified_target_id) {
-                        Ok(result) => {
-                            return Ok(result);
-                        }
-                        Err(e) if first_error.is_none() => {
-                            first_error = Some(e);
-                            continue;
-                        }
-                        _ => continue,
+                        Ok(result) => return Ok(result),
+                        Err(e) => first_error = first_error.or(Some(e)),
                     }
                 }
                 match first_error {
@@ -291,14 +285,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 let mut first_error = None;
                 for inner_target_id in inner_target {
                     match self.unify_terms(simplified_src_id, inner_target_id) {
-                        Ok(result) => {
-                            return Ok(result);
-                        }
-                        Err(e) if first_error.is_none() => {
-                            first_error = Some(e);
-                            continue;
-                        }
-                        _ => continue,
+                        Ok(result) => return Ok(result),
+                        Err(e) => first_error = first_error.or(Some(e)),
                     }
                 }
                 match first_error {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -278,6 +278,11 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 }
             }
 
+            // Union: @@Todo
+            (Term::Union(_), Term::Union(_)) => todo!(),
+            (Term::Union(_), Term::Level0(_)) => todo!(),
+            (Term::Level0(_), Term::Union(_)) => todo!(),
+
             // Access:
             (Term::Access(src_access), Term::Access(target_access))
                 if src_access.name == target_access.name =>

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -911,7 +911,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             // @@Enhance,@@ErrorReporting: we could possibly look at the type of the term?
             // Otherwise we could at least provide a better error message.
             Term::TyFnCall(_) | Term::Access(_) | Term::Var(_) => Ok(false),
-            Term::Merge(terms) => {
+            Term::Merge(terms) | Term::Union(terms) => {
                 // Valid if each element is okay to be used as the return type:
                 let terms = terms.clone();
                 for term in terms {
@@ -950,8 +950,6 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // This should be okay, for example if we are returning some TyFnTy value.
                 Ok(true)
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
         }
     }
 
@@ -970,7 +968,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             // @@Enhance,@@ErrorReporting: we could possibly look at the type of the term?
             // Otherwise we could at least provide a better error message.
             Term::TyFnCall(_) | Term::Access(_) | Term::Var(_) => Ok(false),
-            Term::Merge(terms) => {
+            Term::Union(terms) | Term::Merge(terms) => {
                 // Valid if each element is okay to be used as a parameter type:
                 let terms = terms.clone();
                 for term in terms {
@@ -1008,8 +1006,6 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // @@PotentiallyUnnecessary: is there some use case to allow this?
                 Ok(false)
             }
-            // @@Todo
-            Term::Union(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -476,9 +476,12 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             }
             // Union allowed if each inner term is allowed
             Term::Union(terms) => {
-                for term_id in terms.clone() {
-                    self.validate_merge_element(merge_kind, merge_term_id, term_id)?;
+                let mut initial_merge_kind = *merge_kind;
+                let terms = terms.clone();
+                for term_id in terms.iter() {
+                    self.validate_merge_element(&mut initial_merge_kind, merge_term_id, *term_id)?;
                 }
+                ensure_merge_is_level1(Some(merge_element_term_id))?;
                 Ok(())
             }
             // Level 3 terms are not allowed:

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -311,9 +311,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
     }
 
     /// Ensure the element `union_element_term_id` of the union with the given
-    /// `union_term_id` is level 1.
-    /// Furthermore, if it is level 1, the union should only have zero or one
-    /// nominal definition attached.
+    /// `union_term_id` is level 1, with each element containing 1 nominal.
     fn validate_union_element(
         &self,
         _simplified_term_id: TermId,
@@ -433,6 +431,13 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             Term::Unresolved(_) => {
                 Err(TcError::NeedMoreTypeAnnotationsToResolve { term: merge_element_term_id })
             }
+            // Union allowed if each inner term is allowed
+            Term::Union(terms) => {
+                for term_id in terms.clone() {
+                    self.validate_merge_element(merge_kind, merge_term_id, term_id)?;
+                }
+                Ok(())
+            }
             // Level 3 terms are not allowed:
             Term::Level3(_) => invalid_merge_element(),
             // Level 2 terms are allowed:
@@ -472,11 +477,6 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     self,
                     "Merge term should have already been flattened"
                 )
-            }
-            Term::Union(_) => {
-                // For now invalid
-                // @@Enhancement: implement union-merge simplification
-                invalid_merge_element()
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -64,6 +64,7 @@ impl Term {
             | Term::Var(_)
             | Term::Merge(_)
             | Term::TyFn(_)
+            | Term::Union(_)
             | Term::TyFnTy(_)
             | Term::TyFnCall(_) => TermLevel::Unknown,
             Term::AppSub(AppSub { term, .. }) => store.get(*term).get_term_level(store),
@@ -459,6 +460,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     "Merge term should have already been flattened"
                 )
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
         }
     }
 
@@ -543,6 +546,9 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     Ok(result)
                 }
             }
+
+            // @@Todo
+            Term::Union(_) => todo!(),
 
             // Level 1 terms:
             Term::Level1(level1_term) => match level1_term {
@@ -909,6 +915,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // This should be okay, for example if we are returning some TyFnTy value.
                 Ok(true)
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
         }
     }
 
@@ -965,6 +973,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // @@PotentiallyUnnecessary: is there some use case to allow this?
                 Ok(false)
             }
+            // @@Todo
+            Term::Union(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -89,6 +89,19 @@ impl CoreDefs {
         let any_ty = builder.create_any_ty_term();
         builder.add_pub_member_to_scope("AnyType", builder.create_trt_kind_term(), any_ty);
 
+        // Marker trait for types that are runtime instantiable
+        // We call this "Type" because that's what people usually mean when they say
+        // "type".
+        let runtime_instantiable_trt = builder.create_trt_def("Type", [], []);
+
+        // Never type
+        let never_ty = builder.create_never_ty_term();
+        builder.add_pub_member_to_scope(
+            "never",
+            builder.create_trt_term(runtime_instantiable_trt),
+            never_ty,
+        );
+
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
             Some("Ref"),
@@ -185,11 +198,6 @@ impl CoreDefs {
             ],
             [],
         );
-
-        // Marker trait for types that are runtime instantiable
-        // We call this "Type" because that's what people usually mean when they say
-        // "type".
-        let runtime_instantiable_trt = builder.create_trt_def("Type", [], []);
 
         // Collection types
         let list_ty_fn = builder.create_ty_fn_term(

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -95,7 +95,7 @@ impl CoreDefs {
         let runtime_instantiable_trt = builder.create_trt_def("Type", [], []);
 
         // Never type
-        let never_ty = builder.create_never_ty_term();
+        let never_ty = builder.create_never_term();
         builder.add_pub_member_to_scope(
             "never",
             builder.create_trt_term(runtime_instantiable_trt),

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -680,7 +680,7 @@ impl From<SubSubject> for Term {
 
 /// A substitution containing pairs of `(SubSubject, TermId)` to be applied to a
 /// term.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Sub {
     data: HashMap<SubSubject, TermId>,
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -820,6 +820,14 @@ pub enum Term {
     /// Is level N, where N is the level of the inner types.
     Merge(Vec<TermId>),
 
+    /// Union of multiple types.
+    ///
+    /// Inner types must have the same level. Union is also idempotent,
+    /// associative, and commutative.
+    ///
+    /// Is level N, where N is the level of the inner types.
+    Union(Vec<TermId>),
+
     /// A type function term.
     ///
     /// Is level N, where N is the level of the return term of the function.


### PR DESCRIPTION
This is needed to tackle #363 as well as for the "never" type which was missing up until now. In many ways, unions are dual to merges (and to tuples in other contexts). Currently only nominals can be "unioned", to support enum definitions as unions of structs. In the future this might change.

Closes #357.