### PR TITLE
Tc: error reporting and bug fixes

### DIFF
--- a/compiler/hash-ast-desugaring/src/visitor.rs
+++ b/compiler/hash-ast-desugaring/src/visitor.rs
@@ -24,7 +24,7 @@ impl<'s> AstDesugaring<'s> {
 
     /// Create a [SourceLocation] from a [Span]
     pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, source_id: self.source_id }
+        SourceLocation { span, id: self.source_id }
     }
 }
 

--- a/compiler/hash-ast-passes/src/analysis/mod.rs
+++ b/compiler/hash-ast-passes/src/analysis/mod.rs
@@ -77,6 +77,6 @@ impl<'s> SemanticAnalyser<'s> {
 
     /// Create a [SourceLocation] from a [Span]
     pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, source_id: self.source_id }
+        SourceLocation { span, id: self.source_id }
     }
 }

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -97,11 +97,7 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: Span,
     ) -> TokenKind {
-        self.add_error(LexerError::new(
-            message,
-            kind,
-            SourceLocation { span, source_id: self.source_id },
-        ));
+        self.add_error(LexerError::new(message, kind, SourceLocation { span, id: self.source_id }));
 
         TokenKind::Err
     }
@@ -115,7 +111,7 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: Span,
     ) -> Result<T, LexerError> {
-        Err(LexerError::new(message, kind, SourceLocation { span, source_id: self.source_id }))
+        Err(LexerError::new(message, kind, SourceLocation { span, id: self.source_id }))
     }
 
     /// Returns a reference to the stored token trees for the current job

--- a/compiler/hash-parser/src/diagnostics/warning.rs
+++ b/compiler/hash-parser/src/diagnostics/warning.rs
@@ -82,7 +82,7 @@ impl From<ParseWarningWrapper> for Report {
 
         builder.with_kind(ReportKind::Warning).with_message(message).add_element(
             ReportElement::CodeBlock(ReportCodeBlock::new(
-                SourceLocation { span: warning.location, source_id: id },
+                SourceLocation { span: warning.location, id },
                 "here",
             )),
         );

--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -138,7 +138,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Function to create a [SourceLocation] from a [Span] by using the
     /// provided resolver
     pub(crate) fn source_location(&self, span: &Span) -> SourceLocation {
-        SourceLocation { span: *span, source_id: self.resolver.current_source_id() }
+        SourceLocation { span: *span, id: self.resolver.current_source_id() }
     }
 
     /// Get the current offset of where the stream is at.

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -113,7 +113,7 @@ impl ReportCodeBlock {
         match self.info.get() {
             Some(info) => info,
             None => {
-                let SourceLocation { span, source_id } = self.source_location;
+                let SourceLocation { span, id: source_id } = self.source_location;
                 let source = sources.contents_by_id(source_id);
 
                 // Compute offset rows and columns from the provided span
@@ -152,7 +152,7 @@ impl ReportCodeBlock {
         modules: &'a SourceMap,
     ) -> impl Iterator<Item = (usize, &'a str)> {
         // Get the actual contents of the erroneous span
-        let source_id = self.source_location.source_id;
+        let source_id = self.source_location.id;
         let source = modules.contents_by_id(source_id);
 
         let ReportCodeBlockInfo { start_row, end_row, .. } = self.info(modules);
@@ -355,7 +355,7 @@ impl ReportCodeBlock {
         longest_indent_width: usize,
         report_kind: ReportKind,
     ) -> fmt::Result {
-        let source_id = self.source_location.source_id;
+        let source_id = self.source_location.id;
         let ReportCodeBlockInfo { start_row, end_row, start_col, .. } = self.info(modules);
 
         // Print the filename of the code block...

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -76,18 +76,17 @@ impl fmt::Display for Span {
     }
 }
 
+/// A [SourceLocation] describes the location of something that is relative to
+/// a module that is within the workspace and that has an associated [Span].
+///
+/// [SourceLocation]s are only used when printing reports within the
+/// `hash_reporting` crate. Ideally, data structures that need to store
+/// locations of various items should use [Span] and then convert into
+/// [SourceLocation]s.
 #[derive(Debug, Clone, Copy, Constructor, PartialEq, Eq, Hash)]
 pub struct SourceLocation {
+    /// The associated [Span] with the [SourceLocation].
     pub span: Span,
-    pub source_id: SourceId,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn type_size() {
-        println!("{:?}", std::mem::size_of::<SourceLocation>());
-    }
+    /// The id of the source that the span is referencing.
+    pub id: SourceId,
 }

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -5,14 +5,13 @@ use derive_more::Constructor;
 
 use crate::SourceId;
 
-/// Enum representing a location of a token within the source.
+/// [Span] represents a location of a range of tokens within the source.
 ///
 /// The first element of the tuple represents the starting byte offset and the
 /// second element represents the ending byte offset.
 #[derive(Debug, Eq, Hash, Clone, Copy, PartialEq)]
 pub struct Span(u32, u32);
 
-/// General functions to create [Span] variants
 impl Span {
     /// Create a [Span] by providing a start and end byte position.
     pub fn new(start: usize, end: usize) -> Self {
@@ -27,46 +26,51 @@ impl Span {
     /// This function is used to join a [Span] to another [Span]. The assumption
     /// is made that the left hand-side [Span] ends before the start of the
     /// right hand side [Span]. If that is the case, then a new location is
-    /// created with start pos of the lhs, and the end position of the rhs. If
-    /// that is not the case, the lhs span is returned.
+    /// created with start position of the `self`, and the end position of the
+    /// `other`. If that is not the case, the `self` span is returned.
     ///
     /// In essence, if this was the source stream:
     /// ```text
     /// --------------------------------------------------------------
-    ///  ( <- lhs-start    lhs-end -> )   ( <- rhs-start rhs-end -> )
+    ///  ( <- self.start  self.end -> )   ( <- other.start other.end -> )
     /// --------------------------------------------------------------
     /// ```
     ///
     /// Then the two locations are joined into one, otherwise the lhs is
-    /// returned
+    /// returned.
     #[must_use]
-    pub fn join(&self, end: Self) -> Self {
-        if self.end() <= end.start() {
-            return Span::new(self.start(), end.end());
+    pub fn join(&self, other: Self) -> Self {
+        if self.end() <= other.start() {
+            return Span::new(self.start(), other.end());
         }
 
         *self
     }
 
-    /// Get the start of the location
+    /// Get the start of the [Span].
     pub fn start(&self) -> usize {
         self.0.try_into().unwrap()
     }
 
-    /// Get the end of the location
+    /// Get the end of the [Span].
     pub fn end(&self) -> usize {
         self.1.try_into().unwrap()
     }
 
-    /// Compute the actual size of the span by subtracting the end from start
-    pub fn size(&self) -> usize {
+    /// Compute the actual size of the [Span] by subtracting the end from start.
+    pub fn len(&self) -> usize {
         self.end() - self.start()
+    }
+
+    /// Check if the [Span] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.start() == self.end()
     }
 }
 
 impl Default for Span {
     fn default() -> Self {
-        Self::new(0, 1)
+        Self::new(0, 0)
     }
 }
 

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -318,20 +318,9 @@ impl TokenKindVector {
         Self(smallvec![kind])
     }
 
-    #[inline(always)]
+    /// Create a [TokenKindVector] that provides tokens that can modify the
+    /// visibility of a variable.
     pub fn begin_visibility() -> Self {
         Self(smallvec![TokenKind::Keyword(Keyword::Pub), TokenKind::Keyword(Keyword::Priv)])
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn type_size() {
-        println!("{:?}", std::mem::size_of::<Delimiter>());
-        println!("{:?}", std::mem::size_of::<Token>());
-        println!("{:?}", std::mem::size_of::<TokenKind>());
     }
 }

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -72,11 +72,7 @@ pub enum TcError {
     },
     /// The parameter with the given name is not found in the given parameter
     /// list.
-    ParamNotFound {
-        args_kind: ParamListKind,
-        params_subject: LocationTarget,
-        name: Identifier,
-    },
+    ParamNotFound { args_kind: ParamListKind, params_subject: LocationTarget, name: Identifier },
     /// There is a argument or parameter (at the index) which is
     /// specified twice in the given argument list.
     ParamGivenTwice { param_kind: ParamListKind, index: usize },
@@ -685,10 +681,8 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
                 if let Some(location) = ctx.location_store().get_location(*params_subject) {
                     builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
                         location,
-                        format!(
-                            "the {} is defined here",
-                            ctx.param_ops().origin(args_kind)
-                    ))));
+                        format!("the {} is defined here", ctx.param_ops().origin(args_kind)),
+                    )));
                 }
             }
             TcError::ParamGivenTwice { param_kind, index } => {

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -74,7 +74,6 @@ pub enum TcError {
     /// list.
     ParamNotFound {
         args_kind: ParamListKind,
-        params_id: ParamsId,
         params_subject: LocationTarget,
         name: Identifier,
     },
@@ -666,10 +665,10 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
                     }
                 }
             }
-            TcError::ParamNotFound { args_kind, params_id, params_subject, name } => {
+            TcError::ParamNotFound { args_kind, params_subject, name } => {
                 builder
-                    .with_error_code(HashErrorCode::UnresolvedSymbol)
-                    .with_message(format!("parameter with name `{}` is not defined", name));
+                    .with_error_code(HashErrorCode::UnresolvedNameInValue)
+                    .with_message(format!("{} `{}` is not defined", args_kind.as_noun(), name));
 
                 // find the parameter and report the location
                 let id = ctx.param_ops().get_name_by_index(args_kind, *name).unwrap();
@@ -688,9 +687,8 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
                         location,
                         format!(
                             "the {} is defined here",
-                            ctx.params_store().get_origin(*params_id)
-                        ),
-                    )));
+                            ctx.param_ops().origin(args_kind)
+                    ))));
                 }
             }
             TcError::ParamGivenTwice { param_kind, index } => {

--- a/compiler/hash-typecheck/src/diagnostics/warning.rs
+++ b/compiler/hash-typecheck/src/diagnostics/warning.rs
@@ -14,7 +14,6 @@ use hash_reporting::{
     report::{Report, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind},
 };
 
-
 use crate::{
     fmt::PrepareForFormatting,
     storage::{location::LocationTarget, pats::PatId, terms::TermId, AccessToStorage, StorageRef},

--- a/compiler/hash-typecheck/src/diagnostics/warning.rs
+++ b/compiler/hash-typecheck/src/diagnostics/warning.rs
@@ -13,11 +13,11 @@ use hash_reporting::{
     builder::ReportBuilder,
     report::{Report, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind},
 };
-use hash_source::location::SourceLocation;
+
 
 use crate::{
     fmt::PrepareForFormatting,
-    storage::{pats::PatId, terms::TermId, AccessToStorage, StorageRef},
+    storage::{location::LocationTarget, pats::PatId, terms::TermId, AccessToStorage, StorageRef},
 };
 
 /// A warning that occurs during typechecking.
@@ -65,7 +65,7 @@ pub enum TcWarning {
     /// Debug warning that is generated for debugging purposes
     Debug {
         label: String,
-        location: Option<SourceLocation>,
+        location: LocationTarget,
     },
 }
 
@@ -164,7 +164,7 @@ impl<'tc> From<TcWarningWithStorage<'tc>> for Report {
             TcWarning::Debug { ref label, location } => {
                 builder.with_message(label);
 
-                if let Some(location) = location {
+                if let Some(location) = ctx.location_store().get_location(location) {
                     builder
                         .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(location, "")));
                 }

--- a/compiler/hash-typecheck/src/exhaustiveness/construct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/construct.rs
@@ -121,7 +121,7 @@ impl<'tc> ConstructorOps<'tc> {
 
     /// Create a [SourceLocation] from a provided [Span].
     pub fn location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, source_id: self.local_storage().current_source() }
+        SourceLocation { span, id: self.local_storage().current_source() }
     }
 
     /// Compute the `arity` of this [DeconstructedCtor].

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -814,6 +814,12 @@ impl fmt::Display for ForFormatting<'_, PatId> {
     }
 }
 
+impl fmt::Debug for ForFormatting<'_, PatId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.global_storage.pat_store.get(self.t))
+    }
+}
+
 impl fmt::Display for ForFormatting<'_, ArgsId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         TcFormatter::new(self.global_storage).fmt_args(f, self.t)

--- a/compiler/hash-typecheck/src/ops/oracle.rs
+++ b/compiler/hash-typecheck/src/ops/oracle.rs
@@ -111,6 +111,16 @@ impl<'tc> Oracle<'tc> {
         matches!(reader.get_term(term), Term::Level0(Level0Term::Lit(_)))
     }
 
+    /// If the term is a [StructDef] term.
+    pub fn term_is_struct_def(&self, term: TermId) -> bool {
+        self.term_as_struct_def(term).is_some()
+    }
+
+    /// If the term is a literal term.
+    pub fn term_is_enum_def(&self, term: TermId) -> bool {
+        self.term_as_enum_def(term).is_some()
+    }
+
     /// Get a [Term] as a [StructDef].
     pub fn term_as_struct_def(&self, term: TermId) -> Option<StructDef> {
         match self.reader().get_term(term) {

--- a/compiler/hash-typecheck/src/ops/params.rs
+++ b/compiler/hash-typecheck/src/ops/params.rs
@@ -96,7 +96,6 @@ pub(crate) fn pair_args_with_params<'p, 'a, T: Clone + GetNameOpt>(
                         return Err(TcError::ParamNotFound {
                             params_subject: params_subject.into(),
                             args_kind,
-                            params_id,
                             name: arg_name,
                         });
                     }
@@ -237,7 +236,6 @@ pub(crate) fn validate_param_list_unordered<T: Clone + GetNameOpt>(
 pub(crate) fn validate_named_params_match<T: Clone + GetNameOpt>(
     params: &Params<'_>,
     args: &ParamList<'_, T>,
-    params_id: ParamsId,
     args_id: ParamListKind,
     subject: impl Into<LocationTarget>,
 ) -> TcResult<()> {
@@ -245,7 +243,6 @@ pub(crate) fn validate_named_params_match<T: Clone + GetNameOpt>(
         if let Some(name) = arg.get_name_opt() {
             if params.get_by_name(name).is_none() {
                 return Err(TcError::ParamNotFound {
-                    params_id,
                     args_kind: args_id,
                     params_subject: subject.into(),
                     name,

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -372,7 +372,6 @@ impl<'tc> PatMatcher<'tc> {
                 validate_named_params_match(
                     &ty_members,
                     &pat_members,
-                    ty_members_id,
                     ParamListKind::PatArgs(members),
                     subject,
                 )?;

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -549,22 +549,39 @@ impl<'tc> PatMatcher<'tc> {
         let constructor_args = self.reader().get_pat_args_owned(args);
 
         // For each param pair: accumulate the bound members
-        let bound_members = subject_params
-            .positional()
-            .iter()
-            .zip(constructor_args.positional())
-            .map(|(param, pat_param)| {
-                let param_value =
-                    param.default_value.unwrap_or_else(|| self.builder().create_rt_term(param.ty));
+        let mut bound_members = vec![];
 
-                Ok(self
-                    .match_pat_with_term_and_extract_binds(pat_param.pat, param_value)?
+        for (index, param) in subject_params.positional().iter().enumerate() {
+            let arg = if let Some(name) = param.name {
+                if let Some((_, arg)) = constructor_args.get_by_name(name) {
+                    arg
+                } else {
+                    &constructor_args.positional()[index]
+                }
+            } else {
+                &constructor_args.positional()[index]
+            };
+
+            let param_value =
+                param.default_value.unwrap_or_else(|| self.builder().create_rt_term(param.ty));
+
+            // If the argument has a name, and if the pattern is not a bind, i.e. it's just
+            // setting the name, so that we don't add it twice then add the name
+            // to the scope.
+            if let Some(name) = arg.name && !self.reader().get_pat(arg.pat).is_bind() {
+                bound_members.push((
+                    Member::variable(name, Mutability::Immutable, param.ty, param_value),
+                    arg.pat,
+                ));
+            }
+
+            bound_members.extend(
+                self.match_pat_with_term_and_extract_binds(arg.pat, param_value)?
                     .into_iter()
                     .flatten()
-                    .collect::<Vec<_>>())
-            })
-            .flatten_ok()
-            .collect::<TcResult<Vec<_>>>()?;
+                    .collect_vec(),
+            );
+        }
 
         Ok(Some(bound_members))
     }

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -12,7 +12,7 @@ use crate::{
         macros::{tc_panic, tc_panic_on_many},
         params::ParamListKind,
     },
-    ops::params::validate_param_list,
+    ops::params::{validate_param_list, validate_named_params_match},
     storage::{
         arguments::ArgsId,
         mods::ModDefId,
@@ -1326,6 +1326,8 @@ impl<'tc> Validator<'tc> {
 
         // Apply the mentioned above transformation
         if constructor_is_struct {
+            self.pat_args_store().set_origin(args, ParamOrigin::Struct);
+
             let mut pat_args = reader.get_pat_args_owned(args).into_positional();
             let mut pat_args_length = pat_args.len();
 
@@ -1403,7 +1405,9 @@ impl<'tc> Validator<'tc> {
             pat_args
         };
 
+        // Validate the `args` have no repeats and all fields are specified
         validate_param_list_unordered(&adjusted_args, kind)?;
+        validate_named_params_match(&members, &adjusted_args, kind, subject)?;
 
         // If the constructor pattern has no spread, check that all arguments
         // are in place

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -12,7 +12,7 @@ use crate::{
         macros::{tc_panic, tc_panic_on_many},
         params::ParamListKind,
     },
-    ops::params::{validate_param_list, validate_named_params_match},
+    ops::params::{validate_named_params_match, validate_param_list},
     storage::{
         arguments::ArgsId,
         mods::ModDefId,

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -155,6 +155,12 @@ impl Member {
         }
     }
 
+    /// Get the `value` [Term] of the [Member], if it doesn't exist then
+    /// we fallback to getting the `ty` of the [Member].
+    pub fn value_or_ty(&self) -> TermId {
+        self.value().unwrap_or_else(|| self.ty())
+    }
+
     /// Create a closed constant member with the given data and visibility.
     pub fn closed_constant(
         name: impl Into<Identifier>,
@@ -1261,6 +1267,11 @@ impl Pat {
     /// Check if the pattern is of the [Pat::Spread] variant.
     pub fn is_spread(&self) -> bool {
         matches!(self, Pat::Spread(_))
+    }
+
+    /// Check if the pattern is of the [Pat::Spread] variant.
+    pub fn is_bind(&self) -> bool {
+        matches!(self, Pat::Binding(_))
     }
 }
 

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -119,7 +119,7 @@ impl<'tc> TcVisitor<'tc> {
 
     /// Create a [SourceLocation] from a [Span].
     pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, source_id: self.local_storage().current_source() }
+        SourceLocation { span, id: self.local_storage().current_source() }
     }
 
     /// Create a [SourceLocation] at the given [hash_ast::ast::AstNode].

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -2157,9 +2157,6 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
             // So this should only become a constant if we are a `enum` or `struct`
             // definition. Otherwise, we shadow the variable
             if self.oracle().term_is_struct_def(term) || self.oracle().term_is_enum_def(term) {
-                // @@Hack: we technically want to use the `term` from the scope here, but
-                // because the locations are messed up, instead we just copy the
-                // location to the created term
                 self.location_store().copy_location(ty, var_term);
                 let pat = self.builder().create_pat(Pat::Const(ConstPat { term: var_term }));
 

--- a/compiler/hash-utils/src/printing.rs
+++ b/compiler/hash-utils/src/printing.rs
@@ -3,25 +3,80 @@
 //! reporting errors.
 use std::fmt;
 
+#[macro_export]
+macro_rules! pluralise {
+    ($x:expr) => {
+        if $x != 1 {
+            "s"
+        } else {
+            ""
+        }
+    };
+    ("is", $x:expr) => {
+        if $x == 1 {
+            "is"
+        } else {
+            "are"
+        }
+    };
+    ("was", $x:expr) => {
+        if $x == 1 {
+            "was"
+        } else {
+            "were"
+        }
+    };
+    ("this", $x:expr) => {
+        if $x == 1 {
+            "this"
+        } else {
+            "these"
+        }
+    };
+}
+
 /// The [SequenceJoinKind] represents an options list for how a
 /// [SequenceDisplay] should be phrased as. The phrasing specifically affects
 /// the relationship the items have to one another in the current context. It
 /// could be that either one of the items is desired, or if all of the items are
 /// desired.
 #[derive(Eq, PartialEq)]
-pub enum SequenceJoinKind {
+pub enum SequenceJoinMode {
     /// Items within a [SequenceDisplay] are phrased as all being options
     Either,
     /// Items within a [SequenceDisplay] are phrased as all being required
     All,
 }
 
-impl SequenceJoinKind {
+impl SequenceJoinMode {
     pub fn as_conjunctive(&self) -> &str {
         match self {
-            SequenceJoinKind::Either => "or",
-            SequenceJoinKind::All => "and",
+            SequenceJoinMode::Either => "or",
+            SequenceJoinMode::All => "and",
         }
+    }
+}
+
+pub struct SequenceDisplayOptions {
+    /// Whether this is specifying that *all* elements are applicable, or *any*
+    /// element is applicable.
+    pub mode: SequenceJoinMode,
+
+    /// Limit the number of element printed when displaying sequence...
+    pub limit: Option<usize>,
+}
+
+impl SequenceDisplayOptions {
+    /// Create a [SequenceDisplayOptions] with no limit and a specified
+    /// `joining` mode.
+    pub fn new(mode: SequenceJoinMode) -> Self {
+        SequenceDisplayOptions { mode, limit: None }
+    }
+
+    /// Create a [SequenceDisplayOptions] with a specified limit and a specified
+    /// `joining` mode.
+    pub fn with_limit(mode: SequenceJoinMode, limit: usize) -> Self {
+        SequenceDisplayOptions { mode, limit: Some(limit) }
     }
 }
 
@@ -32,25 +87,31 @@ impl SequenceJoinKind {
 /// together, so they are readable. If the length of the vector kind is one, we
 /// don't use conjunctives to glue kinds together.
 pub struct SequenceDisplay<'a, T: 'a> {
+    /// The items that the display will show
     pub items: &'a [T],
-    mode: SequenceJoinKind,
+
+    /// Options on how to print the sequence display
+    pub options: SequenceDisplayOptions,
 }
 
 impl<'a, T: 'a> SequenceDisplay<'a, T> {
     /// Create a new [SequenceDisplay]
-    pub fn new(items: &'a [T], mode: SequenceJoinKind) -> Self {
-        Self { items, mode }
+    pub fn new(items: &'a [T], options: SequenceDisplayOptions) -> Self {
+        Self { items, options }
     }
 
     /// Create a [SequenceDisplay] with the join mode as
     /// [SequenceJoinKind::Either]
     pub fn either(items: &'a [T]) -> Self {
-        Self { items, mode: SequenceJoinKind::Either }
+        Self {
+            items,
+            options: SequenceDisplayOptions { mode: SequenceJoinMode::Either, limit: None },
+        }
     }
 
     /// Create a [SequenceDisplay] with the join mode as [SequenceJoinKind::All]
     pub fn all(items: &'a [T]) -> Self {
-        Self { items, mode: SequenceJoinKind::All }
+        Self { items, options: SequenceDisplayOptions { mode: SequenceJoinMode::All, limit: None } }
     }
 }
 
@@ -58,27 +119,38 @@ impl<'a, T: fmt::Display + 'a> fmt::Display for SequenceDisplay<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.items.len() {
             0 => write!(f, ""),
-            1 if self.mode == SequenceJoinKind::Either => {
+            1 if self.options.mode == SequenceJoinMode::Either => {
                 write!(f, "a `{}`", self.items.get(0).unwrap())
             }
             1 => {
                 write!(f, "`{}`", self.items.get(0).unwrap())
             }
             _ => {
-                let len = self.items.len();
-                let mut items = self.items.iter().peekable();
+                // We essentially want to limit the number of elements to print
+                // if the `limit` has been reached or surpassed.
+                let (len, overflow) = if let Some(limit) = self.options.limit {
+                    if limit >= self.items.len() {
+                        (self.items.len(), false)
+                    } else {
+                        (limit, true)
+                    }
+                } else {
+                    (self.items.len(), false)
+                };
+
+                let mut items = self.items[0..len].iter().peekable();
 
                 // We only add the prefix `either a` on `Either` join kind...
-                if self.mode == SequenceJoinKind::Either {
-                    write!(f, "either a ")?;
+                if self.options.mode == SequenceJoinMode::Either {
+                    write!(f, "either ")?;
                 }
 
                 let mut count = 0;
 
                 while let Some(item) = items.next() {
                     if items.peek().is_some() {
-                        if count == len - 2 {
-                            write!(f, "`{}`, {} ", item, self.mode.as_conjunctive())?;
+                        if count == len - 2 && !overflow {
+                            write!(f, "`{}`, {} ", item, self.options.mode.as_conjunctive())?;
                         } else {
                             write!(f, "`{}`, ", item)?;
                         }
@@ -88,8 +160,85 @@ impl<'a, T: fmt::Display + 'a> fmt::Display for SequenceDisplay<'a, T> {
                     count += 1;
                 }
 
+                // If we overflowed, and the limit is specified then we will
+                // print the specified number of missing variants
+                if self.options.limit.is_some() && overflow {
+                    let count = self.items.len() - self.options.limit.unwrap();
+                    write!(f, " {} {count} more", self.options.mode.as_conjunctive())?;
+                }
+
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequence_display_tests() {
+        let items = ["apple", "cake", "pear"];
+
+        // Test basic join capabilities
+        assert_eq!(
+            "either `apple`, `cake`, or `pear`",
+            format!("{}", SequenceDisplay::either(&items))
+        );
+        assert_eq!("`apple`, `cake`, and `pear`", format!("{}", SequenceDisplay::all(&items)));
+    }
+
+    #[test]
+    fn sequence_display_with_limits_tests() {
+        let items = ["apple", "cake", "pear", "cider", "steak", "onion"];
+
+        // Test cases where limit should cut off items
+        assert_eq!(
+            "either `apple`, `cake` or 4 more",
+            format!(
+                "{}",
+                SequenceDisplay::new(
+                    &items,
+                    SequenceDisplayOptions::with_limit(SequenceJoinMode::Either, 2)
+                )
+            )
+        );
+        assert_eq!(
+            "`apple`, `cake`, `pear` and 3 more",
+            format!(
+                "{}",
+                SequenceDisplay::new(
+                    &items,
+                    SequenceDisplayOptions::with_limit(SequenceJoinMode::All, 3)
+                )
+            )
+        );
+
+        // Test limit doesn't cap items
+        assert_eq!(
+            "`apple`, `cake`, `pear`, `cider`, `steak`, and `onion`",
+            format!(
+                "{}",
+                SequenceDisplay::new(
+                    &items,
+                    SequenceDisplayOptions::with_limit(SequenceJoinMode::All, 12)
+                )
+            )
+        );
+
+        // Test that `limit` doesn't break when it is set to the same as the length of
+        // the list
+        let items = ["apple", "orange"];
+        assert_eq!(
+            "either `apple`, or `orange`",
+            format!(
+                "{}",
+                SequenceDisplay::new(
+                    &items,
+                    SequenceDisplayOptions::with_limit(SequenceJoinMode::Either, 2)
+                )
+            )
+        );
     }
 }

--- a/tests/cases/exhaustiveness/non-exhaustive-constructor-field.stderr
+++ b/tests/cases/exhaustiveness/non-exhaustive-constructor-field.stderr
@@ -2,5 +2,5 @@ error[0082]: refutable pattern in declaration binding: `X(age = i32::MIN..11_i32
   --> $DIR/non-exhaustive-constructor-field.hash:13:5
 12 |       // Error: age MIN..11 | 13..MAX not covered!
 13 |       X(age = 12, ...) := t;
-   |       ^^^^^^^^^^^^^^^^ pattern `X(age = i32::MIN..11_i32, ...)`, and `X(age = 13_i32..i32::MAX, ...)` not covered
+   |       ^^^^^^^^^^^^^^^^ patterns `X(age = i32::MIN..11_i32, ...)`, and `X(age = 13_i32..i32::MAX, ...)` not covered
 14 |   };

--- a/tests/cases/should_fail/types/unclose_type_args.stderr
+++ b/tests/cases/should_fail/types/unclose_type_args.stderr
@@ -3,4 +3,4 @@ error: expected an operator, however received a `:`
 2 |   
 3 |   k<t := do_something();
   |       ^ here
-  = help: consider adding either a `.`, `=`, or `;`
+  = help: consider adding either `.`, `=`, or `;`

--- a/tests/cases/tc/structs/constructor-binds.hash
+++ b/tests/cases/tc/structs/constructor-binds.hash
@@ -1,0 +1,20 @@
+Dog := struct(
+    age: i32,
+    foo: i32,
+    // width: f32,
+    // height: f32,
+    gender: char
+);
+
+main := () -> i32 => {
+  viktor := Dog(age = 2, foo = 3, gender = 'n');
+
+  item := match viktor {
+    Dog(age = 15, gender, foo) => {
+      age
+    };
+    _ => { 2 };
+  };
+
+  item
+};

--- a/tests/cases/tc/structs/missing-fields.stderr
+++ b/tests/cases/tc/structs/missing-fields.stderr
@@ -5,8 +5,14 @@ error[0017]: struct literal is missing the fields `age`, and `width`
    |       ^^^^^^^^^^^^^^^^^ missing `age`, and `width`
 15 |   };
 
-  --> $DIR/missing-fields.hash:12:15
-11 |   main := () => {
-12 |       viktor := Dog("viktor", 18, 123.6, 129.9);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the struct is defined here
-13 |   
+  --> $DIR/missing-fields.hash:3:8
+ 2 |    
+ 3 |    Dog := struct(
+   |  _________-
+ 4 | |      name: str,
+ 5 | |      age: i32,
+ 6 | |      width: f32,
+ 7 | |      height: f32,
+ 8 | |  );
+   | |___- the struct is defined here
+ 9 |    


### PR DESCRIPTION
This patch brings several fixes to reported locations in the reported terms.

- fix overwriting location when visiting variables, this should only occur for literal values.
- improve printing of sequences by introducing a `limit` term
- fix `term_of_pat` overwriting locations when it shouldn't
- fix validation of non-existent fields in constructor pattern validation


closes #456 