### PR TITLE
Exhaustiveness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -552,7 +552,7 @@ impl IntTy {
 
     /// Get the size of [IntTy] in bytes. Returns [None] for
     /// [IntTy::IBig] and [IntTy::UBig] variants
-    pub fn size(&self) -> Option<u64> {
+    pub const fn size(&self) -> Option<u64> {
         match self {
             IntTy::I8 | IntTy::U8 => Some(1),
             IntTy::I16 | IntTy::U16 => Some(2),

--- a/compiler/hash-typecheck/src/exhaustiveness/constant.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/constant.rs
@@ -34,8 +34,24 @@ impl Constant {
         let size = kind.size().unwrap_or_else(|| int.bits());
         assert!(size < 128);
 
-        let (.., data) = int.into_parts();
-        Constant { data: data.try_into().unwrap(), ty }
+        // @@Hack: this should be done in some better way or tidied up!
+        // This is here because `BigInt::to_be_bytes()` returns the minimum
+        // number of bytes rather than providing functions that could coerce the
+        // type into another. Since we work with only `u128` we need to
+        // perform this ugly bit shifts in order for this to work...
+        if kind.is_signed() {
+            // Cast the `bigint` into a i128 and then convert to big-endian bytes
+            let mut data = (<BigInt as TryInto<i128>>::try_into(int).unwrap()).to_be_bytes();
+
+            // memset the upper 16-kind.size() bytes to zero since they aren't
+            // necessary.
+            data[0..(16 - kind.size().unwrap() as usize)].fill(0);
+
+            Constant { data: u128::from_be_bytes(data), ty }
+        } else {
+            let (_, data) = int.into_parts();
+            Constant { data: data.try_into().unwrap(), ty }
+        }
     }
 
     /// Get the data stored within the [Constant].

--- a/compiler/hash-typecheck/src/exhaustiveness/construct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/construct.rs
@@ -275,7 +275,9 @@ impl<'tc> ConstructorOps<'tc> {
                 self_slice.is_covered_by(*other_slice)
             }
             (DeconstructedCtor::NonExhaustive, _) => false,
-            _ => panic!("trying to compare incompatible constructors {:?} and {:?}", ctor, other),
+            _ => {
+                panic!("trying to compare incompatible constructors `{:?}` and `{:?}`", ctor, other)
+            }
         }
     }
 

--- a/compiler/hash-typecheck/src/exhaustiveness/lower.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/lower.rs
@@ -122,7 +122,7 @@ impl<'tc> LowerPatOps<'tc> {
                 (DeconstructedCtor::Wildcard, vec![])
             }
             Pat::Range(range) => {
-                let range = self.lower_pat_range(range);
+                let range = self.lower_pat_range(ty, range);
                 (DeconstructedCtor::IntRange(range), vec![])
             }
             Pat::Lit(term) => match reader.get_term(term) {
@@ -392,11 +392,8 @@ impl<'tc> LowerPatOps<'tc> {
     /// the [RangePat] was already validated, and so this function will
     /// read `lo`, and `hi` terms, convert them into bytes and put them
     /// into the [IntRange]
-    pub fn lower_pat_range(&self, range: RangePat) -> IntRange {
+    pub fn lower_pat_range(&self, ty: TermId, range: RangePat) -> IntRange {
         let RangePat { lo, hi, end } = range;
-
-        // @@Fix: this should probably happen somewhere else?
-        let ty = self.typer().infer_ty_of_term(lo).unwrap();
 
         let term_to_u128 = |term| {
             // The only types we support we support within ranges is currently a

--- a/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/matrix.rs
@@ -73,7 +73,7 @@ impl<'tc> MatrixOps<'tc> {
             let pat = reader.get_deconstructed_pat(row.head());
 
             if self.deconstruct_pat_ops().is_or_pat(&pat) {
-                matrix.patterns.extend(self.stack_ops().expand_or_pat(&row));
+                return matrix.patterns.extend(self.stack_ops().expand_or_pat(&row));
             }
         }
 

--- a/compiler/hash-typecheck/src/exhaustiveness/range.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/range.rs
@@ -39,10 +39,11 @@ use hash_ast::ast::RangeEnd;
 
 use crate::{
     diagnostics::macros::tc_panic,
-    exhaustiveness::{constant::Constant, PatCtx},
+    exhaustiveness::constant::Constant,
     ops::AccessToOps,
     storage::{
         primitives::{Level0Term, LitTerm, Term},
+        terms::TermId,
         AccessToStorage, StorageRef,
     },
 };
@@ -267,8 +268,8 @@ impl<'tc> IntRangeOps<'tc> {
 
     /// Create an [IntRange] from two specified bounds, and assuming that the
     /// type is an integer (of the column)
-    pub(crate) fn make_range(&self, ctx: PatCtx, lo: u128, hi: u128, end: &RangeEnd) -> IntRange {
-        let bias = self.signed_bias(ctx);
+    pub(crate) fn make_range(&self, ty: TermId, lo: u128, hi: u128, end: &RangeEnd) -> IntRange {
+        let bias = self.signed_bias(ty);
 
         let (lo, hi) = (lo ^ bias, hi ^ bias);
         let offset = (*end == RangeEnd::Excluded) as u128;
@@ -283,9 +284,9 @@ impl<'tc> IntRangeOps<'tc> {
     /// the bias is set to be just at the end of the signed boundary
     /// of the integer size, in other words at the position where the
     /// last byte is that identifies the sign.
-    fn signed_bias(&self, ctx: PatCtx) -> u128 {
+    fn signed_bias(&self, ty: TermId) -> u128 {
         // @@Future: support `ibig` here
-        if let Some(ty) = self.oracle().term_as_int_ty(ctx.ty) {
+        if let Some(ty) = self.oracle().term_as_int_ty(ty) {
             if let Some(size) = ty.size() && ty.is_signed()  {
                 let bits = (size * 8) as u128;
                 return 1u128 << (bits - 1);

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -64,7 +64,7 @@ impl<'tc> SplitWildcardOps<'tc> {
     }
 
     /// Create a [SplitWildcard] from the current context.
-    pub(super) fn from(&mut self, ctx: PatCtx) -> SplitWildcard {
+    pub(super) fn from(&self, ctx: PatCtx) -> SplitWildcard {
         let reader = self.reader();
 
         let make_range = |start, end| {

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -69,7 +69,7 @@ impl<'tc> SplitWildcardOps<'tc> {
 
         let make_range = |start, end| {
             DeconstructedCtor::IntRange(self.int_range_ops().make_range(
-                ctx,
+                ctx.ty,
                 start,
                 end,
                 &RangeEnd::Included,

--- a/compiler/hash-typecheck/src/ops/exhaustiveness.rs
+++ b/compiler/hash-typecheck/src/ops/exhaustiveness.rs
@@ -63,6 +63,9 @@ impl<'tc> ExhaustivenessChecker<'tc> {
         Self { storage }
     }
 
+    /// Performs a lowering operation on all of the specified branches.
+    ///
+    /// This takes in the `term` which is the type of the subject.
     fn lower_pats_to_arms(&self, pats: &[PatId], term: TermId) -> Vec<MatchArm> {
         let reader = self.reader();
 
@@ -82,8 +85,10 @@ impl<'tc> ExhaustivenessChecker<'tc> {
     /// of each branch and whether there are any `useless` patterns that
     /// are present within the
     pub fn is_match_exhaustive(&self, pats: &[PatId], term: TermId) -> TcResult<()> {
-        let arms = self.lower_pats_to_arms(pats, term);
-        let report = self.usefulness_ops().compute_match_usefulness(term, &arms);
+        let term_ty = self.typer().infer_ty_of_term(term)?;
+
+        let arms = self.lower_pats_to_arms(pats, term_ty);
+        let report = self.usefulness_ops().compute_match_usefulness(term_ty, &arms);
 
         // @@Todo: deal with arm reachability in the form of generating
         // warnings in the discussed diagnostic system.
@@ -109,8 +114,10 @@ impl<'tc> ExhaustivenessChecker<'tc> {
         term: TermId,
         origin: Option<MatchOrigin>,
     ) -> TcResult<()> {
-        let arms = self.lower_pats_to_arms(pats, term);
-        let report = self.usefulness_ops().compute_match_usefulness(term, &arms);
+        let term_ty = self.typer().infer_ty_of_term(term)?;
+
+        let arms = self.lower_pats_to_arms(pats, term_ty);
+        let report = self.usefulness_ops().compute_match_usefulness(term_ty, &arms);
 
         // We ignore whether the pattern is unreachable (i.e. whether the type is
         // empty). We only care about exhaustiveness here.


### PR DESCRIPTION
This patch fixes several issues with the exhaustiveness checking:
- `Pat::Const` should be handled as a wildcard with the given type of subject, unless the pattern itself is an enum variant which is currently not implemented. fixes #461 
- `Pat::Access` does not need to perform any special handling since the type of the pattern should already be resolved, it just needs to pass in `ty` to deconstruct_pat() recursively down until it hits `Pat::Const`
- Implement lowering `Pat::Range` into `IntRange`
- fix broken conversion logic between stored `BigInt` and `u128` representation (could be cleaned up)
- the type of the subject term should be passed into `deconstruct_pat` which fixes #462
- fixes problems with expansion of `or` patterns. fixes #468 