### PR TITLE
TC: fix exhaustiveness issues

### DIFF
--- a/compiler/hash-typecheck/src/exhaustiveness/construct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/construct.rs
@@ -24,6 +24,8 @@
 //!
 //! In other words, all the possible (valid) values of the `char` type.
 //! A similar process occurs with all other wildcard types,
+use std::fmt::Debug;
+
 use hash_source::{
     location::{SourceLocation, Span},
     string::Str,
@@ -41,6 +43,7 @@ use crate::{
         list::{List, ListKind, SplitVarList},
         PatCtx,
     },
+    fmt::{ForFormatting, PrepareForFormatting},
     ops::AccessToOps,
     storage::{
         deconstructed::DeconstructedCtorId,
@@ -282,14 +285,14 @@ impl<'tc> ConstructorOps<'tc> {
     /// from a wildcard.
     pub(super) fn is_covered_by_any(
         &self,
-        ctor: DeconstructedCtorId,
+        pat: DeconstructedCtorId,
         used_ctors: &[DeconstructedCtorId],
     ) -> bool {
         if used_ctors.is_empty() {
             return false;
         }
 
-        let ctor = self.reader().get_deconstructed_ctor(ctor);
+        let ctor = self.reader().get_deconstructed_ctor(pat);
 
         match ctor {
             // If `self` is `Single`, `used_ctors` cannot contain anything else than `Single`s.
@@ -317,5 +320,14 @@ impl<'tc> ConstructorOps<'tc> {
                 panic!("Unexpected ctor in all_ctors")
             }
         }
+    }
+}
+
+impl PrepareForFormatting for DeconstructedCtorId {}
+
+impl Debug for ForFormatting<'_, DeconstructedCtorId> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ctor = self.global_storage.deconstructed_ctor_store.get(self.t);
+        write!(f, "{:?}", ctor)
     }
 }

--- a/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
@@ -125,18 +125,18 @@ impl<'tc> DeconstructPatOps<'tc> {
     pub(super) fn specialise(
         &self,
         ctx: PatCtx,
-        pat: DeconstructedPatId,
-        other_ctor_id: DeconstructedCtorId,
+        pat_id: DeconstructedPatId,
+        ctor_id: DeconstructedCtorId,
     ) -> SmallVec<[DeconstructedPatId; 2]> {
         let reader = self.reader();
-        let pat = reader.get_deconstructed_pat(pat);
-        let ctor = reader.get_deconstructed_ctor(pat.ctor);
-        let other_ctor = reader.get_deconstructed_ctor(other_ctor_id);
+        let pat = reader.get_deconstructed_pat(pat_id);
+        let pat_ctor = reader.get_deconstructed_ctor(pat.ctor);
+        let other_ctor = reader.get_deconstructed_ctor(ctor_id);
 
-        match (ctor, other_ctor) {
+        match (pat_ctor, other_ctor) {
             (DeconstructedCtor::Wildcard, _) => {
                 // We return a wildcard for each field of `other_ctor`.
-                self.fields_ops().wildcards(ctx, other_ctor_id).iter_patterns().copied().collect()
+                self.fields_ops().wildcards(ctx, ctor_id).iter_patterns().copied().collect()
             }
             (DeconstructedCtor::List(this_list), DeconstructedCtor::List(other_list))
                 if this_list.arity() != other_list.arity() =>

--- a/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
@@ -133,7 +133,6 @@ impl<'tc> DeconstructPatOps<'tc> {
         let pat_ctor = reader.get_deconstructed_ctor(pat.ctor);
         let other_ctor = reader.get_deconstructed_ctor(other_ctor_id);
 
-        println!("p={:?} o={:?}, ty={}", pat_ctor, other_ctor, self.for_fmt(ctx.ty));
         match (pat_ctor, other_ctor) {
             (DeconstructedCtor::Wildcard, _) => {
                 // We return a wildcard for each field of `other_ctor`.

--- a/compiler/hash-typecheck/src/exhaustiveness/lower.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/lower.rs
@@ -370,7 +370,7 @@ impl<'tc> LowerPatOps<'tc> {
                 panic!("cannot convert an `or` deconstructed pat back into pat")
             }
             DeconstructedCtor::Missing => panic!(
-                "trying to convert a `Missing` constructor into a `Pat`; this is probably a bug, `Missing` should have been processed in `apply_constructors`"
+                "trying to convert a `Missing` constructor into a `Pat`; this is probably a bug, `Missing` should have been processed in `apply_ctors`"
             ),
         };
 

--- a/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
@@ -125,8 +125,14 @@ impl Debug for ForFormatting<'_, Matrix> {
         let Matrix { patterns: m, .. } = &self.t;
 
         // Firstly, get all the patterns within the matrix as strings...
-        let pretty_printed_matrix: Vec<Vec<String>> =
-            m.iter().map(|row| row.iter().map(|pat| format!("{:?}", pat)).collect()).collect();
+        let pretty_printed_matrix: Vec<Vec<String>> = m
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|pat| format!("{:?}", pat.for_formatting(self.global_storage)))
+                    .collect()
+            })
+            .collect();
 
         let column_count = m.iter().map(|row| row.len()).next().unwrap_or(0);
 

--- a/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
@@ -68,11 +68,13 @@ impl<'tc> MatrixOps<'tc> {
     /// Pushes a new row to the matrix. If the row starts with an or-pattern,
     /// this recursively expands it.
     pub(crate) fn push(&self, matrix: &mut Matrix, row: PatStack) {
-        let reader = self.reader();
-        let ctor = reader.get_deconstructed_pat(row.head());
+        if !row.is_empty() {
+            let reader = self.reader();
+            let pat = reader.get_deconstructed_pat(row.head());
 
-        if !row.is_empty() && self.deconstruct_pat_ops().is_or_pat(&ctor) {
-            matrix.patterns.extend(self.stack_ops().expand_or_pat(&row));
+            if self.deconstruct_pat_ops().is_or_pat(&pat) {
+                matrix.patterns.extend(self.stack_ops().expand_or_pat(&row));
+            }
         } else {
             matrix.patterns.push(row);
         }
@@ -95,9 +97,11 @@ impl<'tc> MatrixOps<'tc> {
         // the matrix.
         for row in &matrix.patterns {
             let head = reader.get_deconstructed_pat(row.head());
-            let other = self.constructor_store().get(head.ctor);
+            let row_head_ctor = self.constructor_store().get(head.ctor);
 
-            if self.constructor_ops().is_covered_by(&ctor, &other) {
+            println!("row={:?}, {:?}", self.for_fmt(row.clone()), row_head_ctor);
+
+            if self.constructor_ops().is_covered_by(&ctor, &row_head_ctor) {
                 let new_row = self.stack_ops().pop_head_constructor(ctx, row, ctor_id);
                 self.push(&mut specialised_matrix, new_row);
             }

--- a/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
@@ -75,9 +75,9 @@ impl<'tc> MatrixOps<'tc> {
             if self.deconstruct_pat_ops().is_or_pat(&pat) {
                 matrix.patterns.extend(self.stack_ops().expand_or_pat(&row));
             }
-        } else {
-            matrix.patterns.push(row);
         }
+
+        matrix.patterns.push(row);
     }
 
     /// This computes `S(constructor, matrix)`.
@@ -98,8 +98,6 @@ impl<'tc> MatrixOps<'tc> {
         for row in &matrix.patterns {
             let head = reader.get_deconstructed_pat(row.head());
             let row_head_ctor = self.constructor_store().get(head.ctor);
-
-            println!("row={:?}, {:?}", self.for_fmt(row.clone()), row_head_ctor);
 
             if self.constructor_ops().is_covered_by(&ctor, &row_head_ctor) {
                 let new_row = self.stack_ops().pop_head_constructor(ctx, row, ctor_id);

--- a/compiler/hash-typecheck/src/exhaustiveness/stack.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/stack.rs
@@ -18,7 +18,7 @@ use crate::{
 
 /// A row of a [super::matrix::Matrix]. Rows of len 1 are very common, which is
 /// why `SmallVec[_; /// 2]` works well.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PatStack {
     /// The stored patterns in the row.
     pub pats: SmallVec<[DeconstructedPatId; 2]>,

--- a/compiler/hash-typecheck/src/exhaustiveness/stack.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/stack.rs
@@ -4,11 +4,14 @@
 //! transformations, and [StackOps] contains functions
 //! that are relevant to the usefulness and exhaustiveness
 //! algorithm.
+use std::fmt::Debug;
+
 use smallvec::{smallvec, SmallVec};
 
 use super::AccessToUsefulnessOps;
 use crate::{
     exhaustiveness::PatCtx,
+    fmt::{ForFormatting, PrepareForFormatting},
     ops::AccessToOps,
     storage::{
         deconstructed::{DeconstructedCtorId, DeconstructedPatId},
@@ -110,8 +113,23 @@ impl<'tc> StackOps<'tc> {
         // of `self.head()`.
         let mut new_fields: SmallVec<[_; 2]> =
             self.deconstruct_pat_ops().specialise(ctx, stack.head(), ctor);
+
         new_fields.extend_from_slice(&stack.pats[1..]);
 
         PatStack::from_vec(new_fields)
+    }
+}
+
+impl PrepareForFormatting for PatStack {}
+
+impl Debug for ForFormatting<'_, PatStack> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "|")?;
+
+        for pat in self.t.iter() {
+            write!(f, " {:?} |", pat.for_formatting(self.global_storage))?;
+        }
+
+        Ok(())
     }
 }

--- a/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
@@ -433,6 +433,7 @@ impl<'tc> UsefulnessOps<'tc> {
             self.deconstructed_pat_store().create(self.deconstruct_pat_ops().wildcard(subject));
         let v = PatStack::singleton(wildcard);
 
+        println!("COMPUTING EXHAUSTIVENESS");
         let usefulness = self.is_useful(&matrix, &v, MatchArmKind::ExhaustiveWildcard, false, true);
 
         // It should not be possible to not get any witnesses since we're matching

--- a/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
@@ -54,7 +54,7 @@ impl Usefulness {
     /// Create a `useful` [Usefulness] report.
     pub fn new_useful(preference: MatchArmKind) -> Self {
         match preference {
-            //            A single (empty) witness of reachability.
+            // A single (empty) witness of reachability.
             MatchArmKind::ExhaustiveWildcard => Usefulness::WithWitnesses(vec![Witness(vec![])]),
             MatchArmKind::Real => Usefulness::NoWitnesses { useful: true },
         }
@@ -196,7 +196,7 @@ impl<'tc> UsefulnessOps<'tc> {
     /// pre-specialization. This new usefulness can then be merged
     /// with the results of specializing with the other constructors.
     fn apply_constructor(
-        &mut self,
+        &self,
         ctx: PatCtx,
         usefulness: Usefulness,
         matrix: &Matrix, // used to compute missing ctors
@@ -358,13 +358,13 @@ impl<'tc> UsefulnessOps<'tc> {
             // @@Ranges: we should check that int ranges don't overlap here, in case
             // they're partially covered by other ranges. Additionally, since this isn't
             // necessarily an error, we should integrate this with our warning system.
-            let v_ctor = head.ctor;
             let reader = self.reader();
-
             let ctors = matrix.heads().map(|id| reader.get_deconstructed_pat(id).ctor);
 
             // We split the head constructor of `v`.
+            let v_ctor = head.ctor;
             let split_ctors = self.constructor_ops().split(ctx, v_ctor, ctors);
+
             let start_matrix = &matrix;
 
             // For each constructor, we compute whether there's a value that starts with it

--- a/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
@@ -364,7 +364,6 @@ impl<'tc> UsefulnessOps<'tc> {
             // We split the head constructor of `v`.
             let v_ctor = head.ctor;
             let split_ctors = self.constructor_ops().split(ctx, v_ctor, ctors);
-
             let start_matrix = &matrix;
 
             // For each constructor, we compute whether there's a value that starts with it
@@ -374,13 +373,11 @@ impl<'tc> UsefulnessOps<'tc> {
                 let spec_matrix = self.matrix_ops().specialise_ctor(ctx, start_matrix, ctor);
 
                 let v = self.stack_ops().pop_head_constructor(ctx, v, ctor);
-
                 let usefulness = ensure_sufficient_stack(|| {
                     self.is_useful(&spec_matrix, &v, arm_kind, is_under_guard, false)
                 });
 
                 let usefulness = self.apply_constructor(ctx, usefulness, start_matrix, ctor);
-
                 report.extend(usefulness);
             }
         }

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -92,7 +92,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                 kind if kind.is_signed() => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
                     let size = kind.size().unwrap();
-                    let bits = size * 8;
+                    let bits = (size * 8) as u128;
 
                     let min = 1u128 << (bits - 1);
                     let max = min - 1;

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -164,8 +164,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                         }
                     }
                     Term::Level1(Level1Term::Tuple(_)) => smallvec![DeconstructedCtor::Single],
-                    term => {
-                        println!("non-exhaustive?: {term:?}");
+                    _ => {
                         smallvec![DeconstructedCtor::NonExhaustive]
                     }
                 },

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -164,7 +164,10 @@ impl<'tc> SplitWildcardOps<'tc> {
                         }
                     }
                     Term::Level1(Level1Term::Tuple(_)) => smallvec![DeconstructedCtor::Single],
-                    _ => smallvec![DeconstructedCtor::NonExhaustive],
+                    term => {
+                        println!("non-exhaustive?: {term:?}");
+                        smallvec![DeconstructedCtor::NonExhaustive]
+                    }
                 },
             }
         };

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -164,9 +164,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                         }
                     }
                     Term::Level1(Level1Term::Tuple(_)) => smallvec![DeconstructedCtor::Single],
-                    _ => {
-                        smallvec![DeconstructedCtor::NonExhaustive]
-                    }
+                    _ => smallvec![DeconstructedCtor::NonExhaustive],
                 },
             }
         };

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -251,7 +251,9 @@ impl<'gs> TcFormatter<'gs> {
                         write!(f, "{}{}", value, kind.to_name())
                     }
                     LitTerm::Char(char) => {
-                        write!(f, "\'{}\'", char)
+                        // Use debug implementation since we want to display the `literal` value
+                        // rather than the actual glyph
+                        write!(f, "{:?}", char)
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes two issues that were present within the exhaustiveness sub-system and also implements converting ranges into `Range::Pat` from within the sub-system when producing error reports.