### PR TITLE
TC: Implement traversal for imports

### DIFF
--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -1,7 +1,6 @@
 //! Contains helpers to read various things stored in [crate::storage] with
 //! ease.
 
-
 use crate::storage::{
     primitives::{
         Args, ArgsId, ModDef, ModDefId, NominalDef, NominalDefId, Params, ParamsId, Scope, ScopeId,

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -1,6 +1,6 @@
 //! Contains helpers to read various things stored in [crate::storage] with
 //! ease.
-use hash_source::SourceId;
+
 
 use crate::storage::{
     primitives::{
@@ -60,11 +60,5 @@ impl<'gs> PrimitiveReader<'gs> {
     /// Get the trait definition with the given [TrtDefId].
     pub fn get_trt_def(&self, trt_def_id: TrtDefId) -> &TrtDef {
         self.gs.trt_def_store.get(trt_def_id)
-    }
-
-    /// Get the module definition ID of the given source, if it has already been
-    /// checked.
-    pub fn get_source_term(&self, source_id: SourceId) -> Option<ModDefId> {
-        self.gs.checked_sources.source_type_id(source_id)
     }
 }

--- a/compiler/hash-typecheck/src/storage/sources.rs
+++ b/compiler/hash-typecheck/src/storage/sources.rs
@@ -1,5 +1,5 @@
 //! Contains structures to keep track of which sources have been typechecked.
-use super::primitives::ModDefId;
+use super::primitives::TermId;
 use hash_source::SourceId;
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 /// them to [ModDefId]s.
 #[derive(Debug, Default)]
 pub struct CheckedSources {
-    data: HashMap<SourceId, ModDefId>,
+    data: HashMap<SourceId, TermId>,
 }
 
 impl CheckedSources {
@@ -15,13 +15,13 @@ impl CheckedSources {
         Self::default()
     }
 
-    /// Mark a given source as checked, by providing its module type.
-    pub fn mark_checked(&mut self, source_id: SourceId, mod_def_id: ModDefId) {
-        self.data.insert(source_id, mod_def_id);
+    /// Mark a given source as checked, by providing its module term.
+    pub fn mark_checked(&mut self, source_id: SourceId, mod_def_term: TermId) {
+        self.data.insert(source_id, mod_def_term);
     }
 
-    /// Get the module type of the given source if it has already been checked.
-    pub fn source_type_id(&self, source_id: SourceId) -> Option<ModDefId> {
+    /// Get the module term of the given source if it has already been checked.
+    pub fn get_source_mod_def(&self, source_id: SourceId) -> Option<TermId> {
         self.data.get(&source_id).copied()
     }
 }


### PR DESCRIPTION
This includes marking sources as already checked. However, this does not handle cyclic imports yet, and currently the module resolution will loop forever. This should be tackled in a separate PR once we figure out how to deal with recursive definitions (see #367). 

Closes #335.