### PR TITLE
TC: Implement patterns as typechecking primitives, and literal terms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "hash-utils",
  "if_chain",
  "itertools",
+ "num-bigint",
  "slotmap",
 ]
 
@@ -725,6 +726,36 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -9,6 +9,7 @@ slotmap = "1.0"
 dashmap = "5.1"
 itertools = "0.10"
 if_chain = "1.0.2"
+num-bigint = "0.4"
 
 hash-ast = { path = "../hash-ast" }
 hash-source = { path = "../hash-source" }

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -5,7 +5,8 @@ use crate::storage::{
     primitives::{
         AccessOp, ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm,
         MemberData, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, ParamsId,
-        ScopeId, StructDef, Sub, SubSubject, Term, TermId, TrtDefId, UnresolvedTerm, Visibility,
+        Pattern, PatternId, PatternParamsId, ScopeId, StructDef, Sub, SubSubject, Term, TermId,
+        TrtDefId, UnresolvedTerm, Visibility,
     },
     GlobalStorage,
 };
@@ -517,6 +518,116 @@ impl<'gs> TcFormatter<'gs> {
             },
         }
     }
+
+    /// Format the given [PatternParams] with the given formatter.
+    pub fn fmt_pattern_params(
+        &self,
+        f: &mut fmt::Formatter,
+        pattern_params_id: PatternParamsId,
+    ) -> fmt::Result {
+        let pattern_params = self.global_storage.pattern_params_store.get(pattern_params_id);
+
+        for (i, param) in pattern_params.positional().iter().enumerate() {
+            match param.name {
+                Some(param_name) => {
+                    write!(
+                        f,
+                        "{} = {}",
+                        param_name,
+                        param.pattern.for_formatting(self.global_storage)
+                    )?;
+                }
+                None => {
+                    self.fmt_pattern(f, param.pattern, TcFormatOpts::default())?;
+                }
+            }
+            if i != pattern_params.positional().len() - 1 {
+                write!(f, ", ")?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn fmt_pattern_as_single(
+        &self,
+        f: &mut fmt::Formatter,
+        pattern_id: PatternId,
+        opts: TcFormatOpts,
+    ) -> fmt::Result {
+        let pattern_fmt =
+            format!("{}", pattern_id.for_formatting_with_opts(self.global_storage, opts.clone()));
+        if !opts.is_atomic.get() {
+            write!(f, "(")?;
+        }
+        write!(f, "{}", pattern_fmt)?;
+        if !opts.is_atomic.get() {
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+
+    /// Format a [Pattern](crate::storage::primitives::Pattern) indexed by the
+    /// given [PatternId].
+    pub fn fmt_pattern(
+        &self,
+        f: &mut fmt::Formatter,
+        pattern_id: PatternId,
+        opts: TcFormatOpts,
+    ) -> fmt::Result {
+        let pattern = self.global_storage.pattern_store.get(pattern_id);
+        match pattern {
+            Pattern::Binding(binding) => {
+                let mutability = match binding.mutability {
+                    Mutability::Mutable => "mut ",
+                    Mutability::Immutable => "",
+                };
+                let visibility = match binding.visibility {
+                    Visibility::Public => "pub ",
+                    Visibility::Private => "priv ",
+                };
+                let name = binding.name;
+                opts.is_atomic.set(false);
+                write!(f, "{}{}{}", visibility, mutability, name)
+            }
+            Pattern::Lit(lit_term) => self.fmt_term(f, *lit_term, opts),
+            Pattern::Tuple(tuple_pattern) => {
+                opts.is_atomic.set(true);
+                write!(f, "({})", tuple_pattern.for_formatting(self.global_storage))
+            }
+            Pattern::Constructor(constructor_pattern) => {
+                opts.is_atomic.set(true);
+                self.fmt_term_as_single(f, constructor_pattern.subject, opts)?;
+                write!(f, "({})", constructor_pattern.params.for_formatting(self.global_storage))
+            }
+            Pattern::Or(patterns) => {
+                if patterns.is_empty() {
+                    opts.is_atomic.set(true);
+                    write!(f, "{{empty or pattern}}")?;
+                    Ok(())
+                } else {
+                    opts.is_atomic.set(false);
+                    for (i, pattern_id) in patterns.iter().enumerate() {
+                        self.fmt_pattern_as_single(f, *pattern_id, opts.clone())?;
+                        if i != patterns.len() - 1 {
+                            write!(f, " | ")?;
+                        }
+                    }
+                    Ok(())
+                }
+            }
+            Pattern::If(if_pattern) => {
+                opts.is_atomic.set(false);
+                self.fmt_pattern_as_single(f, if_pattern.pattern, opts.clone())?;
+                write!(f, " if ",)?;
+                self.fmt_term_as_single(f, if_pattern.condition, opts)?;
+                Ok(())
+            }
+            Pattern::Ignore => {
+                write!(f, "_")
+            }
+        }
+    }
 }
 
 /// Wraps a type `T` in a structure that contains information to be able to
@@ -556,6 +667,8 @@ impl PrepareForFormatting for NominalDefId {}
 impl PrepareForFormatting for ParamsId {}
 impl PrepareForFormatting for ArgsId {}
 impl PrepareForFormatting for ScopeId {}
+impl PrepareForFormatting for PatternParamsId {}
+impl PrepareForFormatting for PatternId {}
 impl PrepareForFormatting for &Sub {}
 
 // Convenience implementations of Display for the types that implement
@@ -588,6 +701,18 @@ impl fmt::Display for ForFormatting<'_, NominalDefId> {
 impl fmt::Display for ForFormatting<'_, ParamsId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         TcFormatter::new(self.global_storage).fmt_params(f, self.t)
+    }
+}
+
+impl fmt::Display for ForFormatting<'_, PatternParamsId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        TcFormatter::new(self.global_storage).fmt_pattern_params(f, self.t)
+    }
+}
+
+impl fmt::Display for ForFormatting<'_, PatternId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        TcFormatter::new(self.global_storage).fmt_pattern(f, self.t, self.opts.clone())
     }
 }
 

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -3,9 +3,9 @@
 
 use crate::storage::{
     primitives::{
-        AccessOp, ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, MemberData,
-        ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, ParamsId, ScopeId, StructDef,
-        Sub, SubSubject, Term, TermId, TrtDefId, UnresolvedTerm, Visibility,
+        AccessOp, ArgsId, EnumDef, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm,
+        MemberData, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, ParamsId,
+        ScopeId, StructDef, Sub, SubSubject, Term, TermId, TrtDefId, UnresolvedTerm, Visibility,
     },
     GlobalStorage,
 };
@@ -219,6 +219,20 @@ impl<'gs> TcFormatter<'gs> {
                 self.fmt_term_as_single(f, fn_call.subject, TcFormatOpts::default())?;
                 write!(f, "({})", fn_call.args.for_formatting(self.global_storage))?;
                 Ok(())
+            }
+            Level0Term::Lit(lit_term) => {
+                opts.is_atomic.set(true);
+                match lit_term {
+                    LitTerm::Str(str) => {
+                        write!(f, "\"{}\"", str)
+                    }
+                    LitTerm::Int(int) => {
+                        write!(f, "{}", int)
+                    }
+                    LitTerm::Char(char) => {
+                        write!(f, "\'{}\'", char)
+                    }
+                }
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -4,8 +4,8 @@ use crate::storage::{
     location::LocationTarget,
     primitives::{
         AccessOp, AccessTerm, AppSub, Arg, ArgsId, EnumDef, EnumVariant, EnumVariantValue, FnCall,
-        FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, Member, MemberData, ModDef,
-        ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList,
+        FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm, Member, MemberData,
+        ModDef, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList,
         ParamOrigin, ParamsId, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term,
         TermId, TrtDef, TrtDefId, TupleTy, TyFn, TyFnCall, TyFnCase, TyFnTy, UnresolvedTerm, Var,
         Visibility,
@@ -394,6 +394,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a [Level0Term::Rt] of the given type.
     pub fn create_rt_term(&self, ty_term_id: TermId) -> TermId {
         self.create_term(Term::Level0(Level0Term::Rt(ty_term_id)))
+    }
+
+    /// Create a [Level0Term::Lit] of the given value.
+    pub fn create_lit_term(&self, literal: impl Into<LitTerm>) -> TermId {
+        self.create_term(Term::Level0(Level0Term::Lit(literal.into())))
     }
 
     /// Create a [Level0Term::FnLit] of the given function type and return

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -143,7 +143,12 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
 
     /// Apply the given substitution to the given [Level0Term], producing a new
     /// [Level0Term] with the substituted variables.
-    pub fn apply_sub_to_level0_term(&mut self, sub: &Sub, term: Level0Term) -> TermId {
+    pub fn apply_sub_to_level0_term(
+        &mut self,
+        sub: &Sub,
+        term: Level0Term,
+        original_term: TermId,
+    ) -> TermId {
         match term {
             Level0Term::Rt(ty_term_id) => {
                 // Apply to the type of the runtime value
@@ -174,6 +179,7 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 let subbed_args = self.apply_sub_to_args(sub, fn_call.args);
                 self.builder().create_fn_call_term(subbed_subject, subbed_args)
             }
+            Level0Term::Lit(_) => original_term,
         }
     }
 
@@ -307,7 +313,7 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
             Term::Level3(term) => self.apply_sub_to_level3_term(sub, term),
             Term::Level2(term) => self.apply_sub_to_level2_term(sub, term),
             Term::Level1(term) => self.apply_sub_to_level1_term(sub, term),
-            Term::Level0(term) => self.apply_sub_to_level0_term(sub, term),
+            Term::Level0(term) => self.apply_sub_to_level0_term(sub, term, term_id),
         };
 
         self.location_store_mut().copy_location(term_id, new_term);
@@ -388,6 +394,7 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 self.add_free_vars_in_term_to_set(fn_call.subject, result);
                 self.add_free_vars_in_args_to_set(fn_call.args, result);
             }
+            Level0Term::Lit(_) => {}
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     storage::{
         primitives::{
-            AccessOp, Level0Term, Level1Term, Level2Term, Level3Term, MemberData, ModDefOrigin,
-            Term, TermId,
+            AccessOp, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm, MemberData,
+            ModDefOrigin, Term, TermId,
         },
         AccessToStorage, AccessToStorageMut, StorageRefMut,
     },
@@ -217,6 +217,20 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                     }
                     Level0Term::FnCall(_) => {
                         tc_panic!(term_id, self, "Function call should have been simplified away when trying to get the type of the term!")
+                    }
+                    Level0Term::Lit(lit_term) => {
+                        // This gets the type of the literal
+
+                        let var_to_resolve = match lit_term {
+                            LitTerm::Str(_) => "str",
+                            LitTerm::Int(_) => {
+                                // @@Todo: do some more sophisticated inferring here
+                                "i32"
+                            }
+                            LitTerm::Char(_) => "char",
+                        };
+                        let term = self.builder().create_var_term(var_to_resolve);
+                        Ok(self.simplifier().potentially_simplify_term(term)?)
                     }
                 }
             }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -772,6 +772,10 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                         "Function call in validation should have been simplified!"
                     )
                 }
+                Level0Term::Lit(_) => {
+                    // @@Todo: ensure that integers are not too large
+                    Ok(result)
+                }
             },
 
             // Access
@@ -986,6 +990,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                         "Function call in checking for type function return validity should have been simplified!"
                     )
                     }
+                    Level0Term::Lit(_) => Ok(false),
                 }
             }
             _ => Ok(true),

--- a/compiler/hash-typecheck/src/storage/location.rs
+++ b/compiler/hash-typecheck/src/storage/location.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, collections::HashMap, hash::Hash, rc::Rc};
 
 use hash_source::location::SourceLocation;
 
-use super::primitives::{ArgsId, ParamsId, ParamsPatternId, PatternId, ScopeId, TermId};
+use super::primitives::{ArgsId, ParamsId, PatternId, PatternParamsId, ScopeId, TermId};
 
 /// An index into the location map.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -25,7 +25,7 @@ pub enum LocationTarget {
     Declaration(ScopeId, usize),
     /// A pattern parameter key includes the parent [ParamsPatternId] and an
     /// index to which parameter
-    ParamPattern(ParamsPatternId, usize),
+    ParamPattern(PatternParamsId, usize),
     /// A pattern.
     Pattern(PatternId),
 }
@@ -61,7 +61,7 @@ pub struct LocationStore {
     declaration_map: HashMap<ScopeId, Rc<RefCell<HashMap<usize, SourceLocation>>>>,
     /// A map between [ParamPatternsId] and all of the [SourceLocation]s indexed
     /// by the inner offset.
-    param_pattern_map: HashMap<ParamsPatternId, Rc<RefCell<HashMap<usize, SourceLocation>>>>,
+    param_pattern_map: HashMap<PatternParamsId, Rc<RefCell<HashMap<usize, SourceLocation>>>>,
     /// A map between [PatternId] to [SourceLocation]
     pattern_map: HashMap<PatternId, SourceLocation>,
 }

--- a/compiler/hash-typecheck/src/storage/location.rs
+++ b/compiler/hash-typecheck/src/storage/location.rs
@@ -7,12 +7,12 @@ use std::{cell::RefCell, collections::HashMap, hash::Hash, rc::Rc};
 
 use hash_source::location::SourceLocation;
 
-use super::primitives::{ArgsId, ParamsId, ScopeId, TermId};
+use super::primitives::{ArgsId, ParamsId, ParamsPatternId, PatternId, ScopeId, TermId};
 
 /// An index into the location map.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum LocationTarget {
-    /// A term within stores a [TermId]
+    /// A term.
     Term(TermId),
     /// A parameter key includes the parent [ParamsId] and an index to which
     /// parameter
@@ -23,6 +23,11 @@ pub enum LocationTarget {
     /// A declaration key includes the parent [ScopeId] and an index to which
     /// declaration
     Declaration(ScopeId, usize),
+    /// A pattern parameter key includes the parent [ParamsPatternId] and an
+    /// index to which parameter
+    ParamPattern(ParamsPatternId, usize),
+    /// A pattern.
+    Pattern(PatternId),
 }
 
 /// Stores the source location of various targets in the AST tree.
@@ -54,17 +59,17 @@ pub struct LocationStore {
     /// A map between [ScopeId] and all of the [SourceLocation]s indexed by the
     /// inner offset.
     declaration_map: HashMap<ScopeId, Rc<RefCell<HashMap<usize, SourceLocation>>>>,
+    /// A map between [ParamPatternsId] and all of the [SourceLocation]s indexed
+    /// by the inner offset.
+    param_pattern_map: HashMap<ParamsPatternId, Rc<RefCell<HashMap<usize, SourceLocation>>>>,
+    /// A map between [PatternId] to [SourceLocation]
+    pattern_map: HashMap<PatternId, SourceLocation>,
 }
 
 impl LocationStore {
     /// Create a new [LocationStore]
     pub fn new() -> Self {
-        Self {
-            term_map: HashMap::new(),
-            param_map: HashMap::new(),
-            declaration_map: HashMap::new(),
-            arg_map: HashMap::new(),
-        }
+        Self::default()
     }
 
     /// Add a [SourceLocation] to a specified [LocationTarget]
@@ -98,6 +103,16 @@ impl LocationStore {
                     .or_insert_with(|| Rc::new(RefCell::new(HashMap::new())));
                 map.borrow_mut().insert(index, location);
             }
+            LocationTarget::ParamPattern(param_pattern, index) => {
+                let map = self
+                    .param_pattern_map
+                    .entry(param_pattern)
+                    .or_insert_with(|| Rc::new(RefCell::new(HashMap::new())));
+                map.borrow_mut().insert(index, location);
+            }
+            LocationTarget::Pattern(pattern) => {
+                self.pattern_map.insert(pattern, location);
+            }
         };
     }
 
@@ -111,6 +126,10 @@ impl LocationStore {
             LocationTarget::Arg(arg, index) => Some(*self.arg_map.get(&arg)?.borrow().get(&index)?),
             LocationTarget::Declaration(scope, index) => {
                 Some(*self.declaration_map.get(&scope)?.borrow().get(&index)?)
+            }
+            LocationTarget::Pattern(pattern) => self.pattern_map.get(&pattern).copied(),
+            LocationTarget::ParamPattern(param_pattern, index) => {
+                Some(*self.param_pattern_map.get(&param_pattern)?.borrow().get(&index)?)
             }
         }
     }

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -18,6 +18,7 @@ use self::{
     mods::ModDefStore,
     nominals::NominalDefStore,
     params::ParamsStore,
+    patterns::{PatternParamsStore, PatternStore},
     primitives::{Scope, ScopeId, ScopeKind},
     scope::{ScopeStack, ScopeStore},
     sources::CheckedSources,
@@ -31,6 +32,7 @@ pub mod location;
 pub mod mods;
 pub mod nominals;
 pub mod params;
+pub mod patterns;
 pub mod primitives;
 pub mod scope;
 pub mod sources;
@@ -48,6 +50,8 @@ pub struct GlobalStorage {
     pub trt_def_store: TrtDefStore,
     pub mod_def_store: ModDefStore,
     pub nominal_def_store: NominalDefStore,
+    pub pattern_store: PatternStore,
+    pub pattern_params_store: PatternParamsStore,
     pub checked_sources: CheckedSources,
     /// Used to create the first scope when creating a LocalStorage.
     ///
@@ -69,6 +73,8 @@ impl GlobalStorage {
             trt_def_store: TrtDefStore::new(),
             mod_def_store: ModDefStore::new(),
             nominal_def_store: NominalDefStore::new(),
+            pattern_store: PatternStore::new(),
+            pattern_params_store: PatternParamsStore::new(),
             checked_sources: CheckedSources::new(),
             root_scope,
             params_store: ParamsStore::new(),
@@ -173,6 +179,14 @@ pub trait AccessToStorage {
         &self.global_storage().mod_def_store
     }
 
+    fn pattern_store(&self) -> &PatternStore {
+        &self.global_storage().pattern_store
+    }
+
+    fn pattern_params_store(&self) -> &PatternParamsStore {
+        &self.global_storage().pattern_params_store
+    }
+
     fn checked_sources(&self) -> &CheckedSources {
         &self.global_storage().checked_sources
     }
@@ -243,6 +257,14 @@ pub trait AccessToStorageMut: AccessToStorage {
 
     fn mod_def_store_mut(&mut self) -> &mut ModDefStore {
         &mut self.global_storage_mut().mod_def_store
+    }
+
+    fn pattern_store_mut(&mut self) -> &mut PatternStore {
+        &mut self.global_storage_mut().pattern_store
+    }
+
+    fn pattern_params_store_mut(&mut self) -> &mut PatternParamsStore {
+        &mut self.global_storage_mut().pattern_params_store
     }
 
     fn checked_sources_mut(&mut self) -> &mut CheckedSources {

--- a/compiler/hash-typecheck/src/storage/patterns.rs
+++ b/compiler/hash-typecheck/src/storage/patterns.rs
@@ -1,8 +1,7 @@
 //! Contains structures to keep track of patterns and information relating to
 //! them.
+use super::primitives::{Pattern, PatternId, PatternParams, PatternParamsId};
 use slotmap::SlotMap;
-
-use super::primitives::{Pattern, PatternId};
 
 /// Stores patterns, indexed by [PatternId]s.
 #[derive(Debug, Default)]

--- a/compiler/hash-typecheck/src/storage/patterns.rs
+++ b/compiler/hash-typecheck/src/storage/patterns.rs
@@ -1,0 +1,59 @@
+//! Contains structures to keep track of patterns and information relating to
+//! them.
+use slotmap::SlotMap;
+
+use super::primitives::{Pattern, PatternId};
+
+/// Stores patterns, indexed by [PatternId]s.
+#[derive(Debug, Default)]
+pub struct PatternStore {
+    data: SlotMap<PatternId, Pattern>,
+}
+
+impl PatternStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a pattern, returning its assigned [PatternId].
+    pub fn create(&mut self, pattern: Pattern) -> PatternId {
+        self.data.insert(pattern)
+    }
+
+    /// Get a pattern by [PatternId].
+    pub fn get(&self, pattern_id: PatternId) -> &Pattern {
+        self.data.get(pattern_id).unwrap()
+    }
+
+    /// Get a pattern by [PatternId], mutably.
+    pub fn get_mut(&mut self, pattern_id: PatternId) -> &mut Pattern {
+        self.data.get_mut(pattern_id).unwrap()
+    }
+}
+
+/// Stores pattern parameters, indexed by [PatternParamsId]s.
+#[derive(Debug, Default)]
+pub struct PatternParamsStore {
+    data: SlotMap<PatternParamsId, PatternParams>,
+}
+
+impl PatternParamsStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create pattern parameters, returning its assigned [PatternParamsId].
+    pub fn create(&mut self, pattern_params: PatternParams) -> PatternParamsId {
+        self.data.insert(pattern_params)
+    }
+
+    /// Get pattern parameters by [PatternParamsId].
+    pub fn get(&self, pattern_params_id: PatternParamsId) -> &PatternParams {
+        self.data.get(pattern_params_id).unwrap()
+    }
+
+    /// Get pattern parameters by [PatternParamsId], mutably.
+    pub fn get_mut(&mut self, pattern_params_id: PatternParamsId) -> &mut PatternParams {
+        self.data.get_mut(pattern_params_id).unwrap()
+    }
+}

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -954,6 +954,12 @@ pub struct PatternParam {
     pub pattern: PatternId,
 }
 
+impl GetNameOpt for PatternParam {
+    fn get_name_opt(&self) -> Option<Identifier> {
+        self.name
+    }
+}
+
 /// A pattern of parameters.
 pub type PatternParams = ParamList<PatternParam>;
 
@@ -983,7 +989,7 @@ pub enum Pattern {
     /// The inner term must be `Term::Level0(Level0Term::Lit)`.
     Lit(TermId),
     /// Tuple pattern.
-    Tuple(PatternParams),
+    Tuple(PatternParamsId),
     /// Constructor pattern.
     Constructor(ConstructorPattern),
     /// A set of patterns that are OR-ed together. If any one of them matches

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -1,6 +1,7 @@
 //! Contains type definitions that the rest of the storage and the general
 //! typechecker use.
 use hash_source::{identifier::Identifier, SourceId};
+use num_bigint::BigInt;
 use slotmap::new_key_type;
 use std::{
     collections::{HashMap, HashSet},
@@ -585,6 +586,14 @@ pub struct AccessTerm {
     pub op: AccessOp,
 }
 
+/// A literal term, which is level 0.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LitTerm {
+    Str(String),
+    Int(BigInt),
+    Char(char),
+}
+
 /// A level 3 term.
 ///
 /// Type of: traits, for example: `trait(..)`.
@@ -656,7 +665,7 @@ pub struct FnLit {
 ///
 /// Type of: nothing.
 /// Value of: values, for example `3`, `Result::Ok(3)`, etc.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum Level0Term {
     /// A runtime value, has some Level 1 term as type (the inner data).
     Rt(TermId),
@@ -669,6 +678,9 @@ pub enum Level0Term {
 
     /// An enum variant, which is either a constant term or a function value.
     EnumVariant(EnumVariantValue),
+
+    /// A literal term
+    Lit(LitTerm),
 }
 
 /// The subject of a substitution, either a variable or an unresolved term.
@@ -937,7 +949,9 @@ pub enum Pattern {
     /// Binding pattern.
     Binding(BindingPattern),
     /// Literal pattern, of the given term.
-    Literal(TermId),
+    ///
+    /// The inner term must be `Term::Level0(Level0Term::Lit)`.
+    Lit(TermId),
     /// Tuple pattern.
     Tuple(PatternParams),
     /// Constructor pattern.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -594,6 +594,36 @@ pub enum LitTerm {
     Char(char),
 }
 
+impl From<&str> for LitTerm {
+    fn from(s: &str) -> Self {
+        LitTerm::Str(s.to_owned())
+    }
+}
+
+impl From<String> for LitTerm {
+    fn from(s: String) -> Self {
+        LitTerm::Str(s)
+    }
+}
+
+impl From<u64> for LitTerm {
+    fn from(s: u64) -> Self {
+        LitTerm::Int(s.into())
+    }
+}
+
+impl From<i64> for LitTerm {
+    fn from(s: i64) -> Self {
+        LitTerm::Int(s.into())
+    }
+}
+
+impl From<char> for LitTerm {
+    fn from(s: char) -> Self {
+        LitTerm::Char(s)
+    }
+}
+
 /// A level 3 term.
 ///
 /// Type of: traits, for example: `trait(..)`.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -897,6 +897,60 @@ pub enum Term {
     Root,
 }
 
+/// A binding pattern, which is essentially a declaration left-hand side.
+#[derive(Clone, Debug, Copy)]
+pub struct BindingPattern {
+    pub name: Identifier,
+    pub mutability: Mutability,
+    pub visibility: Visibility,
+}
+
+/// A pattern of a parameter, used for tuple patterns and constructor patterns.
+#[derive(Clone, Debug, Copy)]
+pub struct ParamPattern {
+    pub name: Option<Identifier>,
+    pub pattern: PatternId,
+}
+
+/// A pattern of parameters.
+pub type ParamsPattern = ParamList<ParamPattern>;
+
+/// A constructor pattern, used for enum variants and structs.
+#[derive(Clone, Debug, Copy)]
+pub struct ConstructorPattern {
+    pub subject: TermId,
+    pub params: ParamsPatternId,
+}
+
+/// A conditional pattern, containing a pattern and an condition.
+#[derive(Clone, Debug, Copy)]
+pub struct IfPattern {
+    pub pattern: PatternId,
+    pub condition: TermId,
+}
+
+/// Represents a pattern in the language.
+///
+/// @@Todo: list patterns, spread patterns
+#[derive(Clone, Debug)]
+pub enum Pattern {
+    /// Binding pattern.
+    Binding(BindingPattern),
+    /// Literal pattern, of the given term.
+    Literal(TermId),
+    /// Tuple pattern.
+    Tuple(ParamsPattern),
+    /// Constructor pattern.
+    Constructor(ConstructorPattern),
+    /// A set of patterns that are OR-ed together. If any one of them matches
+    /// then the whole pattern matches.
+    Or(Vec<PatternId>),
+    /// A conditional pattern.
+    If(IfPattern),
+    /// A wildcard pattern, ignoring the subject and always matching.
+    Ignore,
+}
+
 // IDs for all the primitives to be stored on mapped storage.
 
 new_key_type! {
@@ -932,6 +986,16 @@ new_key_type! {
 new_key_type! {
     /// The ID of a [Params]
     pub struct ParamsId;
+}
+
+new_key_type! {
+    /// The ID of a [Pattern]
+    pub struct PatternId;
+}
+
+new_key_type! {
+    /// The ID of a [ParamsPattern]
+    pub struct ParamsPatternId;
 }
 
 /// The ID of a [UnresolvedTerm], separate from its [TermId], stored in

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -907,19 +907,19 @@ pub struct BindingPattern {
 
 /// A pattern of a parameter, used for tuple patterns and constructor patterns.
 #[derive(Clone, Debug, Copy)]
-pub struct ParamPattern {
+pub struct PatternParam {
     pub name: Option<Identifier>,
     pub pattern: PatternId,
 }
 
 /// A pattern of parameters.
-pub type ParamsPattern = ParamList<ParamPattern>;
+pub type PatternParams = ParamList<PatternParam>;
 
 /// A constructor pattern, used for enum variants and structs.
 #[derive(Clone, Debug, Copy)]
 pub struct ConstructorPattern {
     pub subject: TermId,
-    pub params: ParamsPatternId,
+    pub params: PatternParamsId,
 }
 
 /// A conditional pattern, containing a pattern and an condition.
@@ -939,7 +939,7 @@ pub enum Pattern {
     /// Literal pattern, of the given term.
     Literal(TermId),
     /// Tuple pattern.
-    Tuple(ParamsPattern),
+    Tuple(PatternParams),
     /// Constructor pattern.
     Constructor(ConstructorPattern),
     /// A set of patterns that are OR-ed together. If any one of them matches
@@ -995,7 +995,7 @@ new_key_type! {
 
 new_key_type! {
     /// The ID of a [ParamsPattern]
-    pub struct ParamsPatternId;
+    pub struct PatternParamsId;
 }
 
 /// The ID of a [UnresolvedTerm], separate from its [TermId], stored in

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -360,9 +360,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         _ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::StrLiteral>,
     ) -> Result<Self::StrLiteralRet, Self::Error> {
-        let str_def = self.core_defs().str_ty;
-        let ty = self.builder().create_nominal_def_term(str_def);
-        let term = self.builder().create_rt_term(ty);
+        let term = self.builder().create_lit_term(node.0.to_string());
 
         // add the location of the term to the location storage
         self.copy_location_from_node_to_target(node, term);
@@ -377,9 +375,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         _ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::CharLiteral>,
     ) -> Result<Self::CharLiteralRet, Self::Error> {
-        let char_def = self.core_defs().char_ty;
-        let ty = self.builder().create_nominal_def_term(char_def);
-        let term = self.builder().create_rt_term(ty);
+        let term = self.builder().create_lit_term(node.0);
 
         // add the location of the term to the location storage
         self.copy_location_from_node_to_target(node, term);
@@ -411,14 +407,12 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         _ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::BoolLiteral>,
     ) -> Result<Self::BoolLiteralRet, Self::Error> {
-        let bool_def = self.core_defs().bool_ty;
-        let ty = self.builder().create_nominal_def_term(bool_def);
-        let term = self.builder().create_rt_term(ty);
+        let term = self.builder().create_var_term(if node.0 { "true" } else { "false" });
 
         // add the location of the term to the location storage
         self.copy_location_from_node_to_target(node, term);
 
-        Ok(term)
+        Ok(self.validator().validate_term(term)?.simplified_term_id)
     }
 
     type IntLiteralRet = TermId;
@@ -428,9 +422,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         _: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::IntLiteral>,
     ) -> Result<Self::IntLiteralRet, Self::Error> {
-        let i32_def = self.core_defs().i32_ty;
-        let ty = self.builder().create_nominal_def_term(i32_def);
-        let term = self.builder().create_rt_term(ty);
+        let term = self.builder().create_lit_term(node.0);
 
         // add the location of the term to the location storage
         self.copy_location_from_node_to_target(node, term);


### PR DESCRIPTION
This PR implements patterns in a similar way that terms are implemented (with stores etc). This is to aid the process of implementing pattern-related operations like usefulness checks, as well as to be able to represent patterns while traversing.

The next step after this PR is to add functionality to get the type of a pattern (probably from within `Typer`), and then to implement traversal of patterns (part of #329, #331), and then finally usefulness (i.e. given a `Term` and a set of `Pattern`s, are all the patterns useful to match the given term).

To do this, the concept of "literal terms" is added, which is a natural extension of runtime terms to include basic literals like integers, characters and strings. These are now used when traversing literals, and this opens the door to literal typing like in typescript (but not yet). The reason why this is added for this PR is because literal patterns are nothing other than literal terms. I.e. `Pattern::Lit(term_id)` is such that term_id is a literal term (`Term::Level0(Level0Term::Lit)`). This is necessary for usefulness.

Note that literal terms are *values*, not types. Thus, one cannot write `x: "foo" = "foo"` like in typescript (because this doesn't actually make much sense). `x: str := "foo"` is correct. However, one day (wink wink honours dissertation) types can be extended to hold constraints, in which case the previous example would be typed as `x: (str where (x) => x == "foo") = "foo";`

Closes #400, closes #401.