### PR TITLE
tc: refactor `Term::{Merge|Union}` to use `TermListId`

### DIFF
--- a/compiler/hash-alloc/src/collections/row.rs
+++ b/compiler/hash-alloc/src/collections/row.rs
@@ -123,7 +123,7 @@ impl<'c, T> Row<'c, T> {
     /// Returns `None` if there are no elements in the `Row`, otherwise the
     /// popped element.
     pub fn pop(&mut self) -> Option<T> {
-        if self.len() == 0 {
+        if self.is_empty() {
             return None;
         }
 

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1576,7 +1576,7 @@ pub struct ConstructorCallArg {
 pub struct ConstructorCallExpr {
     /// An expression which evaluates to a function value.
     pub subject: AstNode<Expr>,
-    /// Arguments to the function, in the form of [ConstructorCallArgs].
+    /// Arguments to the function, a list of [ConstructorCallArg]s.
     pub args: AstNodes<ConstructorCallArg>,
 }
 

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -394,7 +394,7 @@ impl<'gs> TcFormatter<'gs> {
             }
             Term::Merge(terms) => self.fmt_term_list(f, terms, "~", opts),
             Term::Union(terms) => {
-                if terms.len() == 0 {
+                if terms.is_empty() {
                     opts.is_atomic.set(true);
                     write!(f, "never")
                 } else {

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -304,13 +304,13 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a term [Term::Merge] with the given inner terms.
     pub fn create_merge_term(&self, terms: impl IntoIterator<Item = TermId>) -> TermId {
-        let terms = terms.into_iter().collect();
+        let terms = self.gs.term_list_store.create_from_iter(terms);
         self.create_term(Term::Merge(terms))
     }
 
     /// Create a term [Term::Union] with the given inner terms.
     pub fn create_union_term(&self, terms: impl IntoIterator<Item = TermId>) -> TermId {
-        let terms = terms.into_iter().collect();
+        let terms = self.gs.term_list_store.create_from_iter(terms);
         self.create_term(Term::Union(terms))
     }
 
@@ -330,7 +330,8 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create the never type: [Term::Union] with no members.
     pub fn create_never_ty(&self) -> TermId {
-        self.create_term(Term::Union(vec![]))
+        let terms = self.gs.term_list_store.create_from_slice(&[]);
+        self.create_term(Term::Union(terms))
     }
 
     /// Create a tuple type term [Level1Term::Tuple].

--- a/compiler/hash-typecheck/src/ops/discover.rs
+++ b/compiler/hash-typecheck/src/ops/discover.rs
@@ -1,6 +1,8 @@
 //! Functionality related to discovering variables in terms.
 use std::collections::HashSet;
 
+use hash_utils::store::{SequenceStore, SequenceStoreKey};
+
 use super::AccessToOps;
 use crate::{
     diagnostics::{error::TcResult, macros::tc_panic},
@@ -141,13 +143,15 @@ impl<'tc> Discoverer<'tc> {
             }
             Term::Merge(terms) => {
                 // Free vars in each term:
-                for inner_term_id in terms {
+                for idx in terms.to_index_range() {
+                    let inner_term_id = self.term_list_store().get_at_index(terms, idx);
                     self.add_free_sub_vars_in_term_to_set(inner_term_id, result);
                 }
             }
             Term::Union(terms) => {
                 // Free vars in each term:
-                for inner_term_id in terms {
+                for idx in terms.to_index_range() {
+                    let inner_term_id = self.term_list_store().get_at_index(terms, idx);
                     self.add_free_sub_vars_in_term_to_set(inner_term_id, result);
                 }
             }
@@ -412,13 +416,15 @@ impl<'tc> Discoverer<'tc> {
             }
             Term::Merge(terms) => {
                 // Free vars in each term:
-                for inner_term_id in terms {
+                for idx in terms.to_index_range() {
+                    let inner_term_id = self.term_list_store().get_at_index(terms, idx);
                     self.add_free_bound_vars_in_term_to_set(inner_term_id, result);
                 }
             }
             Term::Union(terms) => {
                 // Free vars in each term:
-                for inner_term_id in terms {
+                for idx in terms.to_index_range() {
+                    let inner_term_id = self.term_list_store().get_at_index(terms, idx);
                     self.add_free_bound_vars_in_term_to_set(inner_term_id, result);
                 }
             }
@@ -736,7 +742,9 @@ impl<'tc> Discoverer<'tc> {
                 // Apply each term:
                 let terms = terms;
                 let mut applied_once = false;
-                let merge_applied = terms
+                let merge_applied = self
+                    .reader()
+                    .get_term_list_owned(terms)
                     .iter()
                     .map(|term| {
                         self.apply_set_bound_to_term_with_flag(
@@ -757,7 +765,9 @@ impl<'tc> Discoverer<'tc> {
                 // Apply each term:
                 let terms = terms;
                 let mut applied_once = false;
-                let union_applied = terms
+                let union_applied = self
+                    .reader()
+                    .get_term_list_owned(terms)
                     .iter()
                     .map(|term| {
                         self.apply_set_bound_to_term_with_flag(

--- a/compiler/hash-typecheck/src/ops/reader.rs
+++ b/compiler/hash-typecheck/src/ops/reader.rs
@@ -1,7 +1,7 @@
 //! Contains helpers to read various things stored in [crate::storage] with
 //! ease.
 
-use hash_utils::store::Store;
+use hash_utils::store::{SequenceStore, Store};
 
 use crate::{
     exhaustiveness::{construct::DeconstructedCtor, deconstruct::DeconstructedPat},
@@ -14,7 +14,7 @@ use crate::{
         pats::{PatArgsId, PatId},
         primitives::{Args, ModDef, NominalDef, Params, Pat, PatArgs, Scope, Term, TrtDef},
         scope::ScopeId,
-        terms::TermId,
+        terms::{TermId, TermListId},
         trts::TrtDefId,
         GlobalStorage,
     },
@@ -65,6 +65,11 @@ impl<'gs> PrimitiveReader<'gs> {
     /// Get the args with the given [ArgsId].
     pub fn get_args_owned(&self, id: ArgsId) -> Args<'static> {
         self.gs.args_store.get_owned_param_list(id)
+    }
+
+    /// Get the associated terms with the given [TermListId].
+    pub fn get_term_list_owned(&self, id: TermListId) -> Vec<TermId> {
+        self.gs.term_list_store.get_vec(id)
     }
 
     /// Get the params with the given [ParamsId].

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -219,19 +219,23 @@ impl<'tc> Substituter<'tc> {
             }
             Term::Merge(terms) => {
                 // Apply the substitution to each element of the merge.
-                let terms = terms
+                let terms = self
+                    .reader()
+                    .get_term_list_owned(terms)
                     .into_iter()
-                    .map(|term| self.apply_sub_to_term(sub, term))
-                    .collect::<Vec<_>>();
-                self.builder().create_term(Term::Merge(terms))
+                    .map(|term| self.apply_sub_to_term(sub, term));
+
+                self.builder().create_merge_term(terms)
             }
             Term::Union(terms) => {
                 // Apply the substitution to each element of the union.
-                let terms = terms
+                let terms = self
+                    .reader()
+                    .get_term_list_owned(terms)
                     .into_iter()
-                    .map(|term| self.apply_sub_to_term(sub, term))
-                    .collect::<Vec<_>>();
-                self.builder().create_term(Term::Union(terms))
+                    .map(|term| self.apply_sub_to_term(sub, term));
+
+                self.builder().create_union_term(terms)
             }
             Term::TyFn(ty_fn) => {
                 // Apply the substitution to the general parameters, return type, and each case.

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -141,10 +141,13 @@ impl<'tc> Typer<'tc> {
             }
             Term::Merge(terms) => {
                 // The type of a merge is a merge of the inner terms:
-                let tys_of_terms: Vec<_> = terms
+                let tys_of_terms: Vec<_> = self
+                    .reader()
+                    .get_term_list_owned(terms)
                     .iter()
                     .map(|term| self.infer_ty_of_term(*term))
                     .collect::<TcResult<_>>()?;
+
                 Ok(self.builder().create_merge_term(tys_of_terms))
             }
             Term::Union(_) => {
@@ -498,9 +501,9 @@ impl<'tc> Typer<'tc> {
                 match tuple_ty {
                     Term::Merge(terms) => {
                         // Try each term:
-                        terms
-                            .iter()
-                            .copied()
+                        self.reader()
+                            .get_term_list_owned(terms)
+                            .into_iter()
                             .map(|term| self.infer_params_ty_of_tuple_term(term))
                             .flatten_ok()
                             .next()
@@ -548,9 +551,9 @@ impl<'tc> Typer<'tc> {
                 match self.reader().get_term(constructed_ty_id) {
                     Term::Union(terms) => {
                         // Accumulate all terms
-                        terms
-                            .iter()
-                            .copied()
+                        self.reader()
+                            .get_term_list_owned(terms)
+                            .into_iter()
                             .map(|term| self.infer_constructor_of_nominal_term(term))
                             .flatten_ok()
                             .collect()
@@ -576,9 +579,9 @@ impl<'tc> Typer<'tc> {
                     }
                     Term::Merge(terms) => {
                         // Try each term:
-                        terms
-                            .iter()
-                            .copied()
+                        self.reader()
+                            .get_term_list_owned(terms)
+                            .into_iter()
                             .map(|term| self.infer_constructor_of_nominal_term(term))
                             .flatten_ok()
                             .collect()

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -1,7 +1,7 @@
 //! Utilities related to type unification and substitution.
 use std::{borrow::Borrow, collections::HashSet};
 
-use hash_utils::store::Store;
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 
 use super::{params::pair_args_with_params, AccessToOps};
 use crate::{
@@ -435,7 +435,9 @@ impl<'tc> Unifier<'tc> {
                 // Try to merge source with each individual term in target. If all succeed,
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
-                for inner_target_id in inner_target {
+                for idx in inner_target.to_index_range() {
+                    let inner_target_id = self.term_list_store().get_at_index(inner_target, idx);
+
                     match self.unify_terms(simplified_src_id, inner_target_id) {
                         Ok(result) => {
                             subs.extend(&result);
@@ -450,12 +452,15 @@ impl<'tc> Unifier<'tc> {
                 // Try to merge each individual term in source, with target. If any one
                 // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
-                for inner_src_id in inner_src {
+                for idx in inner_src.to_index_range() {
+                    let inner_src_id = self.term_list_store().get_at_index(inner_src, idx);
+
                     match self.unify_terms(inner_src_id, simplified_target_id) {
                         Ok(result) => return Ok(result),
                         Err(e) => first_error = first_error.or(Some(e)),
                     }
                 }
+
                 match first_error {
                     Some(first_error) => Err(first_error),
                     None => cannot_unify(),
@@ -467,7 +472,9 @@ impl<'tc> Unifier<'tc> {
                 // Try to merge each individual term in source, with target. If any one
                 // succeeds, then the whole thing should succeed.
                 let mut first_error = None;
-                for inner_target_id in inner_target {
+                for idx in inner_target.to_index_range() {
+                    let inner_target_id = self.term_list_store().get_at_index(inner_target, idx);
+
                     match self.unify_terms(simplified_src_id, inner_target_id) {
                         Ok(result) => return Ok(result),
                         Err(e) => first_error = first_error.or(Some(e)),
@@ -482,7 +489,9 @@ impl<'tc> Unifier<'tc> {
                 // Try to merge source with each individual term in target. If all succeed,
                 // then the whole thing should succeed.
                 let mut subs = Sub::empty();
-                for inner_src_id in inner_src {
+                for idx in inner_src.to_index_range() {
+                    let inner_src_id = self.term_list_store().get_at_index(inner_src, idx);
+
                     match self.unify_terms(inner_src_id, simplified_target_id) {
                         Ok(result) => {
                             subs = self.unify_subs(&subs, &result)?;

--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -40,7 +40,7 @@ use self::{
     primitives::{Scope, ScopeKind},
     scope::{ScopeId, ScopeStack, ScopeStore},
     sources::CheckedSources,
-    terms::TermStore,
+    terms::{TermListStore, TermStore},
     trts::TrtDefStore,
 };
 use crate::{
@@ -53,7 +53,10 @@ use crate::{
 #[derive(Debug)]
 pub struct GlobalStorage {
     pub scope_store: ScopeStore,
+    /// Storage for terms
     pub term_store: TermStore,
+    /// Store for grouped terms
+    pub term_list_store: TermListStore,
     pub location_store: LocationStore,
     pub params_store: ParamsStore,
     pub args_store: ArgsStore,
@@ -94,6 +97,7 @@ impl GlobalStorage {
         let gs = Self {
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
+            term_list_store: TermListStore::new(),
             scope_store,
             diagnostics_store: DiagnosticsStore::default(),
             trt_def_store: TrtDefStore::new(),
@@ -187,6 +191,10 @@ pub trait AccessToStorage {
 
     fn term_store(&self) -> &TermStore {
         &self.global_storage().term_store
+    }
+
+    fn term_list_store(&self) -> &TermListStore {
+        &self.global_storage().term_list_store
     }
 
     fn cache(&self) -> &Cache {

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -21,7 +21,7 @@ use super::{
     params::ParamsId,
     pats::{PatArgsId, PatId},
     scope::ScopeId,
-    terms::TermId,
+    terms::{TermId, TermListId},
     trts::TrtDefId,
 };
 
@@ -1072,7 +1072,7 @@ pub enum Term {
     /// associative, and commutative.
     ///
     /// Is level N, where N is the level of the inner types.
-    Merge(Vec<TermId>),
+    Merge(TermListId),
 
     /// Union of multiple types.
     ///
@@ -1080,7 +1080,7 @@ pub enum Term {
     /// associative, and commutative.
     ///
     /// Is level N, where N is the level of the inner types.
-    Union(Vec<TermId>),
+    Union(TermListId),
 
     /// A type function term.
     ///

--- a/compiler/hash-typecheck/src/storage/terms.rs
+++ b/compiler/hash-typecheck/src/storage/terms.rs
@@ -2,8 +2,8 @@
 use std::cell::Cell;
 
 use hash_utils::{
-    new_store_key,
-    store::{DefaultStore, Store},
+    new_sequence_store_key, new_store_key,
+    store::{DefaultSequenceStore, DefaultStore, Store},
 };
 
 use super::primitives::{ResolutionId, Term};
@@ -48,3 +48,9 @@ impl TermStore {
         ResolutionId(new_id)
     }
 }
+
+new_sequence_store_key!(pub TermListId);
+
+/// Define the [TermListStore], which is a sequence of [Term]s associated
+/// with a [TermListId].
+pub type TermListStore = DefaultSequenceStore<TermListId, TermId>;

--- a/compiler/hash-utils/src/printing.rs
+++ b/compiler/hash-utils/src/printing.rs
@@ -35,7 +35,7 @@ macro_rules! pluralise {
     };
 }
 
-/// The [SequenceJoinKind] represents an options list for how a
+/// The [SequenceJoinMode] represents an options list for how a
 /// [SequenceDisplay] should be phrased as. The phrasing specifically affects
 /// the relationship the items have to one another in the current context. It
 /// could be that either one of the items is desired, or if all of the items are
@@ -101,7 +101,7 @@ impl<'a, T: 'a> SequenceDisplay<'a, T> {
     }
 
     /// Create a [SequenceDisplay] with the join mode as
-    /// [SequenceJoinKind::Either]
+    /// [SequenceJoinMode::Either].
     pub fn either(items: &'a [T]) -> Self {
         Self {
             items,
@@ -109,7 +109,8 @@ impl<'a, T: 'a> SequenceDisplay<'a, T> {
         }
     }
 
-    /// Create a [SequenceDisplay] with the join mode as [SequenceJoinKind::All]
+    /// Create a [SequenceDisplay] with the join mode as
+    /// [SequenceJoinMode::All].
     pub fn all(items: &'a [T]) -> Self {
         Self { items, options: SequenceDisplayOptions { mode: SequenceJoinMode::All, limit: None } }
     }

--- a/tests/testing-internal/src/metadata.rs
+++ b/tests/testing-internal/src/metadata.rs
@@ -129,7 +129,7 @@ pub struct TestMetadataBuilder {
 }
 
 impl TestMetadataBuilder {
-    /// Create a new [FileMetadataBuilder]
+    /// Create a new [TestMetadataBuilder]
     pub fn new() -> Self {
         Self { stage: None, completion: None, warnings: None }
     }

--- a/tests/testing-macros/src/lib.rs
+++ b/tests/testing-macros/src/lib.rs
@@ -168,11 +168,9 @@ fn read_tests_from_dir(
 /// different internal test logic. The prefix must be a specified string
 /// literal, leaving it empty will generate the normal test name.
 ///
-/// - `TEST_FN` must be an expression of type
-///   [`TestingFn`](hash_utils::testing::TestingFn). Every
-/// generated test case body will invoke this function with the appropriate
-/// [`TestingInput`](hash_utils::testing::TestingInput). Within this function,
-/// the actual test logic should be written.
+/// Every generated test case body will invoke this function with the
+/// appropriate [`TestingInput`](hash_testing_internal::TestingInput). Within
+/// this function, the actual test logic should be written.
 #[proc_macro]
 pub fn generate_tests(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as GenerateTestsInput);


### PR DESCRIPTION
closes #387 