### PR TITLE
reporting: Introduce `Diagnostics` trait and intergrate the `Lexer` as a proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ name = "hash-lexer"
 version = "0.1.0"
 dependencies = [
  "derive_more",
+ "hash-reporting",
  "hash-source",
  "hash-token",
  "thiserror",

--- a/compiler/hash-ast-passes/src/diagnostics/mod.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/mod.rs
@@ -1,27 +1,65 @@
 //! Hash AST semantic passes diagnostic definitions and logic.
 #![allow(dead_code)]
 
-use hash_reporting::report::Report;
+use hash_reporting::{diagnostic::Diagnostics, report::Report};
 
 use self::{error::AnalysisError, warning::AnalysisWarning};
+use crate::analysis::SemanticAnalyser;
 
 pub(crate) mod directives;
 pub(crate) mod error;
 pub(crate) mod origins;
 pub(crate) mod warning;
 
-/// Enum representing any generated message that can be emitted by the
-/// [crate::SemanticAnalyser].
-pub(crate) enum Diagnostic {
-    Warning(AnalysisWarning),
-    Error(AnalysisError),
+/// Store [SemanticAnalyser] diagnostics which can be errors or warnings.
+#[derive(Default)]
+pub struct AnalyserDiagnostics {
+    /// Any errors that the [SemanticAnalyser] produces.
+    errors: Vec<AnalysisError>,
+    /// Any warnings that the [SemanticAnalyser] produces.
+    warnings: Vec<AnalysisWarning>,
 }
 
-impl From<Diagnostic> for Report {
-    fn from(message: Diagnostic) -> Self {
-        match message {
-            Diagnostic::Warning(warning) => warning.into(),
-            Diagnostic::Error(err) => err.into(),
-        }
+impl Diagnostics<AnalysisError, AnalysisWarning> for SemanticAnalyser<'_> {
+    type DiagnosticsStore = AnalyserDiagnostics;
+
+    fn store(&self) -> &Self::DiagnosticsStore {
+        &self.diagnostics
+    }
+
+    fn add_error(&mut self, error: AnalysisError) {
+        self.diagnostics.errors.push(error);
+    }
+
+    fn add_warning(&mut self, warning: AnalysisWarning) {
+        self.diagnostics.warnings.push(warning);
+    }
+
+    fn has_errors(&self) -> bool {
+        !self.diagnostics.errors.is_empty()
+    }
+
+    fn has_warnings(&self) -> bool {
+        !self.diagnostics.warnings.is_empty()
+    }
+
+    fn into_reports(self) -> Vec<Report> {
+        self.diagnostics
+            .errors
+            .into_iter()
+            .map(|err| err.into())
+            .chain(self.diagnostics.warnings.into_iter().map(|warn| warn.into()))
+            .collect()
+    }
+
+    fn into_diagnostics(self) -> (Vec<AnalysisError>, Vec<AnalysisWarning>) {
+        (self.diagnostics.errors, self.diagnostics.warnings)
+    }
+
+    fn merge(&mut self, other: impl Diagnostics<AnalysisError, AnalysisWarning>) {
+        let (errors, warnings) = other.into_diagnostics();
+
+        self.diagnostics.errors.extend(errors);
+        self.diagnostics.warnings.extend(warnings);
     }
 }

--- a/compiler/hash-ast-passes/src/lib.rs
+++ b/compiler/hash-ast-passes/src/lib.rs
@@ -12,7 +12,6 @@ use std::collections::HashSet;
 
 use analysis::SemanticAnalyser;
 use crossbeam_channel::unbounded;
-use diagnostics::Diagnostic;
 use hash_ast::{ast::OwnsAstNode, visitor::AstVisitor};
 use hash_pipeline::{sources::Workspace, traits::SemanticPass, CompilerResult};
 use hash_reporting::report::Report;
@@ -45,7 +44,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
         state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> Result<(), Vec<Report>> {
-        let (sender, receiver) = unbounded::<Diagnostic>();
+        let (sender, receiver) = unbounded::<Report>();
 
         let source_map = &workspace.source_map;
         let node_map = &mut workspace.node_map;
@@ -111,7 +110,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
         if messages.is_empty() {
             Ok(())
         } else {
-            Err(messages.into_iter().map(|message| message.into()).collect())
+            Err(messages.into_iter().collect())
         }
     }
 }

--- a/compiler/hash-lexer/Cargo.toml
+++ b/compiler/hash-lexer/Cargo.toml
@@ -10,6 +10,4 @@ derive_more = "0.99"
 
 hash-source = {path = "../hash-source" }
 hash-token = {path = "../hash-token" }
-
-# We will use this when we unify errors from `lexer` and `parse` crates
-# hash-reporting = {path = "../hash-reporting" }
+hash-reporting = {path = "../hash-reporting" }

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -1,5 +1,7 @@
 //! Hash Compiler lexer error data types.
 
+use std::convert::Infallible;
+
 use derive_more::Constructor;
 use hash_reporting::{
     builder::ReportBuilder,
@@ -81,7 +83,7 @@ pub struct LexerDiagnostics {
     errors: Vec<LexerError>,
 }
 
-impl Diagnostics<LexerError, LexerError> for Lexer<'_> {
+impl Diagnostics<LexerError, Infallible> for Lexer<'_> {
     type DiagnosticsStore = LexerDiagnostics;
 
     fn store(&self) -> &Self::DiagnosticsStore {
@@ -95,8 +97,8 @@ impl Diagnostics<LexerError, LexerError> for Lexer<'_> {
 
     /// The lexer does not currently emit any warnings and so if this
     /// is called, it should panic.
-    fn add_warning(&mut self, _: LexerError) {
-        unimplemented!()
+    fn add_warning(&mut self, warning: Infallible) {
+        match warning {}
     }
 
     fn has_errors(&self) -> bool {
@@ -112,11 +114,11 @@ impl Diagnostics<LexerError, LexerError> for Lexer<'_> {
         self.diagnostics.errors.into_iter().map(|err| err.into()).collect()
     }
 
-    fn into_diagnostics(self) -> (Vec<LexerError>, Vec<LexerError>) {
+    fn into_diagnostics(self) -> (Vec<LexerError>, Vec<Infallible>) {
         (self.diagnostics.errors, vec![])
     }
 
-    fn merge(&mut self, other: impl Diagnostics<LexerError, LexerError>) {
+    fn merge(&mut self, other: impl Diagnostics<LexerError, Infallible>) {
         let (errors, _) = other.into_diagnostics();
         self.diagnostics.errors.extend(errors)
     }

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -112,11 +112,12 @@ impl Diagnostics<LexerError, LexerError> for Lexer<'_> {
         self.diagnostics.errors.into_iter().map(|err| err.into()).collect()
     }
 
-    fn into_errors(self) -> Vec<LexerError> {
-        self.diagnostics.errors
+    fn into_diagnostics(self) -> (Vec<LexerError>, Vec<LexerError>) {
+        (self.diagnostics.errors, vec![])
     }
 
     fn merge(&mut self, other: impl Diagnostics<LexerError, LexerError>) {
-        self.diagnostics.errors.extend(other.into_errors())
+        let (errors, _) = other.into_diagnostics();
+        self.diagnostics.errors.extend(errors)
     }
 }

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -17,8 +17,8 @@ pub type LexerResult<T> = Result<T, LexerError>;
 
 /// A [LexerError] represents a encountered error during tokenisation, which
 /// includes an optional message with the error, the [LexerErrorKind] which
-/// classifies the error, and a [Span] that represents where the tokenisation
-/// error occurred.
+/// classifies the error, and a [SourceLocation] that represents where the
+/// tokenisation error occurred.
 #[derive(Debug, Constructor, Error)]
 #[error("{kind}{}", .message.as_ref().map(|s| format!(". {s}")).unwrap_or_else(|| String::from("")))]
 pub struct LexerError {
@@ -75,7 +75,7 @@ impl From<LexerError> for Report {
 }
 
 /// Lexer error store, the lexer stores an internal store so that
-/// it can implement [DiagnosticsStore]
+/// it can implement [Diagnostics::DiagnosticsStore]
 #[derive(Default)]
 pub struct LexerDiagnostics {
     errors: Vec<LexerError>,

--- a/compiler/hash-parser/src/diagnostics/error.rs
+++ b/compiler/hash-parser/src/diagnostics/error.rs
@@ -9,12 +9,15 @@ use hash_source::location::SourceLocation;
 use hash_token::{TokenKind, TokenKindVector};
 use hash_utils::printing::SequenceDisplay;
 
-/// A [AstGenError] represents possible errors that occur when transforming the
+/// Utility wrapper type for [ParseError] in [Result]
+pub type ParseResult<T> = Result<T, ParseError>;
+
+/// A [ParseError] represents possible errors that occur when transforming the
 /// token stream into the AST.
 #[derive(Debug, Constructor)]
-pub struct AstGenError {
+pub struct ParseError {
     /// The kind of the error.
-    kind: AstGenErrorKind,
+    kind: ParseErrorKind,
     /// Location of where the error references
     location: SourceLocation,
     /// An optional vector of tokens that are expected to circumvent the error.
@@ -35,7 +38,7 @@ pub enum TyArgumentKind {
 
 /// Enum representation of the AST generation error variants.
 #[derive(Debug)]
-pub enum AstGenErrorKind {
+pub enum ParseErrorKind {
     /// Expected keyword at current location
     Keyword,
     /// Generic error specifying an expected token atom.
@@ -43,7 +46,7 @@ pub enum AstGenErrorKind {
     /// Expected the beginning of a body block.
     Block,
     /// Expected end of input or token stream here, but encountered tokens.
-    EOF,
+    Eof,
     /// Expecting a re-assignment operator at the specified location.
     /// Re-assignment operators are like normal operators, but they expect
     /// an 'equals' sign after the specified operator.
@@ -103,62 +106,62 @@ impl std::fmt::Display for TyArgumentKind {
 }
 
 /// Conversion implementation from an AST Generator Error into a Parser Error.
-impl From<AstGenError> for Report {
-    fn from(err: AstGenError) -> Self {
+impl From<ParseError> for Report {
+    fn from(err: ParseError) -> Self {
         let expected = err.expected;
 
         let mut base_message = match &err.kind {
-            AstGenErrorKind::Keyword => {
+            ParseErrorKind::Keyword => {
                 format!(
                     "encountered an unexpected keyword {}",
                     err.received.unwrap().as_error_string()
                 )
             }
-            AstGenErrorKind::Expected => match &err.received {
+            ParseErrorKind::Expected => match &err.received {
                 Some(kind) => format!("unexpectedly encountered {}", kind.as_error_string()),
                 None => "unexpectedly reached the end of input".to_string(),
             },
-            AstGenErrorKind::Block => "expected block body, which begins with a `{`".to_string(),
-            AstGenErrorKind::EOF => "unexpectedly reached the end of input".to_string(),
-            AstGenErrorKind::ReAssignmentOp => "expected a re-assignment operator".to_string(),
-            AstGenErrorKind::TypeDefinition(ty) => {
+            ParseErrorKind::Block => "expected block body, which begins with a `{`".to_string(),
+            ParseErrorKind::Eof => "unexpectedly reached the end of input".to_string(),
+            ParseErrorKind::ReAssignmentOp => "expected a re-assignment operator".to_string(),
+            ParseErrorKind::TypeDefinition(ty) => {
                 format!("expected {ty} definition entries here which begin with a `(`")
             }
-            AstGenErrorKind::ExpectedValueAfterTyAnnotation => {
+            ParseErrorKind::ExpectedValueAfterTyAnnotation => {
                 "expected value assignment after type annotation within named tuple".to_string()
             }
-            AstGenErrorKind::ExpectedOperator => "expected an operator".to_string(),
-            AstGenErrorKind::ExpectedExpr => "expected an expression".to_string(),
-            AstGenErrorKind::ExpectedName => "expected a name here".to_string(),
-            AstGenErrorKind::ExpectedArrow => "expected an arrow `=>` ".to_string(),
-            AstGenErrorKind::ExpectedFnArrow => {
+            ParseErrorKind::ExpectedOperator => "expected an operator".to_string(),
+            ParseErrorKind::ExpectedExpr => "expected an expression".to_string(),
+            ParseErrorKind::ExpectedName => "expected a name here".to_string(),
+            ParseErrorKind::ExpectedArrow => "expected an arrow `=>` ".to_string(),
+            ParseErrorKind::ExpectedFnArrow => {
                 "expected an arrow `->` after type arguments denoting a function type".to_string()
             }
-            AstGenErrorKind::ExpectedFnBody => "expected a function body".to_string(),
-            AstGenErrorKind::ExpectedType => "expected a type annotation".to_string(),
-            AstGenErrorKind::ExpectedPropertyAccess => {
+            ParseErrorKind::ExpectedFnBody => "expected a function body".to_string(),
+            ParseErrorKind::ExpectedType => "expected a type annotation".to_string(),
+            ParseErrorKind::ExpectedPropertyAccess => {
                 "expected field name access or a method call".to_string()
             }
-            AstGenErrorKind::ExpectedPat => "expected pattern".to_string(),
-            AstGenErrorKind::ImportPath => {
+            ParseErrorKind::ExpectedPat => "expected pattern".to_string(),
+            ParseErrorKind::ImportPath => {
                 "expected an import path which should be a string".to_string()
             }
-            AstGenErrorKind::ErroneousImport(err) => err.to_string(),
-            AstGenErrorKind::Namespace => {
+            ParseErrorKind::ErroneousImport(err) => err.to_string(),
+            ParseErrorKind::Namespace => {
                 "expected identifier after a name access qualifier `::`".to_string()
             }
-            AstGenErrorKind::MalformedSpreadPattern(dots) => {
+            ParseErrorKind::MalformedSpreadPattern(dots) => {
                 format!(
                     "malformed spread pattern, expected {dots} more `.` to complete the pattern"
                 )
             }
-            AstGenErrorKind::ExpectedLiteral => "expected literal".to_string(),
+            ParseErrorKind::ExpectedLiteral => "expected literal".to_string(),
         };
 
         // `AstGenErrorKind::Expected` format the error message in their own way,
         // whereas all the other error types follow a conformed order to
         // formatting expected tokens
-        if !matches!(&err.kind, AstGenErrorKind::Expected) {
+        if !matches!(&err.kind, ParseErrorKind::Expected) {
             if let Some(kind) = err.received {
                 let atom_msg = format!(", however received {}", kind.as_error_string());
                 base_message.push_str(&atom_msg);

--- a/compiler/hash-parser/src/diagnostics/mod.rs
+++ b/compiler/hash-parser/src/diagnostics/mod.rs
@@ -1,0 +1,4 @@
+//! Hash Parser diagnostic utilities, error and warning definitions.
+//! This module contains all of the logic that provides diagnostic
+//! capabilities within the parser.
+pub mod error;

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -2,6 +2,7 @@
 //! `hash-ast` which provides a general interface to write a parser.
 #![feature(cell_update, is_some_with)]
 
+mod diagnostics;
 mod import_resolver;
 pub mod parser;
 mod source;

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -16,17 +16,17 @@ use hash_pipeline::{
     traits::Parser,
     CompilerResult,
 };
-use hash_reporting::report::Report;
+use hash_reporting::{diagnostic::Diagnostics, report::Report};
 use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId};
 use import_resolver::ImportResolver;
-use parser::{error::ParseError, AstGen};
+use parser::AstGen;
 use source::ParseSource;
 
 /// Messages that are passed from parser workers into the general message queue.
 #[derive(Debug)]
 pub enum ParserAction {
     /// An error occurred during the parsing or lexing of a module.
-    Error(ParseError),
+    Error(Vec<Report>),
     /// A worker has specified that a module should be put in the queue for
     /// lexing and parsing.
     ParseImport { resolved_path: PathBuf, contents: String, sender: Sender<ParserAction> },
@@ -46,12 +46,14 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     // Lex the contents of the module or interactive block
     let mut lexer = Lexer::new(&contents, source_id);
 
-    let tokens = match lexer.tokenise() {
-        Ok(source) => source,
-        Err(err) => {
-            return sender.send(ParserAction::Error(err.into())).unwrap();
-        }
-    };
+    let tokens = lexer.tokenise();
+
+    // Check if the lexer has errors...
+    if lexer.has_errors() {
+        sender.send(ParserAction::Error(lexer.into_reports())).unwrap();
+        return;
+    }
+
     let trees = lexer.into_token_trees();
 
     // Create a new import resolver in the event of more modules that
@@ -64,11 +66,11 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     // message queue, regardless of it being an error or not.
     let action = match &source.source_id() {
         SourceId::Module(id) => match gen.parse_module() {
-            Err(err) => ParserAction::Error(err.into()),
+            Err(err) => ParserAction::Error(vec![err.into()]),
             Ok(node) => ParserAction::SetModuleNode { module_id: *id, node },
         },
         SourceId::Interactive(id) => match gen.parse_expr_from_interactive() {
-            Err(err) => ParserAction::Error(err.into()),
+            Err(err) => ParserAction::Error(vec![err.into()]),
             Ok(node) => ParserAction::SetInteractiveNode { interactive_id: *id, node },
         },
     };
@@ -99,7 +101,7 @@ impl<'pool> HashParser {
         current_dir: PathBuf,
         workspace: &mut Workspace,
         pool: &'pool rayon::ThreadPool,
-    ) -> Vec<ParseError> {
+    ) -> Vec<Report> {
         let mut errors = Vec::new();
         let (sender, receiver) = unbounded::<ParserAction>();
 
@@ -136,7 +138,7 @@ impl<'pool> HashParser {
                         scope.spawn(move |_| parse_source(source, sender));
                     }
                     ParserAction::Error(err) => {
-                        errors.push(err);
+                        errors.extend(err);
                     }
                 }
             }
@@ -155,16 +157,9 @@ impl<'pool> Parser<'pool> for HashParser {
         workspace: &mut Workspace,
         pool: &'pool rayon::ThreadPool,
     ) -> CompilerResult<()> {
-        let current_dir =
-            env::current_dir().map_err(ParseError::from).map_err(|err| vec![Report::from(err)])?;
+        let current_dir = env::current_dir().map_err(|err| vec![err.into()])?;
 
-        // Parse and collect any errors that occurred
-        let errors: Vec<_> = self
-            .begin(target, current_dir, workspace, pool)
-            .into_iter()
-            .map(|err| err.create_report())
-            .collect();
-
+        let errors = self.begin(target, current_dir, workspace, pool);
         if errors.is_empty() {
             Ok(())
         } else {

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -250,11 +250,11 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         kind: AstGenErrorKind,
         expected: Option<TokenKindVector>,
         received: Option<TokenKind>,
-        location: Option<Span>,
+        span: Option<Span>,
     ) -> AstGenError {
         AstGenError::new(
             kind,
-            self.source_location(&location.unwrap_or_else(|| self.current_location())),
+            self.source_location(&span.unwrap_or_else(|| self.current_location())),
             expected,
             received,
         )
@@ -276,9 +276,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         kind: AstGenErrorKind,
         expected: Option<TokenKindVector>,
         received: Option<TokenKind>,
-        location: Span,
+        span: Span,
     ) -> AstGenResult<T> {
-        Err(self.make_error(kind, expected, received, Some(location)))
+        Err(self.make_error(kind, expected, received, Some(span)))
     }
 
     /// Generate an error that represents that within the current [AstGen] the

--- a/compiler/hash-parser/src/parser/name.rs
+++ b/compiler/hash-parser/src/parser/name.rs
@@ -4,19 +4,20 @@ use hash_ast::ast::*;
 use hash_source::identifier::CORE_IDENTIFIERS;
 use hash_token::{Token, TokenKind};
 
-use super::{error::AstGenErrorKind, AstGen, AstGenResult};
+use super::AstGen;
+use crate::diagnostics::error::{ParseErrorKind, ParseResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse a singular [Name] from the current token stream.
     #[inline]
-    pub fn parse_name(&self) -> AstGenResult<AstNode<Name>> {
-        self.parse_name_with_error(AstGenErrorKind::ExpectedName)
+    pub fn parse_name(&self) -> ParseResult<AstNode<Name>> {
+        self.parse_name_with_error(ParseErrorKind::ExpectedName)
     }
 
     /// Parse a singular [Name] from the current token stream. The function
     /// disallows a [Name] to be the special binding `_`.
     #[inline]
-    pub fn parse_name_with_error(&self, err: AstGenErrorKind) -> AstGenResult<AstNode<Name>> {
+    pub fn parse_name_with_error(&self, err: ParseErrorKind) -> ParseResult<AstNode<Name>> {
         match self.next_token() {
             Some(Token { kind: TokenKind::Ident(ident), span })
                 if *ident != CORE_IDENTIFIERS.underscore =>

--- a/compiler/hash-parser/src/parser/operator.rs
+++ b/compiler/hash-parser/src/parser/operator.rs
@@ -3,7 +3,8 @@
 use hash_ast::ast::*;
 use hash_token::{keyword::Keyword, TokenKind};
 
-use super::{error::AstGenErrorKind, AstGen, AstGenResult};
+use super::AstGen;
+use crate::diagnostics::error::{ParseErrorKind, ParseResult};
 
 impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// This function is used to pickup 'glued' operator tokens to form more
@@ -79,12 +80,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     }
 
     /// Function to parse a fat arrow component '=>' in any given context.
-    pub(crate) fn parse_arrow(&self) -> AstGenResult<()> {
+    pub(crate) fn parse_arrow(&self) -> ParseResult<()> {
         // Essentially, we want to re-map the error into a more concise one given
         // the parsing context.
         if self.parse_token_fast(TokenKind::Eq).is_none() {
             return self.error_with_location(
-                AstGenErrorKind::ExpectedArrow,
+                ParseErrorKind::ExpectedArrow,
                 None,
                 None,
                 self.next_location(),
@@ -93,7 +94,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         if self.parse_token_fast(TokenKind::Gt).is_none() {
             return self.error_with_location(
-                AstGenErrorKind::ExpectedArrow,
+                ParseErrorKind::ExpectedArrow,
                 None,
                 None,
                 self.next_location(),
@@ -104,15 +105,15 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     }
 
     /// Function to parse a fat arrow component '=>' in any given context.
-    pub(crate) fn parse_thin_arrow(&self) -> AstGenResult<()> {
+    pub(crate) fn parse_thin_arrow(&self) -> ParseResult<()> {
         // Essentially, we want to re-map the error into a more concise one given
         // the parsing context.
         if self.parse_token_fast(TokenKind::Minus).is_none() {
-            return self.error(AstGenErrorKind::ExpectedFnArrow, None, None)?;
+            return self.error(ParseErrorKind::ExpectedFnArrow, None, None)?;
         }
 
         if self.parse_token_fast(TokenKind::Gt).is_none() {
-            return self.error(AstGenErrorKind::ExpectedFnArrow, None, None)?;
+            return self.error(ParseErrorKind::ExpectedFnArrow, None, None)?;
         }
 
         Ok(())

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -1,0 +1,39 @@
+//! Reporting diagnostic trait which contains internal logic for
+//! adding errors and warnings into an abstract diagnostic store that
+//! some stage within the compiler can implement.
+
+use crate::report::Report;
+
+pub trait Diagnostics<E: Into<Report>, W: Into<Report>> {
+    /// The store that is used to store the relevant diagnostics,
+    /// this is up to the implementation of the trait how the  
+    /// store is implemented.
+    type DiagnosticsStore;
+
+    /// Get a reference to the associated [Self::DiagnosticsStore]
+    fn store(&self) -> &Self::DiagnosticsStore;
+
+    /// Add an error into the [DiagnosticsStore]
+    fn add_error(&mut self, error: E);
+
+    /// Add a warning into the diagnostics store.
+    fn add_warning(&mut self, warning: W);
+
+    /// Check if the diagnostics has an error.
+    fn has_errors(&self) -> bool;
+
+    /// Check if the diagnostics has a warning
+    fn has_warnings(&self) -> bool;
+
+    /// Convert the [Diagnostics] into a [Vec<Report>].
+    fn into_reports(self) -> Vec<Report>;
+
+    /// Convert the [Diagnostics] into a [Vec<E>]. This is useful
+    /// when we just want to get the errors from the diagnostics
+    /// rather than immediately converting the diagnostics into
+    /// [Report]s.
+    fn into_errors(self) -> Vec<E>;
+
+    /// Merge another diagnostic store with this one.
+    fn merge(&mut self, other: impl Diagnostics<E, W>);
+}

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -13,7 +13,7 @@ pub trait Diagnostics<E: Into<Report>, W: Into<Report>> {
     /// Get a reference to the associated [Self::DiagnosticsStore]
     fn store(&self) -> &Self::DiagnosticsStore;
 
-    /// Add an error into the [DiagnosticsStore]
+    /// Add an error into the [Self]
     fn add_error(&mut self, error: E);
 
     /// Add a warning into the diagnostics store.

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -28,11 +28,12 @@ pub trait Diagnostics<E: Into<Report>, W: Into<Report>> {
     /// Convert the [Diagnostics] into a [Vec<Report>].
     fn into_reports(self) -> Vec<Report>;
 
-    /// Convert the [Diagnostics] into a [Vec<E>]. This is useful
+    /// Convert the [Diagnostics] into it's respective parts.
+    /// This is useful
     /// when we just want to get the errors from the diagnostics
     /// rather than immediately converting the diagnostics into
     /// [Report]s.
-    fn into_errors(self) -> Vec<E>;
+    fn into_diagnostics(self) -> (Vec<E>, Vec<W>);
 
     /// Merge another diagnostic store with this one.
     fn merge(&mut self, other: impl Diagnostics<E, W>);

--- a/compiler/hash-reporting/src/lib.rs
+++ b/compiler/hash-reporting/src/lib.rs
@@ -1,7 +1,8 @@
-//! Hash Compiler error and warning reporting module
+//! Hash Compiler error and warning reporting module.
 #![feature(decl_macro)]
 
 pub mod builder;
+pub mod diagnostic;
 pub mod errors;
 pub mod highlight;
 pub mod macros;

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -1,5 +1,5 @@
 //! Hash diagnostic report data structures.
-use std::{cell::Cell, fmt, io};
+use std::{cell::Cell, convert::Infallible, fmt, io};
 
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_source::location::SourceLocation;
@@ -164,5 +164,11 @@ impl From<io::Error> for Report {
         // @@ErrorReporting: we might want to show a bit more info here.
         report.with_kind(ReportKind::Error).with_message(err.to_string());
         report.build()
+    }
+}
+
+impl From<Infallible> for Report {
+    fn from(err: Infallible) -> Self {
+        match err {}
     }
 }

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -1,10 +1,13 @@
 //! Hash diagnostic report data structures.
-use std::{cell::Cell, fmt};
+use std::{cell::Cell, fmt, io};
 
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_source::location::SourceLocation;
 
-use crate::highlight::{highlight, Colour, Modifier};
+use crate::{
+    builder::ReportBuilder,
+    highlight::{highlight, Colour, Modifier},
+};
 
 /// A data type representing a comment/message on a specific span in a code
 /// block.
@@ -150,5 +153,16 @@ impl Report {
     /// Check if the report denotes an occurred warning.
     pub fn is_warning(&self) -> bool {
         self.kind == ReportKind::Warning
+    }
+}
+
+/// Some basic conversions into reports
+impl From<io::Error> for Report {
+    fn from(err: io::Error) -> Self {
+        let mut report = ReportBuilder::new();
+
+        // @@ErrorReporting: we might want to show a bit more info here.
+        report.with_kind(ReportKind::Error).with_message(err.to_string());
+        report.build()
     }
 }

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -195,6 +195,10 @@ pub enum TokenKind {
     /// A token that was unexpected by the lexer, e.g. a unicode symbol not
     /// within string literal.
     Unexpected(char),
+
+    /// Error token within the tokenisation process, essentially aiding deferred
+    /// error reporting
+    Err,
 }
 
 impl TokenKind {
@@ -263,6 +267,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Ident(ident) => {
                 write!(f, "{}", String::from(*ident))
             }
+            TokenKind::Err => write!(f, "<error>"),
         }
     }
 }

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -82,7 +82,7 @@ impl<'gs> PrimitiveReader<'gs> {
         self.gs.deconstructed_pat_store.get(id)
     }
 
-    /// Get the associated [DeconstructedCtor] from [ConstructorId].
+    /// Get the associated [DeconstructedCtor] from [DeconstructedCtorId].
     pub fn get_deconstructed_ctor(&self, id: DeconstructedCtorId) -> DeconstructedCtor {
         self.gs.deconstructed_ctor_store.get(id)
     }

--- a/compiler/hash-typecheck/src/storage/sources.rs
+++ b/compiler/hash-typecheck/src/storage/sources.rs
@@ -5,7 +5,7 @@ use hash_utils::store::{DefaultPartialStore, PartialStore};
 use super::terms::TermId;
 
 /// Contains a record of all the sources which have been typechecked, and maps
-/// them to (ModDefId)[crate::storage::primitives::ModDefId]s.
+/// them to (ModDefId)[crate::storage::mods::ModDefId]s.
 #[derive(Debug, Default)]
 pub struct CheckedSources {
     /// A map between [SourceId] and the module definition.

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -33,6 +33,81 @@ macro_rules! new_store_key {
     };
 }
 
+/// Create a new [`Store`] with the given name, key and value type.
+#[macro_export]
+macro_rules! new_store {
+    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
+        #[derive(Default, Debug)]
+        $visibility struct $name {
+            data: std::cell::RefCell<Vec<$Value>>,
+        }
+
+        #[allow(dead_code)]
+        impl $name {
+            /// Create a new empty store.
+            $visibility fn new() -> Self {
+                Self { data: std::cell::RefCell::new(Vec::new()) }
+            }
+        }
+
+        impl $crate::store::Store<$Key, $Value> for $name {
+            fn internal_data(&self) -> &std::cell::RefCell<Vec<$Value>> {
+                &self.data
+            }
+        }
+    };
+}
+
+/// Create a new [`PartialStore`] with the given name, key and value type.
+#[macro_export]
+macro_rules! new_partial_store {
+    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
+        #[derive(Default, Debug)]
+        $visibility struct $name {
+            data: std::cell::RefCell<std::collections::HashMap<$Key, $Value>>,
+        }
+
+        #[allow(dead_code)]
+        impl $name {
+            /// Create a new empty store.
+            $visibility fn new() -> Self {
+                Self { data: std::cell::RefCell::new(std::collections::HashMap::new()) }
+            }
+        }
+
+        impl $crate::store::PartialStore<$Key, $Value> for $name {
+            fn internal_data(&self) -> &std::cell::RefCell<std::collections::HashMap<$Key, $Value>> {
+                &self.data
+            }
+        }
+    };
+}
+
+/// Create a new [`SequenceStore`] with the given name, key and value type.
+#[macro_export]
+macro_rules! new_sequence_store {
+    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
+        #[derive(Default, Debug)]
+        $visibility struct $name {
+            data: std::cell::RefCell<Vec<$Value>>,
+        }
+
+        #[allow(dead_code)]
+        impl $name {
+            /// Create a new empty store.
+            $visibility fn new() -> Self {
+                Self { data: std::cell::RefCell::new(Vec::new()) }
+            }
+        }
+
+        impl $crate::store::SequenceStore<$Key, $Value> for $name {
+            fn internal_data(&self) -> &std::cell::RefCell<Vec<$Value>> {
+                &self.data
+            }
+        }
+    };
+}
+
 /// A store, which provides a way to efficiently store values indexed by opaque
 /// generated keys.
 ///
@@ -117,31 +192,6 @@ pub trait Store<Key: StoreKey, Value: Clone> {
         self.set(key, value);
         ret
     }
-}
-
-/// Create a new [`Store`] with the given name, key and value type.
-#[macro_export]
-macro_rules! new_store {
-    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
-        #[derive(Default, Debug)]
-        $visibility struct $name {
-            data: std::cell::RefCell<Vec<$Value>>,
-        }
-
-        #[allow(dead_code)]
-        impl $name {
-            /// Create a new empty store.
-            $visibility fn new() -> Self {
-                Self { data: std::cell::RefCell::new(Vec::new()) }
-            }
-        }
-
-        impl $crate::store::Store<$Key, $Value> for $name {
-            fn internal_data(&self) -> &std::cell::RefCell<Vec<$Value>> {
-                &self.data
-            }
-        }
-    };
 }
 
 /// A default implementation of [`Store`].
@@ -437,7 +487,7 @@ pub trait SequenceStoreCopy<Key: SequenceStoreKey, Value: Copy>: SequenceStore<K
     ///
     /// It is safe to provide a closure `f` to this function that modifies the
     /// store in some way (`create_*` etc). If you do not need to modify the
-    /// store, consider using [`Self::modify_fast()`] instead.
+    /// store, consider using `modify_fast()` instead.
     fn modify_copied<T>(&self, key: Key, f: impl FnOnce(&mut [Value]) -> T) -> T {
         let mut value = self.get_vec(key);
         let ret = f(&mut value);
@@ -473,31 +523,6 @@ impl<Key: SequenceStoreKey, Value: Clone, T: SequenceStore<Key, Value>>
             self.internal_data().borrow().get(key.index() + index).unwrap().clone()
         })
     }
-}
-
-/// Create a new [`SequenceStore`] with the given name, key and value type.
-#[macro_export]
-macro_rules! new_sequence_store {
-    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
-        #[derive(Default, Debug)]
-        $visibility struct $name {
-            data: std::cell::RefCell<Vec<$Value>>,
-        }
-
-        #[allow(dead_code)]
-        impl $name {
-            /// Create a new empty store.
-            $visibility fn new() -> Self {
-                Self { data: std::cell::RefCell::new(Vec::new()) }
-            }
-        }
-
-        impl $crate::store::SequenceStore<$Key, $Value> for $name {
-            fn internal_data(&self) -> &std::cell::RefCell<Vec<$Value>> {
-                &self.data
-            }
-        }
-    };
 }
 
 /// A default implementation of [`SequenceStore`].
@@ -618,31 +643,6 @@ pub trait PartialStore<Key: Copy + Eq + Hash, Value: Clone> {
     fn clear(&self) {
         self.internal_data().borrow_mut().clear()
     }
-}
-
-/// Create a new [`PartialStore`] with the given name, key and value type.
-#[macro_export]
-macro_rules! new_partial_store {
-    ($visibility:vis $name:ident<$Key:ty, $Value:ty>) => {
-        #[derive(Default, Debug)]
-        $visibility struct $name {
-            data: std::cell::RefCell<std::collections::HashMap<$Key, $Value>>,
-        }
-
-        #[allow(dead_code)]
-        impl $name {
-            /// Create a new empty store.
-            $visibility fn new() -> Self {
-                Self { data: std::cell::RefCell::new(std::collections::HashMap::new()) }
-            }
-        }
-
-        impl $crate::store::PartialStore<$Key, $Value> for $name {
-            fn internal_data(&self) -> &std::cell::RefCell<std::collections::HashMap<$Key, $Value>> {
-                &self.data
-            }
-        }
-    };
 }
 
 /// A default implementation of [`PartialStore`].

--- a/tests/parser/benches/benches.rs
+++ b/tests/parser/benches/benches.rs
@@ -27,7 +27,7 @@ macro_rules! bench_func {
                 // create a new lexer
                 let mut lex = Lexer::new($source, SourceId::Interactive(interactive_id));
 
-                while let Ok(Some(token)) = lex.advance_token() {
+                while let Some(token) = lex.advance_token() {
                     black_box(token);
                 }
             });

--- a/tests/parser/tests/cases/should_fail/multi_error_char/case.hash
+++ b/tests/parser/tests/cases/should_fail/multi_error_char/case.hash
@@ -1,0 +1,6 @@
+// Should report that both these have invalid codepoints but recover from the error.
+main := () => {
+    a := 'ab';
+
+    c := 'ddddd';
+};

--- a/tests/parser/tests/cases/should_fail/multi_error_char/case.stderr
+++ b/tests/parser/tests/cases/should_fail/multi_error_char/case.stderr
@@ -1,0 +1,13 @@
+error: invalid character literal `ab`, character literals may only contain one codepoint
+ --> $DIR/case.hash:3:10
+2 |   main := () => {
+3 |       a := 'ab';
+  |            ^^^^ here
+4 |   
+
+error: invalid character literal `ddddd`, character literals may only contain one codepoint
+ --> $DIR/case.hash:5:10
+4 |   
+5 |       c := 'ddddd';
+  |            ^^^^^^^ here
+6 |   };

--- a/tests/parser/tests/cases/should_fail/non_existant_import/case.stderr
+++ b/tests/parser/tests/cases/should_fail/non_existant_import/case.stderr
@@ -1,4 +1,4 @@
-error: Couldn't import module `does_not_exist`: Module couldn't be found
+error: couldn't import `does_not_exist`, module couldn't be found
  --> $DIR/case.hash:1:6
 1 |   k := import("does_not_exist");
   |        ^^^^^^^^^^^^^^^^^^^^^^^^ here

--- a/tests/parser/tests/cases/should_fail/non_hex_unicode_char/case.stderr
+++ b/tests/parser/tests/cases/should_fail/non_hex_unicode_char/case.stderr
@@ -1,4 +1,4 @@
-error: invalid character escape sequence. Expected `}` after a escape sequence
+error: invalid character escape sequence. expected `}` after a escape sequence
  --> $DIR/case.hash:1:10
 1 |   k := '\u{g00000}';
   |            ^ here

--- a/tests/parser/tests/cases/should_fail/unclosed_unicode_literal/case.stderr
+++ b/tests/parser/tests/cases/should_fail/unclosed_unicode_literal/case.stderr
@@ -1,4 +1,4 @@
-error: invalid character escape sequence. Expected `}` after a escape sequence
+error: invalid character escape sequence. expected `}` after a escape sequence
  --> $DIR/case.hash:1:14
 1 |   k := '\u{005a';
   |                ^ here

--- a/tests/parser/tests/cases/should_fail/unknown_escape_sequence/case.stderr
+++ b/tests/parser/tests/cases/should_fail/unknown_escape_sequence/case.stderr
@@ -1,4 +1,4 @@
-error: invalid character escape sequence. Unknown escape sequence `j`
+error: invalid character escape sequence. unknown escape sequence `j`
  --> $DIR/case.hash:1:8
 1 |   k := '\j';
   |          ^ here


### PR DESCRIPTION
This patch adds the `Diagnostics` trait into reporting and integrates it as a proof of concept with the Lexer. This also means that the lexer is now capable of error recovery and multiple error reporting!

Additionally, this simplifies the interaction between error types within the Parser and the Lexer. Things like the `LexerError` don't need to be converted into `ParseError` and the reported, this now happens directly. Similarly, this also removes the intermediate `AstGenError` since this has now been de-coupled from `ImportError` and `LexerError`, so it is now just `ParseError`, and `ParseResult` 

closes #437
closes #443