### PR TITLE
Tc: diagnostics

### DIFF
--- a/compiler/hash-ast-passes/src/diagnostics/mod.rs
+++ b/compiler/hash-ast-passes/src/diagnostics/mod.rs
@@ -27,16 +27,12 @@ impl Diagnostics<AnalysisError, AnalysisWarning> for SemanticAnalyser<'_> {
         &self.diagnostics
     }
 
-    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore {
-        &mut self.diagnostics
-    }
-
     fn add_error(&mut self, error: AnalysisError) {
         self.diagnostics.errors.push(error);
     }
 
     fn add_warning(&mut self, warning: AnalysisWarning) {
-        self.diagnostic_store_mut().warnings.push(warning);
+        self.diagnostics.warnings.push(warning);
     }
 
     fn has_errors(&self) -> bool {

--- a/compiler/hash-lexer/src/error.rs
+++ b/compiler/hash-lexer/src/error.rs
@@ -141,13 +141,9 @@ impl Diagnostics<LexerError, Infallible> for Lexer<'_> {
         &self.diagnostics
     }
 
-    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore {
-        &mut self.diagnostics
-    }
-
     /// Add an error into the store
     fn add_error(&mut self, error: LexerError) {
-        self.diagnostic_store_mut().errors.push(error);
+        self.diagnostics.errors.push(error);
     }
 
     /// The lexer does not currently emit any warnings and so if this

--- a/compiler/hash-parser/src/diagnostics/mod.rs
+++ b/compiler/hash-parser/src/diagnostics/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod error;
 pub(crate) mod warning;
 
-use hash_reporting::diagnostic::Diagnostics;
+use hash_reporting::{diagnostic::Diagnostics, report::Report};
 use smallvec::SmallVec;
 
 use self::{
@@ -70,7 +70,7 @@ impl<'stream, 'resolver> Diagnostics<ParseError, ParseWarning> for AstGen<'strea
         !self.diagnostic_store().warnings.is_empty()
     }
 
-    fn into_reports(self) -> Vec<hash_reporting::report::Report> {
+    fn into_reports(self) -> Vec<Report> {
         self.diagnostics
             .errors
             .into_iter()

--- a/compiler/hash-parser/src/diagnostics/mod.rs
+++ b/compiler/hash-parser/src/diagnostics/mod.rs
@@ -50,16 +50,12 @@ impl<'stream, 'resolver> Diagnostics<ParseError, ParseWarning> for AstGen<'strea
         &self.diagnostics
     }
 
-    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore {
-        &mut self.diagnostics
-    }
-
     fn add_error(&mut self, error: ParseError) {
-        self.diagnostic_store_mut().errors.push(error);
+        self.diagnostics.errors.push(error);
     }
 
     fn add_warning(&mut self, warning: ParseWarning) {
-        self.diagnostic_store_mut().warnings.push(warning);
+        self.diagnostics.warnings.push(warning);
     }
 
     fn has_errors(&self) -> bool {

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -70,6 +70,12 @@ pub enum CompilerMode {
     Full,
 }
 
+impl Default for CompilerMode {
+    fn default() -> Self {
+        CompilerMode::Full
+    }
+}
+
 impl Display for CompilerMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -4,7 +4,7 @@
 
 use crate::report::Report;
 
-pub trait Diagnostics<E: Into<Report>, W> {
+pub trait Diagnostics<E, W> {
     /// The store that is used to store the relevant diagnostics,
     /// this is up to the implementation of the trait how the  
     /// store is implemented.
@@ -34,6 +34,10 @@ pub trait Diagnostics<E: Into<Report>, W> {
 
     /// Check if the diagnostics has a warning
     fn has_warnings(&self) -> bool;
+
+    fn has_diagnostics(&self) -> bool {
+        self.has_errors() || self.has_warnings()
+    }
 
     /// Convert the [Diagnostics] into a [Vec<Report>].
     fn into_reports(self) -> Vec<Report>;

--- a/compiler/hash-reporting/src/diagnostic.rs
+++ b/compiler/hash-reporting/src/diagnostic.rs
@@ -13,9 +13,6 @@ pub trait Diagnostics<E, W> {
     /// Get a reference to the associated [Self::DiagnosticsStore]
     fn diagnostic_store(&self) -> &Self::DiagnosticsStore;
 
-    /// Get a mutable reference to [Self::DiagnosticsStore]
-    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore;
-
     /// Add an error into the [Self]
     fn add_error(&mut self, error: E);
 

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -144,8 +144,6 @@ pub enum TcError {
         // "terms".
         trt_def_missing_member_term_id: TermId,
     },
-    /// Given match case is never going to match the subject.
-    UselessMatchCase { pat: PatId, subject: TermId },
     /// Cannot use pattern matching in a declaration without an assignment
     CannotPatMatchWithoutAssignment { pat: PatId },
     /// Cannot use a non-name as an assign subject.

--- a/compiler/hash-typecheck/src/diagnostics/mod.rs
+++ b/compiler/hash-typecheck/src/diagnostics/mod.rs
@@ -22,17 +22,17 @@ use crate::storage::AccessToStorage;
 /// [TcDiagnostics] is a struct that stores the generated errors
 /// and warnings for the typechecking instance.
 #[derive(Debug, Default)]
-pub struct TcDiagnostics {
+pub struct DiagnosticsStore {
     /// The errors that the typechecking instance has emitted.
     pub(super) errors: RefCell<SmallVec<[TcError; 1]>>,
     /// The warnings that the typechecking instance has emitted.
     pub(super) warnings: RefCell<Vec<TcWarning>>,
 }
 
-pub struct TcDiagnosticsWrapper<'tc, T: ?Sized>(pub(crate) &'tc T);
+pub struct TcDiagnostics<'tc, T: ?Sized>(pub(crate) &'tc T);
 
-impl<'tc, T: AccessToStorage> Diagnostics<TcError, TcWarning> for TcDiagnosticsWrapper<'tc, T> {
-    type DiagnosticsStore = TcDiagnostics;
+impl<'tc, T: AccessToStorage> Diagnostics<TcError, TcWarning> for TcDiagnostics<'tc, T> {
+    type DiagnosticsStore = DiagnosticsStore;
 
     fn diagnostic_store(&self) -> &'tc Self::DiagnosticsStore {
         self.0.diagnostic_store()
@@ -55,7 +55,7 @@ impl<'tc, T: AccessToStorage> Diagnostics<TcError, TcWarning> for TcDiagnosticsW
     }
 
     fn into_reports(self) -> Vec<hash_reporting::report::Report> {
-        let TcDiagnostics { errors, warnings } = self.diagnostic_store();
+        let DiagnosticsStore { errors, warnings } = self.diagnostic_store();
 
         let errors = errors.clone().into_inner();
         let warnings = warnings.clone().into_inner();

--- a/compiler/hash-typecheck/src/diagnostics/mod.rs
+++ b/compiler/hash-typecheck/src/diagnostics/mod.rs
@@ -38,12 +38,6 @@ impl<'tc, T: AccessToStorage> Diagnostics<TcError, TcWarning> for TcDiagnosticsW
         self.0.diagnostic_store()
     }
 
-    /// Implementing this access method is not possible for the typechecking
-    /// context and in fact is un-necessary
-    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore {
-        unimplemented!()
-    }
-
     fn add_error(&mut self, error: TcError) {
         self.diagnostic_store().errors.borrow_mut().push(error);
     }

--- a/compiler/hash-typecheck/src/diagnostics/mod.rs
+++ b/compiler/hash-typecheck/src/diagnostics/mod.rs
@@ -1,8 +1,95 @@
 //! Module file for diagnostic creation and reporting within the typechecking
 //! crate.
-
 pub mod error;
 pub mod params;
 pub mod reporting;
+pub mod warning;
 
 pub(crate) mod macros;
+
+use std::cell::RefCell;
+
+use hash_reporting::diagnostic::Diagnostics;
+use smallvec::SmallVec;
+
+use self::{
+    error::TcError,
+    reporting::TcErrorWithStorage,
+    warning::{TcWarning, TcWarningWithStorage},
+};
+use crate::storage::AccessToStorage;
+
+/// [TcDiagnostics] is a struct that stores the generated errors
+/// and warnings for the typechecking instance.
+#[derive(Debug, Default)]
+pub struct TcDiagnostics {
+    /// The errors that the typechecking instance has emitted.
+    pub(super) errors: RefCell<SmallVec<[TcError; 1]>>,
+    /// The warnings that the typechecking instance has emitted.
+    pub(super) warnings: RefCell<Vec<TcWarning>>,
+}
+
+pub struct TcDiagnosticsWrapper<'tc, T: ?Sized>(pub(crate) &'tc T);
+
+impl<'tc, T: AccessToStorage> Diagnostics<TcError, TcWarning> for TcDiagnosticsWrapper<'tc, T> {
+    type DiagnosticsStore = TcDiagnostics;
+
+    fn diagnostic_store(&self) -> &'tc Self::DiagnosticsStore {
+        self.0.diagnostic_store()
+    }
+
+    /// Implementing this access method is not possible for the typechecking
+    /// context and in fact is un-necessary
+    fn diagnostic_store_mut(&mut self) -> &mut Self::DiagnosticsStore {
+        unimplemented!()
+    }
+
+    fn add_error(&mut self, error: TcError) {
+        self.diagnostic_store().errors.borrow_mut().push(error);
+    }
+
+    fn add_warning(&mut self, warning: TcWarning) {
+        self.diagnostic_store().warnings.borrow_mut().push(warning);
+    }
+
+    fn has_errors(&self) -> bool {
+        !self.diagnostic_store().errors.borrow().is_empty()
+    }
+
+    fn has_warnings(&self) -> bool {
+        !self.diagnostic_store().warnings.borrow().is_empty()
+    }
+
+    fn into_reports(self) -> Vec<hash_reporting::report::Report> {
+        let TcDiagnostics { errors, warnings } = self.diagnostic_store();
+
+        let errors = errors.clone().into_inner();
+        let warnings = warnings.clone().into_inner();
+
+        errors
+            .into_iter()
+            .map(|error| TcErrorWithStorage { error, storage: self.0.storages() }.into())
+            .chain(
+                warnings.into_iter().map(|warning| {
+                    TcWarningWithStorage { warning, storage: self.0.storages() }.into()
+                }),
+            )
+            .collect()
+    }
+
+    fn into_diagnostics(self) -> (Vec<TcError>, Vec<TcWarning>) {
+        let diagnostics = self.diagnostic_store();
+
+        (
+            diagnostics.errors.clone().into_inner().to_vec(),
+            diagnostics.warnings.clone().into_inner(),
+        )
+    }
+
+    fn merge_diagnostics(&mut self, other: impl Diagnostics<TcError, TcWarning>) {
+        let (errors, warnings) = other.into_diagnostics();
+
+        self.diagnostic_store().errors.borrow_mut().extend(errors);
+        self.diagnostic_store().warnings.borrow_mut().extend(warnings);
+    }
+}

--- a/compiler/hash-typecheck/src/diagnostics/reporting.rs
+++ b/compiler/hash-typecheck/src/diagnostics/reporting.rs
@@ -1025,28 +1025,6 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
                     )));
                 }
             }
-            TcError::UselessMatchCase { pat, subject } => {
-                // @@Todo: error code
-                builder.with_message(format!(
-                    "match case `{}` is redundant when matching on `{}`",
-                    pat.for_formatting(err.global_storage()),
-                    subject.for_formatting(err.global_storage())
-                ));
-
-                if let Some(location) = err.location_store().get_location(subject) {
-                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        location,
-                        "the match subject is given here...",
-                    )));
-                }
-
-                if let Some(location) = err.location_store().get_location(pat) {
-                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
-                        location,
-                        "...and this pattern will never match the subject".to_string(),
-                    )));
-                }
-            }
             TcError::CannotPatMatchWithoutAssignment { pat } => {
                 // @@Todo: error code
                 builder.with_message(

--- a/compiler/hash-typecheck/src/diagnostics/warning.rs
+++ b/compiler/hash-typecheck/src/diagnostics/warning.rs
@@ -1,0 +1,90 @@
+//! Hash typechecking warning data structures and implementation.
+//! Warnings within the typechecker are essentially generated and
+//! are meant as a guide for the user when compiling programs. These
+//! warnings do not affect the resultant output of the program, and
+//! are never fatal to the compilation stage.
+//!
+//! @@Future: In the future, it should be possible to have a general
+//! corpus of all the warnings that the compiler could emit, and support
+//! for configuring if those warnings should be emitted for a given
+//! job.
+
+use hash_reporting::{
+    builder::ReportBuilder,
+    report::{Report, ReportCodeBlock, ReportElement, ReportKind},
+};
+
+use crate::{
+    fmt::PrepareForFormatting,
+    storage::{pats::PatId, terms::TermId, AccessToStorage, StorageRef},
+};
+
+/// A warning that occurs during typechecking.
+#[derive(Debug, Clone)]
+pub enum TcWarning {
+    /// Given match case is never going to match the subject.
+    UselessMatchCase {
+        pat: PatId,
+        subject: TermId,
+    },
+    // Exhaustiveness checking has found this pattern to
+    // be unreachable in the current context. In other words, the branch
+    // that the pattern corresponds to will never be reached because it
+    // is always caught by a predecessing pattern.
+    UnreachablePat {
+        pat: PatId,
+    },
+}
+
+/// A [TcWarning] with attached typechecker storage.
+pub(crate) struct TcWarningWithStorage<'tc> {
+    pub warning: TcWarning,
+    pub storage: StorageRef<'tc>,
+}
+
+impl<'tc> AccessToStorage for TcWarningWithStorage<'tc> {
+    fn storages(&self) -> StorageRef {
+        self.storage.storages()
+    }
+}
+
+impl<'tc> From<TcWarningWithStorage<'tc>> for Report {
+    fn from(item: TcWarningWithStorage<'tc>) -> Self {
+        let mut builder = ReportBuilder::new();
+        builder.with_kind(ReportKind::Warning);
+
+        match item.warning {
+            TcWarning::UselessMatchCase { pat, subject } => {
+                builder.with_message(format!(
+                    "match case `{}` is redundant when matching on `{}`",
+                    pat.for_formatting(item.global_storage()),
+                    subject.for_formatting(item.global_storage())
+                ));
+
+                if let Some(location) = item.location_store().get_location(subject) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "the match subject is given here...",
+                    )));
+                }
+
+                if let Some(location) = item.location_store().get_location(pat) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "...and this pattern will never match the subject".to_string(),
+                    )));
+                }
+            }
+            TcWarning::UnreachablePat { pat } => {
+                builder.with_message("pattern is unreachable".to_string());
+
+                if let Some(location) = item.location_store().get_location(pat) {
+                    builder
+                        .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(location, "")));
+                }
+            }
+        }
+
+        builder.build()
+    }
+}

--- a/compiler/hash-typecheck/src/exhaustiveness/range.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/range.rs
@@ -36,13 +36,18 @@ use std::{
 };
 
 use hash_ast::ast::RangeEnd;
+use hash_reporting::diagnostic::Diagnostics;
+use hash_utils::store::Store;
 
+use super::AccessToUsefulnessOps;
 use crate::{
-    diagnostics::macros::tc_panic,
+    diagnostics::{macros::tc_panic, warning::TcWarning},
     exhaustiveness::constant::Constant,
     ops::AccessToOps,
     storage::{
-        primitives::{Level0Term, LitTerm, Term},
+        deconstructed::DeconstructedPatId,
+        pats::PatId,
+        primitives::{Level0Term, LitTerm, RangePat, Term},
         terms::TermId,
         AccessToStorage, StorageRef,
     },
@@ -108,6 +113,23 @@ impl IntRange {
         } else {
             false
         }
+    }
+
+    /// Check whether [Self] has a `suspicious` intersection with another range.
+    /// This occurs when:
+    ///
+    /// - the lower bound of `self` is equal to the upper  bound of the `other`
+    ///   intersection.
+    ///
+    /// - the upper bound of `self` is equal to the lower bound of the `other`
+    ///   intersection.
+    ///
+    /// Provided that both ranges are  not singletons.
+    pub fn suspicious_intersection(&self, other: &Self) -> bool {
+        let (lo, hi) = self.boundaries();
+        let (other_lo, other_hi) = other.boundaries();
+
+        (lo == other_hi || hi == other_lo) && !self.is_singleton() && !other.is_singleton()
     }
 }
 
@@ -294,5 +316,77 @@ impl<'tc> IntRangeOps<'tc> {
         };
 
         0
+    }
+
+    /// Function to check if any provided ranges have overlapping
+    /// ends. This might occur when the user wasn't clearly marking
+    /// the `start` and `end` of particular ranges which causes a
+    /// subtle overlap within the range.
+    ///
+    /// @@Future: Generally lint for overlapping ranges, and not just endpoints!
+    ///
+    /// @@Future: currently we can't handle patterns that have multiple rows
+    /// because that would mean we have to handle the fact that the patterns
+    /// of other rows must be structurally identical. Consider this
+    /// scenario:
+    ///
+    /// ```ignore
+    /// k := (1, false); // (i32, bool)
+    ///
+    /// match k {
+    ///  (1..50, false) => {...};
+    ///  (50..100, true) => {...};
+    /// }
+    /// ```
+    ///
+    /// Here, the ranges in the first column do `overlap` but the second element
+    /// of the tuple pattern yields a different pattern which means that
+    /// this overlap might not necessarily be applicative here
+    pub(super) fn check_for_overlapping_endpoints(
+        &self,
+        pat: PatId,
+        range: IntRange,
+        pats: impl Iterator<Item = DeconstructedPatId>,
+        column_count: usize,
+        ty: TermId,
+    ) {
+        // Don't lint literals... this is covered by useless match cases
+        if range.is_singleton() {
+            return;
+        }
+
+        // As described in the function doc... multiple columns aren't handled yet
+        if column_count != 1 {
+            return;
+        }
+
+        let reader = self.reader();
+
+        let overlaps: Vec<_> = pats
+            .filter_map(|pat| {
+                let d = reader.get_deconstructed_pat(pat);
+                let ctor =
+                    self.constructor_store().map_fast(d.ctor, |c| c.as_int_range().cloned())?;
+
+                Some((ctor, d.id.unwrap()))
+            })
+            .filter(|(other_range, _)| range.suspicious_intersection(other_range))
+            .map(|(range, id)| (range.intersection(&range).unwrap(), id))
+            .collect();
+
+        if overlaps.is_empty() {
+            return;
+        };
+
+        // Emit diagnostics for all of the found overlaps
+        for (overlapping_range, id) in overlaps {
+            let RangePat { hi, .. } = self.pat_lowerer().construct_range_pat(overlapping_range, ty);
+
+            self.diagnostics().add_warning(TcWarning::OverlappingRangeEnd {
+                range: id,
+                overlaps: pat,
+                overlapping_term: hi,
+            })
+        }
     }
 }

--- a/compiler/hash-typecheck/src/exhaustiveness/range.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/range.rs
@@ -341,7 +341,7 @@ impl<'tc> IntRangeOps<'tc> {
     ///
     /// Here, the ranges in the first column do `overlap` but the second element
     /// of the tuple pattern yields a different pattern which means that
-    /// this overlap might not necessarily be applicative here
+    /// this overlap might not necessarily be applicable here
     pub(super) fn check_for_overlapping_endpoints(
         &self,
         pat: PatId,

--- a/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/usefulness.rs
@@ -359,14 +359,26 @@ impl<'tc> UsefulnessOps<'tc> {
                 }
             }
         } else {
-            // @@Ranges: we should check that int ranges don't overlap here, in case
-            // they're partially covered by other ranges. Additionally, since this isn't
-            // necessarily an error, we should integrate this with our warning system.
             let reader = self.reader();
             let ctors = matrix.heads().map(|id| reader.get_deconstructed_pat(id).ctor);
 
-            // We split the head constructor of `v`.
             let v_ctor = head.ctor;
+
+            // check that int ranges don't overlap here, in case
+            // they're partially covered by other ranges.
+            if let DeconstructedCtor::IntRange(range) = reader.get_deconstructed_ctor(v_ctor) {
+                if let Some(head_id) = head.id {
+                    self.int_range_ops().check_for_overlapping_endpoints(
+                        head_id,
+                        range,
+                        matrix.heads(),
+                        matrix.column_count().unwrap_or(0),
+                        ty,
+                    );
+                }
+            }
+
+            // We split the head constructor of `v`.
             let split_ctors = self.constructor_ops().split(ctx, v_ctor, ctors);
             let start_matrix = &matrix;
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -9,8 +9,9 @@
 
 use diagnostics::reporting::TcErrorWithStorage;
 use hash_pipeline::{traits::Tc, CompilerResult};
+use hash_reporting::diagnostic::Diagnostics;
 use hash_source::SourceId;
-use storage::{AccessToStorage, GlobalStorage, LocalStorage, StorageRefMut};
+use storage::{AccessToStorage, GlobalStorage, LocalStorage, StorageRef};
 use traverse::TcVisitor;
 
 use crate::fmt::PrepareForFormatting;
@@ -74,9 +75,9 @@ impl Tc<'_> for TcImpl {
 
         // Instantiate a visitor with the source and visit the source, using the
         // previous local storage.
-        let storage = StorageRefMut {
-            global_storage: &mut state.global_storage,
-            local_storage: &mut state.prev_local_storage,
+        let storage = StorageRef {
+            global_storage: &state.global_storage,
+            local_storage: &state.prev_local_storage,
             source_map: &workspace.source_map,
         };
         let mut tc_visitor = TcVisitor::new_in_source(storage.storages(), workspace.node_map());
@@ -103,23 +104,24 @@ impl Tc<'_> for TcImpl {
     ) -> CompilerResult<()> {
         // Instantiate a visitor with the source and visit the source, using a new local
         // storage.
-        let mut local_storage = LocalStorage::new(&state.global_storage, SourceId::Module(id));
+        let local_storage = LocalStorage::new(&state.global_storage, SourceId::Module(id));
 
-        let storage = StorageRefMut {
-            global_storage: &mut state.global_storage,
-            local_storage: &mut local_storage,
+        let storage = StorageRef {
+            global_storage: &state.global_storage,
+            local_storage: &local_storage,
             source_map: &sources.source_map,
         };
 
         let mut tc_visitor = TcVisitor::new_in_source(storage.storages(), sources.node_map());
 
-        match tc_visitor.visit_source() {
-            Ok(_) => Ok(()),
-            Err(error) => {
-                // Turn the error into a report:
-                let err_with_storage = TcErrorWithStorage { error, storage: storage.storages() };
-                Err(vec![err_with_storage.into()])
-            }
+        if let Err(err) = tc_visitor.visit_source() {
+            tc_visitor.diagnostics().add_error(err);
+        }
+
+        if tc_visitor.diagnostics().has_diagnostics() {
+            Err(tc_visitor.diagnostics().into_reports())
+        } else {
+            Ok(())
         }
     }
 }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -11,6 +11,7 @@ use diagnostics::reporting::TcErrorWithStorage;
 use hash_pipeline::{traits::Tc, CompilerResult};
 use hash_reporting::diagnostic::Diagnostics;
 use hash_source::SourceId;
+use ops::AccessToOps;
 use storage::{AccessToStorage, GlobalStorage, LocalStorage, StorageRef};
 use traverse::TcVisitor;
 

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -26,7 +26,7 @@ use self::{
     reader::PrimitiveReader, scope::ScopeManager, simplify::Simplifier, substitute::Substituter,
     typing::Typer, unify::Unifier, validate::Validator,
 };
-use crate::storage::{scope::ScopeId, AccessToStorage, AccessToStorageMut};
+use crate::storage::{scope::ScopeId, AccessToStorage};
 
 /// Trait to access various structures that can perform typechecking queries,
 /// by a reference to a [StorageRef](crate::storage::StorageRef).
@@ -111,9 +111,3 @@ pub trait AccessToOps: AccessToStorage {
 }
 
 impl<T: AccessToStorage> AccessToOps for T {}
-
-/// Trait to access various structures that can perform typechecking operations,
-/// by a reference to a [StorageRefMut](crate::storage::StorageRefMut).
-pub trait AccessToOpsMut: AccessToStorageMut {}
-
-impl<T: AccessToStorageMut> AccessToOpsMut for T {}

--- a/compiler/hash-typecheck/src/ops/mod.rs
+++ b/compiler/hash-typecheck/src/ops/mod.rs
@@ -26,7 +26,10 @@ use self::{
     reader::PrimitiveReader, scope::ScopeManager, simplify::Simplifier, substitute::Substituter,
     typing::Typer, unify::Unifier, validate::Validator,
 };
-use crate::storage::{scope::ScopeId, AccessToStorage};
+use crate::{
+    diagnostics::TcDiagnostics,
+    storage::{scope::ScopeId, AccessToStorage},
+};
 
 /// Trait to access various structures that can perform typechecking queries,
 /// by a reference to a [StorageRef](crate::storage::StorageRef).
@@ -57,6 +60,11 @@ pub trait AccessToOps: AccessToStorage {
     /// Create an instance of [CacheManager].
     fn cacher(&self) -> CacheManager {
         CacheManager::new(self.storages())
+    }
+
+    /// Create a [TcDiagnostics]
+    fn diagnostics(&self) -> TcDiagnostics<Self> {
+        TcDiagnostics(self)
     }
 
     /// Create an instance of [Unifier].

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -44,7 +44,7 @@ use self::{
     trts::TrtDefStore,
 };
 use crate::{
-    diagnostics::{TcDiagnostics, TcDiagnosticsWrapper},
+    diagnostics::DiagnosticsStore,
     fmt::{ForFormatting, PrepareForFormatting},
     ops::bootstrap::create_core_defs_in,
 };
@@ -65,7 +65,7 @@ pub struct GlobalStorage {
     pub checked_sources: CheckedSources,
 
     /// Storage for tc diagnostics
-    pub diagnostics_store: TcDiagnostics,
+    pub diagnostics_store: DiagnosticsStore,
 
     /// Pattern fields from
     /// [super::exhaustiveness::deconstruct::DeconstructedPat]
@@ -95,7 +95,7 @@ impl GlobalStorage {
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
             scope_store,
-            diagnostics_store: TcDiagnostics::default(),
+            diagnostics_store: DiagnosticsStore::default(),
             trt_def_store: TrtDefStore::new(),
             mod_def_store: ModDefStore::new(),
             nominal_def_store: NominalDefStore::new(),
@@ -164,24 +164,10 @@ pub struct StorageRef<'tc> {
     pub source_map: &'tc SourceMap,
 }
 
-/// A mutable reference to the storage, which includes both local and global
-/// storage, as well as core definitions.
-// #[derive(Debug)]
-// pub struct StorageRefMut<'tc> {
-//     pub local_storage: &'tc mut LocalStorage,
-//     pub global_storage: &'tc mut GlobalStorage,
-//     pub source_map: &'tc SourceMap,
-// }
-
 /// Trait that provides convenient accessor methods to various parts of the
 /// storage given a path to a [StorageRef] object.
 pub trait AccessToStorage {
     fn storages(&self) -> StorageRef;
-
-    /// Create a [TcDiagnosticsWrapper]
-    fn diagnostics(&self) -> TcDiagnosticsWrapper<Self> {
-        TcDiagnosticsWrapper(self)
-    }
 
     fn global_storage(&self) -> &GlobalStorage {
         self.storages().global_storage
@@ -191,7 +177,7 @@ pub trait AccessToStorage {
         self.storages().local_storage
     }
 
-    fn diagnostic_store(&self) -> &TcDiagnostics {
+    fn diagnostic_store(&self) -> &DiagnosticsStore {
         &self.storages().global_storage.diagnostics_store
     }
 

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -16,7 +16,7 @@ pub trait StoreKey: Copy + Eq + Hash {
 #[macro_export]
 macro_rules! new_store_key {
     ($visibility:vis $name:ident) => {
-        #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Debug)]
         $visibility struct $name {
             index: u32,
         }

--- a/tests/cases/exhaustiveness/non-exhaustive-decl.hash
+++ b/tests/cases/exhaustiveness/non-exhaustive-decl.hash
@@ -1,0 +1,8 @@
+// run=fail
+
+get_name := () -> str => {
+    "a name"
+};
+
+a := get_name();
+"str" := a;

--- a/tests/cases/exhaustiveness/non-exhaustive-decl.stderr
+++ b/tests/cases/exhaustiveness/non-exhaustive-decl.stderr
@@ -1,0 +1,5 @@
+error[0082]: refutable pattern in declaration binding: `_` not covered
+ --> $DIR/non-exhaustive-decl.hash:8:1
+7 |   a := get_name();
+8 |   "str" := a;
+  |   ^^^^^ pattern `_` not covered

--- a/tests/cases/exhaustiveness/overlapping_range_ends.hash
+++ b/tests/cases/exhaustiveness/overlapping_range_ends.hash
@@ -1,15 +1,15 @@
 // run=pass, warnings=compare
 
 // Should print a warning about `overlapping` ranges on patterns `70..127` and `127..130`
-// main := () => {
-//     a := 6;
+main := () => {
+    a := 6;
 
-//     match a {
-//         0..20 => {};
-//         -50..<0 => {};
-//         70..127 => {};
-//         127..130 => {};
-//         a => {};
-//     }
-// };
+    match a {
+        0..20 => {};
+        -50..<0 => {};
+        70..127 => {};
+        127..130 => {};
+        a => {};
+    }
+};
 

--- a/tests/cases/exhaustiveness/overlapping_range_ends.hash
+++ b/tests/cases/exhaustiveness/overlapping_range_ends.hash
@@ -1,0 +1,15 @@
+// run=pass, warnings=compare
+
+// Should print a warning about `overlapping` ranges on patterns `70..127` and `127..130`
+// main := () => {
+//     a := 6;
+
+//     match a {
+//         0..20 => {};
+//         -50..<0 => {};
+//         70..127 => {};
+//         127..130 => {};
+//         a => {};
+//     }
+// };
+

--- a/tests/cases/exhaustiveness/overlapping_range_ends.stderr
+++ b/tests/cases/exhaustiveness/overlapping_range_ends.stderr
@@ -1,0 +1,12 @@
+warn: range pattern has an overlap with another pattern
+  --> $DIR/overlapping_range_ends.hash:10:9
+ 9 |           -50..<0 => {};
+10 |           70..127 => {};
+   |           ^^^^^^^ this range overlaps on `127i32`...
+11 |           127..130 => {};
+
+  --> $DIR/overlapping_range_ends.hash:11:9
+10 |           70..127 => {};
+11 |           127..130 => {};
+   |           ^^^^^^^^ ...with this range
+12 |           a => {};

--- a/tests/cases/exhaustiveness/simple_unreachable_pats.hash
+++ b/tests/cases/exhaustiveness/simple_unreachable_pats.hash
@@ -1,0 +1,13 @@
+// run=pass, warnings=compare
+
+main := () => {
+    a := 5;
+
+    match a {
+        3 => {};
+        2 => {};
+        3 => {};
+        k => {};
+        _ => {};
+    }
+};

--- a/tests/cases/exhaustiveness/simple_unreachable_pats.stderr
+++ b/tests/cases/exhaustiveness/simple_unreachable_pats.stderr
@@ -1,0 +1,52 @@
+warn: match case `3i32` is redundant when matching on `5i32`
+ --> $DIR/simple_unreachable_pats.hash:6:11
+5 |   
+6 |       match a {
+  |             ^ the match subject is given here...
+7 |           3 => {};
+
+ --> $DIR/simple_unreachable_pats.hash:7:9
+6 |       match a {
+7 |           3 => {};
+  |           ^ ...and this pattern will never match the subject
+8 |           2 => {};
+
+warn: match case `2i32` is redundant when matching on `5i32`
+ --> $DIR/simple_unreachable_pats.hash:6:11
+5 |   
+6 |       match a {
+  |             ^ the match subject is given here...
+7 |           3 => {};
+
+ --> $DIR/simple_unreachable_pats.hash:8:9
+7 |           3 => {};
+8 |           2 => {};
+  |           ^ ...and this pattern will never match the subject
+9 |           3 => {};
+
+warn: match case `3i32` is redundant when matching on `5i32`
+  --> $DIR/simple_unreachable_pats.hash:6:11
+ 5 |   
+ 6 |       match a {
+   |             ^ the match subject is given here...
+ 7 |           3 => {};
+
+  --> $DIR/simple_unreachable_pats.hash:9:9
+ 8 |           2 => {};
+ 9 |           3 => {};
+   |           ^ ...and this pattern will never match the subject
+10 |           k => {};
+
+warn: pattern is unreachable
+  --> $DIR/simple_unreachable_pats.hash:9:9
+ 8 |           2 => {};
+ 9 |           3 => {};
+   |           ^ 
+10 |           k => {};
+
+warn: pattern is unreachable
+  --> $DIR/simple_unreachable_pats.hash:11:9
+10 |           k => {};
+11 |           _ => {};
+   |           ^ 
+12 |       }

--- a/tests/testing-internal/src/metadata.rs
+++ b/tests/testing-internal/src/metadata.rs
@@ -33,10 +33,9 @@ impl Default for TestResult {
 
 impl ToTokens for TestResult {
     fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
-        match self {
-            TestResult::Fail => tokens.extend(quote!(TestResult::Fail)),
-            TestResult::Pass => tokens.extend(quote!(TestResult::Pass)),
-        }
+        let item: quote::__private::TokenStream =
+            format!("TestResult::{:?}", self).parse().unwrap();
+        tokens.extend(item)
     }
 }
 
@@ -69,11 +68,9 @@ impl Default for HandleWarnings {
 
 impl ToTokens for HandleWarnings {
     fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
-        tokens.extend(match self {
-            HandleWarnings::Ignore => quote!(HandleWarnings::Ignore),
-            HandleWarnings::Compare => quote!(HandleWarnings::Compare),
-            HandleWarnings::Disallow => quote!(HandleWarnings::Disallow),
-        })
+        let item: quote::__private::TokenStream =
+            format!("HandleWarnings::{:?}", self).parse().unwrap();
+        tokens.extend(item)
     }
 }
 


### PR DESCRIPTION
This patch introduces the ability for the typechecker to emit diagnostics that can either be errors or warnings. This patch does not attempt to change functions to follow a non-immediate failure pattern but allows for this pattern to be implemented. 

Additionally, as a proof of concept, the typechecker now emits `OverlappingRangeEnd`, `UselessMatchCase`, and `UnreachablePat` warnings across the typechecker.

closes #444 