### PR TITLE
TC: Implement assignment and start dealing with recursive definitions

### DIFF
--- a/compiler/hash-ast-passes/src/visitor.rs
+++ b/compiler/hash-ast-passes/src/visitor.rs
@@ -4,8 +4,6 @@
 //! analyser to perform a variety of semantic checks.
 
 use ::if_chain::if_chain;
-use std::{collections::HashSet, convert::Infallible, mem};
-
 use hash_ast::{
     ast::{
         BindingPat, Block, BlockExpr, DestructuringPat, ExprKind, LitExpr, Mutability, ParamOrigin,
@@ -15,6 +13,7 @@ use hash_ast::{
 };
 use hash_reporting::macros::panic_on_span;
 use hash_source::{identifier::CORE_IDENTIFIERS, ModuleKind};
+use std::{collections::HashSet, convert::Infallible, mem};
 
 use crate::{
     analysis::SemanticAnalyser,

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -18,6 +18,7 @@ error_codes! {
     InvalidPropertyAccess = 16,
     MissingStructField = 17,
     UninitialisedMember = 18,
+    InvalidAssignSubject = 19,
 
     // Type errors
     TypeMismatch = 20,

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -2,14 +2,11 @@
 
 use crate::storage::{
     location::LocationTarget,
-    primitives::{AccessTerm, ArgsId, ParamsId, PatId, TermId, TyFnCase},
+    primitives::{AccessOp, AccessTerm, ArgsId, ParamsId, PatId, TermId, TyFnCase},
 };
 use hash_source::identifier::Identifier;
 
-use super::{
-    params::{ParamListKind, ParamUnificationErrorReason},
-    symbol::NameFieldOrigin,
-};
+use super::params::{ParamListKind, ParamUnificationErrorReason};
 
 /// Convenient type alias for a result with a [TcError] as the error type.
 pub type TcResult<T> = Result<T, TcError>;
@@ -66,7 +63,13 @@ pub enum TcError {
     /// It is invalid to use a positional argument after a named argument.
     AmbiguousArgumentOrdering { param_kind: ParamListKind, index: usize },
     /// The given name cannot be resolved in the given value.
-    UnresolvedNameInValue { name: Identifier, origin: NameFieldOrigin, value: TermId },
+    UnresolvedNameInValue {
+        // @@ErrorReporting: add more info about the term. Maybe we need a general way of
+        // characterising terms as a string (i.e. "struct", "enum", "module", etc).
+        name: Identifier,
+        op: AccessOp,
+        value: TermId,
+    },
     /// The given variable cannot be resolved in the current context.
     UnresolvedVariable { name: Identifier, value: TermId },
     /// The given value does not support accessing (of the given name).

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -1,12 +1,11 @@
 //! Error-related data structures for errors that occur during typechecking.
 
+use super::params::{ParamListKind, ParamUnificationErrorReason};
 use crate::storage::{
     location::LocationTarget,
     primitives::{AccessOp, AccessTerm, ArgsId, ParamsId, PatId, TermId, TyFnCase},
 };
-use hash_source::identifier::Identifier;
-
-use super::params::{ParamListKind, ParamUnificationErrorReason};
+use hash_source::{identifier::Identifier, location::SourceLocation};
 
 /// Convenient type alias for a result with a [TcError] as the error type.
 pub type TcResult<T> = Result<T, TcError>;
@@ -143,4 +142,6 @@ pub enum TcError {
     UselessMatchCase { pat: PatId, subject: TermId },
     /// Cannot use pattern matching in a declaration without an assignment
     CannotPatMatchWithoutAssignment { pat: PatId },
+    /// Cannot use a non-name as an assign subject.
+    InvalidAssignSubject { location: SourceLocation },
 }

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -556,7 +556,7 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                     )));
                 }
             }
-            TcError::UnresolvedNameInValue { name, origin, value } => {
+            TcError::UnresolvedNameInValue { name, op, value } => {
                 builder.with_error_code(HashErrorCode::UnresolvedNameInValue).with_message(
                     format!(
                         "the field `{}` is not present within `{}`",
@@ -568,7 +568,12 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                 if let Some(location) = err.location_store().get_location(value) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
-                        format!("{} does not contain the named property `{}`", origin, name),
+                        format!(
+                            "{} does not contain the {} `{}`",
+                            value.for_formatting(err.global_storage()),
+                            op,
+                            name
+                        ),
                     )));
                 }
             }

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -1002,7 +1002,8 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                 }
             }
             TcError::InvalidFnCallSubject { term } => {
-                builder.with_error_code(HashErrorCode::TypeIsNotTrait).with_message(format!(
+                // @@Todo: error code
+                builder.with_message(format!(
                     "cannot use `{}` as a function call subject",
                     term.for_formatting(err.global_storage())
                 ));
@@ -1015,7 +1016,8 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                 }
             }
             TcError::UselessMatchCase { pat, subject } => {
-                builder.with_error_code(HashErrorCode::TypeMismatch).with_message(format!(
+                // @@Todo: error code
+                builder.with_message(format!(
                     "match case `{}` is redundant when matching on `{}`",
                     pat.for_formatting(err.global_storage()),
                     subject.for_formatting(err.global_storage())
@@ -1036,7 +1038,8 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                 }
             }
             TcError::CannotPatMatchWithoutAssignment { pat } => {
-                builder.with_error_code(HashErrorCode::TypeMismatch).with_message(
+                // @@Todo: error code
+                builder.with_message(
                     "declaration left-hand side cannot contain a pattern if no value is provided"
                         .to_string(),
                 );
@@ -1050,6 +1053,16 @@ impl<'gs, 'ls, 'cd, 's> From<TcErrorWithStorage<'gs, 'ls, 'cd, 's>> for Report {
                         ),
                     )));
                 }
+            }
+            TcError::InvalidAssignSubject { location } => {
+                builder
+                    .with_error_code(HashErrorCode::InvalidAssignSubject)
+                    .with_message("assignment left-hand side needs to be a variable".to_string());
+
+                builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                    *location,
+                    "non-variable term given in an assignment here",
+                )));
             }
         };
 

--- a/compiler/hash-typecheck/src/diagnostics/symbol.rs
+++ b/compiler/hash-typecheck/src/diagnostics/symbol.rs
@@ -3,11 +3,6 @@
 
 use std::fmt::Display;
 
-use crate::storage::{
-    primitives::{AppSub, Level0Term, Level1Term, Term},
-    terms::TermStore,
-};
-
 /// An enum representing the origin of a named field access.
 /// This is used to provide additional contextual information
 /// when the validator fails to find a named field within
@@ -24,36 +19,6 @@ pub enum NameFieldOrigin {
     Mod,
     /// Tuple parent subject
     Tuple,
-}
-
-impl NameFieldOrigin {
-    /// Utility function to convert a [Term] into a [NameFieldOrigin].
-    ///
-    /// This assumes that the provided term does yield a [NameFieldOrigin]
-    /// and any other variant of term will cause the function to *panic*.
-    pub fn from_term(term: &Term, store: &TermStore) -> Self {
-        let term_from_level_1 = |t: &Level1Term| match t {
-            Level1Term::ModDef(_) => Self::Mod,
-            Level1Term::NominalDef(_) => Self::Enum,
-            Level1Term::Tuple(_) => Self::Tuple,
-            Level1Term::Fn(_) => panic!("`NameFieldOrigin::from_term` hit fn literal type"),
-        };
-
-        match term {
-            Term::Level1(inner) => term_from_level_1(inner),
-            Term::Level0(Level0Term::Rt(inner)) => {
-                // we can extract the inner type since it's
-                // known that this should be a level-1 term
-                NameFieldOrigin::from_term(store.get(*inner), store)
-            }
-            Term::AppSub(AppSub { term, .. }) => {
-                NameFieldOrigin::from_term(store.get(*term), store)
-            }
-            _ => panic!(
-                "`NameFieldOrigin::from_term` should only be used on level-1 or level-0 terms"
-            ),
-        }
-    }
 }
 
 impl Display for NameFieldOrigin {

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -449,8 +449,14 @@ impl<'gs> TcFormatter<'gs> {
                     )
                 )
             }
-            Term::ScopeVar(_) => todo!(),
-            Term::BoundVar(_) => todo!(),
+            Term::ScopeVar(var) => {
+                opts.is_atomic.set(true);
+                write!(f, "{}", var.name)
+            }
+            Term::BoundVar(var) => {
+                opts.is_atomic.set(true);
+                write!(f, "{}", var.name)
+            }
         }
     }
 

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -449,6 +449,8 @@ impl<'gs> TcFormatter<'gs> {
                     )
                 )
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -307,6 +307,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
             data: MemberData::InitialisedWithTy { ty, value },
             visibility: Visibility::Private,
             mutability: Mutability::Immutable,
+            is_closed: true,
         }
     }
 
@@ -323,6 +324,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
             data: MemberData::InitialisedWithInferredTy { value },
             visibility,
             mutability: Mutability::Immutable,
+            is_closed: true,
         }
     }
 
@@ -339,6 +341,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
             data: MemberData::InitialisedWithTy { ty, value },
             visibility,
             mutability: Mutability::Immutable,
+            is_closed: true,
         }
     }
 
@@ -354,6 +357,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
             data: MemberData::Uninitialised { ty },
             visibility,
             mutability: Mutability::Immutable,
+            is_closed: true,
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -302,13 +302,12 @@ impl<'gs> PrimitiveBuilder<'gs> {
         ty: TermId,
         value: TermId,
     ) -> Member {
-        Member {
-            name: name.into(),
-            data: MemberData::InitialisedWithTy { ty, value },
-            visibility: Visibility::Private,
-            mutability: Mutability::Immutable,
-            is_closed: true,
-        }
+        Member::closed(
+            name.into(),
+            Visibility::Private,
+            Mutability::Immutable,
+            MemberData::InitialisedWithTy { ty, value },
+        )
     }
 
     /// Create a public member with the given name and value, with inferred
@@ -319,13 +318,12 @@ impl<'gs> PrimitiveBuilder<'gs> {
         value: TermId,
         visibility: Visibility,
     ) -> Member {
-        Member {
-            name: name.into(),
-            data: MemberData::InitialisedWithInferredTy { value },
+        Member::closed(
+            name.into(),
             visibility,
-            mutability: Mutability::Immutable,
-            is_closed: true,
-        }
+            Mutability::Immutable,
+            MemberData::InitialisedWithInferredTy { value },
+        )
     }
 
     /// Create a public member with the given name, type and value.
@@ -336,13 +334,12 @@ impl<'gs> PrimitiveBuilder<'gs> {
         value: TermId,
         visibility: Visibility,
     ) -> Member {
-        Member {
-            name: name.into(),
-            data: MemberData::InitialisedWithTy { ty, value },
+        Member::closed(
+            name.into(),
             visibility,
-            mutability: Mutability::Immutable,
-            is_closed: true,
-        }
+            Mutability::Immutable,
+            MemberData::InitialisedWithTy { ty, value },
+        )
     }
 
     /// Create a public member with the given name, type and unset value.
@@ -352,13 +349,12 @@ impl<'gs> PrimitiveBuilder<'gs> {
         ty: TermId,
         visibility: Visibility,
     ) -> Member {
-        Member {
-            name: name.into(),
-            data: MemberData::Uninitialised { ty },
+        Member::closed(
+            name.into(),
             visibility,
-            mutability: Mutability::Immutable,
-            is_closed: true,
-        }
+            Mutability::Immutable,
+            MemberData::Uninitialised { ty },
+        )
     }
 
     /// Create a [Term::Root].

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -3,12 +3,12 @@
 use crate::storage::{
     location::LocationTarget,
     primitives::{
-        AccessOp, AccessTerm, AppSub, Arg, ArgsId, BindingPat, ConstructorPat, EnumDef,
+        AccessOp, AccessTerm, AppSub, Arg, ArgsId, BindingPat, BoundVar, ConstructorPat, EnumDef,
         EnumVariant, EnumVariantValue, FnCall, FnLit, FnTy, IfPat, Level0Term, Level1Term,
         Level2Term, Level3Term, LitTerm, Member, MemberData, ModDef, ModDefId, ModDefOrigin,
         ModPat, Mutability, NominalDef, NominalDefId, Param, ParamList, ParamsId, Pat, PatId,
-        PatParam, PatParamsId, Scope, ScopeId, ScopeKind, StructDef, StructFields, Sub, Term,
-        TermId, TrtDef, TrtDefId, TupleLit, TupleTy, TyFn, TyFnCall, TyFnCase, TyFnTy,
+        PatParam, PatParamsId, Scope, ScopeId, ScopeKind, ScopeVar, StructDef, StructFields, Sub,
+        Term, TermId, TrtDef, TrtDefId, TupleLit, TupleTy, TyFn, TyFnCall, TyFnCase, TyFnTy,
         UnresolvedTerm, Var, Visibility,
     },
     GlobalStorage,
@@ -59,6 +59,26 @@ impl<'gs> PrimitiveBuilder<'gs> {
     pub fn create_var_term(&self, var_name: impl Into<Identifier>) -> TermId {
         let var = self.create_var(var_name);
         self.create_term(Term::Var(var))
+    }
+
+    /// Create a scope variable with the given name, scope and index.
+    pub fn create_scope_var_term(
+        &self,
+        name: impl Into<Identifier>,
+        scope: ScopeId,
+        index: usize,
+    ) -> TermId {
+        self.create_term(Term::ScopeVar(ScopeVar { name: name.into(), scope, index }))
+    }
+
+    /// Create a bound variable with the given name, parameters and index.
+    pub fn create_bound_var_term(
+        &self,
+        name: impl Into<Identifier>,
+        params: ParamsId,
+        index: usize,
+    ) -> TermId {
+        self.create_term(Term::BoundVar(BoundVar { name: name.into(), params, index }))
     }
 
     /// Add the given nominal definition to the scope.

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -4,7 +4,7 @@
 //! Code from this module is to be used while traversing and typing the AST, in
 //! order to unify types and ensure correctness.
 use self::{
-    building::PrimitiveBuilder, pats::PatMatcher, reader::PrimitiveReader, scope::ScopeResolver,
+    building::PrimitiveBuilder, pats::PatMatcher, reader::PrimitiveReader, scope::ScopeManager,
     simplify::Simplifier, substitute::Substituter, typing::Typer, unify::Unifier,
     validate::Validator,
 };
@@ -73,9 +73,9 @@ pub trait AccessToOpsMut: AccessToStorageMut {
         Validator::new(self.storages_mut())
     }
 
-    /// Create an instance of [ScopeResolver].
-    fn scope_resolver(&mut self) -> ScopeResolver {
-        ScopeResolver::new(self.storages_mut())
+    /// Create an instance of [ScopeManager].
+    fn scope_manager(&mut self) -> ScopeManager {
+        ScopeManager::new(self.storages_mut())
     }
 
     /// Create an instance of [PatMatcher].

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -60,6 +60,7 @@ impl<'gs, 'ls, 'cd, 's> PatMatcher<'gs, 'ls, 'cd, 's> {
                 mutability: binding.mutability,
                 visibility: binding.visibility,
                 data: MemberData::from_ty_and_value(Some(term_ty_id), Some(simplified_term_id)),
+                is_closed: true,
             }])),
             // Ignore: No bindings but always matches
             Pat::Ignore => Ok(Some(vec![])),

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -55,13 +55,12 @@ impl<'gs, 'ls, 'cd, 's> PatMatcher<'gs, 'ls, 'cd, 's> {
         let pat = self.reader().get_pat(pat_id).clone();
         match pat {
             // Binding: Add the binding as a member
-            Pat::Binding(binding) => Ok(Some(vec![Member {
-                name: binding.name,
-                mutability: binding.mutability,
-                visibility: binding.visibility,
-                data: MemberData::from_ty_and_value(Some(term_ty_id), Some(simplified_term_id)),
-                is_closed: true,
-            }])),
+            Pat::Binding(binding) => Ok(Some(vec![Member::closed(
+                binding.name,
+                binding.visibility,
+                binding.mutability,
+                MemberData::from_ty_and_value(Some(term_ty_id), Some(simplified_term_id)),
+            )])),
             // Ignore: No bindings but always matches
             Pat::Ignore => Ok(Some(vec![])),
             // Lit: Unify the literal with the subject

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -2,10 +2,7 @@
 
 use super::{AccessToOps, AccessToOpsMut};
 use crate::{
-    diagnostics::{
-        error::{TcError, TcResult},
-        macros::tc_panic,
-    },
+    diagnostics::error::{TcError, TcResult},
     storage::{
         primitives::{
             MemberData, ParamsId, ScopeId, ScopeMember, Sub, SubSubject, TermId, Visibility,
@@ -144,9 +141,10 @@ impl<'gs, 'ls, 'cd, 's> ScopeManager<'gs, 'ls, 'cd, 's> {
         let _ = self.unifier().unify_terms(rhs_ty, member_data.ty)?;
 
         let member = self.scope_store_mut().get_mut(scope_id).get_mut_by_index(index);
-        if member.is_closed() {
-            tc_panic!(value, self, "Cannot assign to closed member");
-        }
+        // @@Todo: add back once this is property implemented
+        // if member.is_closed() {
+        //     tc_panic!(value, self, "Cannot assign to closed member");
+        // }
 
         member.assignments_until_closed -= 1;
         match member.data {

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -16,22 +16,22 @@ use crate::{
 use hash_source::identifier::Identifier;
 
 /// Contains actions related to variable resolution.
-pub struct ScopeResolver<'gs, 'ls, 'cd, 's> {
+pub struct ScopeManager<'gs, 'ls, 'cd, 's> {
     storage: StorageRefMut<'gs, 'ls, 'cd, 's>,
 }
 
-impl<'gs, 'ls, 'cd, 's> AccessToStorage for ScopeResolver<'gs, 'ls, 'cd, 's> {
+impl<'gs, 'ls, 'cd, 's> AccessToStorage for ScopeManager<'gs, 'ls, 'cd, 's> {
     fn storages(&self) -> StorageRef {
         self.storage.storages()
     }
 }
-impl<'gs, 'ls, 'cd, 's> AccessToStorageMut for ScopeResolver<'gs, 'ls, 'cd, 's> {
+impl<'gs, 'ls, 'cd, 's> AccessToStorageMut for ScopeManager<'gs, 'ls, 'cd, 's> {
     fn storages_mut(&mut self) -> StorageRefMut {
         self.storage.storages_mut()
     }
 }
 
-impl<'gs, 'ls, 'cd, 's> ScopeResolver<'gs, 'ls, 'cd, 's> {
+impl<'gs, 'ls, 'cd, 's> ScopeManager<'gs, 'ls, 'cd, 's> {
     /// Create a new [ScopeResolver].
     pub fn new(storage: StorageRefMut<'gs, 'ls, 'cd, 's>) -> Self {
         Self { storage }

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -2,9 +2,14 @@
 
 use super::{AccessToOps, AccessToOpsMut};
 use crate::{
-    diagnostics::error::{TcError, TcResult},
+    diagnostics::{
+        error::{TcError, TcResult},
+        macros::tc_panic,
+    },
     storage::{
-        primitives::{ParamsId, ScopeId, ScopeMember, Sub, SubSubject, TermId, Visibility},
+        primitives::{
+            MemberData, ParamsId, ScopeId, ScopeMember, Sub, SubSubject, TermId, Visibility,
+        },
         AccessToStorage, AccessToStorageMut, StorageRef, StorageRefMut,
     },
 };
@@ -118,5 +123,44 @@ impl<'gs, 'ls, 'cd, 's> ScopeResolver<'gs, 'ls, 'cd, 's> {
             }));
         self.scopes_mut().append(param_scope);
         param_scope
+    }
+
+    /// Assign the given value to the given member as a `(ScopeId, usize)` pair.
+    ///
+    /// This will unify the value with the index, decrement the
+    /// `assignments_until_closed` counter for the member, and will panic if
+    /// the counter is zero already.
+    pub fn assign_member(
+        &mut self,
+        scope_id: ScopeId,
+        index: usize,
+        value: TermId,
+    ) -> TcResult<()> {
+        let member = self.scope_store_mut().get_mut(scope_id).get_by_index(index);
+
+        // Unify types:
+        let member_data = self.typer().infer_member_ty(member.data)?;
+        let rhs_ty = self.typer().infer_ty_of_term(value)?;
+        let _ = self.unifier().unify_terms(rhs_ty, member_data.ty)?;
+
+        let member = self.scope_store_mut().get_mut(scope_id).get_mut_by_index(index);
+        if member.is_closed() {
+            tc_panic!(value, self, "Cannot assign to closed member");
+        }
+
+        member.assignments_until_closed -= 1;
+        match member.data {
+            MemberData::Uninitialised { .. } => {
+                member.data = MemberData::InitialisedWithInferredTy { value }
+            }
+            MemberData::InitialisedWithTy { ty, .. } => {
+                member.data = MemberData::InitialisedWithTy { value, ty }
+            }
+            MemberData::InitialisedWithInferredTy { .. } => {
+                member.data = MemberData::InitialisedWithInferredTy { value }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -497,7 +497,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             }
             Term::AppSub(app_sub) => {
                 // Add substitution to the scope:
-                let sub_scope = self.scope_resolver().enter_sub_param_scope(&app_sub.sub);
+                let sub_scope = self.scope_manager().enter_sub_param_scope(&app_sub.sub);
 
                 let inner_applied_term =
                     self.apply_access_term(&AccessTerm { subject: app_sub.term, ..*access_term })?;
@@ -1128,7 +1128,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             Term::Var(var) => {
                 // First resolve the name:
                 let scope_member =
-                    self.scope_resolver().resolve_name_in_scopes(var.name, term_id)?;
+                    self.scope_manager().resolve_name_in_scopes(var.name, term_id)?;
 
                 let maybe_resolved_term_id = scope_member.member.data.value();
 
@@ -1149,7 +1149,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 // Simplify general params and return
                 let simplified_general_params = self.simplify_params(ty_fn.general_params)?;
 
-                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn.general_params);
+                let param_scope = self.scope_manager().enter_ty_param_scope(ty_fn.general_params);
                 let simplified_general_return_ty = self.simplify_term(ty_fn.general_return_ty)?;
                 self.scopes_mut().pop_the_scope(param_scope);
 
@@ -1160,7 +1160,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     .map(|case| {
                         let simplified_params = self.simplify_params(case.params)?;
 
-                        let param_scope = self.scope_resolver().enter_ty_param_scope(case.params);
+                        let param_scope = self.scope_manager().enter_ty_param_scope(case.params);
                         let simplified_return_ty = self.simplify_term(case.return_ty)?;
                         let simplified_return_value = self.simplify_term(case.return_value)?;
                         self.scopes_mut().pop_the_scope(param_scope);
@@ -1205,7 +1205,7 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 // simplified.
                 let simplified_params = self.simplify_params(ty_fn_ty.params)?;
 
-                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn_ty.params);
+                let param_scope = self.scope_manager().enter_ty_param_scope(ty_fn_ty.params);
                 let simplified_return_ty = self.simplify_term(ty_fn_ty.return_ty)?;
                 self.scopes_mut().pop_the_scope(param_scope);
 

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -531,6 +531,8 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                 // We cannot perform any accessing here:
                 Ok(None)
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -642,6 +644,8 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     Ok(None)
                 }
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -823,6 +827,8 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             | Term::Union(_)
             | Term::TyOf(_)
             | Term::Access(_) => cannot_use_as_fn_call_subject(),
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -1232,6 +1238,8 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             Term::Level0(term) => self.simplify_level0_term(&term, term_id),
             // Root cannot be simplified:
             Term::Root => Ok(None),
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }?;
 
         // Copy over the location if a new term was created

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -527,12 +527,14 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             // @@Enhancement: maybe we can allow this and add it to some hints context of the
             // variable.
             Term::Unresolved(_) => does_not_support_access(access_term),
-            Term::Access(_) | Term::Var(_) | Term::TyFnCall(_) => {
+            Term::ScopeVar(_)
+            | Term::BoundVar(_)
+            | Term::Access(_)
+            | Term::Var(_)
+            | Term::TyFnCall(_) => {
                 // We cannot perform any accessing here:
                 Ok(None)
             }
-            Term::ScopeVar(_) => todo!(),
-            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -624,6 +626,8 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
             | Term::Level2(_)
             | Term::Level1(_)
             | Term::Level0(_)
+            | Term::ScopeVar(_)
+            | Term::BoundVar(_)
             | Term::TyOf(_) => {
                 // Cannot apply if it didn't simplify to a type function:
                 cannot_apply()
@@ -644,8 +648,6 @@ impl<'gs, 'ls, 'cd, 's> Simplifier<'gs, 'ls, 'cd, 's> {
                     Ok(None)
                 }
             }
-            Term::ScopeVar(_) => todo!(),
-            Term::BoundVar(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -318,6 +318,8 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
             Term::Level2(term) => self.apply_sub_to_level2_term(sub, term),
             Term::Level1(term) => self.apply_sub_to_level1_term(sub, term),
             Term::Level0(term) => self.apply_sub_to_level0_term(sub, term, term_id),
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         };
 
         self.location_store_mut().copy_location(term_id, new_term);
@@ -580,6 +582,8 @@ impl<'gs, 'ls, 'cd, 's> Substituter<'gs, 'ls, 'cd, 's> {
             }
             // No vars:
             Term::Root => {}
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -137,7 +137,7 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
             Term::Var(var) => {
                 // The type of a variable can be found by looking at the scopes to its
                 // declaration:
-                let var_member = self.scope_resolver().resolve_name_in_scopes(var.name, term_id)?;
+                let var_member = self.scope_manager().resolve_name_in_scopes(var.name, term_id)?;
                 Ok(self.infer_member_ty(var_member.member.data)?.ty)
             }
             Term::TyFn(ty_fn) => {

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -250,6 +250,8 @@ impl<'gs, 'ls, 'cd, 's> Typer<'gs, 'ls, 'cd, 's> {
                 let builder = self.builder();
                 Ok(builder.create_ty_of_term(builder.create_root_term()))
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }?;
 
         self.location_store_mut().copy_location(term_id, new_term);

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -649,6 +649,9 @@ impl<'gs, 'ls, 'cd, 's> Unifier<'gs, 'ls, 'cd, 's> {
             // Root unifies with root and nothing else:
             (Term::Root, Term::Root) => Ok(Sub::empty()),
             (_, Term::Root) | (Term::Root, _) => cannot_unify(),
+
+            // @@Todo: vars
+            _ => todo!(),
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -811,7 +811,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 let ty_fn_ty = ty_fn_ty.clone();
                 self.validate_params(ty_fn_ty.params)?;
 
-                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn_ty.params);
+                let param_scope = self.scope_manager().enter_ty_param_scope(ty_fn_ty.params);
                 let _ = self.validate_term(ty_fn_ty.return_ty);
 
                 let params = self.params_store().get(ty_fn_ty.params).clone();
@@ -840,7 +840,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 self.validate_params(ty_fn.general_params)?;
 
                 // Enter param scope:
-                let param_scope = self.scope_resolver().enter_ty_param_scope(ty_fn.general_params);
+                let param_scope = self.scope_manager().enter_ty_param_scope(ty_fn.general_params);
 
                 let general_return_validation = self.validate_term(ty_fn.general_return_ty)?;
 
@@ -855,7 +855,7 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 for case in &ty_fn.cases {
                     self.validate_params(case.params)?;
 
-                    let param_scope = self.scope_resolver().enter_ty_param_scope(case.params);
+                    let param_scope = self.scope_manager().enter_ty_param_scope(case.params);
                     self.validate_term(case.return_ty)?;
                     self.validate_term(case.return_value)?;
 

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -73,6 +73,8 @@ impl Term {
             Term::Level2(_) => TermLevel::Level2,
             Term::Level1(_) => TermLevel::Level1,
             Term::Level0(_) => TermLevel::Level0,
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 }
@@ -410,6 +412,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     "Union term should have already been flattened"
                 )
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -575,6 +579,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                     "Merge term should have already been flattened"
                 )
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -915,6 +921,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // Nothing to do, should have already been validated by the typer.
                 Ok(result)
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -1060,6 +1068,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // This should be okay, for example if we are returning some TyFnTy value.
                 Ok(true)
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 
@@ -1116,6 +1126,8 @@ impl<'gs, 'ls, 'cd, 's> Validator<'gs, 'ls, 'cd, 's> {
                 // @@PotentiallyUnnecessary: is there some use case to allow this?
                 Ok(false)
             }
+            Term::ScopeVar(_) => todo!(),
+            Term::BoundVar(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -513,6 +513,22 @@ pub struct Var {
     pub name: Identifier,
 }
 
+/// A scope variable, identified by a `ScopeId` and `usize` index.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct ScopeVar {
+    pub name: Identifier,
+    pub scope: ScopeId,
+    pub index: usize,
+}
+
+/// A bound variable, identified by a `ParamsId` and `usize` index.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct BoundVar {
+    pub name: Identifier,
+    pub params: ParamsId,
+    pub index: usize,
+}
+
 /// The action of applying a set of arguments to a type function.
 ///
 /// This essentially creates a lambda calculus within the Hash type system,
@@ -881,12 +897,18 @@ pub enum Term {
     /// Is level N, where N is the level of the resultant access.
     Access(AccessTerm),
 
-    /// A type-level variable, with some type that is stored in the current
+    /// A variable, with some type that is stored in the current
     /// scope.
     ///
     /// Is level N-1, where N is the level of the type of the variable in the
     /// context
     Var(Var),
+
+    /// A variable that corresponds to some scope member.
+    ScopeVar(ScopeVar),
+
+    /// A variable that is bound by some params.
+    BoundVar(BoundVar),
 
     /// Merge of multiple terms.
     ///

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -897,17 +897,22 @@ pub enum Term {
     /// Is level N, where N is the level of the resultant access.
     Access(AccessTerm),
 
-    /// A variable, with some type that is stored in the current
-    /// scope.
+    /// A variable, referencing either a scope variable or a bound variable.
     ///
     /// Is level N-1, where N is the level of the type of the variable in the
     /// context
     Var(Var),
 
     /// A variable that corresponds to some scope member.
+    ///
+    /// Is level N-1, where N is the level of the type of the variable in the
+    /// context
     ScopeVar(ScopeVar),
 
     /// A variable that is bound by some params.
+    ///
+    /// Is level N-1, where N is the level of the type of the variable in the
+    /// context
     BoundVar(BoundVar),
 
     /// Merge of multiple terms.

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -50,6 +50,21 @@ impl MemberData {
         }
     }
 
+    /// Set the value of the member.
+    pub fn set_value(&mut self, value: TermId) {
+        match *self {
+            MemberData::Uninitialised { .. } => {
+                *self = MemberData::InitialisedWithInferredTy { value }
+            }
+            MemberData::InitialisedWithTy { ty, .. } => {
+                *self = MemberData::InitialisedWithTy { value, ty }
+            }
+            MemberData::InitialisedWithInferredTy { .. } => {
+                *self = MemberData::InitialisedWithInferredTy { value }
+            }
+        }
+    }
+
     /// Turn the given type and value into a [MemberData].
     pub fn from_ty_and_value(ty: Option<TermId>, value: Option<TermId>) -> Self {
         match (ty, value) {
@@ -68,6 +83,8 @@ pub struct Member {
     pub data: MemberData,
     pub visibility: Visibility,
     pub mutability: Mutability,
+    /// Whether the member has finished initialising or not.
+    pub is_closed: bool,
 }
 
 /// A member of a scope, i.e. a variable or a type definition.
@@ -133,6 +150,11 @@ impl Scope {
         let index = self.member_names.get(&member_name).copied()?;
 
         Some((self.members[index], index))
+    }
+
+    /// Get a member by index, mutably, asserting that it exists.
+    pub fn get_mut_by_index(&mut self, index: usize) -> &mut Member {
+        &mut self.members[index]
     }
 
     /// Iterate through all the members in insertion order (oldest first).


### PR DESCRIPTION
This PR implements assign expression traversal. It also adds `ScopeVar` and `BoundVar` in preparation for #367 and #419 (work to be continued in separate PRs). NameFieldOrigin is also removed since it was considered to be too flaky and prone to panics. See #423 instead.

Closes #125.