### PR TITLE
tc: implement traversal for `trait impl`s and `impl` blocks

### DIFF
--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -1,8 +1,5 @@
 //! Functionality related to resolving variables in scopes.
 
-// @@Temporary
-#![allow(dead_code)]
-
 use super::{AccessToOps, AccessToOpsMut};
 use crate::{
     diagnostics::error::{TcError, TcResult},

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -1,6 +1,4 @@
 //! Contains utilities to validate terms.
-#![allow(dead_code)]
-
 use std::fmt::Display;
 
 use super::{AccessToOps, AccessToOpsMut};


### PR DESCRIPTION
This is the final sub-task of implementing trait def/impl/mod blocks.

closes #340