### PR TITLE
TC: Add `Term::TyOf` in order to be able to perform algebra with types of terms

### DIFF
--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -1,5 +1,6 @@
 //! Contains utilities to format types for displaying in error messages and
 //! debug output.
+
 use crate::storage::{
     primitives::{
         AccessOp, ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, MemberData,
@@ -417,6 +418,16 @@ impl<'gs> TcFormatter<'gs> {
             Term::Root => {
                 opts.is_atomic.set(true);
                 write!(f, "Root")
+            }
+            Term::TyOf(term) => {
+                write!(
+                    f,
+                    "typeof({})",
+                    term.for_formatting_with_opts(
+                        self.global_storage,
+                        TcFormatOpts { expand: opts.expand, ..TcFormatOpts::default() }
+                    )
+                )
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -246,6 +246,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         def_id
     }
 
+    /// Create a [Term::TypeOf].
+    pub fn create_ty_of_term(&self, inner: TermId) -> TermId {
+        self.create_term(Term::TyOf(inner))
+    }
+
     /// Add a member to the scope, marking it as public.
     ///
     /// All other methods call this one to actually add members to the scope.

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -298,6 +298,11 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                     term: subbed_term,
                 }))
             }
+            Term::TyOf(term) => {
+                // Apply sub to inner:
+                let subbed_term = self.apply_sub_to_term(sub, term);
+                self.builder().create_ty_of_term(subbed_term)
+            }
             // Definite-level terms:
             Term::Level3(term) => self.apply_sub_to_level3_term(sub, term),
             Term::Level2(term) => self.apply_sub_to_level2_term(sub, term),
@@ -541,6 +546,10 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 for range_el in app_sub.sub.range() {
                     self.add_free_vars_in_term_to_set(range_el, result);
                 }
+            }
+            Term::TyOf(term) => {
+                // Add free vars in the inner term
+                self.add_free_vars_in_term_to_set(*term, result);
             }
             // Definite-level terms:
             Term::Level3(term) => {

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -220,8 +220,15 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                     }
                 }
             }
-            // The type of root is root
-            Term::Root => Ok(self.builder().create_root_term()),
+            Term::TyOf(_) => {
+                // Since this is simplified already, all we can do is wrap it again..
+                Ok(self.builder().create_ty_of_term(term_id))
+            }
+            // The type of root is typeof(root)
+            Term::Root => {
+                let builder = self.builder();
+                Ok(builder.create_ty_of_term(builder.create_root_term()))
+            }
         }?;
 
         self.location_store_mut().copy_location(term_id, new_term);

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -165,8 +165,8 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                 Ok(self.substituter().apply_sub_to_term(&app_sub.sub, ty_of_subject))
             }
             Term::Unresolved(_) => {
-                // The type of an unresolved variable is unresolved:
-                Ok(self.builder().create_unresolved_term())
+                // The type of an unresolved variable X is typeof(X):
+                Ok(self.builder().create_ty_of_term(term_id))
             }
             Term::Level3(level3_term) => match level3_term {
                 Level3Term::TrtKind => {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -540,6 +540,12 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
             // Root unifies with root and nothing else:
             (Term::Root, Term::Root) => Ok(Sub::empty()),
             (_, Term::Root) | (Term::Root, _) => cannot_unify(),
+
+            // Typeof unifies if the inner terms unify.
+            (Term::TyOf(src_inner), Term::TyOf(dest_inner)) => {
+                self.unify_terms(src_inner, dest_inner)
+            }
+            (_, Term::TyOf(_)) | (Term::TyOf(_), _) => cannot_unify(),
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -62,6 +62,7 @@ impl Term {
             | Term::Var(_)
             | Term::Merge(_)
             | Term::TyFn(_)
+            | Term::TyOf(_)
             | Term::Union(_)
             | Term::TyFnTy(_)
             | Term::TyFnCall(_) => TermLevel::Unknown,
@@ -396,6 +397,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             | Term::TyFnTy(_)
             | Term::Level0(_)
             | Term::Root
+            | Term::TyOf(_)
             | Term::TyFnCall(_)
             | Term::Access(_)
             | Term::Var(_) => invalid_union_element(),
@@ -562,6 +564,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             Term::Level0(_) => invalid_merge_element(),
             // Root is not allowed
             Term::Root => invalid_merge_element(),
+            // Unsimplifiable typeof is not allowed
+            Term::TyOf(_) => invalid_merge_element(),
             // This should have been flattened already:
             Term::Merge(_) => {
                 tc_panic_on_many!(
@@ -885,6 +889,9 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 Ok(result)
             }
 
+            // Typeof: recurse to inner
+            Term::TyOf(term) => self.validate_term(*term),
+
             // Type function application:
             Term::TyFnCall(app_ty_fn) => {
                 // Since this could be typed, it means the application is valid in terms of
@@ -1002,7 +1009,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             // These have not been resolved, for now we don't allow them.
             // @@Enhance,@@ErrorReporting: we could possibly look at the type of the term?
             // Otherwise we could at least provide a better error message.
-            Term::TyFnCall(_) | Term::Access(_) | Term::Var(_) => Ok(false),
+            Term::TyOf(_) | Term::TyFnCall(_) | Term::Access(_) | Term::Var(_) => Ok(false),
             Term::Merge(terms) | Term::Union(terms) => {
                 // Valid if each element is okay to be used as the return type:
                 let terms = terms.clone();
@@ -1094,7 +1101,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
             Term::Level2(_) | Term::Level3(_) => Ok(true),
             // Level 1 terms are not ok (because their instances are runtime)
             Term::Level1(_) => Ok(false),
-            Term::Root => {
+            Term::TyOf(_) | Term::Root => {
                 // @@PotentiallyUnnecessary: is there some use case to allow this?
                 Ok(false)
             }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -870,6 +870,12 @@ pub enum Term {
     /// substitution has been applied.
     AppSub(AppSub),
 
+    /// Type of a term
+    ///
+    /// Equivalent to calling `ty_of_term` on [crate::ops::typing::Typer] before
+    /// simplification.
+    TyOf(TermId),
+
     /// Not yet resolved.
     ///
     /// Unknown level (but not 0), to be determined by unification.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -872,8 +872,7 @@ pub enum Term {
 
     /// Type of a term
     ///
-    /// Equivalent to calling `ty_of_term` on [crate::ops::typing::Typer] before
-    /// simplification.
+    /// Simplifies to calling `ty_of_term` on the inner term.
     TyOf(TermId),
 
     /// Not yet resolved.

--- a/tests/parser/tests/test_runner.rs
+++ b/tests/parser/tests/test_runner.rs
@@ -118,6 +118,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn ensure_regenerate_output_is_disabled() {
         assert!(
             !REGENERATE_OUTPUT,


### PR DESCRIPTION
This is needed for a few reasons:
1. So that we can support a typeof expression in the future
2. To eliminate the current inconsistency that typeof(Root) = Root.
3. To be able to implement mutually recursive definitions, by deferring the typing of various terms (instead leaving them as typeof(X)) until they are resolved.

Closes #385.