### PR TITLE
TC: Implement traversal of index expressions and property access

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -236,6 +236,10 @@ impl<T> AstNodes<T> {
     pub fn span(&self) -> Option<Span> {
         self.span.or_else(|| Some(self.nodes.first()?.span().join(self.nodes.last()?.span())))
     }
+
+    pub fn ast_ref_iter(&self) -> impl Iterator<Item = AstNodeRef<T>> {
+        self.nodes.iter().map(|x| x.ast_ref())
+    }
 }
 
 impl<T> Deref for AstNodes<T> {

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -2,9 +2,9 @@
 //! debug output.
 use crate::storage::{
     primitives::{
-        ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, MemberData, ModDefId,
-        ModDefOrigin, Mutability, NominalDef, NominalDefId, ParamsId, ScopeId, StructDef, Sub,
-        SubSubject, Term, TermId, TrtDefId, UnresolvedTerm, Visibility,
+        AccessOp, ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, MemberData,
+        ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, ParamsId, ScopeId, StructDef,
+        Sub, SubSubject, Term, TermId, TrtDefId, UnresolvedTerm, Visibility,
     },
     GlobalStorage,
 };
@@ -311,7 +311,11 @@ impl<'gs> TcFormatter<'gs> {
             Term::Access(access_term) => {
                 opts.is_atomic.set(true);
                 self.fmt_term_as_single(f, access_term.subject, opts)?;
-                write!(f, "::{}", access_term.name)?;
+                let op = match access_term.op {
+                    AccessOp::Namespace => "::",
+                    AccessOp::Property => ".",
+                };
+                write!(f, "{}{}", op, access_term.name)?;
                 Ok(())
             }
             Term::Var(var) => {

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -292,6 +292,22 @@ impl<'gs> PrimitiveBuilder<'gs> {
         }
     }
 
+    /// Create a public member with the given name and value, with inferred
+    /// type.
+    pub fn create_constant_member_infer_ty(
+        &self,
+        name: impl Into<Identifier>,
+        value: TermId,
+        visibility: Visibility,
+    ) -> Member {
+        Member {
+            name: name.into(),
+            data: MemberData::InitialisedWithInferredTy { value },
+            visibility,
+            mutability: Mutability::Immutable,
+        }
+    }
+
     /// Create a public member with the given name, type and value.
     pub fn create_constant_member(
         &self,
@@ -589,6 +605,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create an argument with the given name and value.
     pub fn create_arg(&self, name: impl Into<Identifier>, value: TermId) -> Arg {
         Arg { name: Some(name.into()), value }
+    }
+
+    /// Create a nameless argument with the given value.
+    pub fn create_nameless_arg(&self, value: TermId) -> Arg {
+        Arg { name: None, value }
     }
 
     /// Create a type function application type, given type function value and

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -836,13 +836,14 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 // Apply the function:
 
                 // Must be a function:
-                let fn_ty = self.use_term_as_fn_call_subject(fn_call.subject)?;
+                let simplified_subject = self.potentially_simplify_term(fn_call.subject)?;
+                let fn_ty = self.use_term_as_fn_call_subject(simplified_subject)?;
 
                 // Unify params with args:
                 let params_sub = self.unifier().unify_params_with_args(
                     fn_ty.params,
                     fn_call.args,
-                    fn_call.subject,
+                    simplified_subject,
                     originating_term,
                     UnifyParamsWithArgsMode::UnifyParamTypesWithArgTypes,
                 )?;

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -97,14 +97,14 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
     }
 
     /// Convert an accessed type (or any other type for that matter) along with
-    /// a subject type, into a method call type.
+    /// a subject type, into a method call term.
     ///
     /// This is done by first ensuring that the accessed type is a function
     /// type. Then the first argument of the function type (self) is unified
     /// with the subject type. If that succeeds, a method function type is
     /// created, which is the same as the resolved function type without the
     /// first parameter (with the substitution from the unification applied).
-    fn turn_accessed_ty_and_subject_ty_into_method_ty(
+    fn turn_accessed_ty_and_subject_ty_into_method(
         &mut self,
         accessed_ty: TermId,
         subject_ty: TermId,
@@ -143,13 +143,13 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 let builder = self.builder();
 
                 // Return the substituted type without the first parameter:
-                Ok(builder.create_fn_ty_term(
+                Ok(builder.create_rt_term(builder.create_fn_ty_term(
                     builder.create_params(
                         subbed_params.into_positional().into_iter().skip(1),
                         ParamOrigin::Fn,
                     ),
                     fn_ty.return_ty,
-                ))
+                )))
             }
             _ => {
                 // Invalid because it is not a method:
@@ -249,7 +249,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     // To get the function type, we need to get the type of the result.
                     let ty_of_ty_access_result = self.typer().ty_of_term(ty_access_result)?;
                     // Then we can try turn this into a method call
-                    return Some(self.turn_accessed_ty_and_subject_ty_into_method_ty(
+                    return Some(self.turn_accessed_ty_and_subject_ty_into_method(
                         ty_of_ty_access_result,
                         *ty_term_id,
                         access_term.subject,
@@ -274,7 +274,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 match accessed_result {
                     Some(accessed_result) => {
                         // Now we can try turn this into a method call
-                        Some(self.turn_accessed_ty_and_subject_ty_into_method_ty(
+                        Some(self.turn_accessed_ty_and_subject_ty_into_method(
                             accessed_result,
                             *ty_term_id,
                             access_term.subject,
@@ -462,18 +462,16 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 }
             }
             Term::AppSub(app_sub) => {
-                // Apply the access on the subject:
+                // Add substitution to the scope:
+                let sub_scope = self.scope_resolver().enter_sub_param_scope(&app_sub.sub);
+
                 let inner_applied_term =
                     self.apply_access_term(&AccessTerm { subject: app_sub.term, ..*access_term })?;
-                match inner_applied_term {
-                    Some(inner_applied_term) => {
-                        // Successful access operation, apply the substitution on the result:
-                        Ok(Some(
-                            self.substituter().apply_sub_to_term(&app_sub.sub, inner_applied_term),
-                        ))
-                    }
-                    None => Ok(None), // Access resulted in no change
-                }
+
+                // Pop back the scope
+                self.scopes_mut().pop_the_scope(sub_scope);
+
+                Ok(inner_applied_term)
             }
             Term::Level3(level3_term) => {
                 self.apply_access_to_level3_term(&level3_term, access_term)

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -347,8 +347,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
             {
                 // Unify inner, then unify the resultant substitution with the ones given here:
                 let inner_sub = self.unify_terms(src_app_sub.term, target_app_sub.term)?;
-                let unified_app_subs = self.unify_subs(&src_app_sub.sub, &target_app_sub.sub)?;
-                self.unify_subs(&unified_app_subs, &inner_sub)
+                self.unify_subs(&src_app_sub.sub, &inner_sub)
             }
             (Term::AppSub(_), _) | (_, Term::AppSub(_)) => {
                 // Otherwise they don't unify (since we start with simplified terms)

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -6,7 +6,7 @@
 //! typechecker is concerned. This includes: integers, floats, characters,
 //! strings, lists, maps, references, etc.
 use super::{
-    primitives::{NominalDefId, ParamOrigin, TermId, TrtDefId, Visibility},
+    primitives::{ModDefOrigin, NominalDefId, ParamOrigin, TermId, TrtDefId, Visibility},
     GlobalStorage,
 };
 use crate::ops::building::PrimitiveBuilder;
@@ -37,6 +37,7 @@ pub struct CoreDefs {
     pub raw_reference_mut_ty_fn: TermId,
     pub hash_trt: TrtDefId,
     pub eq_trt: TrtDefId,
+    pub index_trt: TrtDefId,
     pub runtime_instantiable_trt: TrtDefId,
 }
 
@@ -94,6 +95,9 @@ impl CoreDefs {
         // "type".
         let runtime_instantiable_trt = builder.create_trt_def(Some("Type"), [], []);
 
+        // Helper for general type bound
+        let ty_term = builder.create_trt_term(runtime_instantiable_trt);
+
         // Never type
         let never_ty = builder.create_never_term();
         builder.add_pub_member_to_scope(
@@ -105,44 +109,32 @@ impl CoreDefs {
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
             Some("Ref"),
-            builder.create_params(
-                [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TyFn,
-            ),
-            builder.create_any_ty_term(),
+            builder.create_params([builder.create_param("T", ty_term)], ParamOrigin::TyFn),
+            ty_term,
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
         );
         let reference_mut_ty_fn = builder.create_ty_fn_term(
             Some("RefMut"),
-            builder.create_params(
-                [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TyFn,
-            ),
-            builder.create_any_ty_term(),
+            builder.create_params([builder.create_param("T", ty_term)], ParamOrigin::TyFn),
+            ty_term,
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
         );
         let raw_reference_ty_fn = builder.create_ty_fn_term(
             Some("RawRef"),
-            builder.create_params(
-                [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TyFn,
-            ),
-            builder.create_any_ty_term(),
+            builder.create_params([builder.create_param("T", ty_term)], ParamOrigin::TyFn),
+            ty_term,
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
         );
         let raw_reference_mut_ty_fn = builder.create_ty_fn_term(
             Some("RawRefMut"),
-            builder.create_params(
-                [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TyFn,
-            ),
-            builder.create_any_ty_term(),
+            builder.create_params([builder.create_param("T", ty_term)], ParamOrigin::TyFn),
+            ty_term,
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
@@ -154,11 +146,7 @@ impl CoreDefs {
         let hash_trt = builder.create_trt_def(
             Some("Hash"),
             [
-                builder.create_uninitialised_constant_member(
-                    "Self",
-                    builder.create_any_ty_term(),
-                    Visibility::Public,
-                ),
+                builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member(
                     "hash",
                     builder.create_fn_ty_term(
@@ -176,11 +164,7 @@ impl CoreDefs {
         let eq_trt = builder.create_trt_def(
             Some("Eq"),
             [
-                builder.create_uninitialised_constant_member(
-                    "Self",
-                    builder.create_any_ty_term(),
-                    Visibility::Public,
-                ),
+                builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member(
                     "eq",
                     builder.create_fn_ty_term(
@@ -199,17 +183,102 @@ impl CoreDefs {
             [],
         );
 
+        // Index trait
+        let index_trt = builder.create_trt_def(
+            "Index",
+            [
+                builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
+                builder.create_uninitialised_constant_member("Index", ty_term, Visibility::Public),
+                builder.create_uninitialised_constant_member("Output", ty_term, Visibility::Public),
+                builder.create_uninitialised_constant_member(
+                    "index",
+                    builder.create_fn_ty_term(
+                        builder.create_params(
+                            [
+                                builder.create_param("self", builder.create_var_term("Self")),
+                                builder.create_param("index", builder.create_var_term("Index")),
+                            ],
+                            ParamOrigin::Fn,
+                        ),
+                        builder.create_var_term("Output"),
+                    ),
+                    Visibility::Public,
+                ),
+            ],
+            [],
+        );
+
         // Collection types
+        let index_trt_term = builder.create_trt_term(index_trt);
+        let list_index_impl = builder.create_nameless_mod_def(
+            ModDefOrigin::TrtImpl(index_trt_term),
+            builder.create_constant_scope([
+                builder.create_constant_member(
+                    "Self",
+                    ty_term,
+                    builder.create_app_ty_fn_term(
+                        builder.create_var_term("List"),
+                        builder.create_args(
+                            [builder.create_nameless_arg(builder.create_var_term("T"))],
+                            ParamOrigin::TyFn,
+                        ),
+                    ),
+                    Visibility::Public,
+                ),
+                builder.create_constant_member(
+                    "Index",
+                    ty_term,
+                    // @@Todo: change this to use usize once we have a better way of inferring
+                    // numerics.
+                    builder.create_nominal_def_term(i32_ty),
+                    Visibility::Public,
+                ),
+                builder.create_constant_member(
+                    "Output",
+                    ty_term,
+                    builder.create_var_term("T"),
+                    Visibility::Public,
+                ),
+                builder.create_constant_member(
+                    "index",
+                    builder.create_fn_ty_term(
+                        builder.create_params(
+                            [
+                                builder.create_param("self", builder.create_var_term("Self")),
+                                builder.create_param("index", builder.create_var_term("Index")),
+                            ],
+                            ParamOrigin::Fn,
+                        ),
+                        builder.create_var_term("Output"),
+                    ),
+                    builder.create_fn_lit_term(
+                        builder.create_fn_ty_term(
+                            builder.create_params(
+                                [
+                                    builder.create_param("self", builder.create_var_term("Self")),
+                                    builder.create_param("index", builder.create_var_term("Index")),
+                                ],
+                                ParamOrigin::Fn,
+                            ),
+                            builder.create_var_term("Output"),
+                        ),
+                        builder.create_rt_term(builder.create_var_term("Output")),
+                    ),
+                    Visibility::Public,
+                ),
+            ]),
+            [builder.create_var("T")],
+        );
         let list_ty_fn = builder.create_ty_fn_term(
             Some("List"),
-            builder.create_params(
-                [builder.create_param("T", builder.create_any_ty_term())],
-                ParamOrigin::TyFn,
-            ),
-            builder.create_any_ty_term(),
-            builder.create_nominal_def_term(
-                builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
-            ),
+            builder.create_params([builder.create_param("T", ty_term)], ParamOrigin::TyFn),
+            ty_term,
+            builder.create_merge_term([
+                builder.create_nominal_def_term(
+                    builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
+                ),
+                builder.create_mod_def_term(list_index_impl),
+            ]),
         );
 
         let set_ty_fn = builder.create_ty_fn_term(
@@ -224,7 +293,7 @@ impl CoreDefs {
                 )],
                 ParamOrigin::TyFn,
             ),
-            builder.create_any_ty_term(),
+            ty_term,
             builder.create_nominal_def_term(
                 builder.create_nameless_opaque_struct_def([builder.create_var("T")]),
             ),
@@ -241,11 +310,11 @@ impl CoreDefs {
                             builder.create_trt_term(eq_trt),
                         ]),
                     ),
-                    builder.create_param("V", builder.create_any_ty_term()),
+                    builder.create_param("V", ty_term),
                 ],
                 ParamOrigin::TyFn,
             ),
-            builder.create_any_ty_term(),
+            ty_term,
             builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def([
                 builder.create_var("K"),
                 builder.create_var("V"),
@@ -276,6 +345,7 @@ impl CoreDefs {
             reference_mut_ty_fn,
             hash_trt,
             eq_trt,
+            index_trt,
             runtime_instantiable_trt,
         }
     }

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -185,7 +185,7 @@ impl CoreDefs {
 
         // Index trait
         let index_trt = builder.create_trt_def(
-            "Index",
+            Some("Index"),
             [
                 builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member("Index", ty_term, Visibility::Public),

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1594,10 +1594,8 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         // We just translate this to a function call:
         let builder = self.builder();
-        let index_fn_call_args = builder.create_args(
-            [builder.create_nameless_arg(subject), builder.create_nameless_arg(index_expr)],
-            ParamOrigin::Fn,
-        );
+        let index_fn_call_args =
+            builder.create_args([builder.create_nameless_arg(index_expr)], ParamOrigin::Fn);
         let index_fn_call_subject = builder.create_prop_access(subject, "index");
         let index_fn_call = builder.create_fn_call_term(index_fn_call_subject, index_fn_call_args);
 

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 use hash_ast::{
-    ast::{OwnsAstNode, RefKind},
+    ast::{AstNodeRef, OwnsAstNode, RefKind},
     visitor::{self, walk, AstVisitor},
 };
 use hash_pipeline::sources::{NodeMap, SourceRef};
@@ -100,9 +100,42 @@ impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
         Ok(result)
     }
 
-    /// Create a [SourceLocation] from a [Span]
+    /// Create a [SourceLocation] from a [Span].
     pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
         SourceLocation { span, source_id: self.source_id }
+    }
+
+    /// Create a [SourceLocation] at the given [hash_ast::ast::AstNode].
+    pub(crate) fn source_location_at_node<N>(&self, node: AstNodeRef<N>) -> SourceLocation {
+        let node_span = node.span();
+        self.source_location(node_span)
+    }
+
+    /// Copy the [SourceLocation] of the given [hash_ast::ast::AstNode] to the
+    /// given [LocationTarget].
+    pub(crate) fn copy_location_from_node_to_target<N>(
+        &mut self,
+        node: AstNodeRef<N>,
+        target: impl Into<LocationTarget>,
+    ) {
+        let location = self.source_location_at_node(node);
+        self.location_store_mut().add_location_to_target(target, location);
+    }
+
+    /// Copy the [SourceLocation] of the given [hash_ast::ast::AstNode] list to
+    /// the given [LocationTarget] list represented by a type `Target` where
+    /// `(Target, usize)` implements [Into<LocationTarget>].
+    pub(crate) fn copy_location_from_nodes_to_targets<'n, N: 'n, Target>(
+        &mut self,
+        nodes: impl IntoIterator<Item = AstNodeRef<'n, N>>,
+        targets: Target,
+    ) where
+        (Target, usize): Into<LocationTarget>,
+        Target: Copy,
+    {
+        for (index, param) in nodes.into_iter().enumerate() {
+            self.copy_location_from_node_to_target(param, (targets, index));
+        }
     }
 }
 
@@ -205,8 +238,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = builder.create_rt_term(map_ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -244,8 +276,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = builder.create_rt_term(list_ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -271,8 +302,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = builder.create_rt_term(set_ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -291,8 +321,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let value_ty = self.typer().ty_of_term(value)?;
 
         // Append location to value term
-        let value_location = self.source_location(node.value.span());
-        self.location_store_mut().add_location_to_target(value_ty, value_location);
+        self.copy_location_from_node_to_target(node.value.ast_ref(), value_ty);
 
         // Check that the type of the value and the type annotation match and then apply
         // the substitution onto ty
@@ -317,15 +346,9 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let params = builder.create_params(elements, ParamOrigin::Tuple);
         let term = builder.create_rt_term(builder.create_tuple_ty_term(params));
 
-        // add the location of each parameter
-        for (index, param) in node.elements.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((params, index), location);
-        }
-
-        // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        // add the location of each parameter, and the term, to the location storage
+        self.copy_location_from_nodes_to_targets(node.elements.ast_ref_iter(), params);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -342,8 +365,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -360,8 +382,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -378,8 +399,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -396,8 +416,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -414,8 +433,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(ty);
 
         // add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -459,8 +477,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
     ) -> Result<Self::VariableExprRet, Self::Error> {
         let walk::VariableExpr { name, .. } = walk::walk_variable_expr(self, ctx, node)?;
 
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(name, location);
+        self.copy_location_from_node_to_target(node, name);
 
         let TermValidation { simplified_term_id, .. } = self.validator().validate_term(name)?;
         Ok(simplified_term_id)
@@ -506,10 +523,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let args = self.builder().create_args(entries, ParamOrigin::Unknown);
 
         // Add locations:
-        for (index, arg) in node.entries.iter().enumerate() {
-            let location = self.source_location(arg.span());
-            self.location_store_mut().add_location_to_target((args, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.entries.ast_ref_iter(), args);
 
         Ok(args)
     }
@@ -529,8 +543,8 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let return_term = self.builder().create_rt_term(return_term_ty);
 
         // Set location:
-        let fn_call_location = self.source_location(node.span());
-        self.builder().add_location_to_target(return_term_ty, fn_call_location);
+        self.copy_location_from_node_to_target(node, return_term);
+        self.copy_location_from_node_to_target(node, return_term_ty);
 
         Ok(self.validator().validate_term(return_term)?.simplified_term_id)
     }
@@ -572,8 +586,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = builder.create_rt_term(ref_ty);
 
         // Add location to the type:
-        let ref_expr_span = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, ref_expr_span);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -632,8 +645,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(inner_ty);
 
         // Add the location to the type
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -736,8 +748,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
             None => {
                 // This should never happen because all modules should have been parsed by now.
                 let unresolved_import_term = self.builder().create_unresolved_term();
-                let import_location = self.source_location(node.span());
-                self.builder().add_location_to_target(unresolved_import_term, import_location);
+                self.copy_location_from_node_to_target(node, unresolved_import_term);
                 tc_panic!(
                     unresolved_import_term,
                     self,
@@ -778,18 +789,12 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let members = self.builder().create_params(entries, ParamOrigin::Tuple);
 
-        // We have to append locations to each of the parameters
-        for (index, entry) in node.body().entries.iter().enumerate() {
-            let location = self.source_location(entry.span());
-            self.location_store_mut().add_location_to_target((members, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.entries.ast_ref_iter(), members);
 
         let builder = self.builder();
         let term = builder.create_tuple_ty_term(members);
 
-        // Add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -813,9 +818,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let term = builder.create_rt_term(list_ty);
 
-        // Add the location to the type
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -839,9 +842,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let term = builder.create_rt_term(set_ty);
 
-        // Add the location to the type
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -868,9 +869,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let term = builder.create_rt_term(map_ty);
 
-        // Add the location to the type
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -883,11 +882,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::NamedFieldTyEntry>,
     ) -> Result<Self::NamedFieldTyRet, Self::Error> {
         let walk::NamedFieldTyEntry { ty, name } = walk::walk_named_field_ty(self, ctx, node)?;
-
-        // Add the location of the type
-        let location = self.source_location(node.ty.span());
-        self.location_store_mut().add_location_to_target(ty, location);
-
+        self.copy_location_from_node_to_target(node, ty);
         Ok(Param { ty, name, default_value: None })
     }
 
@@ -902,17 +897,13 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let params = self.builder().create_params(params, ParamOrigin::Fn);
 
         // Add all the locations to the parameters:
-        for (index, param) in node.params.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((params, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.params.ast_ref_iter(), params);
 
         // Create the function type term:
         let fn_ty_term = self.builder().create_fn_ty_term(params, return_ty);
 
         // Add location to the type:
-        let fn_ty_location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(fn_ty_term, fn_ty_location);
+        self.copy_location_from_node_to_target(node, fn_ty_term);
 
         Ok(self.validator().validate_term(fn_ty_term)?.simplified_term_id)
     }
@@ -957,17 +948,13 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         self.scopes_mut().pop_the_scope(param_scope);
 
         // Add all the locations to the parameters:
-        for (index, param) in node.params.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((params, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.params.ast_ref_iter(), params);
 
         // Create the type function type term:
         let ty_fn_ty_term = self.builder().create_ty_fn_ty_term(params, return_value);
 
         // Add location to the type:
-        let fn_ty_location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(ty_fn_ty_term, fn_ty_location);
+        self.copy_location_from_node_to_target(node, ty_fn_ty_term);
 
         Ok(self.validator().validate_term(ty_fn_ty_term)?.simplified_term_id)
     }
@@ -1000,17 +987,13 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         );
 
         // Add all the locations to the args:
-        for (index, entry) in node.body().args.iter().enumerate() {
-            let location = self.source_location(entry.span());
-            self.location_store_mut().add_location_to_target((args, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.args.ast_ref_iter(), args);
 
         // Create the type function call term:
         let app_ty_fn_term = self.builder().create_app_ty_fn_term(subject, args);
 
         // Add the location of the term to the location storage
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(app_ty_fn_term, location);
+        self.copy_location_from_node_to_target(node, app_ty_fn_term);
 
         Ok(self.validator().validate_term(app_ty_fn_term)?.simplified_term_id)
     }
@@ -1025,8 +1008,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         if node.name.path.len() == 1 && *node.name.path[0].body() == Identifier::from("_") {
             // Infer type if it is an underscore:
             let infer_term = self.builder().create_unresolved_term();
-            let infer_term_location = self.source_location(node.span());
-            self.builder().add_location_to_target(infer_term, infer_term_location);
+            self.copy_location_from_node_to_target(node, infer_term);
             Ok(infer_term)
         } else {
             let var = walk::walk_named_ty(self, ctx, node)?.name;
@@ -1059,15 +1041,13 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
                 self.core_defs().raw_reference_mut_ty_fn
             }
         };
-        let ref_ty_location = self.source_location(node.span());
-        let inner_ty_location = self.source_location(node.inner.span());
         let builder = self.builder();
         let ref_args = builder.create_args([builder.create_arg("T", inner)], ParamOrigin::TyFn);
         let ref_ty = builder.create_app_ty_fn_term(ref_def, ref_args);
 
         // Add locations:
-        builder.add_location_to_target(ref_ty, ref_ty_location);
-        builder.add_location_to_target(LocationTarget::Arg(ref_args, 0), inner_ty_location);
+        self.copy_location_from_node_to_target(node, ref_ty);
+        self.copy_location_from_node_to_target(node.inner.ast_ref(), (ref_args, 0));
 
         Ok(self.validator().validate_term(ref_ty)?.simplified_term_id)
     }
@@ -1084,8 +1064,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let merge_term = self.builder().create_merge_term(elements);
 
         // Add location
-        let merge_term_location = self.source_location(node.span());
-        self.builder().add_location_to_target(merge_term, merge_term_location);
+        self.copy_location_from_node_to_target(node, merge_term);
 
         Ok(self.validator().validate_term(merge_term)?.simplified_term_id)
     }
@@ -1105,10 +1084,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let params = self.builder().create_params(param_elements, ParamOrigin::TyFn);
 
         // Add all the locations to the parameters:
-        for (index, param) in node.params.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((params, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.params.ast_ref_iter(), params);
 
         // Enter parameter scope:
         let param_scope = self.scope_resolver().enter_ty_param_scope(params);
@@ -1130,8 +1106,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
             self.builder().create_nameless_ty_fn_term(params, ty_fn_return_ty, ty_fn_return_value);
 
         // Add location to the type function:
-        let fn_ty_location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(ty_fn_term, fn_ty_location);
+        self.copy_location_from_node_to_target(node, ty_fn_term);
 
         let simplified_ty_fn_term = self.validator().validate_term(ty_fn_term)?.simplified_term_id;
 
@@ -1188,11 +1163,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
             self.substituter().apply_sub_to_params(&body_sub, params_potentially_unresolved);
 
         // Add all the locations to the parameters
-        // @@Todo(feds01): re-factor this into a helper function
-        for (index, param) in node.params.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((params, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.params.ast_ref_iter(), params);
 
         // Remove the scope of the params after the body has been checked.
         self.scopes_mut().pop_the_scope(param_scope);
@@ -1201,6 +1172,8 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
         let fn_ty_term =
             builder.create_fn_lit_term(builder.create_fn_ty_term(params, return_ty), return_value);
+
+        self.copy_location_from_node_to_target(node, fn_ty_term);
 
         Ok(self.validator().validate_term(fn_ty_term)?.simplified_term_id)
     }
@@ -1268,8 +1241,8 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let term = self.builder().create_rt_term(void_ty);
 
         // Add the location of the type as the whole block
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1326,8 +1299,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         self.validator().validate_mod_def(mod_def, term)?;
 
         // Add location to the term
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1430,8 +1402,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let ret_ty = builder.create_void_ty_term();
         let term = builder.create_rt_term(ret_ty);
 
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1447,8 +1418,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let void_ty = builder.create_void_ty_term();
         let term = builder.create_rt_term(void_ty);
 
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1464,8 +1434,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let void_ty = builder.create_void_ty_term();
         let term = builder.create_rt_term(void_ty);
 
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1547,8 +1516,10 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
             visibility: Visibility::Private,
         });
 
-        let location = self.source_location(node.pattern.span());
-        self.location_store_mut().add_location_to_target((current_scope_id, member_id), location);
+        self.copy_location_from_node_to_target(
+            node.pattern.ast_ref(),
+            (current_scope_id, member_id),
+        );
 
         // Declaration should return its value if any:
         match value {
@@ -1612,10 +1583,23 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
 
     fn visit_index_expr(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::IndexExpression>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::IndexExpression>,
     ) -> Result<Self::IndexExpressionRet, Self::Error> {
-        todo!()
+        let walk::IndexExpr { index_expr, subject } = walk::walk_index_expr(self, ctx, node)?;
+
+        // We just translate this to a function call:
+        let builder = self.builder();
+        let index_fn_call_args =
+            builder.create_args([builder.create_arg("value", index_expr)], ParamOrigin::Fn);
+        let index_fn_call = builder.create_fn_call_term(subject, index_fn_call_args);
+
+        // Add locations:
+        self.copy_location_from_node_to_target(node, index_fn_call);
+        self.copy_location_from_node_to_target(node.index_expr.ast_ref(), (index_fn_call_args, 0));
+
+        // @@ErrorReporting: We could provide customised error reporting here.
+        Ok(self.validator().validate_term(index_fn_call)?.simplified_term_id)
     }
 
     type StructDefEntryRet = Param;
@@ -1690,10 +1674,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         let fields = self.builder().create_params(entries, ParamOrigin::Struct);
 
         // add the location of each parameter
-        for (index, param) in node.entries.iter().enumerate() {
-            let location = self.source_location(param.span());
-            self.location_store_mut().add_location_to_target((fields, index), location);
-        }
+        self.copy_location_from_nodes_to_targets(node.entries.ast_ref_iter(), fields);
 
         // take the declaration hint here...
         let name = self.state.declaration_name_hint.take();
@@ -1706,8 +1687,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         self.validator().validate_nominal_def(nominal_id)?;
 
         // add location to the struct definition
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -1765,8 +1745,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         self.validator().validate_nominal_def(nominal_id)?;
 
         // add location to the struct definition
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         Ok(term)
     }
@@ -2040,8 +2019,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         self.validator().validate_mod_def(mod_def, term)?;
 
         // Add location to the term
-        let location = self.source_location(node.span());
-        self.location_store_mut().add_location_to_target(term, location);
+        self.copy_location_from_node_to_target(node, term);
 
         self.scopes_mut().pop_the_scope(members);
 


### PR DESCRIPTION
In addition, this PR introduces convenience methods to make dealing with locations in the TC visitor more ergonomic.

Closes #332, closes #373.

Also opened #372 in order to actually make method calls work--right now you have to surround the subject in parentheses `(a.b)(c)` vs `a.b(c)`.