### PR TITLE
parser+ast: support for `union` type notation

### DIFF
--- a/compiler/hash-ast-desugaring/src/visitor.rs
+++ b/compiler/hash-ast-desugaring/src/visitor.rs
@@ -511,6 +511,16 @@ impl<'s> AstVisitorMut for AstDesugaring<'s> {
         Ok(())
     }
 
+    type UnionTyRet = ();
+
+    fn visit_union_ty(
+        &mut self,
+        _: &Self::Ctx,
+        _: hash_ast::ast::AstNodeRefMut<hash_ast::ast::UnionTy>,
+    ) -> Result<Self::UnionTyRet, Self::Error> {
+        Ok(())
+    }
+
     type TyFnDefRet = ();
 
     fn visit_ty_fn_def(

--- a/compiler/hash-ast-desugaring/src/visitor.rs
+++ b/compiler/hash-ast-desugaring/src/visitor.rs
@@ -513,13 +513,13 @@ impl<'s> AstVisitorMut for AstDesugaring<'s> {
         Ok(())
     }
 
-    type MergedTyRet = ();
+    type MergeTyRet = ();
 
-    fn visit_merged_ty(
+    fn visit_merge_ty(
         &mut self,
         _: &Self::Ctx,
-        _: hash_ast::ast::AstNodeRefMut<hash_ast::ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error> {
+        _: hash_ast::ast::AstNodeRefMut<hash_ast::ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error> {
         Ok(())
     }
 

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -509,6 +509,16 @@ impl AstVisitor for SemanticAnalyser<'_> {
         Ok(())
     }
 
+    type UnionTyRet = ();
+
+    fn visit_union_ty(
+        &mut self,
+        _: &Self::Ctx,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::UnionTy>,
+    ) -> Result<Self::UnionTyRet, Self::Error> {
+        Ok(())
+    }
+
     type TyFnDefRet = ();
 
     fn visit_ty_fn_def(

--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -510,13 +510,13 @@ impl AstVisitor for SemanticAnalyser<'_> {
         Ok(())
     }
 
-    type MergedTyRet = ();
+    type MergeTyRet = ();
 
-    fn visit_merged_ty(
+    fn visit_merge_ty(
         &mut self,
         _: &Self::Ctx,
-        _: hash_ast::ast::AstNodeRef<hash_ast::ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error> {
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error> {
         Ok(())
     }
 

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -397,9 +397,39 @@ pub struct TyFnCall {
 }
 
 /// A merged type meaning that multiple types are considered to be
-/// specified in place of one, e.g. `Conv ~ Eq ~ Print`
+/// specified in place of one, e.g. `Conv ~ Eq`
 #[derive(Debug, PartialEq, Clone)]
-pub struct MergedTy(pub AstNodes<Ty>);
+pub struct MergedTy {
+    pub lhs: AstNode<Ty>,
+    pub rhs: AstNode<Ty>,
+}
+
+/// A merged type meaning that multiple types are considered to be
+/// specified in place of one, e.g. `f64 | i64`
+#[derive(Debug, PartialEq, Clone)]
+pub struct UnionTy {
+    pub lhs: AstNode<Ty>,
+    pub rhs: AstNode<Ty>,
+}
+
+/// Binary type operators enumeration.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum TyOp {
+    /// The union of two types, essentially an or, e.g `f64 | u64`
+    Union,
+    /// The intersection between two types, essentially an `and`, `Ord ~ Eq`
+    Merge,
+}
+
+impl TyOp {
+    /// Compute the precedence for an operator
+    pub fn infix_binding_power(&self) -> (u8, u8) {
+        match self {
+            TyOp::Merge => (2, 3),
+            TyOp::Union => (4, 5),
+        }
+    }
+}
 
 /// A type.
 #[derive(Debug, PartialEq, Clone)]
@@ -412,6 +442,7 @@ pub enum Ty {
     Named(NamedTy),
     Ref(RefTy),
     Merged(MergedTy),
+    Union(UnionTy),
     TyFn(TyFn),
     TyFnCall(TyFnCall),
 }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -396,16 +396,15 @@ pub struct TyFnCall {
     pub args: AstNodes<NamedFieldTyEntry>,
 }
 
-/// A merged type meaning that multiple types are considered to be
+/// A merge type meaning that multiple types are considered to be
 /// specified in place of one, e.g. `Conv ~ Eq`
 #[derive(Debug, PartialEq, Clone)]
-pub struct MergedTy {
+pub struct MergeTy {
     pub lhs: AstNode<Ty>,
     pub rhs: AstNode<Ty>,
 }
 
-/// A merged type meaning that multiple types are considered to be
-/// specified in place of one, e.g. `f64 | i64`
+/// A union type meaning that multiple types are accepted, e.g. `f64 | i64`
 #[derive(Debug, PartialEq, Clone)]
 pub struct UnionTy {
     pub lhs: AstNode<Ty>,
@@ -414,19 +413,19 @@ pub struct UnionTy {
 
 /// Binary type operators enumeration.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum TyOp {
+pub enum BinTyOp {
     /// The union of two types, essentially an or, e.g `f64 | u64`
     Union,
     /// The intersection between two types, essentially an `and`, `Ord ~ Eq`
     Merge,
 }
 
-impl TyOp {
+impl BinTyOp {
     /// Compute the precedence for an operator
     pub fn infix_binding_power(&self) -> (u8, u8) {
         match self {
-            TyOp::Merge => (2, 3),
-            TyOp::Union => (4, 5),
+            BinTyOp::Merge => (2, 3),
+            BinTyOp::Union => (4, 5),
         }
     }
 }
@@ -441,7 +440,7 @@ pub enum Ty {
     Fn(FnTy),
     Named(NamedTy),
     Ref(RefTy),
-    Merged(MergedTy),
+    Merge(MergeTy),
     Union(UnionTy),
     TyFn(TyFn),
     TyFnCall(TyFnCall),

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -594,16 +594,16 @@ impl AstVisitor for AstTreeGenerator {
         ))
     }
 
-    type MergedTyRet = TreeNode;
-    fn visit_merged_ty(
+    type MergeTyRet = TreeNode;
+    fn visit_merge_ty(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error> {
-        let walk::MergedTy { lhs, rhs } = walk::walk_merged_ty(self, ctx, node)?;
+        node: ast::AstNodeRef<ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error> {
+        let walk::MergeTy { lhs, rhs } = walk::walk_merge_ty(self, ctx, node)?;
 
         Ok(TreeNode::branch(
-            "merged_ty",
+            "merge_ty",
             vec![TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
         ))
     }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -577,8 +577,26 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::MergedTy>,
     ) -> Result<Self::MergedTyRet, Self::Error> {
-        let walk::MergedTy(tys) = walk::walk_merged_ty(self, ctx, node)?;
-        Ok(TreeNode::branch("merged", tys))
+        let walk::MergedTy { lhs, rhs } = walk::walk_merged_ty(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            "merged_ty",
+            vec![TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
+        ))
+    }
+
+    type UnionTyRet = TreeNode;
+    fn visit_union_ty(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: ast::AstNodeRef<ast::UnionTy>,
+    ) -> Result<Self::UnionTyRet, Self::Error> {
+        let walk::UnionTy { lhs, rhs } = walk::walk_union_ty(self, ctx, node)?;
+
+        Ok(TreeNode::branch(
+            "union",
+            vec![TreeNode::branch("lhs", vec![lhs]), TreeNode::branch("rhs", vec![rhs])],
+        ))
     }
 
     type TyFnDefRet = TreeNode;

--- a/compiler/hash-ast/src/visitor.rs
+++ b/compiler/hash-ast/src/visitor.rs
@@ -350,12 +350,12 @@ pub trait AstVisitor: Sized {
         node: ast::AstNodeRef<ast::RefTy>,
     ) -> Result<Self::RefTyRet, Self::Error>;
 
-    type MergedTyRet;
-    fn visit_merged_ty(
+    type MergeTyRet;
+    fn visit_merge_ty(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRef<ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error>;
+        node: ast::AstNodeRef<ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error>;
 
     type UnionTyRet;
     fn visit_union_ty(
@@ -1078,12 +1078,12 @@ pub trait AstVisitorMut: Sized {
         node: ast::AstNodeRefMut<ast::RefTy>,
     ) -> Result<Self::RefTyRet, Self::Error>;
 
-    type MergedTyRet;
-    fn visit_merged_ty(
+    type MergeTyRet;
+    fn visit_merge_ty(
         &mut self,
         ctx: &Self::Ctx,
-        node: ast::AstNodeRefMut<ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error>;
+        node: ast::AstNodeRefMut<ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error>;
 
     type UnionTyRet;
     fn visit_union_ty(
@@ -2456,17 +2456,17 @@ pub mod walk {
         })
     }
 
-    pub struct MergedTy<V: AstVisitor> {
+    pub struct MergeTy<V: AstVisitor> {
         pub lhs: V::TyRet,
         pub rhs: V::TyRet,
     }
 
-    pub fn walk_merged_ty<V: AstVisitor>(
+    pub fn walk_merge_ty<V: AstVisitor>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        node: ast::AstNodeRef<ast::MergedTy>,
-    ) -> Result<MergedTy<V>, V::Error> {
-        Ok(MergedTy {
+        node: ast::AstNodeRef<ast::MergeTy>,
+    ) -> Result<MergeTy<V>, V::Error> {
+        Ok(MergeTy {
             lhs: visitor.visit_ty(ctx, node.lhs.ast_ref())?,
             rhs: visitor.visit_ty(ctx, node.rhs.ast_ref())?,
         })
@@ -2559,7 +2559,7 @@ pub mod walk {
         Map(V::MapTyRet),
         Named(V::NamedTyRet),
         Ref(V::RefTyRet),
-        Merged(V::MergedTyRet),
+        Merge(V::MergeTyRet),
         Union(V::UnionTyRet),
         TyFn(V::TyFnRet),
         TyFnCall(V::TyFnCallRet),
@@ -2578,7 +2578,7 @@ pub mod walk {
             ast::Ty::Map(r) => Ty::Map(visitor.visit_map_ty(ctx, node.with_body(r))?),
             ast::Ty::Named(r) => Ty::Named(visitor.visit_named_ty(ctx, node.with_body(r))?),
             ast::Ty::Ref(r) => Ty::Ref(visitor.visit_ref_ty(ctx, node.with_body(r))?),
-            ast::Ty::Merged(r) => Ty::Merged(visitor.visit_merged_ty(ctx, node.with_body(r))?),
+            ast::Ty::Merge(r) => Ty::Merge(visitor.visit_merge_ty(ctx, node.with_body(r))?),
             ast::Ty::Union(r) => Ty::Union(visitor.visit_union_ty(ctx, node.with_body(r))?),
             ast::Ty::TyFn(r) => Ty::TyFn(visitor.visit_ty_fn_ty(ctx, node.with_body(r))?),
             ast::Ty::TyFnCall(r) => Ty::TyFnCall(visitor.visit_ty_fn_call(ctx, node.with_body(r))?),
@@ -2599,7 +2599,7 @@ pub mod walk {
             MapTyRet = Ret,
             NamedTyRet = Ret,
             RefTyRet = Ret,
-            MergedTyRet = Ret,
+            MergeTyRet = Ret,
             UnionTyRet = Ret,
             TyFnRet = Ret,
             TyFnCallRet = Ret,
@@ -2613,7 +2613,7 @@ pub mod walk {
             Ty::Map(r) => r,
             Ty::Named(r) => r,
             Ty::Ref(r) => r,
-            Ty::Merged(r) => r,
+            Ty::Merge(r) => r,
             Ty::Union(r) => r,
             Ty::TyFn(r) => r,
             Ty::TyFnCall(r) => r,
@@ -4256,17 +4256,17 @@ pub mod walk_mut {
         })
     }
 
-    pub struct MergedTy<V: AstVisitorMut> {
+    pub struct MergeTy<V: AstVisitorMut> {
         pub lhs: V::TyRet,
         pub rhs: V::TyRet,
     }
 
-    pub fn walk_merged_ty<V: AstVisitorMut>(
+    pub fn walk_merge_ty<V: AstVisitorMut>(
         visitor: &mut V,
         ctx: &V::Ctx,
-        mut node: ast::AstNodeRefMut<ast::MergedTy>,
-    ) -> Result<MergedTy<V>, V::Error> {
-        Ok(MergedTy {
+        mut node: ast::AstNodeRefMut<ast::MergeTy>,
+    ) -> Result<MergeTy<V>, V::Error> {
+        Ok(MergeTy {
             lhs: visitor.visit_ty(ctx, node.lhs.ast_ref_mut())?,
             rhs: visitor.visit_ty(ctx, node.rhs.ast_ref_mut())?,
         })
@@ -4344,7 +4344,7 @@ pub mod walk_mut {
         Map(V::MapTyRet),
         Named(V::NamedTyRet),
         Ref(V::RefTyRet),
-        Merged(V::MergedTyRet),
+        Merge(V::MergeTyRet),
         Union(V::UnionTyRet),
         TyFn(V::TyFnRet),
         TyFnCall(V::TyFnCallRet),
@@ -4372,8 +4372,8 @@ pub mod walk_mut {
                 Ty::Named(visitor.visit_named_ty(ctx, AstNodeRefMut::new(r, span, id))?)
             }
             ast::Ty::Ref(r) => Ty::Ref(visitor.visit_ref_ty(ctx, AstNodeRefMut::new(r, span, id))?),
-            ast::Ty::Merged(r) => {
-                Ty::Merged(visitor.visit_merged_ty(ctx, AstNodeRefMut::new(r, span, id))?)
+            ast::Ty::Merge(r) => {
+                Ty::Merge(visitor.visit_merge_ty(ctx, AstNodeRefMut::new(r, span, id))?)
             }
             ast::Ty::Union(r) => {
                 Ty::Union(visitor.visit_union_ty(ctx, AstNodeRefMut::new(r, span, id))?)
@@ -4401,7 +4401,7 @@ pub mod walk_mut {
             MapTyRet = Ret,
             NamedTyRet = Ret,
             RefTyRet = Ret,
-            MergedTyRet = Ret,
+            MergeTyRet = Ret,
             UnionTyRet = Ret,
             TyFnRet = Ret,
             TyFnCallRet = Ret,
@@ -4415,7 +4415,7 @@ pub mod walk_mut {
             Ty::Map(r) => r,
             Ty::Named(r) => r,
             Ty::Ref(r) => r,
-            Ty::Merged(r) => r,
+            Ty::Merge(r) => r,
             Ty::Union(r) => r,
             Ty::TyFn(r) => r,
             Ty::TyFnCall(r) => r,

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -85,7 +85,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(self.node_with_joined_span(EnumDefEntry { name, args }, &name_span))
     }
 
-    /// Parse a [TypeFunctionDef]. Type functions specify logic at the type
+    /// Parse a [TyFnDef]. Type functions specify logic at the type
     /// level on expressions such as struct, enum, function, and trait
     /// definitions.
     pub fn parse_type_function_def(&self) -> AstGenResult<TyFnDef> {
@@ -135,7 +135,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(TyFnDef { params, return_ty, expr })
     }
 
-    // Parse a [TypeFunctionDefParam] which consists the name of the argument and
+    // Parse a [TyFnDefParam] which consists the name of the argument and
     // then any specified bounds on the argument which are essentially types
     // that are separated by a `~`
     fn parse_type_function_def_arg(&self) -> AstGenResult<AstNode<TyFnDefParam>> {

--- a/compiler/hash-parser/src/parser/expression.rs
+++ b/compiler/hash-parser/src/parser/expression.rs
@@ -398,13 +398,13 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                         );
 
                         // since we don't descend, we still need to update the precedence to
-                        // being 'r_prec'.
+                        // being `r_prec`.
                         min_prec = r_prec;
                     } else {
                         let rhs = self.parse_expression_with_precedence(r_prec)?;
                         self.is_compound_expr.set(true);
 
-                        // transform the operator into an OperatorFn
+                        // transform the operator into an `BinaryExpr`
                         lhs = self.node_with_joined_span(
                             Expression::new(ExpressionKind::BinaryExpr(BinaryExpression {
                                 lhs,

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -63,6 +63,17 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
     }
 
+    /// Function to parse a [TyOp] which returns a type operator if one is
+    /// present, and the number of tokens consumed. If no type operator follows,
+    /// then the consumed tokens count will be 0.
+    pub(crate) fn parse_type_operator(&self) -> (Option<TyOp>, u8) {
+        match self.peek() {
+            Some(token) if token.has_kind(TokenKind::Pipe) => (Some(TyOp::Union), 1),
+            Some(token) if token.has_kind(TokenKind::Tilde) => (Some(TyOp::Merge), 1),
+            _ => (None, 0),
+        }
+    }
+
     /// Function to parse a fat arrow component '=>' in any given context.
     pub(crate) fn parse_arrow(&self) -> AstGenResult<()> {
         // Essentially, we want to re-map the error into a more concise one given

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -66,10 +66,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Function to parse a [TyOp] which returns a type operator if one is
     /// present, and the number of tokens consumed. If no type operator follows,
     /// then the consumed tokens count will be 0.
-    pub(crate) fn parse_type_operator(&self) -> (Option<TyOp>, u8) {
+    pub(crate) fn parse_type_operator(&self) -> (Option<BinTyOp>, u8) {
         match self.peek() {
-            Some(token) if token.has_kind(TokenKind::Pipe) => (Some(TyOp::Union), 1),
-            Some(token) if token.has_kind(TokenKind::Tilde) => (Some(TyOp::Merge), 1),
+            Some(token) if token.has_kind(TokenKind::Pipe) => (Some(BinTyOp::Union), 1),
+            Some(token) if token.has_kind(TokenKind::Tilde) => (Some(BinTyOp::Merge), 1),
             _ => (None, 0),
         }
     }

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -40,14 +40,13 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     let rhs = self.parse_type_with_precedence(r_prec)?;
 
                     // transform the operator into an `UnaryTy` or `MergeTy` based on the operator
-                    lhs = match op {
-                        TyOp::Union => {
-                            self.node_with_joined_span(Ty::Union(UnionTy { lhs, rhs }), &lhs_span)
+                    lhs =
+                        match op {
+                            BinTyOp::Union => self
+                                .node_with_joined_span(Ty::Union(UnionTy { lhs, rhs }), &lhs_span),
+                            BinTyOp::Merge => self
+                                .node_with_joined_span(Ty::Merge(MergeTy { lhs, rhs }), &lhs_span),
                         }
-                        TyOp::Merge => {
-                            self.node_with_joined_span(Ty::Merged(MergedTy { lhs, rhs }), &lhs_span)
-                        }
-                    }
                 }
                 _ => break,
             }
@@ -56,9 +55,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(lhs)
     }
 
-    /// Parse a [Ty]. This includes only singular forms of a type. This means
-    /// that [Type::Merged] variant is not handled because it makes the
-    /// `parse_type` function carry context from one call to the other.
+    /// Parse a [Ty]. This includes only singular forms of a type.
     fn parse_singular_type(&self) -> AstGenResult<AstNode<Ty>> {
         let token = self.peek().ok_or_else(|| {
             self.make_error(AstGenErrorKind::ExpectedType, None, None, Some(self.next_location()))

--- a/compiler/hash-parser/src/parser/types.rs
+++ b/compiler/hash-parser/src/parser/types.rs
@@ -1,37 +1,62 @@
 //! Hash Compiler AST generation sources. This file contains the sources to the
 //! logic that transforms tokens into an AST.
-use hash_ast::{ast::*, ast_nodes};
+use hash_ast::ast::*;
 use hash_token::{delimiter::Delimiter, keyword::Keyword, Token, TokenKind, TokenKindVector};
 
 use super::{error::AstGenErrorKind, AstGen, AstGenResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
-    /// Parse a [Type]. This includes all forms of a [Type]. This function
-    /// does not deal with any kind of [Type] annotation or [TypeFunctionDef]
+    /// Parse a [Ty]. This includes all forms of a [Ty]. This function
+    /// does not deal with any kind of [Ty] annotation or [TyFnDef]
     /// syntax.
     pub(crate) fn parse_type(&self) -> AstGenResult<AstNode<Ty>> {
-        let start = self.current_location();
-        let initial_ty = self.parse_singular_type()?;
-
-        if self.parse_token_fast(TokenKind::Tilde).is_some() {
-            let mut inner_tys = ast_nodes!(initial_ty);
-
-            loop {
-                inner_tys.nodes.push(self.parse_singular_type()?);
-
-                match self.parse_token_fast(TokenKind::Tilde) {
-                    Some(_) => continue,
-                    None => break,
-                }
-            }
-
-            return Ok(self.node_with_joined_span(Ty::Merged(MergedTy(inner_tys)), &start));
-        }
-
-        Ok(initial_ty)
+        self.parse_type_with_precedence(0)
     }
 
-    /// Parse a [Type]. This includes only singular forms of a type. This means
+    /// Parse a [Ty] with precedence in mind. The type notation within hash
+    /// contains [TyOp] operators which are binary operators for type terms.
+    /// This function implements the same precedence algorithm for correctly
+    /// forming binary type expressions.
+    fn parse_type_with_precedence(&self, min_prec: u8) -> AstGenResult<AstNode<Ty>> {
+        let mut lhs = self.parse_singular_type()?;
+        let lhs_span = lhs.span();
+
+        loop {
+            let (op, consumed_tokens) = self.parse_type_operator();
+
+            match op {
+                Some(op) => {
+                    let (l_prec, r_prec) = op.infix_binding_power();
+
+                    // If the precedence from this operator is lower than our `min_prec` we
+                    // need to backtrack...
+                    if l_prec < min_prec {
+                        break;
+                    }
+
+                    self.offset.update(|x| x + consumed_tokens as usize);
+
+                    // Now recurse and get the `rhs` of the operator.
+                    let rhs = self.parse_type_with_precedence(r_prec)?;
+
+                    // transform the operator into an `UnaryTy` or `MergeTy` based on the operator
+                    lhs = match op {
+                        TyOp::Union => {
+                            self.node_with_joined_span(Ty::Union(UnionTy { lhs, rhs }), &lhs_span)
+                        }
+                        TyOp::Merge => {
+                            self.node_with_joined_span(Ty::Merged(MergedTy { lhs, rhs }), &lhs_span)
+                        }
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        Ok(lhs)
+    }
+
+    /// Parse a [Ty]. This includes only singular forms of a type. This means
     /// that [Type::Merged] variant is not handled because it makes the
     /// `parse_type` function carry context from one call to the other.
     fn parse_singular_type(&self) -> AstGenResult<AstNode<Ty>> {
@@ -199,7 +224,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
     /// Parses a [Type::Fn] which involves a parenthesis token tree with some
     /// arbitrary number of comma separated types followed by a return
-    /// [Type] that is preceded by an `thin-arrow` (->) after the
+    /// [Ty] that is preceded by an `thin-arrow` (->) after the
     /// parentheses. e.g. `(i32) -> str`
     fn parse_function_or_tuple_type(&self) -> AstGenResult<Ty> {
         let mut params = AstNodes::empty();

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1068,16 +1068,14 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         Ok(self.validator().validate_term(ref_ty)?.simplified_term_id)
     }
 
-    type MergedTyRet = TermId;
+    type MergeTyRet = TermId;
 
-    fn visit_merged_ty(
+    fn visit_merge_ty(
         &mut self,
         ctx: &Self::Ctx,
-        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergedTy>,
-    ) -> Result<Self::MergedTyRet, Self::Error> {
-        let walk::MergedTy { lhs, rhs } = walk::walk_merged_ty(self, ctx, node)?;
-
-        // @@Todo: do we need to potentially flatten the lhs and rhs?
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error> {
+        let walk::MergeTy { lhs, rhs } = walk::walk_merge_ty(self, ctx, node)?;
         let merge_term = self.builder().create_merge_term(vec![lhs, rhs]);
 
         // Add location
@@ -1094,8 +1092,6 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::UnionTy>,
     ) -> Result<Self::UnionTyRet, Self::Error> {
         let walk::UnionTy { lhs, rhs } = walk::walk_union_ty(self, ctx, node)?;
-
-        // @@Todo: do we need to potentially flatten the lhs and rhs?
         let union_term = self.builder().create_union_term(vec![lhs, rhs]);
 
         // Add location

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1065,14 +1065,33 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergedTy>,
     ) -> Result<Self::MergedTyRet, Self::Error> {
-        let walk::MergedTy(elements) = walk::walk_merged_ty(self, ctx, node)?;
+        let walk::MergedTy { lhs, rhs } = walk::walk_merged_ty(self, ctx, node)?;
 
-        let merge_term = self.builder().create_merge_term(elements);
+        // @@Todo: do we need to potentially flatten the lhs and rhs?
+        let merge_term = self.builder().create_merge_term(vec![lhs, rhs]);
 
         // Add location
         self.copy_location_from_node_to_target(node, merge_term);
 
         Ok(self.validator().validate_term(merge_term)?.simplified_term_id)
+    }
+
+    type UnionTyRet = TermId;
+
+    fn visit_union_ty(
+        &mut self,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::UnionTy>,
+    ) -> Result<Self::UnionTyRet, Self::Error> {
+        let walk::UnionTy { lhs, rhs } = walk::walk_union_ty(self, ctx, node)?;
+
+        // @@Todo: do we need to potentially flatten the lhs and rhs?
+        let union_term = self.builder().create_union_term(vec![lhs, rhs]);
+
+        // Add location
+        self.copy_location_from_node_to_target(node, union_term);
+
+        Ok(self.validator().validate_term(union_term)?.simplified_term_id)
     }
 
     type TyFnDefRet = TermId;

--- a/docs/src/features/types.md
+++ b/docs/src/features/types.md
@@ -13,7 +13,8 @@ type =
   | function_type
   | type_function_call
   | type_function
-  | merged_types
+  | merge_type
+  | union_type
   | ref_type
 
 tuple_type = ( "(" ( type "," )* ")" ) | ( "(" ( type "," )+ type ")" )
@@ -39,7 +40,8 @@ type_function_param = ident ( ":" type )? ( "=" type )?
 
 type_function = "<" ( type_function_param "," )* type_function_param? ">" "->" type
 
-merged_types = ( type "~" )+ type
+merge_type = ( type "~" )+ type
+union_type = ( type "|" )+ type
 
 ref_type = "&" ( "raw" )? ( "mut" )? type
 ```


### PR DESCRIPTION
This patch adds support within the AST and parser for
union type notation. The patch introduces the notion
of type operators which are equivalent to binary operators
but for types. Currently, `TyOp` has two variants which
are `Union` and `Merge`, where union operator has a
higher precedence then the merge operator.

closes [#362](https://github.com/hash-org/lang/issues/362)