### PR TITLE
TC: Implement pattern matching, as well as pattern and control flow traversal

### DIFF
--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -16,9 +16,19 @@ pub type TcResult<T> = Result<T, TcError>;
 pub enum TcError {
     /// Cannot unify the two terms.
     CannotUnify { src: TermId, target: TermId },
+    /// Cannot unify the two argument lists. This can occur if the names
+    /// don't match of the arguments or if the number of arguments isn't the
+    /// same.
+    CannotUnifyArgs {
+        src_args_id: ArgsId,
+        target_args_id: ArgsId,
+        src: TermId,
+        target: TermId,
+        reason: ParamUnificationErrorReason,
+    },
     /// Cannot unify the two parameter lists. This can occur if the names
     /// don't match of the parameters or if the number of parameters isn't the
-    /// same.
+    /// same, or the types mismatch.
     CannotUnifyParams {
         src_params_id: ParamsId,
         target_params_id: ParamsId,

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -1,6 +1,9 @@
 //! Error-related data structures for errors that occur during typechecking.
 
-use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, PatternId, TermId, TyFnCase};
+use crate::storage::{
+    location::LocationTarget,
+    primitives::{AccessTerm, ArgsId, ParamsId, PatternId, TermId, TyFnCase},
+};
 use hash_source::identifier::Identifier;
 
 use super::{
@@ -32,8 +35,8 @@ pub enum TcError {
     CannotUnifyParams {
         src_params_id: ParamsId,
         target_params_id: ParamsId,
-        src: TermId,
-        target: TermId,
+        src: LocationTarget,
+        target: LocationTarget,
         reason: ParamUnificationErrorReason,
     },
     /// The given term should be a type function but it isn't.
@@ -44,12 +47,17 @@ pub enum TcError {
     MismatchingArgParamLength {
         args_id: ArgsId,
         params_id: ParamsId,
-        params_subject: TermId,
-        args_subject: TermId,
+        params_subject: LocationTarget,
+        args_subject: LocationTarget,
     },
     /// The parameter with the given name is not found in the given parameter
     /// list.
-    ParamNotFound { args_id: ArgsId, params_id: ParamsId, params_subject: TermId, name: Identifier },
+    ParamNotFound {
+        args_id: ArgsId,
+        params_id: ParamsId,
+        params_subject: LocationTarget,
+        name: Identifier,
+    },
     /// There is a argument or parameter (at the index) which is
     /// specified twice in the given argument list.
     ParamGivenTwice { param_kind: ParamListKind, index: usize },

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -128,4 +128,6 @@ pub enum TcError {
     },
     /// Given match case is never going to match the subject.
     UselessMatchCase { match_case_pattern: PatternId, subject: TermId },
+    /// Cannot use pattern matching in a declaration without an assignment
+    CannotPatternMatchWithoutAssignment { pattern: PatternId },
 }

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -1,6 +1,6 @@
 //! Error-related data structures for errors that occur during typechecking.
 
-use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, TermId, TyFnCase};
+use crate::storage::primitives::{AccessTerm, ArgsId, ParamsId, PatternId, TermId, TyFnCase};
 use hash_source::identifier::Identifier;
 
 use super::{
@@ -116,4 +116,6 @@ pub enum TcError {
         // "terms".
         trt_def_missing_member_term_id: TermId,
     },
+    /// Given match case is never going to match the subject.
+    UselessMatchCase { match_case_pattern: PatternId, subject: TermId },
 }

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -19,6 +19,8 @@ pub type TcResult<T> = Result<T, TcError>;
 pub enum TcError {
     /// Cannot unify the two terms.
     CannotUnify { src: TermId, target: TermId },
+    // @@Refactor: It would be nice to not have separate variants for `CannotUnifyArgs` and
+    // `CannotUnifyParams`.
     /// Cannot unify the two argument lists. This can occur if the names
     /// don't match of the arguments or if the number of arguments isn't the
     /// same.

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -86,7 +86,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         builder
                             .with_error_code(HashErrorCode::ParameterLengthMismatch)
                             .with_message(format!(
-                                "{} expects `{}` arguments, however `{}` arguments were given",
+                                "{} expects {} arguments, however {} arguments were given",
                                 origin,
                                 target_args.len(),
                                 src_args.len()
@@ -97,7 +97,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
                                 format!(
-                                    "this {} expects `{}` arguments.",
+                                    "this {} expects {} arguments...",
                                     origin,
                                     target_args.len(),
                                 ),
@@ -108,7 +108,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         if let Some(location) = err.location_store().get_location(src) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
-                                "incorrect number of arguments here",
+                                format!("...but got {} arguments here", src_args.len()),
                             )));
                         }
                     }
@@ -207,18 +207,18 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         builder
                             .with_error_code(HashErrorCode::ParameterLengthMismatch)
                             .with_message(format!(
-                                "{} expects `{}` arguments, however `{}` arguments were given",
+                                "{} expects {} parameters, however {} parameters were given",
                                 origin,
                                 target_params.len(),
                                 src_params.len()
                             ));
 
                         // Provide information about the location of the target type if available
-                        if let Some(location) = err.location_store().get_location(target) {
+                        if let Some(location) = err.location_store().get_location(*target) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
                                 format!(
-                                    "this {} expects `{}` arguments.",
+                                    "this {} expects {} parameters...",
                                     origin,
                                     target_params.len(),
                                 ),
@@ -226,10 +226,10 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         }
 
                         // Provide information about the source of the unification error
-                        if let Some(location) = err.location_store().get_location(src) {
+                        if let Some(location) = err.location_store().get_location(*src) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
-                                "incorrect number of arguments here",
+                                format!("...but got {} parameters here", src_params.len()),
                             )));
                         }
                     }
@@ -374,7 +374,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                             ));
 
                             // Add note about what fields are missing from the struct
-                            if let Some(location) = err.location_store().get_location(args_subject)
+                            if let Some(location) = err.location_store().get_location(*args_subject)
                             {
                                 builder.add_element(ReportElement::CodeBlock(
                                     ReportCodeBlock::new(
@@ -400,7 +400,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                             // Add note about what fields shouldn't be there
                             // @@Future: It would be nice to highlight the exact fields and just
                             // show them specifically rather than the whole subject expression...
-                            if let Some(location) = err.location_store().get_location(args_subject)
+                            if let Some(location) = err.location_store().get_location(*args_subject)
                             {
                                 builder.add_element(ReportElement::CodeBlock(
                                     ReportCodeBlock::new(
@@ -415,7 +415,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         }
 
                         // Provide information about the location of the target type if available
-                        if let Some(location) = err.location_store().get_location(params_subject) {
+                        if let Some(location) = err.location_store().get_location(*params_subject) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
                                 "the struct is defined here",
@@ -425,25 +425,28 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     _ => {
                         // @@ErrorReporting: get more customised messages for other variant
                         // mismatch...
-                        builder.with_message(format!(
-                            "{} expects `{}` arguments, however `{}` arguments were given",
-                            params.origin(),
-                            params.len(),
-                            args.len()
-                        ));
+                        builder
+                            .with_error_code(HashErrorCode::ParameterLengthMismatch)
+                            .with_message(format!(
+                                "{} expects {} arguments, however {} arguments were given",
+                                params.origin(),
+                                params.len(),
+                                args.len()
+                            ));
 
                         // Provide information about the location of the target type if available
-                        if let Some(location) = err.location_store().get_location(args_subject) {
+                        if let Some(location) = err.location_store().get_location(*args_subject) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                                location, "here",
+                                location,
+                                format!("got {} arguments here...", args.len()),
                             )));
                         }
 
                         // Provide information about the location of the target type if available
-                        if let Some(location) = err.location_store().get_location(params_subject) {
+                        if let Some(location) = err.location_store().get_location(*params_subject) {
                             builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                                 location,
-                                format!("this expects `{}` arguments.", params.len()),
+                                format!("...but this expects {} arguments.", params.len()),
                             )));
                         }
                     }
@@ -468,7 +471,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                 }
 
                 // Provide information about the location of the target type if available
-                if let Some(location) = err.location_store().get_location(params_subject) {
+                if let Some(location) = err.location_store().get_location(*params_subject) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         format!("the {} is defined here", params.origin()),

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -1012,10 +1012,10 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     )));
                 }
             }
-            TcError::UselessMatchCase { match_case_pattern, subject } => {
+            TcError::UselessMatchCase { pattern, subject } => {
                 builder.with_error_code(HashErrorCode::TypeMismatch).with_message(format!(
                     "match case `{}` is redundant when matching on `{}`",
-                    match_case_pattern.for_formatting(err.global_storage()),
+                    pattern.for_formatting(err.global_storage()),
                     subject.for_formatting(err.global_storage())
                 ));
 
@@ -1026,7 +1026,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     )));
                 }
 
-                if let Some(location) = err.location_store().get_location(match_case_pattern) {
+                if let Some(location) = err.location_store().get_location(pattern) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         "...and this pattern will never match the subject".to_string(),

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -1016,8 +1016,6 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     subject.for_formatting(err.global_storage())
                 ));
 
-                // Now get the spans for the two terms and add them to the
-                // report
                 if let Some(location) = err.location_store().get_location(subject) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
@@ -1029,6 +1027,22 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
                         "...and this pattern will never match the subject".to_string(),
+                    )));
+                }
+            }
+            TcError::CannotPatternMatchWithoutAssignment { pattern } => {
+                builder.with_error_code(HashErrorCode::TypeMismatch).with_message(
+                    "declaration left-hand side cannot contain a pattern if no value is provided"
+                        .to_string(),
+                );
+
+                if let Some(location) = err.location_store().get_location(pattern) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        format!(
+                            "pattern `{}` is given here on an unset declaration",
+                            pattern.for_formatting(err.global_storage())
+                        ),
                     )));
                 }
             }

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -603,7 +603,10 @@ impl<'gs> TcFormatter<'gs> {
             Pattern::Constructor(constructor_pattern) => {
                 opts.is_atomic.set(true);
                 self.fmt_term_as_single(f, constructor_pattern.subject, opts)?;
-                write!(f, "({})", constructor_pattern.params.for_formatting(self.global_storage))
+                if let Some(params) = constructor_pattern.params {
+                    write!(f, "({})", params.for_formatting(self.global_storage))?;
+                }
+                Ok(())
             }
             Pattern::Or(patterns) => {
                 if patterns.is_empty() {

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -225,15 +225,19 @@ impl<'gs> TcFormatter<'gs> {
                 opts.is_atomic.set(true);
                 match lit_term {
                     LitTerm::Str(str) => {
-                        write!(f, "\"{}\"", str)
+                        write!(f, "{{literal \"{}\"}}", str)
                     }
                     LitTerm::Int(int) => {
-                        write!(f, "{}", int)
+                        write!(f, "{{literal {}}}", int)
                     }
                     LitTerm::Char(char) => {
-                        write!(f, "\'{}\'", char)
+                        write!(f, "{{literal \'{}\'}}", char)
                     }
                 }
+            }
+            Level0Term::Tuple(tuple_lit) => {
+                opts.is_atomic.set(true);
+                write!(f, "{{literal ({})}}", tuple_lit.members.for_formatting(self.global_storage))
             }
         }
     }

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -196,23 +196,24 @@ impl<'gs> TcFormatter<'gs> {
         match term {
             Level0Term::Rt(ty_id) => {
                 opts.is_atomic.set(true);
-                write!(f, "{{runtime value of type {}}}", ty_id.for_formatting(self.global_storage))
+                write!(f, "{{value {}}}", ty_id.for_formatting(self.global_storage))
             }
             Level0Term::FnLit(fn_lit) => {
                 opts.is_atomic.set(true);
                 write!(
                     f,
-                    "{{function literal of type {}}}",
-                    fn_lit.fn_ty.for_formatting(self.global_storage)
+                    "{} => {}",
+                    fn_lit.fn_ty.for_formatting(self.global_storage),
+                    fn_lit.return_value.for_formatting(self.global_storage),
                 )
             }
             Level0Term::EnumVariant(enum_variant) => {
                 opts.is_atomic.set(true);
                 write!(
                     f,
-                    "{{enum variant '{}' of {}}}",
+                    "{}::{}",
+                    enum_variant.enum_def_id.for_formatting(self.global_storage),
                     enum_variant.variant_name,
-                    enum_variant.enum_def_id.for_formatting(self.global_storage)
                 )
             }
             Level0Term::FnCall(fn_call) => {
@@ -225,19 +226,19 @@ impl<'gs> TcFormatter<'gs> {
                 opts.is_atomic.set(true);
                 match lit_term {
                     LitTerm::Str(str) => {
-                        write!(f, "{{literal \"{}\"}}", str)
+                        write!(f, "\"{}\"", str)
                     }
                     LitTerm::Int(int) => {
-                        write!(f, "{{literal {}}}", int)
+                        write!(f, "{}", int)
                     }
                     LitTerm::Char(char) => {
-                        write!(f, "{{literal \'{}\'}}", char)
+                        write!(f, "\'{}\'", char)
                     }
                 }
             }
             Level0Term::Tuple(tuple_lit) => {
                 opts.is_atomic.set(true);
-                write!(f, "{{literal ({})}}", tuple_lit.members.for_formatting(self.global_storage))
+                write!(f, "({})", tuple_lit.members.for_formatting(self.global_storage))
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -8,8 +8,8 @@ use crate::storage::{
         Level2Term, Level3Term, LitTerm, Member, MemberData, ModDef, ModDefId, ModDefOrigin,
         ModPattern, Mutability, NominalDef, NominalDefId, Param, ParamList, ParamOrigin, ParamsId,
         Pattern, PatternId, PatternParam, PatternParamsId, Scope, ScopeId, ScopeKind, StructDef,
-        StructFields, Sub, Term, TermId, TrtDef, TrtDefId, TupleTy, TyFn, TyFnCall, TyFnCase,
-        TyFnTy, UnresolvedTerm, Var, Visibility,
+        StructFields, Sub, Term, TermId, TrtDef, TrtDefId, TupleLit, TupleTy, TyFn, TyFnCall,
+        TyFnCase, TyFnTy, UnresolvedTerm, Var, Visibility,
     },
     GlobalStorage,
 };
@@ -393,6 +393,13 @@ impl<'gs> PrimitiveBuilder<'gs> {
         })))
     }
 
+    /// Create the void term: [Level0Term::Tuple] with no members.
+    pub fn create_void_term(&self) -> TermId {
+        self.create_term(Term::Level0(Level0Term::Tuple(TupleLit {
+            members: self.create_args([], ParamOrigin::Tuple),
+        })))
+    }
+
     /// Create the never term: [Term::Union] with no members.
     pub fn create_never_term(&self) -> TermId {
         self.create_term(Term::Union(vec![]))
@@ -401,6 +408,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
     /// Create a tuple type term [Level1Term::Tuple].
     pub fn create_tuple_ty_term(&self, members: ParamsId) -> TermId {
         self.create_term(Term::Level1(Level1Term::Tuple(TupleTy { members })))
+    }
+
+    /// Create a tuple literal term [Level0Term::Tuple].
+    pub fn create_tuple_lit_term(&self, members: ArgsId) -> TermId {
+        self.create_term(Term::Level0(Level0Term::Tuple(TupleLit { members })))
     }
 
     /// Create a [Level0Term::Rt] of the given type.

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -3,12 +3,13 @@
 use crate::storage::{
     location::LocationTarget,
     primitives::{
-        AccessOp, AccessTerm, AppSub, Arg, ArgsId, EnumDef, EnumVariant, EnumVariantValue, FnCall,
-        FnLit, FnTy, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm, Member, MemberData,
-        ModDef, ModDefId, ModDefOrigin, Mutability, NominalDef, NominalDefId, Param, ParamList,
-        ParamOrigin, ParamsId, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term,
-        TermId, TrtDef, TrtDefId, TupleTy, TyFn, TyFnCall, TyFnCase, TyFnTy, UnresolvedTerm, Var,
-        Visibility,
+        AccessOp, AccessTerm, AppSub, Arg, ArgsId, BindingPattern, ConstructorPattern, EnumDef,
+        EnumVariant, EnumVariantValue, FnCall, FnLit, FnTy, IfPattern, Level0Term, Level1Term,
+        Level2Term, Level3Term, LitTerm, Member, MemberData, ModDef, ModDefId, ModDefOrigin,
+        ModPattern, Mutability, NominalDef, NominalDefId, Param, ParamList, ParamOrigin, ParamsId,
+        Pattern, PatternId, PatternParam, PatternParamsId, Scope, ScopeId, ScopeKind, StructDef,
+        StructFields, Sub, Term, TermId, TrtDef, TrtDefId, TupleTy, TyFn, TyFnCall, TyFnCase,
+        TyFnTy, UnresolvedTerm, Var, Visibility,
     },
     GlobalStorage,
 };
@@ -433,6 +434,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.gs.borrow_mut().term_store.create(term)
     }
 
+    /// Create a pattern with the given pattern value.
+    pub fn create_pattern(&self, pattern: Pattern) -> PatternId {
+        self.gs.borrow_mut().pattern_store.create(pattern)
+    }
+
     /// Create a [Level1Term::Fn] term with the given parameters and return
     /// type.
     pub fn create_fn_ty_term(&self, params: ParamsId, return_ty: TermId) -> TermId {
@@ -639,6 +645,88 @@ impl<'gs> PrimitiveBuilder<'gs> {
     pub fn create_app_ty_fn_term(&self, subject: TermId, args: ArgsId) -> TermId {
         let app_ty_fn = self.create_app_ty_fn(subject, args);
         self.create_term(Term::TyFnCall(app_ty_fn))
+    }
+
+    /// Create pattern parameters from the given pattern parameter iterator.
+    pub fn create_pattern_params(
+        &self,
+        params: impl IntoIterator<Item = PatternParam>,
+        origin: ParamOrigin,
+    ) -> PatternParamsId {
+        self.gs
+            .borrow_mut()
+            .pattern_params_store
+            .create(ParamList::new(params.into_iter().collect(), origin))
+    }
+
+    /// Create a pattern parameter
+    pub fn create_pattern_param(
+        &self,
+        name: impl Into<Identifier>,
+        pattern: PatternId,
+    ) -> PatternParam {
+        PatternParam { name: Some(name.into()), pattern }
+    }
+
+    /// Create a constructor pattern.
+    pub fn create_constructor_pattern(
+        &self,
+        subject: TermId,
+        params: PatternParamsId,
+    ) -> PatternId {
+        self.create_pattern(Pattern::Constructor(ConstructorPattern {
+            subject,
+            params: Some(params),
+        }))
+    }
+
+    /// Create a constructor pattern without parameters.
+    pub fn create_constant_pattern(&self, subject: TermId) -> PatternId {
+        self.create_pattern(Pattern::Constructor(ConstructorPattern { subject, params: None }))
+    }
+
+    /// Create a binding pattern.
+    pub fn create_binding_pattern(
+        &self,
+        name: impl Into<Identifier>,
+        mutability: Mutability,
+        visibility: Visibility,
+    ) -> PatternId {
+        self.create_pattern(Pattern::Binding(BindingPattern {
+            name: name.into(),
+            mutability,
+            visibility,
+        }))
+    }
+
+    /// Create a module pattern.
+    pub fn create_mod_pattern(&self, members: PatternParamsId) -> PatternId {
+        self.create_pattern(Pattern::Mod(ModPattern { members }))
+    }
+
+    /// Create a tuple pattern.
+    pub fn create_tuple_pattern(&self, members: PatternParamsId) -> PatternId {
+        self.create_pattern(Pattern::Tuple(members))
+    }
+
+    /// Create a literal pattern.
+    pub fn create_lit_pattern(&self, lit_term: TermId) -> PatternId {
+        self.create_pattern(Pattern::Lit(lit_term))
+    }
+
+    /// Create an OR-pattern.
+    pub fn create_or_pattern(&self, patterns: impl IntoIterator<Item = PatternId>) -> PatternId {
+        self.create_pattern(Pattern::Or(patterns.into_iter().collect()))
+    }
+
+    /// Create a conditional pattern.
+    pub fn create_if_pattern(&self, pattern: PatternId, condition: TermId) -> PatternId {
+        self.create_pattern(Pattern::If(IfPattern { pattern, condition }))
+    }
+
+    /// Create an ignore pattern ("_").
+    pub fn create_ignore_pattern(&self) -> PatternId {
+        self.create_pattern(Pattern::Ignore)
     }
 
     /// Add a [SourceLocation] to a [LocationTarget].

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -4,14 +4,15 @@
 //! Code from this module is to be used while traversing and typing the AST, in
 //! order to unify types and ensure correctness.
 use self::{
-    building::PrimitiveBuilder, reader::PrimitiveReader, scope::ScopeResolver,
-    simplify::Simplifier, substitute::Substituter, typing::Typer, unify::Unifier,
-    validate::Validator,
+    building::PrimitiveBuilder, patterns::PatternMatcher, reader::PrimitiveReader,
+    scope::ScopeResolver, simplify::Simplifier, substitute::Substituter, typing::Typer,
+    unify::Unifier, validate::Validator,
 };
 use crate::storage::{primitives::ScopeId, AccessToStorage, AccessToStorageMut};
 
 pub mod building;
 pub mod params;
+pub mod patterns;
 pub mod reader;
 pub mod scope;
 pub mod simplify;
@@ -75,6 +76,11 @@ pub trait AccessToOpsMut: AccessToStorageMut {
     /// Create an instance of [ScopeResolver].
     fn scope_resolver(&mut self) -> ScopeResolver {
         ScopeResolver::new(self.storages_mut())
+    }
+
+    /// Create an instance of [PatternMatcher].
+    fn pattern_matcher(&mut self) -> PatternMatcher {
+        PatternMatcher::new(self.storages_mut())
     }
 }
 

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -1,0 +1,43 @@
+//! Functionality related to pattern matching.
+
+use crate::{
+    diagnostics::error::TcResult,
+    storage::{
+        primitives::{Member, PatternId, TermId},
+        AccessToStorage, AccessToStorageMut, StorageRef, StorageRefMut,
+    },
+};
+
+/// Contains functions related to pattern matching.
+pub struct PatternMatcher<'gs, 'ls, 'cd, 's> {
+    storage: StorageRefMut<'gs, 'ls, 'cd, 's>,
+}
+
+impl<'gs, 'ls, 'cd, 's> AccessToStorage for PatternMatcher<'gs, 'ls, 'cd, 's> {
+    fn storages(&self) -> StorageRef {
+        self.storage.storages()
+    }
+}
+impl<'gs, 'ls, 'cd, 's> AccessToStorageMut for PatternMatcher<'gs, 'ls, 'cd, 's> {
+    fn storages_mut(&mut self) -> StorageRefMut {
+        self.storage.storages_mut()
+    }
+}
+
+impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
+    /// Create a new [PatternMatcher].
+    pub fn new(storage: StorageRefMut<'gs, 'ls, 'cd, 's>) -> Self {
+        Self { storage }
+    }
+
+    /// Match the given pattern with the given term, returning
+    /// `Some(member_list)` if the pattern matches (with a list of bound
+    /// members), or `None` if it doesn't match. If the types mismatch, it
+    /// returns an error.
+    pub fn match_pattern_with_term(
+        _pattern: PatternId,
+        _term: TermId,
+    ) -> TcResult<Option<Vec<Member>>> {
+        todo!()
+    }
+}

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -46,7 +46,7 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
     ) -> TcResult<Option<Vec<Member>>> {
         let TermValidation { simplified_term_id, term_ty_id } =
             self.validator().validate_term(term_id)?;
-        let pattern_ty = self.typer().ty_of_pattern(pattern_id)?;
+        let pattern_ty = self.typer().infer_ty_of_pattern(pattern_id)?;
 
         // First unify the pattern type with the subject type to ensure the match is
         // valid:
@@ -73,7 +73,7 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
             // Tuple: Unify the tuple with the subject, and then recurse to inner patterns
             Pattern::Tuple(tuple_pattern_params_id) => {
                 // Get the term of the tuple and try to unify it with the subject:
-                let tuple_term = self.typer().term_of_pattern(pattern_id)?;
+                let tuple_term = self.typer().get_term_of_pattern(pattern_id)?;
                 match self.unifier().unify_terms(tuple_term, simplified_term_id) {
                     Ok(_) => {
                         let tuple_pattern_params =
@@ -82,12 +82,12 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
                         // First, we get the tuple pattern parameters in the form of args (for
                         // `pair_args_with_params` error reporting):
                         let tuple_pattern_params_as_args_id =
-                            self.typer().args_of_pattern_params(tuple_pattern_params_id)?;
+                            self.typer().infer_args_of_pattern_params(tuple_pattern_params_id)?;
 
                         // We get the subject tuple's parameters:
                         let subject_params_id = self
                             .typer()
-                            .params_ty_of_tuple_term(simplified_term_id)?
+                            .get_params_ty_of_tuple_term(simplified_term_id)?
                             .unwrap_or_else(|| {
                                 tc_panic!(simplified_term_id, self, "This is not a tuple term.")
                             });
@@ -128,7 +128,7 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
             }
             Pattern::Constructor(_) => {
                 // Get the term of the constructor and try to unify it with the subject:
-                let constructor_term = self.typer().term_of_pattern(pattern_id)?;
+                let constructor_term = self.typer().get_term_of_pattern(pattern_id)?;
                 match self.unifier().unify_terms(constructor_term, simplified_term_id) {
                     Ok(_) => {
                         // @@Todo: Get the vars:

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -140,7 +140,13 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
             Pattern::Or(_) => {
                 todo!()
             }
-            Pattern::If(_) => todo!(),
+            Pattern::If(if_pattern) => {
+                // Recurse to inner, but never say it is redundant:
+                match self.match_pattern_with_term(if_pattern.pattern, term_id)? {
+                    Some(result) => Ok(Some(result)),
+                    None => Ok(Some(vec![])),
+                }
+            }
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -129,7 +129,7 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
             Pattern::Constructor(_) => {
                 // Get the term of the constructor and try to unify it with the subject:
                 let constructor_term = self.typer().term_of_pattern(pattern_id)?;
-                match self.unifier().unify_terms(tuple_term, simplified_term_id) {
+                match self.unifier().unify_terms(constructor_term, simplified_term_id) {
                     Ok(_) => {
                         // @@Todo: Get the vars:
                         Ok(Some(vec![]))

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -2,11 +2,14 @@
 
 use crate::{
     diagnostics::error::TcResult,
+    ops::{validate::TermValidation, AccessToOpsMut},
     storage::{
-        primitives::{Member, PatternId, TermId},
+        primitives::{Member, MemberData, Pattern, PatternId, TermId},
         AccessToStorage, AccessToStorageMut, StorageRef, StorageRefMut,
     },
 };
+
+use super::AccessToOps;
 
 /// Contains functions related to pattern matching.
 pub struct PatternMatcher<'gs, 'ls, 'cd, 's> {
@@ -36,9 +39,62 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
     /// returns an error.
     pub fn match_pattern_with_term(
         &mut self,
-        _pattern: PatternId,
-        _term: TermId,
+        pattern_id: PatternId,
+        term_id: TermId,
     ) -> TcResult<Option<Vec<Member>>> {
-        todo!()
+        let TermValidation { simplified_term_id, term_ty_id } =
+            self.validator().validate_term(term_id)?;
+        let pattern_ty = self.typer().ty_of_pattern(pattern_id)?;
+
+        // First unify the pattern type with the subject type to ensure the match is
+        // valid:
+        let _ = self.unifier().unify_terms(pattern_ty, term_ty_id)?;
+
+        let pattern = self.reader().get_pattern(pattern_id).clone();
+        match pattern {
+            Pattern::Binding(binding) => Ok(Some(vec![Member {
+                name: binding.name,
+                mutability: binding.mutability,
+                visibility: binding.visibility,
+                data: MemberData::from_ty_and_value(Some(term_ty_id), Some(simplified_term_id)),
+            }])),
+            Pattern::Ignore => Ok(Some(vec![])),
+            Pattern::Lit(lit_term) => {
+                match self.unifier().unify_terms(lit_term, simplified_term_id) {
+                    Ok(_) => Ok(Some(vec![])),
+                    Err(_) => Ok(None),
+                }
+            }
+            Pattern::Tuple(_) => {
+                // Get the term of the tuple and try to unify it with the subject:
+                let tuple_term = self.typer().term_of_pattern(pattern_id)?;
+                match self.unifier().unify_terms(tuple_term, simplified_term_id) {
+                    Ok(_) => {
+                        // @@Todo: Get the vars:
+                        Ok(Some(vec![]))
+                    }
+                    Err(_) => Ok(None),
+                }
+            }
+            Pattern::Mod(_) => {
+                //  Here we have to basically try to access the given members using ns access...
+                todo!()
+            }
+            Pattern::Constructor(_) => {
+                // Get the term of the constructor and try to unify it with the subject:
+                let tuple_term = self.typer().term_of_pattern(pattern_id)?;
+                match self.unifier().unify_terms(tuple_term, simplified_term_id) {
+                    Ok(_) => {
+                        // @@Todo: Get the vars:
+                        Ok(Some(vec![]))
+                    }
+                    Err(_) => Ok(None),
+                }
+            }
+            Pattern::Or(_) => {
+                todo!()
+            }
+            Pattern::If(_) => todo!(),
+        }
     }
 }

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -54,19 +54,23 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
 
         let pattern = self.reader().get_pattern(pattern_id).clone();
         match pattern {
+            // Binding: Add the binding as a member
             Pattern::Binding(binding) => Ok(Some(vec![Member {
                 name: binding.name,
                 mutability: binding.mutability,
                 visibility: binding.visibility,
                 data: MemberData::from_ty_and_value(Some(term_ty_id), Some(simplified_term_id)),
             }])),
+            // Ignore: No bindings but always matches
             Pattern::Ignore => Ok(Some(vec![])),
+            // Lit: Unify the literal with the subject
             Pattern::Lit(lit_term) => {
                 match self.unifier().unify_terms(lit_term, simplified_term_id) {
                     Ok(_) => Ok(Some(vec![])),
                     Err(_) => Ok(None),
                 }
             }
+            // Tuple: Unify the tuple with the subject, and then recurse to inner patterns
             Pattern::Tuple(tuple_pattern_params_id) => {
                 // Get the term of the tuple and try to unify it with the subject:
                 let tuple_term = self.typer().term_of_pattern(pattern_id)?;

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -35,6 +35,7 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
     /// members), or `None` if it doesn't match. If the types mismatch, it
     /// returns an error.
     pub fn match_pattern_with_term(
+        &mut self,
         _pattern: PatternId,
         _term: TermId,
     ) -> TcResult<Option<Vec<Member>>> {

--- a/compiler/hash-typecheck/src/ops/patterns.rs
+++ b/compiler/hash-typecheck/src/ops/patterns.rs
@@ -138,6 +138,9 @@ impl<'gs, 'ls, 'cd, 's> PatternMatcher<'gs, 'ls, 'cd, 's> {
                 }
             }
             Pattern::Or(_) => {
+                // Here we have to get the union of all the pattern terms, and also need to
+                // ensure that the bound variables are the same for each
+                // branch and of the same type
                 todo!()
             }
             Pattern::If(if_pattern) => {

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -3,8 +3,8 @@
 
 use crate::storage::{
     primitives::{
-        Args, ArgsId, ModDef, ModDefId, NominalDef, NominalDefId, Params, ParamsId, Scope, ScopeId,
-        Term, TermId, TrtDef, TrtDefId,
+        Args, ArgsId, ModDef, ModDefId, NominalDef, NominalDefId, Params, ParamsId, Pattern,
+        PatternId, PatternParams, PatternParamsId, Scope, ScopeId, Term, TermId, TrtDef, TrtDefId,
     },
     GlobalStorage,
 };
@@ -31,6 +31,11 @@ impl<'gs> PrimitiveReader<'gs> {
         self.gs.term_store.get(term_id)
     }
 
+    /// Get the pattern with the given [PatternId].
+    pub fn get_pattern(&self, pattern_id: PatternId) -> &Pattern {
+        self.gs.pattern_store.get(pattern_id)
+    }
+
     /// Get the module definition with the given [ModDefId].
     pub fn get_mod_def(&self, mod_def_id: ModDefId) -> &ModDef {
         self.gs.mod_def_store.get(mod_def_id)
@@ -54,6 +59,11 @@ impl<'gs> PrimitiveReader<'gs> {
     /// Get the params with the given [ParamsId].
     pub fn get_params(&self, params_id: ParamsId) -> &Params {
         self.gs.params_store.get(params_id)
+    }
+
+    /// Get the pattern_params with the given [PatternParamsId].
+    pub fn get_pattern_params(&self, pattern_params_id: PatternParamsId) -> &PatternParams {
+        self.gs.pattern_params_store.get(pattern_params_id)
     }
 
     /// Get the trait definition with the given [TrtDefId].

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -12,18 +12,15 @@ use hash_source::identifier::Identifier;
 
 /// Contains actions related to variable resolution.
 pub struct ScopeResolver<'gs, 'ls, 'cd, 's> {
-    /// Inner storage for global, local and core definitions.
     storage: StorageRefMut<'gs, 'ls, 'cd, 's>,
 }
 
 impl<'gs, 'ls, 'cd, 's> AccessToStorage for ScopeResolver<'gs, 'ls, 'cd, 's> {
-    /// Get the inner storage for resolving.
     fn storages(&self) -> StorageRef {
         self.storage.storages()
     }
 }
 impl<'gs, 'ls, 'cd, 's> AccessToStorageMut for ScopeResolver<'gs, 'ls, 'cd, 's> {
-    /// Get the inner storage for resolving.
     fn storages_mut(&mut self) -> StorageRefMut {
         self.storage.storages_mut()
     }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -247,7 +247,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 });
                 if let Ok(Some(ty_access_result)) = ty_access_result {
                     // To get the function type, we need to get the type of the result.
-                    let ty_of_ty_access_result = self.typer().ty_of_term(ty_access_result)?;
+                    let ty_of_ty_access_result = self.typer().infer_ty_of_term(ty_access_result)?;
                     // Then we can try turn this into a method call
                     return Some(self.turn_accessed_ty_and_subject_ty_into_method(
                         ty_of_ty_access_result,
@@ -264,7 +264,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 //
                 // This is possible because traits will return the type of their
                 // members when accessing members.
-                let ty_of_ty_term_id = self.typer().ty_of_term(*ty_term_id)?;
+                let ty_of_ty_term_id = self.typer().infer_ty_of_term(*ty_term_id)?;
                 let accessed_result = self.apply_access_term(&AccessTerm {
                     subject: ty_of_ty_term_id,
                     name: access_term.name,
@@ -315,7 +315,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             }
             Level0Term::Lit(_) => {
                 // Create an Rt(..) of the value wrapped, and use that as the subject.
-                let term = &Level0Term::Rt(self.typer().ty_of_term(originating_term)?);
+                let term = &Level0Term::Rt(self.typer().infer_ty_of_term(originating_term)?);
                 self.apply_access_to_level0_term(term, access_term, originating_term)
             }
         }
@@ -408,7 +408,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
 
                 // Resolve the type of the name:
                 let name_var = self.builder().create_var_term(access_term.name);
-                let result = self.typer().ty_of_term(name_var)?;
+                let result = self.typer().infer_ty_of_term(name_var)?;
 
                 // Pop back the scope
                 self.scopes_mut().pop_scope();
@@ -1204,7 +1204,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             }
             Term::TyOf(term) => {
                 // Get the type of the term:
-                Ok(Some(self.typer().ty_of_term(term)?))
+                Ok(Some(self.typer().infer_ty_of_term(term)?))
             }
             Term::Unresolved(_) => {
                 // Cannot do anything here:

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -949,7 +949,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
         // Only return the new args if we simplified them:
         if simplified_once {
             let new_args = self.builder().create_args(result, args.origin());
-            self.location_store_mut().copy_args_locations(args_id, new_args);
+            self.location_store_mut().copy_locations(args_id, new_args);
 
             Ok(Some(new_args))
         } else {
@@ -997,7 +997,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
         // Only return the new params if we simplified them:
         if simplified_once {
             let new_params = self.builder().create_params(result, params.origin());
-            self.location_store_mut().copy_params_locations(params_id, new_params);
+            self.location_store_mut().copy_locations(params_id, new_params);
 
             Ok(Some(new_params))
         } else {

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -179,6 +179,10 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 let subbed_args = self.apply_sub_to_args(sub, fn_call.args);
                 self.builder().create_fn_call_term(subbed_subject, subbed_args)
             }
+            Level0Term::Tuple(tuple_lit) => {
+                let subbed_args = self.apply_sub_to_args(sub, tuple_lit.members);
+                self.builder().create_tuple_lit_term(subbed_args)
+            }
             Level0Term::Lit(_) => original_term,
         }
     }
@@ -393,6 +397,9 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
                 // Forward to subject and args:
                 self.add_free_vars_in_term_to_set(fn_call.subject, result);
                 self.add_free_vars_in_args_to_set(fn_call.args, result);
+            }
+            Level0Term::Tuple(tuple_lit) => {
+                self.add_free_vars_in_args_to_set(tuple_lit.members, result);
             }
             Level0Term::Lit(_) => {}
         }

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -1,7 +1,4 @@
 //! Contains operations to get the type of a term.
-
-#![allow(dead_code)] // @@Todo: remove
-
 use crate::{
     diagnostics::{
         error::{TcError, TcResult},
@@ -289,30 +286,6 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
             .collect::<TcResult<_>>()?;
 
         Ok(self.builder().create_args(param_types, origin))
-    }
-
-    /// From the given [PatternParamsId], infer a [ParamsId] describing the type
-    /// of the arguments.
-    pub(crate) fn params_of_pattern_params(
-        &mut self,
-        pattern_params_id: PatternParamsId,
-    ) -> TcResult<ParamsId> {
-        let pattern_params = self.reader().get_pattern_params(pattern_params_id).clone();
-        let origin = pattern_params.origin();
-        let param_types: Vec<_> = pattern_params
-            .into_positional()
-            .into_iter()
-            .map(|param| {
-                let pattern_term = self.term_of_pattern(param.pattern)?;
-                Ok(Param {
-                    name: param.name,
-                    default_value: None,
-                    ty: self.ty_of_term(pattern_term)?,
-                })
-            })
-            .collect::<TcResult<_>>()?;
-
-        Ok(self.builder().create_params(param_types, origin))
     }
 
     /// Get the type of the given pattern, as a term.

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -343,7 +343,7 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
             }
             Pattern::Constructor(constructor_pattern) => match constructor_pattern.params {
                 Some(params) => {
-                    // We have params to apply
+                    // We have params to apply, so we need to create an FnCall
                     let args_id = self.args_of_pattern_params(params)?;
                     let builder = self.builder();
                     Ok(builder.create_fn_call_term(constructor_pattern.subject, args_id))

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -7,6 +7,7 @@ use crate::{
         params::ParamUnificationErrorReason,
     },
     storage::{
+        location::LocationTarget,
         primitives::{
             ArgsId, Level0Term, Level1Term, Level2Term, Level3Term, ParamsId, Sub, Term, TermId,
         },
@@ -224,8 +225,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
         &mut self,
         src_params_id: ParamsId,
         target_params_id: ParamsId,
-        src_id: TermId,
-        target_id: TermId,
+        src: impl Into<LocationTarget>,
+        target: impl Into<LocationTarget>,
     ) -> TcResult<Sub> {
         let src_params = self.params_store().get(src_params_id).clone();
         let target_params = self.params_store().get(target_params_id).clone();
@@ -235,8 +236,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                 src_params_id,
                 target_params_id,
                 reason,
-                src: src_id,
-                target: target_id,
+                src: src.into(),
+                target: target.into(),
             })
         };
 

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -149,7 +149,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
 
         for (param, arg) in pairs.into_iter() {
             // Ensure their types unify:
-            let ty_of_arg = self.typer().ty_of_term(arg.value)?;
+            let ty_of_arg = self.typer().infer_ty_of_term(arg.value)?;
             let ty_sub = self.unify_terms(ty_of_arg, param.ty)?;
 
             match mode {
@@ -459,7 +459,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                     // Here we use the target's subject but it shouldn't matter.
                     .apply_sub_to_term(&subject_sub, target_app_ty_fn.subject);
 
-                let subject_ty_id = self.typer().ty_of_term(subject)?;
+                let subject_ty_id = self.typer().infer_ty_of_term(subject)?;
                 let reader = self.reader();
                 let subject_ty = reader.get_term(subject_ty_id);
                 match subject_ty {
@@ -635,9 +635,10 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                     (Level0Term::Lit(_) | Level0Term::Tuple(_) | Level0Term::EnumVariant(_), _) => {
                         // Try to get the type of the src literal, and the type of the target, and
                         // unify:
-                        let src_lit_ty = self.typer().ty_of_simplified_term(simplified_src_id)?;
+                        let src_lit_ty =
+                            self.typer().infer_ty_of_simplified_term(simplified_src_id)?;
                         let target_non_lit_ty =
-                            self.typer().ty_of_simplified_term(simplified_target_id)?;
+                            self.typer().infer_ty_of_simplified_term(simplified_target_id)?;
                         self.unify_terms(src_lit_ty, target_non_lit_ty)
                     }
                     // Any other level-0 term does not unify:

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -632,7 +632,7 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                             target_id,
                         )
                     }
-                    (Level0Term::Lit(_) | Level0Term::Tuple(_), _) => {
+                    (Level0Term::Lit(_) | Level0Term::Tuple(_) | Level0Term::EnumVariant(_), _) => {
                         // Try to get the type of the src literal, and the type of the target, and
                         // unify:
                         let src_lit_ty = self.typer().ty_of_simplified_term(simplified_src_id)?;

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -170,6 +170,53 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
         Ok(sub)
     }
 
+    /// Unify the two given argument lists, by argument-wise unifying terms.
+    /// The function requires a reference to the parent source and target
+    /// terms in order to give meaningful error messages.
+    pub(crate) fn unify_args(
+        &mut self,
+        src_args_id: ArgsId,
+        target_args_id: ArgsId,
+        src_id: TermId,
+        target_id: TermId,
+    ) -> TcResult<Sub> {
+        let src_args = self.args_store().get(src_args_id).clone();
+        let target_args = self.args_store().get(target_args_id).clone();
+
+        let cannot_unify = |reason: ParamUnificationErrorReason| {
+            Err(TcError::CannotUnifyArgs {
+                src_args_id,
+                target_args_id,
+                reason,
+                src: src_id,
+                target: target_id,
+            })
+        };
+
+        // Ensure the argument lengths match
+        if src_args.positional().len() != target_args.positional().len() {
+            return cannot_unify(ParamUnificationErrorReason::LengthMismatch);
+        }
+
+        // For each argument, ensure it is the same:
+        let mut cumulative_sub = Sub::empty();
+        let pairs = src_args.positional().iter().zip(target_args.positional());
+        for (index, (src_param, target_param)) in pairs.enumerate() {
+            // Names match
+            if src_param.name != target_param.name {
+                return cannot_unify(ParamUnificationErrorReason::NameMismatch(index));
+            }
+            // Values match
+            let ty_sub = self.unify_terms(src_param.value, target_param.value)?;
+
+            // Add to cumulative substitution
+            cumulative_sub.extend(&ty_sub);
+        }
+
+        // Return the cumulative substitution of all the arguments:
+        Ok(cumulative_sub)
+    }
+
     /// Unify the two given parameter lists, by parameter-wise unifying terms.
     /// The function requires a reference to the parent source and target
     /// terms in order to give meaningful error messages.
@@ -562,6 +609,31 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
                         } else {
                             cannot_unify()
                         }
+                    }
+                    (Level0Term::Lit(src_lit), Level0Term::Lit(target_lit)) => {
+                        if src_lit == target_lit {
+                            // They are the same literal:
+                            Ok(Sub::empty())
+                        } else {
+                            cannot_unify()
+                        }
+                    }
+                    (Level0Term::Tuple(src_tuple_lit), Level0Term::Tuple(target_tuple_lit)) => {
+                        // Unify each argument:
+                        self.unifier().unify_args(
+                            src_tuple_lit.members,
+                            target_tuple_lit.members,
+                            src_id,
+                            target_id,
+                        )
+                    }
+                    (Level0Term::Lit(_) | Level0Term::Tuple(_), _) => {
+                        // Try to get the type of the src literal, and the type of the target, and
+                        // unify:
+                        let src_lit_ty = self.typer().ty_of_simplified_term(simplified_src_id)?;
+                        let target_non_lit_ty =
+                            self.typer().ty_of_simplified_term(simplified_target_id)?;
+                        self.unify_terms(src_lit_ty, target_non_lit_ty)
                     }
                     // Any other level-0 term does not unify:
                     _ => cannot_unify(),

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -316,6 +316,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
 
                     Ok(Sub::from_pairs([(inner, instantiated_target)]))
                 }
+                // If the inner is not runtime instantiable, it succeeds but with no substitution.
+                Term::Unresolved(_) => Ok(Sub::empty()),
                 _ => cannot_unify(),
             },
             (_, Term::TyOf(target_inner)) => match self.term_store().get(target_inner).clone() {
@@ -329,6 +331,8 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
 
                     Ok(Sub::from_pairs([(inner, instantiated_source)]))
                 }
+                // If the inner is not runtime instantiable, it succeeds but with no substitution.
+                Term::Unresolved(_) => Ok(Sub::empty()),
                 _ => cannot_unify(),
             },
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -234,12 +234,12 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
 
                 // Ensure all members have been implemented:
                 for trt_member in trt_def_members.iter() {
-                    let trt_member_data = self.typer().infer_member_data(trt_member.data)?;
+                    let trt_member_data = self.typer().infer_member_ty(trt_member.data)?;
 
                     if let Some(scope_member) = scope.get(trt_member.name) {
                         // Infer the type of the scope member:
                         let scope_member_data =
-                            self.typer().infer_member_data(scope_member.0.data)?;
+                            self.typer().infer_member_ty(scope_member.0.data)?;
 
                         // Apply the substitution to the trait member first:
                         let trt_member_ty_subbed =

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -776,6 +776,12 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     // @@Todo: ensure that integers are not too large
                     Ok(result)
                 }
+                Level0Term::Tuple(tuple_lit) => {
+                    self.validate_args(tuple_lit.members)?;
+                    // Validate its type to ensure members are runtime instantiable:
+                    self.validate_term(term_ty_id)?;
+                    Ok(result)
+                }
             },
 
             // Access
@@ -991,6 +997,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     )
                     }
                     Level0Term::Lit(_) => Ok(false),
+                    Level0Term::Tuple(_) => Ok(false),
                 }
             }
             _ => Ok(true),

--- a/compiler/hash-typecheck/src/storage/location.rs
+++ b/compiler/hash-typecheck/src/storage/location.rs
@@ -188,6 +188,18 @@ impl From<&TermId> for LocationTarget {
     }
 }
 
+impl From<PatternId> for LocationTarget {
+    fn from(id: PatternId) -> Self {
+        Self::Pattern(id)
+    }
+}
+
+impl From<&PatternId> for LocationTarget {
+    fn from(id: &PatternId) -> Self {
+        Self::Pattern(*id)
+    }
+}
+
 impl From<(ParamsId, usize)> for LocationTarget {
     fn from((id, index): (ParamsId, usize)) -> Self {
         Self::Param(id, index)
@@ -203,5 +215,11 @@ impl From<(ArgsId, usize)> for LocationTarget {
 impl From<(ScopeId, usize)> for LocationTarget {
     fn from((id, index): (ScopeId, usize)) -> Self {
         Self::Declaration(id, index)
+    }
+}
+
+impl From<(PatternParamsId, usize)> for LocationTarget {
+    fn from((id, index): (PatternParamsId, usize)) -> Self {
+        Self::ParamPattern(id, index)
     }
 }

--- a/compiler/hash-typecheck/src/storage/location.rs
+++ b/compiler/hash-typecheck/src/storage/location.rs
@@ -25,9 +25,53 @@ pub enum LocationTarget {
     Declaration(ScopeId, usize),
     /// A pattern parameter key includes the parent [ParamsPatternId] and an
     /// index to which parameter
-    ParamPattern(PatternParamsId, usize),
+    PatternParam(PatternParamsId, usize),
     /// A pattern.
     Pattern(PatternId),
+}
+
+/// Types that paired with an index, create a [LocationTarget].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum IndexedLocationTarget {
+    Params(ParamsId),
+    Args(ArgsId),
+    Scope(ScopeId),
+    PatternParams(PatternParamsId),
+}
+
+impl From<ParamsId> for IndexedLocationTarget {
+    fn from(id: ParamsId) -> Self {
+        IndexedLocationTarget::Params(id)
+    }
+}
+
+impl From<ArgsId> for IndexedLocationTarget {
+    fn from(id: ArgsId) -> Self {
+        IndexedLocationTarget::Args(id)
+    }
+}
+
+impl From<PatternParamsId> for IndexedLocationTarget {
+    fn from(id: PatternParamsId) -> Self {
+        IndexedLocationTarget::PatternParams(id)
+    }
+}
+
+impl From<ScopeId> for IndexedLocationTarget {
+    fn from(id: ScopeId) -> Self {
+        IndexedLocationTarget::Scope(id)
+    }
+}
+
+impl From<(IndexedLocationTarget, usize)> for LocationTarget {
+    fn from((target, i): (IndexedLocationTarget, usize)) -> Self {
+        match target {
+            IndexedLocationTarget::Params(params) => LocationTarget::Param(params, i),
+            IndexedLocationTarget::Args(args) => LocationTarget::Arg(args, i),
+            IndexedLocationTarget::PatternParams(params) => LocationTarget::PatternParam(params, i),
+            IndexedLocationTarget::Scope(scope) => LocationTarget::Declaration(scope, i),
+        }
+    }
 }
 
 /// Stores the source location of various targets in the AST tree.
@@ -103,7 +147,7 @@ impl LocationStore {
                     .or_insert_with(|| Rc::new(RefCell::new(HashMap::new())));
                 map.borrow_mut().insert(index, location);
             }
-            LocationTarget::ParamPattern(param_pattern, index) => {
+            LocationTarget::PatternParam(param_pattern, index) => {
                 let map = self
                     .param_pattern_map
                     .entry(param_pattern)
@@ -128,36 +172,62 @@ impl LocationStore {
                 Some(*self.declaration_map.get(&scope)?.borrow().get(&index)?)
             }
             LocationTarget::Pattern(pattern) => self.pattern_map.get(&pattern).copied(),
-            LocationTarget::ParamPattern(param_pattern, index) => {
+            LocationTarget::PatternParam(param_pattern, index) => {
                 Some(*self.param_pattern_map.get(&param_pattern)?.borrow().get(&index)?)
             }
         }
     }
 
-    /// Copy a parameter set within [LocationStore]. This will copy the internal
-    /// reference of the src [ParamsId] to the `dest` [ParamsId]. This does not
-    /// create a new separate copy of locations.
-    pub fn copy_params_locations(&mut self, src: ParamsId, dest: ParamsId) {
-        if let Some(origin) = self.param_map.get(&src) {
-            self.param_map.insert(dest, origin.clone());
-        }
-    }
+    /// Copy a set of locations from the first [IndexedLocationTarget] to the
+    /// second [IndexedLocationTarget].
+    pub fn copy_locations(
+        &mut self,
+        src: impl Into<IndexedLocationTarget> + Clone,
+        dest: impl Into<IndexedLocationTarget> + Clone,
+    ) {
+        let src = src.into();
+        let dest = dest.into();
 
-    /// Copy a arguments set within [LocationStore]. This will copy the internal
-    /// reference of the src [ArgsId] to the `dest` [ArgsId]. This does not
-    /// create a new separate copy of locations.
-    pub fn copy_args_locations(&mut self, src: ArgsId, dest: ArgsId) {
-        if let Some(origin) = self.arg_map.get(&src) {
-            self.arg_map.insert(dest, origin.clone());
+        macro_rules! insert_dest {
+            ($origin:expr) => {
+                match dest {
+                    IndexedLocationTarget::Params(dest) => {
+                        self.param_map.insert(dest, $origin.clone());
+                    }
+                    IndexedLocationTarget::Args(dest) => {
+                        self.arg_map.insert(dest, $origin.clone());
+                    }
+                    IndexedLocationTarget::PatternParams(dest) => {
+                        self.param_pattern_map.insert(dest, $origin.clone());
+                    }
+                    IndexedLocationTarget::Scope(dest) => {
+                        self.declaration_map.insert(dest, $origin.clone());
+                    }
+                }
+            };
         }
-    }
 
-    /// Copy a declaration set within [LocationStore]. This will copy the
-    /// internal reference of the src [ScopeId] to the `dest` [ScopeId].
-    /// This does not create a new separate copy of locations.
-    pub fn copy_declarations_locations(&mut self, src: ScopeId, dest: ScopeId) {
-        if let Some(origin) = self.declaration_map.get(&src) {
-            self.declaration_map.insert(dest, origin.clone());
+        match src {
+            IndexedLocationTarget::Params(src) => {
+                if let Some(origin) = self.param_map.get(&src) {
+                    insert_dest!(origin);
+                }
+            }
+            IndexedLocationTarget::Args(src) => {
+                if let Some(origin) = self.arg_map.get(&src) {
+                    insert_dest!(origin);
+                }
+            }
+            IndexedLocationTarget::PatternParams(src) => {
+                if let Some(origin) = self.param_pattern_map.get(&src) {
+                    insert_dest!(origin);
+                }
+            }
+            IndexedLocationTarget::Scope(src) => {
+                if let Some(origin) = self.declaration_map.get(&src) {
+                    insert_dest!(origin);
+                }
+            }
         }
     }
 
@@ -220,6 +290,6 @@ impl From<(ScopeId, usize)> for LocationTarget {
 
 impl From<(PatternParamsId, usize)> for LocationTarget {
     fn from((id, index): (PatternParamsId, usize)) -> Self {
-        Self::ParamPattern(id, index)
+        Self::PatternParam(id, index)
     }
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -241,7 +241,7 @@ impl<ParamType: GetNameOpt + Clone> FromIterator<ParamType> for ParamList<ParamT
 }
 
 /// An argument to a parameter.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Copy)]
 pub struct Arg {
     pub name: Option<Identifier>,
     pub value: TermId,
@@ -258,7 +258,7 @@ pub type Args = ParamList<Arg>;
 
 /// A parameter, declaring a potentially named variable with a given type and
 /// default value.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Copy)]
 pub struct Param {
     pub name: Option<Identifier>,
     pub ty: TermId,

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -967,7 +967,9 @@ pub type PatternParams = ParamList<PatternParam>;
 #[derive(Clone, Debug, Copy)]
 pub struct ConstructorPattern {
     pub subject: TermId,
-    pub params: PatternParamsId,
+    /// If `params` is `None`, it means that the constructor has no parameters;
+    /// it is a unit.
+    pub params: Option<PatternParamsId>,
 }
 
 /// A conditional pattern, containing a pattern and an condition.
@@ -975,6 +977,13 @@ pub struct ConstructorPattern {
 pub struct IfPattern {
     pub pattern: PatternId,
     pub condition: TermId,
+}
+
+/// A module pattern, containing a list of patterns to be used to match module
+/// members.
+#[derive(Clone, Debug, Copy)]
+pub struct ModPattern {
+    pub members: PatternParamsId,
 }
 
 /// Represents a pattern in the language.
@@ -990,6 +999,8 @@ pub enum Pattern {
     Lit(TermId),
     /// Tuple pattern.
     Tuple(PatternParamsId),
+    /// Module pattern.
+    Mod(ModPattern),
     /// Constructor pattern.
     Constructor(ConstructorPattern),
     /// A set of patterns that are OR-ed together. If any one of them matches

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -691,6 +691,12 @@ pub struct FnLit {
     pub return_value: TermId,
 }
 
+/// A tuple literal, containing arguments as members.
+#[derive(Debug, Clone, Copy)]
+pub struct TupleLit {
+    pub members: ArgsId,
+}
+
 /// A level 0 term.
 ///
 /// Type of: nothing.
@@ -708,6 +714,9 @@ pub enum Level0Term {
 
     /// An enum variant, which is either a constant term or a function value.
     EnumVariant(EnumVariantValue),
+
+    /// Tuple literal.
+    Tuple(TupleLit),
 
     /// A literal term
     Lit(LitTerm),

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     ops::{AccessToOps, AccessToOpsMut},
     storage::{
-        location::LocationTarget,
+        location::{IndexedLocationTarget, LocationTarget},
         primitives::{
             AccessOp, Arg, ArgsId, BindingPattern, BoundVars, EnumVariant, Member, MemberData,
             ModDefOrigin, Mutability, Param, ParamOrigin, Pattern, PatternId, PatternParam, Sub,
@@ -133,16 +133,14 @@ impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
     /// Copy the [SourceLocation] of the given [hash_ast::ast::AstNode] list to
     /// the given [LocationTarget] list represented by a type `Target` where
     /// `(Target, usize)` implements [Into<LocationTarget>].
-    pub(crate) fn copy_location_from_nodes_to_targets<'n, N: 'n, Target>(
+    pub(crate) fn copy_location_from_nodes_to_targets<'n, N: 'n>(
         &mut self,
         nodes: impl IntoIterator<Item = AstNodeRef<'n, N>>,
-        targets: Target,
-    ) where
-        (Target, usize): Into<LocationTarget>,
-        Target: Copy,
-    {
+        targets: impl Into<IndexedLocationTarget> + Clone,
+    ) {
+        let targets = targets.into();
         for (index, param) in nodes.into_iter().enumerate() {
-            self.copy_location_from_node_to_target(param, (targets, index));
+            self.copy_location_from_node_to_target(param, LocationTarget::from((targets, index)));
         }
     }
 }

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -2122,7 +2122,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::TuplePattern>,
     ) -> Result<Self::TuplePatternRet, Self::Error> {
         let walk::TuplePattern { elements } = walk::walk_tuple_pattern(self, ctx, node)?;
-        let members = self.builder().create_pattern_params(elements, ParamOrigin::Unknown);
+        let members = self.builder().create_pattern_params(elements, ParamOrigin::Tuple);
         let tuple_pattern = self.builder().create_tuple_pattern(members);
 
         self.copy_location_from_nodes_to_targets(node.fields.ast_ref_iter(), members);

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1316,10 +1316,8 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
                     }
                     None => {
                         // Does not match, indicate that the case is useless!
-                        redundant_errors.push(TcError::UselessMatchCase {
-                            match_case_pattern: case_pattern,
-                            subject,
-                        });
+                        redundant_errors
+                            .push(TcError::UselessMatchCase { pattern: case_pattern, subject });
                         Ok(None)
                     }
                 }
@@ -1645,7 +1643,7 @@ impl<'gs, 'ls, 'cd, 'src> visitor::AstVisitor for TcVisitor<'gs, 'ls, 'cd, 'src>
                     Some(members) => members,
                     None => {
                         return Err(TcError::UselessMatchCase {
-                            match_case_pattern: pattern_id,
+                            pattern: pattern_id,
                             subject: value,
                         })
                     }

--- a/compiler/hash-typecheck/src/traverse/sequence.rs
+++ b/compiler/hash-typecheck/src/traverse/sequence.rs
@@ -26,7 +26,7 @@ impl<'gs, 'ls, 'cd, 'src> TcVisitor<'gs, 'ls, 'cd, 'src> {
         let mut shared_term = self.builder().create_unresolved_term();
 
         while let Some(element) = elements.next() {
-            let element_ty = self.typer().ty_of_term(element)?;
+            let element_ty = self.typer().infer_ty_of_term(element)?;
             let sub = self.unifier().unify_terms(element_ty, shared_term)?;
 
             // apply the substitution on the `shared_term`


### PR DESCRIPTION
This PR implements pattern and control flow traversal. There are still a few things to be done:
- Adding constructor pattern bindings to scope: #407 
- Matching or patterns: #409 
- Matching mod patterns: #408 

Closes #410, #331, #329.