### PR TITLE
TC: Factor out constant scope traversal

### DIFF
--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -1269,7 +1269,7 @@ impl AstVisitor for SemanticAnalyser<'_> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::Module>,
     ) -> Result<Self::ModuleRet, Self::Error> {
         let error_indices =
-            self.check_statements_are_declarative(&node.contents, BlockOrigin::Root);
+            self.check_members_are_declarative(node.contents.ast_ref_iter(), BlockOrigin::Root);
 
         Ok(error_indices)
     }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1068,6 +1068,14 @@ pub struct BodyBlock {
     pub expr: Option<AstNode<Expression>>,
 }
 
+impl BodyBlock {
+    /// Get the members of the body block: the list of statements as well as the
+    /// optional ending expression.
+    pub fn members(&self) -> impl Iterator<Item = AstNodeRef<Expression>> + '_ {
+        self.statements.ast_ref_iter().chain(self.expr.as_ref().map(|x| x.ast_ref()))
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct LoopBlock(pub AstNode<Block>);
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -449,11 +449,10 @@ impl<'gs> PrimitiveBuilder<'gs> {
     pub fn create_trt_def(
         &self,
         trait_name: Option<impl Into<Identifier>>,
-        members: impl IntoIterator<Item = Member>,
+        members: ScopeId,
         bound_vars: impl IntoIterator<Item = Var>,
     ) -> TrtDefId {
         let name = trait_name.map(|t| t.into());
-        let members = self.create_constant_scope(members);
 
         let trt_def_id = self.gs.borrow_mut().trt_def_store.create(TrtDef {
             name,

--- a/compiler/hash-typecheck/src/storage/core.rs
+++ b/compiler/hash-typecheck/src/storage/core.rs
@@ -93,7 +93,8 @@ impl CoreDefs {
         // Marker trait for types that are runtime instantiable
         // We call this "Type" because that's what people usually mean when they say
         // "type".
-        let runtime_instantiable_trt = builder.create_trt_def(Some("Type"), [], []);
+        let runtime_instantiable_trt =
+            builder.create_trt_def(Some("Type"), builder.create_constant_scope([]), []);
 
         // Helper for general type bound
         let ty_term = builder.create_trt_term(runtime_instantiable_trt);
@@ -153,7 +154,7 @@ impl CoreDefs {
         // Hash and Eq traits
         let hash_trt = builder.create_trt_def(
             Some("Hash"),
-            [
+            builder.create_constant_scope([
                 builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member(
                     "hash",
@@ -166,12 +167,12 @@ impl CoreDefs {
                     ),
                     Visibility::Public,
                 ),
-            ],
+            ]),
             [],
         );
         let eq_trt = builder.create_trt_def(
             Some("Eq"),
-            [
+            builder.create_constant_scope([
                 builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member(
                     "eq",
@@ -187,14 +188,14 @@ impl CoreDefs {
                     ),
                     Visibility::Public,
                 ),
-            ],
+            ]),
             [],
         );
 
         // Index trait
         let index_trt = builder.create_trt_def(
             Some("Index"),
-            [
+            builder.create_constant_scope([
                 builder.create_uninitialised_constant_member("Self", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member("Index", ty_term, Visibility::Public),
                 builder.create_uninitialised_constant_member("Output", ty_term, Visibility::Public),
@@ -212,7 +213,7 @@ impl CoreDefs {
                     ),
                     Visibility::Public,
                 ),
-            ],
+            ]),
             [],
         );
 

--- a/compiler/hash-typecheck/src/traverse/scopes.rs
+++ b/compiler/hash-typecheck/src/traverse/scopes.rs
@@ -1,0 +1,54 @@
+//! Typechecking traversal for constant scopes. This includes modules, mod/impl
+//! blocks, trait blocks.
+
+use super::TcVisitor;
+use crate::{
+    diagnostics::error::TcResult,
+    ops::AccessToOpsMut,
+    storage::{primitives::ScopeId, AccessToStorageMut},
+};
+use hash_ast::{ast, visitor::AstVisitor};
+use hash_source::identifier::Identifier;
+
+pub(crate) struct VisitConstantScope {
+    pub(crate) scope_name: Option<Identifier>,
+    pub(crate) scope_id: ScopeId,
+}
+
+impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
+    /// Visit a constant scope, creating a [ScopeId] corresponding to it, and a
+    /// derived name from a parent declaration.
+    ///
+    /// The `scope_to_use` parameter is optional and is used to override the
+    /// scope that is used to append all the members into. If not given, a new
+    /// constant scope is created and used.
+    pub(crate) fn visit_constant_scope<'m>(
+        &mut self,
+        ctx: &<Self as AstVisitor>::Ctx,
+        members: impl Iterator<Item = ast::AstNodeRef<'m, ast::Expression>>,
+        scope_to_use: Option<ScopeId>,
+    ) -> TcResult<VisitConstantScope> {
+        // Create a scope and enter it, for adding all the members:
+        let scope_id = scope_to_use.unwrap_or_else(|| self.builder().create_constant_scope([]));
+        self.scopes_mut().append(scope_id);
+
+        // @@Todo: deal with recursive declarations
+
+        // Invariant: It is already checked during semantics that only declarations are
+        // present in constant scopes.
+        for (i, member) in members.enumerate() {
+            self.visit_expression(ctx, member)?;
+
+            // Add location to the declaration
+            self.copy_location_from_node_to_target(member, (scope_id, i));
+        }
+
+        self.scopes_mut().pop_the_scope(scope_id);
+
+        // Get the name of the scope from the surrounding declaration hint, if any.
+        // This is only useful for mod/impl/trait blocks
+        let scope_name = self.state.declaration_name_hint.take();
+
+        Ok(VisitConstantScope { scope_name, scope_id })
+    }
+}


### PR DESCRIPTION
This is in order to be able to implement recursive definition support
from a central place.

Another change is to allow ending expressions in constant scopes,
treating them as the final declaration (similar to how tuples etc do not
need an ending delimiter).