### PR TITLE
Prelude injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "hash-pipeline",
  "hash-reporting",
  "hash-source",
+ "if_chain",
  "rayon",
 ]
 
@@ -600,6 +601,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "hash-reporting",
  "hash-source",
  "hash-utils",
+ "if_chain",
  "itertools",
  "slotmap",
 ]

--- a/compiler/hash-ast-passes/Cargo.toml
+++ b/compiler/hash-ast-passes/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 rayon = "1.5.0"
 crossbeam-channel = "0.5.1"
+if_chain = "1.0.2"
 
 hash-ast = {path = "../hash-ast" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-ast-passes/src/analysis/block.rs
+++ b/compiler/hash-ast-passes/src/analysis/block.rs
@@ -8,7 +8,7 @@ use hash_ast::{
     visitor::AstVisitor,
 };
 
-use crate::diagnostics::{error::AnalysisErrorKind, BlockOrigin};
+use crate::diagnostics::{error::AnalysisErrorKind, origins::BlockOrigin};
 
 use super::SemanticAnalyser;
 

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -2,6 +2,7 @@
 //! definition with some shared functions to append diagnostics to the analyser.
 
 use crossbeam_channel::Sender;
+use hash_pipeline::sources::ModuleKind;
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId, SourceMap,
@@ -9,8 +10,9 @@ use hash_source::{
 
 use crate::diagnostics::{
     error::{AnalysisError, AnalysisErrorKind},
+    origins::BlockOrigin,
     warning::{AnalysisWarning, AnalysisWarningKind},
-    BlockOrigin, Diagnostic,
+    Diagnostic,
 };
 
 mod block;
@@ -32,11 +34,17 @@ pub struct SemanticAnalyser<'s> {
     /// The current scope of the traversal, representing which block the
     /// analyser is walking.
     pub(crate) current_block: BlockOrigin,
+    /// The kind of module that the semantic analysis is currently traversing.
+    pub(crate) module_kind: Option<ModuleKind>,
 }
 
 impl<'s> SemanticAnalyser<'s> {
     /// Create a new semantic analyser
-    pub fn new(source_map: &'s SourceMap, source_id: SourceId) -> Self {
+    pub fn new(
+        source_map: &'s SourceMap,
+        source_id: SourceId,
+        module_kind: Option<ModuleKind>,
+    ) -> Self {
         Self {
             is_in_loop: false,
             is_in_function: false,
@@ -45,6 +53,7 @@ impl<'s> SemanticAnalyser<'s> {
             source_id,
             source_map,
             current_block: BlockOrigin::Root,
+            module_kind,
         }
     }
 

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -2,7 +2,6 @@
 //! definition with some shared functions to append diagnostics to the analyser.
 
 use crossbeam_channel::Sender;
-use hash_pipeline::sources::ModuleKind;
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId, SourceMap,
@@ -34,17 +33,11 @@ pub struct SemanticAnalyser<'s> {
     /// The current scope of the traversal, representing which block the
     /// analyser is walking.
     pub(crate) current_block: BlockOrigin,
-    /// The kind of module that the semantic analysis is currently traversing.
-    pub(crate) module_kind: Option<ModuleKind>,
 }
 
 impl<'s> SemanticAnalyser<'s> {
     /// Create a new semantic analyser
-    pub fn new(
-        source_map: &'s SourceMap,
-        source_id: SourceId,
-        module_kind: Option<ModuleKind>,
-    ) -> Self {
+    pub fn new(source_map: &'s SourceMap, source_id: SourceId) -> Self {
         Self {
             is_in_loop: false,
             is_in_function: false,
@@ -53,7 +46,6 @@ impl<'s> SemanticAnalyser<'s> {
             source_id,
             source_map,
             current_block: BlockOrigin::Root,
-            module_kind,
         }
     }
 

--- a/compiler/hash-ast-passes/src/analysis/pat.rs
+++ b/compiler/hash-ast-passes/src/analysis/pat.rs
@@ -3,7 +3,7 @@
 
 use hash_ast::ast::{AstNodes, Pattern, TuplePatternEntry};
 
-use crate::diagnostics::{error::AnalysisErrorKind, PatternOrigin};
+use crate::diagnostics::{error::AnalysisErrorKind, origins::PatternOrigin};
 
 use super::SemanticAnalyser;
 

--- a/compiler/hash-ast-passes/src/diagnostics/directives.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/directives.rs
@@ -1,0 +1,114 @@
+//! Defined data types for constructing diagnostics in regards to directive
+//! expressions.
+
+use std::fmt::Display;
+
+use hash_ast::ast::{Block, BlockExpr, ExpressionKind};
+
+/// [DirectiveArgument] is a mapping between [ExpressionKind] to a simplified
+/// version for reporting on if a directive received the 'wrong' kind of
+/// argument. Some variants of [ExpressionKind] are collapsed into the general
+/// [DirectiveArgument::Expr] because it is irrelevant from the context of
+/// directive what the expression is.
+///
+/// Additionally, some of the inner variants of [ExpressionKind::Block] are
+/// expanded into the [DirectiveArgument] variants as their own standalone
+/// variants.
+pub enum DirectiveArgument {
+    ConstructorCall,
+    Directive,
+    Declaration,
+    Unsafe,
+    Literal,
+    Cast,
+    /// Since the AST is de-sugared at this point, it should be that `for`,
+    /// `while` and `loop` blocks end up here...
+    Loop,
+    /// Since the AST is de-sugared at this point, it should be that both
+    /// `match` and `if` blocks end up here...
+    Match,
+    /// The [hash_ast::ast::Block::Impl] variant
+    ImplBlock,
+    /// The [hash_ast::ast::Block::Mod] variant
+    ModBlock,
+    /// The [hash_ast::ast::Block::Body] variant
+    Block,
+    Import,
+    StructDef,
+    EnumDef,
+    TyFnDef,
+    TraitDef,
+    FnDef,
+    Ty,
+    Return,
+    Break,
+    Continue,
+    MergeDeclaration,
+    TraitImpl,
+    /// General expression
+    Expr,
+}
+
+impl From<&ExpressionKind> for DirectiveArgument {
+    fn from(expr: &ExpressionKind) -> Self {
+        match expr {
+            ExpressionKind::ConstructorCall(_) => DirectiveArgument::ConstructorCall,
+            ExpressionKind::Directive(_) => DirectiveArgument::Directive,
+            ExpressionKind::Declaration(_) => DirectiveArgument::Declaration,
+            ExpressionKind::Unsafe(_) => DirectiveArgument::Unsafe,
+            ExpressionKind::LiteralExpr(_) => DirectiveArgument::Literal,
+            ExpressionKind::Cast(_) => DirectiveArgument::Cast,
+            ExpressionKind::Block(BlockExpr(block)) => match block.body() {
+                Block::Loop(_) | Block::While(_) | Block::For(_) => DirectiveArgument::Loop,
+                Block::Match(_) | Block::If(_) => DirectiveArgument::Match,
+                Block::Mod(_) => DirectiveArgument::ModBlock,
+                Block::Body(_) => DirectiveArgument::Block,
+                Block::Impl(_) => DirectiveArgument::ImplBlock,
+            },
+            ExpressionKind::Import(_) => DirectiveArgument::Import,
+            ExpressionKind::StructDef(_) => DirectiveArgument::StructDef,
+            ExpressionKind::EnumDef(_) => DirectiveArgument::EnumDef,
+            ExpressionKind::TyFnDef(_) => DirectiveArgument::TyFnDef,
+            ExpressionKind::TraitDef(_) => DirectiveArgument::TraitDef,
+            ExpressionKind::FnDef(_) => DirectiveArgument::FnDef,
+            ExpressionKind::Ty(_) => DirectiveArgument::Ty,
+            ExpressionKind::Return(_) => DirectiveArgument::Return,
+            ExpressionKind::Break(_) => DirectiveArgument::Break,
+            ExpressionKind::Continue(_) => DirectiveArgument::Continue,
+            ExpressionKind::MergeDeclaration(_) => DirectiveArgument::MergeDeclaration,
+            ExpressionKind::TraitImpl(_) => DirectiveArgument::TraitImpl,
+            _ => DirectiveArgument::Expr,
+        }
+    }
+}
+
+impl Display for DirectiveArgument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DirectiveArgument::ConstructorCall => write!(f, "a constructor call"),
+            DirectiveArgument::Directive => write!(f, "directive"),
+            DirectiveArgument::Declaration => write!(f, "declaration"),
+            DirectiveArgument::MergeDeclaration => write!(f, "merge declaration"),
+            DirectiveArgument::Unsafe => write!(f, "unsafe expression"),
+            DirectiveArgument::Literal => write!(f, "literal"),
+            DirectiveArgument::Cast => write!(f, "type cast"),
+            DirectiveArgument::Loop => write!(f, "`loop` block"),
+            DirectiveArgument::Match => write!(f, "`match` block"),
+            DirectiveArgument::ImplBlock => write!(f, "`impl` block"),
+            DirectiveArgument::ModBlock => write!(f, "`mod` block"),
+            DirectiveArgument::Block => write!(f, "body block"),
+            DirectiveArgument::Import => write!(f, "import"),
+            DirectiveArgument::StructDef => write!(f, "struct definition"),
+            DirectiveArgument::EnumDef => write!(f, "`enum` definition"),
+            DirectiveArgument::TyFnDef => write!(f, "`type` function definition"),
+            DirectiveArgument::TraitDef => write!(f, "`trait` definition"),
+            DirectiveArgument::FnDef => write!(f, "`function` definition"),
+            DirectiveArgument::Ty => write!(f, "type"),
+            DirectiveArgument::Return => write!(f, "return statement"),
+            DirectiveArgument::Break => write!(f, "break statement"),
+            DirectiveArgument::Continue => write!(f, "continue statement"),
+            DirectiveArgument::TraitImpl => write!(f, "`trait` implementation"),
+            DirectiveArgument::Expr => write!(f, "expression"),
+        }
+    }
+}

--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -2,12 +2,11 @@
 
 use hash_ast::ast::Visibility;
 use hash_error_codes::error_codes::HashErrorCode;
-use hash_pipeline::sources::ModuleKind;
 use hash_reporting::{
     builder::ReportBuilder,
     report::{Report, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind},
 };
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{identifier::Identifier, location::SourceLocation, ModuleKind};
 
 use super::{
     directives::DirectiveArgument,
@@ -204,15 +203,15 @@ impl From<AnalysisError> for Report {
                     )));
             }
             AnalysisErrorKind::DisallowedDirective { name, module_kind } => {
-                builder.with_message(format!(
-                    "the `{}` directive is disallowed within a non-prelude context",
-                    name
-                ));
-
                 let origin = match module_kind {
                     Some(_) => "this module",
                     None => "an interactive",
                 };
+
+                builder.with_message(format!(
+                    "the `{}` directive is disallowed within {} context",
+                    name, origin
+                ));
 
                 // Show the location where the directive is being used...
                 builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(

--- a/compiler/hash-ast-passes/src/diagnostics/error.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/error.rs
@@ -2,13 +2,17 @@
 
 use hash_ast::ast::Visibility;
 use hash_error_codes::error_codes::HashErrorCode;
+use hash_pipeline::sources::ModuleKind;
 use hash_reporting::{
     builder::ReportBuilder,
     report::{Report, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind},
 };
-use hash_source::location::SourceLocation;
+use hash_source::{identifier::Identifier, location::SourceLocation};
 
-use super::{BlockOrigin, FieldOrigin, PatternOrigin};
+use super::{
+    directives::DirectiveArgument,
+    origins::{BlockOrigin, FieldOrigin, PatternOrigin},
+};
 
 /// An error that can occur during the semantic pass
 pub struct AnalysisError {
@@ -62,6 +66,15 @@ pub(crate) enum AnalysisErrorKind {
     /// annotation and a default value, which means that there is not enough
     /// information at later stages to deduce the type of the field.
     InsufficientTypeAnnotations { origin: FieldOrigin },
+    /// When a directive is not allowed in the current module or context
+    DisallowedDirective { name: Identifier, module_kind: Option<ModuleKind> },
+    /// When a directive is expecting a particular expression, but received an
+    /// unexpected kind...
+    InvalidDirectiveArgument {
+        name: Identifier,
+        expected: DirectiveArgument,
+        given: DirectiveArgument,
+    },
 }
 
 impl From<AnalysisError> for Report {
@@ -189,6 +202,35 @@ impl From<AnalysisError> for Report {
                         ReportNoteKind::Help,
                         format!("consider giving this {} field a type annotation", origin),
                     )));
+            }
+            AnalysisErrorKind::DisallowedDirective { name, module_kind } => {
+                builder.with_message(format!(
+                    "the `{}` directive is disallowed within a non-prelude context",
+                    name
+                ));
+
+                let origin = match module_kind {
+                    Some(_) => "this module",
+                    None => "an interactive",
+                };
+
+                // Show the location where the directive is being used...
+                builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                    err.location,
+                    format!("`{}` cannot be used within {} context", name, origin),
+                )));
+            }
+            AnalysisErrorKind::InvalidDirectiveArgument { name, expected, given } => {
+                builder.with_message(format!(
+                    "the `{}` directive expects a {} as an argument",
+                    name, expected
+                ));
+
+                // Show the location where the directive is being used...
+                builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                    err.location,
+                    format!("a {} cannot be given to the `{}` directive", given, name),
+                )));
             }
         };
 

--- a/compiler/hash-ast-passes/src/diagnostics/mod.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/mod.rs
@@ -3,106 +3,11 @@
 
 use self::{error::AnalysisError, warning::AnalysisWarning};
 use hash_reporting::report::Report;
-use std::fmt::Display;
 
+pub(crate) mod directives;
 pub(crate) mod error;
+pub(crate) mod origins;
 pub(crate) mod warning;
-
-/// Denotes where a pattern was used as in the parent of the pattern. This is
-/// useful for propagating errors upwards by signalling what is the current
-/// parent of the pattern. This only contains patterns that can be compound
-/// (hold multiple children patterns).
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum PatternOrigin {
-    Tuple,
-    NamedField,
-    Constructor,
-    List,
-    Namespace,
-}
-
-impl PatternOrigin {
-    /// Convert the [PatternOrigin] into a string which can be used for
-    /// displaying within error messages.
-    fn to_str(self) -> &'static str {
-        match self {
-            PatternOrigin::Tuple => "tuple",
-            PatternOrigin::NamedField => "named field",
-            PatternOrigin::Constructor => "constructor",
-            PatternOrigin::List => "list",
-            PatternOrigin::Namespace => "namespace",
-        }
-    }
-}
-
-impl Display for PatternOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_str())
-    }
-}
-
-/// Denotes where an error occurred from which type of block. This is useful
-/// when giving more context about errors such as
-/// [AnalysisErrorKind::NonDeclarativeExpression] occur from.
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum BlockOrigin {
-    Root,
-    Mod,
-    Impl,
-    Body,
-}
-
-impl BlockOrigin {
-    /// Convert the [BlockOrigin] into a string which can be used for displaying
-    /// within error messages.
-    fn to_str(self) -> &'static str {
-        match self {
-            BlockOrigin::Root | BlockOrigin::Mod => "module",
-            BlockOrigin::Impl => "impl",
-            BlockOrigin::Body => "body",
-        }
-    }
-}
-
-impl Default for BlockOrigin {
-    fn default() -> Self {
-        BlockOrigin::Root
-    }
-}
-
-impl Display for BlockOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_str())
-    }
-}
-
-/// Denotes where an error occurred in regards to a field within a defined
-/// structural type which contains fields, such as `struct`, `tuple`, or
-/// `function literal`.
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum FieldOrigin {
-    Struct,
-    Tuple,
-    FnLiteral,
-}
-
-impl FieldOrigin {
-    /// Convert the [BlockOrigin] into a string which can be used for displaying
-    /// within error messages.
-    fn to_str(self) -> &'static str {
-        match self {
-            FieldOrigin::Struct => "struct",
-            FieldOrigin::Tuple => "tuple",
-            FieldOrigin::FnLiteral => "function literal",
-        }
-    }
-}
-
-impl Display for FieldOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_str())
-    }
-}
 
 /// Enum representing any generated message that can be emitted by the
 /// [SemanticAnalyser].

--- a/compiler/hash-ast-passes/src/diagnostics/origins.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/origins.rs
@@ -1,0 +1,101 @@
+//! Semantic analysis diagnostic origin data types definitions. The origin
+//! of an error in regards to a particular pattern, block or field type
+//! is recorded using the defined data types within this module.
+
+use std::fmt::Display;
+
+/// Denotes where a pattern was used as in the parent of the pattern. This is
+/// useful for propagating errors upwards by signalling what is the current
+/// parent of the pattern. This only contains patterns that can be compound
+/// (hold multiple children patterns).
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PatternOrigin {
+    Tuple,
+    NamedField,
+    Constructor,
+    List,
+    Namespace,
+}
+
+impl PatternOrigin {
+    /// Convert the [PatternOrigin] into a string which can be used for
+    /// displaying within error messages.
+    fn to_str(self) -> &'static str {
+        match self {
+            PatternOrigin::Tuple => "tuple",
+            PatternOrigin::NamedField => "named field",
+            PatternOrigin::Constructor => "constructor",
+            PatternOrigin::List => "list",
+            PatternOrigin::Namespace => "namespace",
+        }
+    }
+}
+
+impl Display for PatternOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+/// Denotes where an error occurred from which type of block. This is useful
+/// when giving more context about errors such as
+/// [AnalysisErrorKind::NonDeclarativeExpression] occur from.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum BlockOrigin {
+    Root,
+    Mod,
+    Impl,
+    Body,
+}
+
+impl BlockOrigin {
+    /// Convert the [BlockOrigin] into a string which can be used for displaying
+    /// within error messages.
+    fn to_str(self) -> &'static str {
+        match self {
+            BlockOrigin::Root | BlockOrigin::Mod => "module",
+            BlockOrigin::Impl => "impl",
+            BlockOrigin::Body => "body",
+        }
+    }
+}
+
+impl Default for BlockOrigin {
+    fn default() -> Self {
+        BlockOrigin::Root
+    }
+}
+
+impl Display for BlockOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}
+
+/// Denotes where an error occurred in regards to a field within a defined
+/// structural type which contains fields, such as `struct`, `tuple`, or
+/// `function literal`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum FieldOrigin {
+    Struct,
+    Tuple,
+    FnLiteral,
+}
+
+impl FieldOrigin {
+    /// Convert the [BlockOrigin] into a string which can be used for displaying
+    /// within error messages.
+    fn to_str(self) -> &'static str {
+        match self {
+            FieldOrigin::Struct => "struct",
+            FieldOrigin::Tuple => "tuple",
+            FieldOrigin::FnLiteral => "function literal",
+        }
+    }
+}
+
+impl Display for FieldOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}

--- a/compiler/hash-ast-passes/src/lib.rs
+++ b/compiler/hash-ast-passes/src/lib.rs
@@ -57,7 +57,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     let source = node_map.get_interactive_block_mut(id);
 
                     // setup a visitor and the context
-                    let mut visitor = SemanticAnalyser::new(source_map, entry_point);
+                    let mut visitor = SemanticAnalyser::new(source_map, entry_point, None);
 
                     visitor.visit_body_block(&(), source.node_ref()).unwrap();
                     visitor.send_generated_messages(&sender);
@@ -74,7 +74,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     continue;
                 }
 
-                let mut visitor = SemanticAnalyser::new(source_map, source_id);
+                let mut visitor = SemanticAnalyser::new(source_map, source_id, Some(module.kind()));
 
                 // Check that all of the root scope statements are only declarations
                 let errors = visitor.visit_module(&(), module.node_ref()).unwrap();
@@ -91,7 +91,8 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     let sender = sender.clone();
 
                     scope.spawn(move |_| {
-                        let mut visitor = SemanticAnalyser::new(source_map, source_id);
+                        let mut visitor =
+                            SemanticAnalyser::new(source_map, source_id, Some(module.kind()));
 
                         visitor.visit_expression(&(), expr.ast_ref()).unwrap();
                         visitor.send_generated_messages(&sender);

--- a/compiler/hash-ast-passes/src/lib.rs
+++ b/compiler/hash-ast-passes/src/lib.rs
@@ -57,7 +57,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     let source = node_map.get_interactive_block_mut(id);
 
                     // setup a visitor and the context
-                    let mut visitor = SemanticAnalyser::new(source_map, entry_point, None);
+                    let mut visitor = SemanticAnalyser::new(source_map, entry_point);
 
                     visitor.visit_body_block(&(), source.node_ref()).unwrap();
                     visitor.send_generated_messages(&sender);
@@ -74,7 +74,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     continue;
                 }
 
-                let mut visitor = SemanticAnalyser::new(source_map, source_id, Some(module.kind()));
+                let mut visitor = SemanticAnalyser::new(source_map, source_id);
 
                 // Check that all of the root scope statements are only declarations
                 let errors = visitor.visit_module(&(), module.node_ref()).unwrap();
@@ -91,8 +91,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                     let sender = sender.clone();
 
                     scope.spawn(move |_| {
-                        let mut visitor =
-                            SemanticAnalyser::new(source_map, source_id, Some(module.kind()));
+                        let mut visitor = SemanticAnalyser::new(source_map, source_id);
 
                         visitor.visit_expression(&(), expr.ast_ref()).unwrap();
                         visitor.send_generated_messages(&sender);

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -276,6 +276,14 @@ pub struct Name {
     pub ident: Identifier,
 }
 
+impl Name {
+    /// Function to check whether a [Name] has a particular associated name with
+    /// it.
+    pub fn is(&self, other: impl Into<Identifier>) -> bool {
+        self.ident == other.into()
+    }
+}
+
 /// A namespaced name, i.e. access name.
 #[derive(Debug, PartialEq, Clone)]
 pub struct AccessName {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -270,7 +270,7 @@ impl<T> DerefMut for AstNode<T> {
 }
 
 /// A single name/symbol.
-#[derive(Hash, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Hash, Debug, Clone, Copy)]
 pub struct Name {
     // The name of the symbol.
     pub ident: Identifier,

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -36,6 +36,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, V>(
     mut compiler: Compiler<'pool, P, D, S, C, V>,
+    mut compiler_state: CompilerState<'c, 'pool, D, S, C, V>,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -49,7 +50,6 @@ where
     print_version();
 
     let mut rl = Editor::<()>::new();
-    let mut compiler_state = compiler.create_state().unwrap();
 
     loop {
         let line = rl.readline(">>> ");

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -56,7 +56,7 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
 
     // Create a new import resolver in the event of more modules that
     // are encountered whilst parsing this module.
-    let resolver = ImportResolver::new(source_id, source.current_dir(), sender);
+    let resolver = ImportResolver::new(source_id, source.path(), sender);
 
     let gen = AstGen::new(&tokens, &trees, &resolver);
 

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -16,7 +16,7 @@ use hash_pipeline::{
     CompilerResult,
 };
 use hash_reporting::report::Report;
-use hash_source::{InteractiveId, ModuleId, SourceId};
+use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId};
 use import_resolver::ImportResolver;
 use parser::{error::ParseError, AstGen};
 use source::ParseSource;
@@ -126,8 +126,11 @@ impl<'pool> HashParser {
                             continue;
                         }
 
-                        let module_id =
-                            workspace.add_module(contents, Module::new(resolved_path.clone()));
+                        let module_id = workspace.add_module(
+                            contents,
+                            Module::new(resolved_path.clone()),
+                            ModuleKind::Normal,
+                        );
 
                         let source = ParseSource::from_module(module_id, workspace);
                         scope.spawn(move |_| parse_source(source, sender));

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -24,6 +24,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         match &(token.unwrap()).kind {
             // Since the 'as' keyword is also a binary operator, we have to handle it here...
             TokenKind::Keyword(Keyword::As) => (Some(BinOp::As), 1),
+            TokenKind::Tilde => match self.peek_second() {
+                Some(token) if token.kind == TokenKind::Eq =>(None, 0), // merge declaration
+                _ =>  (Some(BinOp::Merge), 1),
+            }
             TokenKind::Eq => match self.peek_second() {
                 Some(token) if token.kind == TokenKind::Eq => (Some(BinOp::EqEq), 2),
                 _ => (None, 0),

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -25,9 +25,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             // Since the 'as' keyword is also a binary operator, we have to handle it here...
             TokenKind::Keyword(Keyword::As) => (Some(BinOp::As), 1),
             TokenKind::Tilde => match self.peek_second() {
-                Some(token) if token.kind == TokenKind::Eq =>(None, 0), // merge declaration
-                _ =>  (Some(BinOp::Merge), 1),
-            }
+                Some(token) if token.kind == TokenKind::Eq => (None, 0), // merge declaration
+                _ => (Some(BinOp::Merge), 1),
+            },
             TokenKind::Eq => match self.peek_second() {
                 Some(token) if token.kind == TokenKind::Eq => (Some(BinOp::EqEq), 2),
                 _ => (None, 0),

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -66,7 +66,7 @@ impl ParseSource {
     }
 
     /// Get the `associated_path` with the [ParseSource]
-    pub fn current_dir(&self) -> &PathBuf {
+    pub fn path(&self) -> &PathBuf {
         &self.path
     }
 }

--- a/compiler/hash-pipeline/build.rs
+++ b/compiler/hash-pipeline/build.rs
@@ -1,0 +1,15 @@
+//! Build file for the `hash-pipeline` crate. This simply inlines the
+//! executable version into the executable.
+
+use std::path::PathBuf;
+
+/// The location of a build directory of this package, this used to resolve
+/// where the standard library is located at.
+static BUILD_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
+/// This is run at compile time to compute some meta data about the produced
+/// executable
+fn main() {
+    let stdlib_path: PathBuf = [BUILD_DIR, "..", "..", "stdlib"].iter().collect();
+    println!("cargo:rustc-env=STDLIB_PATH={}", stdlib_path.as_path().to_str().unwrap());
+}

--- a/compiler/hash-pipeline/src/fs.rs
+++ b/compiler/hash-pipeline/src/fs.rs
@@ -12,10 +12,10 @@ use thiserror::Error;
 
 /// The location of a build directory of this package, this used to resolve
 /// where the standard library is located at.
-static BUILD_DIR: &str = env!("CARGO_MANIFEST_DIR");
+static STDLIB: &str = env!("STDLIB_PATH");
 
 /// Name of the prelude module
-static PRELUDE: &str = "prelude";
+pub static PRELUDE: &str = concat!(env!("STDLIB_PATH"), "/", "prelude");
 
 /// Import error is an abstraction to represent errors that are in relevance to
 /// IO operations rather than parsing operations.
@@ -137,8 +137,7 @@ pub fn resolve_path(
     let path = path.as_ref();
     let wd = wd.as_ref();
 
-    let stdlib_path: PathBuf = [BUILD_DIR, "..", "stdlib"].iter().collect();
-    let modules = get_stdlib_modules(stdlib_path);
+    let modules = get_stdlib_modules(STDLIB);
 
     // check if the given path is equal to any of the standard library paths
     if modules.contains(&path.to_path_buf()) {
@@ -170,7 +169,7 @@ pub fn resolve_path(
         Err(ImportError {
             filename: path.to_path_buf(),
             message:
-                "This directory likely doesn't have a 'index.hash' module, consider creating one."
+                "This directory likely doesn't have a `index.hash` module, consider creating one."
                     .to_string(),
             src: location,
         })

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -488,7 +488,7 @@ where
         // Create the entry point and run!
         let entry_point = compiler_state
             .workspace
-            .add_module(contents.unwrap(), Module::new_with_kind(filename.clone(), kind));
+            .add_module(contents.unwrap(), Module::new_with_kind(filename, kind));
 
         self.run(SourceId::Module(entry_point), compiler_state, job_params)
     }

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -49,7 +49,7 @@ impl ast::OwnsAstNode<ast::BodyBlock> for InteractiveBlock {
 /// The [ModuleKind] enumeration describes what kind of module this is. If it is
 /// a [ModuleKind::Prelude], then certain things are allowed within this module
 /// in order to allow for `compiler` magic to interact with the prelude file.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ModuleKind {
     /// Any normal module that is within a workspace, including modules within
     /// the standard library.

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -215,9 +215,6 @@ pub struct Workspace {
     pub source_map: SourceMap,
     /// Stores all of the generated AST for modules and nodes
     pub node_map: NodeMap,
-    /// Whether or not this workspace has handled the bootstrapping of the
-    /// prelude which should happen for any workspace.
-    pub bootstrapped: bool,
 }
 
 impl Workspace {
@@ -227,7 +224,6 @@ impl Workspace {
             node_map: NodeMap::new(),
             source_map: SourceMap::new(),
             dependencies: HashMap::new(),
-            bootstrapped: false,
         }
     }
 

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -86,12 +86,16 @@ pub struct IdentifierMap<'c> {
 /// generating the AST.
 pub struct CoreIdentifiers {
     pub underscore: Identifier,
+    pub intrinsics: Identifier,
 }
 
 impl CoreIdentifiers {
     /// Create the core identifiers inside the given [IdentifierMap].
     pub fn from_ident_map(ident_map: &IdentifierMap) -> Self {
-        Self { underscore: ident_map.create_ident("_") }
+        Self {
+            underscore: ident_map.create_ident("_"),
+            intrinsics: ident_map.create_ident("intrinsics"),
+        }
     }
 }
 

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 slotmap = "1.0"
 dashmap = "5.1"
 itertools = "0.10"
+if_chain = "1.0.2"
 
 hash-ast = { path = "../hash-ast" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -46,7 +46,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
         match &err.error {
             TcError::CannotUnify { src, target } => {
                 builder.with_error_code(HashErrorCode::TypeMismatch).with_message(format!(
-                    "types mismatch wanted `{}`, but got `{}`",
+                    "types mismatch, wanted `{}`, but got `{}`",
                     target.for_formatting(err.global_storage()),
                     src.for_formatting(err.global_storage())
                 ));
@@ -510,7 +510,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         format!(
-                            "The property `{}` cannot be accessed from `{}`, it does not support property. accessing",
+                            "the property `{}` cannot be accessed from `{}`, it does not support property accessing",
                             name,
                             value.for_formatting(err.global_storage()),
                         ),

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     GlobalStorage,
 };
 use core::fmt;
-use std::{cell::Cell, rc::Rc};
+use std::{cell::Cell, fmt::Display, rc::Rc};
 
 // Contains various options regarding the formatting of terms.
 #[derive(Debug, Clone)]
@@ -534,6 +534,7 @@ pub trait PrepareForFormatting: Sized {
     }
 }
 
+impl<T: PrepareForFormatting> PrepareForFormatting for Option<T> {}
 impl PrepareForFormatting for TermId {}
 impl PrepareForFormatting for TrtDefId {}
 impl PrepareForFormatting for ModDefId {}
@@ -591,5 +592,25 @@ impl fmt::Display for ForFormatting<'_, ScopeId> {
 impl fmt::Display for ForFormatting<'_, &Sub> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         TcFormatter::new(self.global_storage).fmt_sub(f, self.t)
+    }
+}
+
+impl<'gs, T: PrepareForFormatting + Clone> fmt::Display for ForFormatting<'gs, Option<T>>
+where
+    ForFormatting<'gs, T>: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.t.as_ref() {
+            Some(t) => {
+                write!(
+                    f,
+                    "Some({})",
+                    t.clone().for_formatting_with_opts(self.global_storage, self.opts.clone())
+                )
+            }
+            None => {
+                write!(f, "None")
+            }
+        }
     }
 }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -337,7 +337,6 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
 
                 // Pop back the scope
                 self.scopes_mut().pop_the_scope(mod_def_scope);
-
                 Ok(result)
             }
             // Nominals:
@@ -420,6 +419,9 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
     fn apply_access_term(&mut self, access_term: &AccessTerm) -> TcResult<Option<TermId>> {
         let simplified_subject_id = self.potentially_simplify_term(access_term.subject)?;
         let simplified_subject = self.reader().get_term(simplified_subject_id).clone();
+
+        // Overwrite the the `subject` with `simplified_subject_id`
+        let access_term = &AccessTerm { subject: simplified_subject_id, ..*access_term };
 
         match simplified_subject {
             Term::Union(terms) => {

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -259,6 +259,9 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 self.unify_terms(src_inner, dest_inner)
             }
             (Term::TyOf(src_inner), _) => match self.term_store().get(src_inner).clone() {
+                // When the `src_inner` is an unresolved term, the unification between the target
+                // will yield a substitution `unresolved` -> `Rt(inner)`, so we need to verify
+                // that the inner term is runtime instantiable...
                 Term::Unresolved(inner)
                     if self.validator().term_is_runtime_instantiable(simplified_target_id)? =>
                 {
@@ -269,6 +272,9 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 _ => cannot_unify(),
             },
             (_, Term::TyOf(target_inner)) => match self.term_store().get(target_inner).clone() {
+                // When the `target_inner` is an unresolved term, the unification between the target
+                // will yield a substitution `unresolved` -> `Rt(inner)`, so we need to verify
+                // that the inner term is runtime instantiable...
                 Term::Unresolved(inner)
                     if self.validator().term_is_runtime_instantiable(simplified_src_id)? =>
                 {

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -270,6 +270,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
         &mut self,
         mod_def_id: ModDefId,
         originating_term_id: TermId,
+        allow_uninitialised: bool,
     ) -> TcResult<()> {
         let reader = self.reader();
         let mod_def = reader.get_mod_def(mod_def_id);
@@ -278,7 +279,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
 
         // Validate all members:
         // Bound vars should already be in scope.
-        self.validate_constant_scope(mod_def_members, false)?;
+        self.validate_constant_scope(mod_def_members, allow_uninitialised)?;
 
         // Ensure if it is a trait impl it implements all the trait members.
         if let ModDefOrigin::TrtImpl(trt_def_term_id) = mod_def_origin {

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -869,7 +869,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     // Ensure that the return type can be unified with the type of the return value:
                     // @@Safety: should be already simplified from above the match.
                     let return_value_ty = self.typer().ty_of_simplified_term(case.return_value)?;
-                    let _ = self.unifier().unify_terms(case.return_ty, return_value_ty)?;
+                    let _ = self.unifier().unify_terms(return_value_ty, case.return_ty)?;
 
                     // Ensure the return value of each case is a subtype of the general return type.
                     let _ = self.unifier().unify_terms(

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -106,6 +106,14 @@ impl CoreDefs {
             never_ty,
         );
 
+        // Void type
+        let void_ty = builder.create_void_ty_term();
+        builder.add_pub_member_to_scope(
+            "void",
+            builder.create_trt_term(runtime_instantiable_trt),
+            void_ty,
+        );
+
         // Reference types
         let reference_ty_fn = builder.create_ty_fn_term(
             Some("Ref"),

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -11,15 +11,15 @@ use hash_ast_passes::HashSemanticAnalysis;
 use hash_parser::HashParser;
 use hash_pipeline::{
     settings::{CompilerJobParams, CompilerMode, CompilerSettings},
-    sources::ModuleKind,
     Compiler,
 };
 use hash_reporting::errors::CompilerError;
+use hash_source::ModuleKind;
 use hash_typecheck::TcImpl;
 use hash_vm::vm::{Interpreter, InterpreterOptions};
 use log::LevelFilter;
 use logger::CompilerLogger;
-use std::{num::NonZeroUsize, panic, process::exit};
+use std::{num::NonZeroUsize, panic};
 
 use crate::{
     args::{AstGenMode, CheckMode, CompilerOptions, DeSugarMode, IrGenMode, SubCmd},
@@ -97,7 +97,7 @@ fn main() {
 
     let mut compiler =
         Compiler::new(parser, desugarer, semantic_analyser, checker, vm, &pool, compiler_settings);
-    let compiler_state = compiler.bootstrap().unwrap_or_else(|_| exit(-1));
+    let compiler_state = compiler.bootstrap();
 
     execute(|| {
         match entry_point {

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -120,7 +120,7 @@ fn main() {
                 compiler.run_on_filename(path, compiler_state, job_settings);
             }
             None => {
-                hash_interactive::init(compiler)?;
+                hash_interactive::init(compiler, compiler_state)?;
             }
         };
 

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -5,123 +5,47 @@
 // Description: Critical runtime module that is imported into any Hash
 // runtime by default. This module defines all the bindings between the
 // compiler interals and the program runtime.
+Intrinsics := #intrinsics mod {
+    // Output a line to standard output
+    pub print : (msg: str) -> void;
+ 
+    // Read a line from standard input
+    pub input : () -> str;
 
-// Output a line to standard output
-print := (msg: str) -> void => intrinsic_print(msg);
+    // Panic - kill the process and exit with a message.
+    pub panic : (msg: str) -> void;
 
-// Read a line from standard input
-input := () -> str => intrinsic_input();
-
-// Panic
-// Kill the process and exit with a message.
-panic := (msg: str) -> never => #intrinsic_panic(msg);
-
-// Unreachable case filling
-// For when you do a match case and need to provide a '_' case
-// you should use the 'unreachable' function
-unreachable := () -> never => panic("Reached unreachable case!");
-
-// Convert type A to type B
-Conv := <A, B> => trait {
-    conv : (item: A) -> B;
+    // The following are implemented for all numeric primitives:
+    //
 };
 
-// we provide a number of implementations for converting types
 
-// Blanket to string
-Conv ~= <T> => impl Conv<T, str> {
-    conv := (_) => "<unknown>";
+// Equality
+Eq := <T> => trait {
+    eq: (&T, &T) -> bool;
 };
 
-Conv ~= impl Conv<u64, f64> {
-    conv := (item) => intrinsic_conv_to_float(num);
+// Ordering
+// Implemented for numeric primitives and strings.
+Ordering := enum( Lt, Eq, Gt, );
+
+// Eq ~= impl Eq<Ordering> {
+//     eq := (a, b) => match (a, b) {
+//         (Eq, Eq) => true;
+//         (Lt, Lt) => true;
+//         (Gt, Gt) => true;
+//         _ => false;
+//     };
+// };
+
+Ord := <T> => trait {
+    ord: (a: T, b: T) -> Ordering;
 };
-
-// Fallible conversion methods for float, int, char from a `str`
-Conv ~= impl Conv<str, Result<float, str>> {
-    conv := (s) => #intrinsic_conv_to_float(s);
-};
-
-Conv ~= impl Conv<str, Result<int, str>> {
-    conv := (s) => intrinsic_conv_to_int(s);
-};
-
-Conv ~= impl Conv<int, Result<char, str>> {
-    conv := (s) => intrinsic_conv_to_char(s);
-};
-
-Conv ~= impl Conv<char, int> {  
-    conv := (ch) => intrinsic_conv_to_int(ch); 
-};
-
-Conv ~= impl Conv<float, int> { 
-    conv := (num) => intrinsic_conv_to_int(num); 
-};
-
-Conv ~= impl Conv<str, Result<int, str>> {
-    conv := (s) => intrinsic_conv_to_int(s);
-};
-
-Conv ~= impl Conv<bool, str> {
-    conv := (x) => match x {
-    true => "true";
-    false => "false";
-    };
-};
-
-Conv ~= impl Conv<int, str> { conv := (num) => intrinsic_conv_to_str(num); };
-Conv ~= impl Conv<float, str> { conv := (num) => intrinsic_conv_to_str(num); };
-Conv ~= impl Conv<char, str> { conv := (ch) => intrinsic_conv_to_str(ch); };
-Conv ~= impl Conv<void, str> { conv := (v) => ""; };
-
-Conv ~= impl Conv<{A:B}, str> { 
-    conv := (map) => intrinsic_conv_map_to_str(
-        map, 
-        (a) => conv<A, str>(a), 
-        (b) => conv<B, str>(b)
-    ); 
-};
-
-Conv ~= impl Conv<{A}, str> {
-    conv := (set) => intrinsic_conv_bracketted_to_str(set, (a) => conv<A, str>(a));
-};
-
-Conv ~= impl Conv<[A], str> {
-    conv := (arr) => intrinsic_conv_bracketted_to_str(arr, (a) => conv<A, str>(a)); 
-}; 
-
-// Tuples conv: @@TODO
-
-// Trait to get the size of an item, such as a bracktted type or a string
-Size := <A> => trait {
-    size : (item: A) -> usize;
-};
-
-Size ~= impl Size<[T]>    { size := (item) => intrinsic_size(item); };
-Size ~= impl Size<str>    { size := (item) => intrinsic_size(item); };
-Size ~= impl Size<{T}>    { size := (item) => intrinsic_size(item); };
-Size ~= impl Size<{K: V}> { size := (item) => intrinsic_size(item); };
 
 
 // Convert some type `T` into a `u64`. Hashing trait.
 Hash := <T> => trait {
-    hash : (item: T) -> u64;
-};
-
-Hash ~= impl Hash<int> { 
-    hash := (num) => #intrinsic_hash(num); 
-};
-
-Hash ~= impl Hash<float> { 
-    hash := (num) => #intrinsic_hash(num); 
-};
-
-Hash ~= impl Hash<char> { 
-    hash := (ch) => #intrinsic_hash(ch); 
-};
-
-Hash ~= impl Hash<str> { 
-    hash := (string) => #intrinsic_hash(string); 
+    hash : (item: &T) -> u64;
 };
 
 // Add operator (+)
@@ -130,223 +54,271 @@ Add := <T> => trait {
     add: (T, T) -> T;
 };
 
-Add ~= impl Add<int>   { add := (left, right) => intrinsic_add(left, right); };
-Add ~= impl Add<float> { add := (left, right) => intrinsic_add(left, right); };
-Add ~= impl Add<str>   { add := (left, right) => intrinsic_add(left, right);  };
-
-// adding sets and maps together
-// Add ~= impl Add<[A]>   { add := (left, right) => intrinsic_add(left, right); };
-// Add ~= impl Add<{A}>   { add := (left, right) => intrinsic_set_add(left, right); };
-// Add ~= impl Add<{A: B}>   { add := (left, right) => intrinsic_map_add(left, right); };
-
-// The following are implemented for all numeric primitives:
-
 // Subtract operator (-)
 Sub := <T> => trait {
     sub: (T, T) -> T;
 };
-
-Sub ~= impl Sub<int>   { sub := (left, right) => intrinsic_sub(left, right); };
-Sub ~= impl Sub<float> { sub := (left, right) => intrinsic_sub(left, right); };
 
 // Multiply operator (*)
 Mul := <T> => trait {
     mul: (T, T) -> T;
 };
 
-Mul ~= impl Mul<int>   { mul := (left, right) => intrinsic_mul(left, right); };
-Mul ~= impl Mul<float> { mul := (left, right) => intrinsic_mul(left, right); };
+// Mul ~= impl Mul<int>   { mul := (left, right) => intrinsic_mul(left, right); };
+// Mul ~= impl Mul<float> { mul := (left, right) => intrinsic_mul(left, right); };
 
 // Divide operator (/)
 Div := <T> => trait {
     div: (T, T) -> T;
 };
 
-Div ~= impl Div<int>   { div := (left, right) => intrinsic_div(left, right); };
-Div ~= impl Div<float> { div := (left, right) => intrinsic_div(left, right); };
+// Div ~= impl Div<int>   { div := (left, right) => intrinsic_div(left, right); };
+// Div ~= impl Div<float> { div := (left, right) => intrinsic_div(left, right); };
 
 // Modulus operator (%)
 Mod := <T> => trait {
     modulo: (T, T) -> T;
 };
 
-Mod ~= impl Mod<int>   { modulo := (left, right) => intrinsic_mod(left, right); };
-Mod ~= impl Mod<float> { modulo := (left, right) => intrinsic_mod(left, right); };
+// Mod ~= impl Mod<int>   { modulo := (left, right) => intrinsic_mod(left, right); };
+// Mod ~= impl Mod<float> { modulo := (left, right) => intrinsic_mod(left, right); };
 
-// Negation
+// Negation (-)
 Neg := <T> => trait {
     neg: (T) -> T;
 };
 
-Neg ~= impl Neg<int>   { neg := (item) => intrinsic_neg(item); };
-Neg ~= impl Neg<float> { neg := (item) => intrinsic_neg(item); };
-
-// Bitwise operations
-BitShr := <T> => trait {bit_shr : (T, T) -> T;};
-BitShl := <T> => trait {bit_shl : (T, T) -> T;};
-BitOr  := <T> => trait {bit_or  : (T, T) -> T;};
-BitXor := <T> => trait {bit_xor : (T, T) -> T;};
-
-BitNot := <T> => trait {bit_not : (T) -> T;};
-BitAnd := <T> => trait {bit_and : (T, T) -> T;};
-
-BitShr := impl BitShr<int> {bit_shr := (a, b) => #intrinsic_bit_shr(a, b); };
-BitShl := impl BitShl<int> {bit_shl := (a, b) => #intrinsic_bit_shl(a, b); };
-BitOr  := impl BitOr <int> {bit_or  := (a, b)=> #intrinsic_bit_or(b); };
-BitXor := impl BitXor<int> {bit_xor := (a, b)=> #intrinsic_bit_xor(b); };
-
-BitNot := impl BitNot<int> {bit_not := (a) => #intrinsic_bit_not(a); };
-BitAnd := impl BitAnd<int> {bit_and := (a) => #intrinsic_bit_and(a); };
+// Neg ~= impl Neg<int>   { neg := (item) => intrinsic_neg(item); };
+// Neg ~= impl Neg<float> { neg := (item) => intrinsic_neg(item); };
 
 
-// Equality
-Eq := <T> => trait {
-    eq: (T, T) -> bool;
+// // Bitwise shift right (<<)
+BitShr := <T> => trait {
+    bit_shr: (T, T) -> T; 
 };
 
+// BitShr := impl BitShr<int> {bit_shr := (a, b) => #intrinsic_bit_shr(a, b); };
 
-Eq ~= impl Eq<int> {
-    eq := (a, b) => intrinsic_eq(a, b);
+// Bitwise shift left (>>)
+BitShl := <T> => trait {
+    bit_shl: (T, T) -> T; 
 };
 
-Eq ~= impl Eq<char> {
-    eq := (a, b) => intrinsic_eq(a, b);
+// BitShl := impl BitShl<int> {bit_shl := (a, b) => #intrinsic_bit_shl(a, b); };
+
+// Bitwise or (|)
+BitOr  := <T> => trait {
+    bit_or: (T, T) -> T; 
 };
 
-Eq ~= impl Eq<float> {
-    eq := (a, b) => intrinsic_eq(a, b);
+// BitOr  := impl BitOr <int> {bit_or  := (a, b)=> #intrinsic_bit_or(b); };
+
+// Bitwise exclusice or (^)
+BitXor := <T> => trait {
+    bit_xor: (T, T) -> T; 
 };
 
-Eq ~= impl Eq<str> {
-    eq := (a, b) => intrinsic_eq(a, b);
+// BitXor := impl BitXor<int> {bit_xor := (a, b)=> #intrinsic_bit_xor(b); };
+
+// Bitwise not (~)
+BitNot := <T> => trait { 
+    bit_not: (T) -> T; 
 };
 
-Eq ~= <A: Eq> => impl Eq<[A]> {
-    eq := (a, b) => intrinsic_eq_bracketted(a, b, (x, y) => eq<A>(x, y));
+// BitNot := impl BitNot<int> {bit_not := (a) => #intrinsic_bit_not(a); };
+
+// Bitwise and (&)
+BitAnd := trait { 
+    Self: Type;
+
+    bit_and: (Self, Self) -> Self; 
 };
 
-// @@TODO: I think these are still flaky
-// let eq<{A}> where eq<A>, hash<A> = (a, b) => #intrinsic_eq_bracketted(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-// let eq<{A:B}> where eq<A>, hash<A>, eq<B> = (a, b) => #intrinsic_eq_map(a, b, (a) => hash<A>(a), (x, y) => eq<A>(x, y), (x, y) => eq<B>(x, y));
-
-
-// Ordering
-// Implemented for numeric primitives and strings.
-Ordering := enum( Lt, Eq, Gt, );
-
-Eq ~= impl Eq<Ordering> {
-    eq := (a, b) => match (a, b) {
-        (Eq, Eq) => true;
-        (Lt, Lt) => true;
-        (Gt, Gt) => true;
-        _ => false;
-    };
+BitAnd := impl BitAnd {
+    Self := u64;
+    // @@BUG: should fail here bruv
+    bit_and := (a: u64, b: u32) => 'c'; 
 };
 
-pub _int_to_ord := (i: int) -> Ordering => match i {
-    0 => Eq;
-    1 => Lt; 
-    x if x == -1 => Gt;
-    _ => unreachable();
+// Convert type A to type B
+Conv := <A, B> => trait {
+    conv : (item: A) -> B;
 };
 
+// we provide a number of implementations for converting types
 
-Ord := <T> => trait {
-    ord: (a: T, b: T) -> Ordering;
-};
+// // Enum primitive conv
+// Conv ~= <A: Conv<str>, B: Conv<str>> => impl Conv<Result<A, B>, str> {
+//     conv := (res: Result<A, B>) => match res { 
+//         Ok(a) => "Ok(" + conv(a) + ")"; 
+//         Err(b) => "Err(" + conv(b) + ")"; 
+//     };
+// };
+
+// Conv ~= <A: Conv<str>> => impl Conv<Option<A>, str> {
+//     conv := (res) => match res { 
+//         Some(a) => "Somw(" + conv(a) + ")"; 
+//         None => "None"; 
+//     };
+// };
+
+// Conv ~= impl Conv<u64, f64> {
+//     conv := (item) => intrinsic_conv_to_float(num);
+// };
+
+// // Fallible conversion methods for float, int, char from a `str`
+// Conv ~= impl Conv<str, Result<float, str>> {
+//     conv := (s) => #intrinsic_conv_to_float(s);
+// };
+
+// Conv ~= impl Conv<str, Result<int, str>> {
+//     conv := (s) => intrinsic_conv_to_int(s);
+// };
+
+// Conv ~= impl Conv<int, Result<char, str>> {
+//     conv := (s) => intrinsic_conv_to_char(s);
+// };
+
+// Conv ~= impl Conv<char, int> {  
+//     conv := (ch) => intrinsic_conv_to_int(ch); 
+// };
+
+// Conv ~= impl Conv<float, int> { 
+//     conv := (num) => intrinsic_conv_to_int(num); 
+// };
+
+// Conv ~= impl Conv<str, Result<int, str>> {
+//     conv := (s) => intrinsic_conv_to_int(s);
+// };
+
+// Conv ~= impl Conv<bool, str> {
+//     conv := (x) => match x {
+//     true => "true";
+//     false => "false";
+//     };
+// };
+
+// Conv ~= impl Conv<int, str> { conv := (num) => intrinsic_conv_to_str(num); };
+// Conv ~= impl Conv<float, str> { conv := (num) => intrinsic_conv_to_str(num); };
+// Conv ~= impl Conv<char, str> { conv := (ch) => intrinsic_conv_to_str(ch); };
+// Conv ~= impl Conv<void, str> { conv := (v) => ""; };
+
+// Conv ~= impl Conv<{A:B}, str> { 
+//     conv := (map) => intrinsic_conv_map_to_str(
+//         map, 
+//         (a) => conv<A, str>(a), 
+//         (b) => conv<B, str>(b)
+//     ); 
+// };
+
+// Conv ~= impl Conv<{A}, str> {
+//     conv := (set) => intrinsic_conv_bracketted_to_str(set, (a) => conv<A, str>(a));
+// };
+
+// Conv ~= impl Conv<[A], str> {
+//     conv := (arr) => intrinsic_conv_bracketted_to_str(arr, (a) => conv<A, str>(a)); 
+// }; 
+
+// Hash ~= impl Hash<int> { 
+//     hash := (num) => #intrinsic_hash(num); 
+// };
+
+// Hash ~= impl Hash<float> { 
+//     hash := (num) => #intrinsic_hash(num); 
+// };
+
+// Hash ~= impl Hash<char> { 
+//     hash := (ch) => #intrinsic_hash(ch); 
+// };
+
+// Hash ~= impl Hash<str> { 
+//     hash := (string) => #intrinsic_hash(string); 
+// };
 
 
-Ord ~= impl Ord<int> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
-Ord ~= impl Ord<char> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
-Ord ~= impl Ord<float> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
-Ord ~= impl Ord<str> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+
+// Index := <T, I, O> => trait {
+//     index : (T, I) -> O;
+// };
+
+// IndexMut := <T, I> => trait {
+//     index_mut : (T, I, O) -> void;
+// };
+
+// Add ~= impl Add<int>   { add := (left, right) => intrinsic_add(left, right); };
+// Add ~= impl Add<float> { add := (left, right) => intrinsic_add(left, right); };
+// Add ~= impl Add<str>   { add := (left, right) => intrinsic_add(left, right); };
+// Sub ~= impl Sub<int>   { sub := (left, right) => intrinsic_sub(left, right); };
+// Sub ~= impl Sub<float> { sub := (left, right) => intrinsic_sub(left, right); };
+
+// Eq ~= impl Eq<int> {
+//     eq := (a, b) => intrinsic_eq(a, b);
+// };
+
+// Eq ~= impl Eq<char> {
+//     eq := (a, b) => intrinsic_eq(a, b);
+// };
+
+// Eq ~= impl Eq<float> {
+//     eq := (a, b) => intrinsic_eq(a, b);
+// };
+
+// Eq ~= impl Eq<str> {
+//     eq := (a, b) => intrinsic_eq(a, b);
+// };
+
+// Eq ~= <A: Eq> => impl Eq<[A]> {
+//     eq := (a, b) => intrinsic_eq_bracketted(a, b, (x, y) => eq<A>(x, y));
+// };
+
+// pub _int_to_ord := (i: int) -> Ordering => match i {
+//     0 => Eq;
+//     1 => Lt; 
+//     x if x == -1 => Gt;
+//     _ => unreachable();
+// };
+
+
+// Ord ~= impl Ord<int> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+// Ord ~= impl Ord<char> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+// Ord ~= impl Ord<float> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
+// Ord ~= impl Ord<str> { ord := (a, b) => _int_to_ord(intrinsic_ord(a, b)); };
 
 // Indexing
 // Implemented for maps and lists.
 
-Index := <T, I, O> => trait {
-    index : (T, I) -> O;
-};
 
-IndexMut := <T, I> => trait {
-    index_mut : (T, I, O) -> void;
-};
+// Index ~= impl Index<[T], usize, T> { index := (arr, index) => intrinsic_index_get(arr, index); }; 
+// Index ~= impl Index<{A:B}, A, B> { index := (map, index) => intrinsic_index_map_get(map, index); }; 
 
+// IndexMut ~= impl IndexMut<[T], usize, T> { index := (arr, index, value) => intrinsic_index_mut(arr, index, value); }; 
+// IndexMut ~= impl IndexMut<{A:B}, A, B> { index := (map, index, value) => intrinsic_index_map_mut(map, index, value); }; 
 
-Index ~= impl Index<[T], usize, T> { index := (arr, index) => intrinsic_index_get(arr, index); }; 
-Index ~= impl Index<{A:B}, A, B> { index := (map, index) => intrinsic_index_map_get(map, index); }; 
-
-IndexMut ~= impl IndexMut<[T], usize, T> { index := (arr, index, value) => intrinsic_index_mut(arr, index, value); }; 
-IndexMut ~= impl IndexMut<{A:B}, A, B> { index := (map, index, value) => intrinsic_index_map_mut(map, index, value); }; 
-
-// Index a string, returning a character
-Index ~= impl Index<str, int, char> { 
-    index := (string, idx) => intrinsic_index_get(string, idx); 
-};
+// // Index a string, returning a character
+// Index ~= impl Index<str, int, char> { 
+//     index := (string, idx) => intrinsic_index_get(string, idx); 
+// };
 
 
 // append an item to a list
-Sequence := <A: Eq> => trait { 
-    inner := type A;
+// Sequence := <A: Eq> => trait { 
+//     inner := type A;
 
-    try_get : (Self, usize) -> Option<A>;
-    push: (Self, A) -> void;
-    push_front: (Self, A) -> void;
-    pop: (Self) -> A;
-    contains: (Self, A) -> bool;
-    insert: (Self, A, usize) -> void;
-    remove: (Self, usize) -> void;
-};
+//     try_get : (Self, usize) -> Option<A>;
+//     push: (Self, A) -> void;
+//     push_front: (Self, A) -> void;
+//     pop: (Self) -> A;
+//     contains: (Self, A) -> bool;
+//     insert: (Self, A, usize) -> void;
+//     remove: (Self, usize) -> void;
+// };
 
-Sequence ~= impl Sequence<[A]> {
-    try_get := (list, item) => intrinsic_list_try_get(list, item);
-    push := (list, item) => intrinsic_list_push(list, item);
-    push_front := (list, item) => intrinsic_list_push_front(list, item);
-    pop := (list) => intrinsic_list_pop(list);
-    contains := (list, item) => intrinsic_contains(list, item);
-    insert := (list, item, index) => intrinsic_list_insert(list, item, index);
-    remove := (list, index) => intrinsic_list_remove(list, index);
-};
-
-// checking if items exist within a bracketted type
-// trait contains = <B, A> => (B, A) => bool;
-
-// let contains<[A], A> where eq<A> = (arr, item) => #intrinsic_contains(arr, item);
-
-// let contains<{A}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-
-// let contains<{A:B}, A> where eq<A>, hash<A> = (arr, item) => #intrinsic_bracketted_contains(arr, item, (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-
-// // Delete a key from a map, and return its value.
-// trait remove = <C, A, B> => (C, A) => B;
-
-// let remove<[A], A, A> where eq<A> = (arr, key) => #intrinsic_list_remove(arr, key, (x, y) => eq<A>(x, y));
-
-// let remove<{A:B}, A, B> where eq<A>, hash<A> = (map, key) => #intrinsic_bracketted_remove(map, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-
-// let remove<{A}, A, A> where eq<A>, hash<A> = (set, key) => #intrinsic_bracketted_remove(set, key,  (a) => hash<A>(a), (x, y) => eq<A>(x, y));
-
-// Index a map a key, returning a value if the key exists
-// trait try_get = <A, B> where eq<A>, hash<A> => ({A:B}, A) => Option<B>; //@@TODO: should we add this?
-// let try_get<A, B> where eq<A>, hash<A>;
-
-
-// Enum primitive conv
-Conv ~= <A: Conv<str>, B: Conv<str>> => impl Conv<Result<A, B>, str> {
-    conv := (res: Result<A, B>) => match res { 
-        Ok(a) => "Ok(" + conv(a) + ")"; 
-        Err(b) => "Err(" + conv(b) + ")"; 
-    };
-};
-
-Conv ~= <A: Conv<str>> => impl Conv<Option<A>, str> {
-    conv := (res) => match res { 
-        Some(a) => "Somw(" + conv(a) + ")"; 
-        None => "None"; 
-    };
-};
-
-
-// @@TODO: Potentially move this to `string.hash`?
-// Slice a string at [begin, end)
-slice := (string: str, start: usize, end: usize) -> str => intrinsic_slice(string, start, end);
+// Sequence ~= impl Sequence<[A]> {
+//     try_get := (list, item) => intrinsic_list_try_get(list, item);
+//     push := (list, item) => intrinsic_list_push(list, item);
+//     push_front := (list, item) => intrinsic_list_push_front(list, item);
+//     pop := (list) => intrinsic_list_pop(list);
+//     contains := (list, item) => intrinsic_contains(list, item);
+//     insert := (list, item, index) => intrinsic_list_insert(list, item, index);
+//     remove := (list, index) => intrinsic_list_remove(list, index);
+// };

--- a/stdlib/string.hash
+++ b/stdlib/string.hash
@@ -1,0 +1,3 @@
+// @@TODO: Potentially move this to `string.hash`?
+// Slice a string at [begin, end)
+slice := (string: str, start: usize, end: usize) -> str => intrinsic_slice(string, start, end);

--- a/tests/parser/tests/test_runner.rs
+++ b/tests/parser/tests/test_runner.rs
@@ -9,7 +9,7 @@ use hash_pipeline::{
     traits::Parser,
 };
 use hash_reporting::{report::Report, writer::ReportWriter};
-use hash_source::SourceId;
+use hash_source::{ModuleKind, SourceId};
 use hash_utils::testing::TestingInput;
 use hash_utils_testing_macros::generate_tests;
 use lazy_static::lazy_static;
@@ -89,7 +89,7 @@ fn handle_test(input: TestingInput) {
     let target = Module::new(content_path.clone());
     let contents = read_in_path(content_path.as_path()).unwrap();
 
-    let target_id = workspace.add_module(contents, target);
+    let target_id = workspace.add_module(contents, target, ModuleKind::Normal);
 
     let mut parser = HashParser::new();
 


### PR DESCRIPTION
This patch expands the pipeline to automatically inject the `prelude`.  This also implements semantic checks for using the `intrinsic` directive 

Additionally, this fixes several issues within the typechecker.