### PR TITLE
TC: Fix spread bug when the spread affects all tuple members and add test

### DIFF
--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -91,7 +91,7 @@ impl Tc<'_> for TcImpl {
 
         match tc_visitor.visit_source() {
             Err(err) => {
-                tc_visitor.diagnostics().add_error(err.clone());
+                tc_visitor.diagnostics().add_error(err);
             }
             Ok(source_term) if !tc_visitor.diagnostics().has_errors() => {
                 // Print the result if no errors

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -89,15 +89,15 @@ impl Tc<'_> for TcImpl {
         };
         let mut tc_visitor = TcVisitor::new_in_source(storage.storages(), workspace.node_map());
 
-        let result = tc_visitor.visit_source();
-
-        if let Err(err) = result {
-            tc_visitor.diagnostics().add_error(err);
-        } else {
-            // Print the result if no errors
-            if let Ok(source_term) = result {
+        match tc_visitor.visit_source() {
+            Err(err) => {
+                tc_visitor.diagnostics().add_error(err.clone());
+            }
+            Ok(source_term) if !tc_visitor.diagnostics().has_errors() => {
+                // Print the result if no errors
                 println!("{}", source_term.for_formatting(storage.global_storage()));
             }
+            Ok(_) => {}
         }
 
         // If there are diagnostics that were generated or the result itself returned

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -91,20 +91,20 @@ impl Tc<'_> for TcImpl {
 
         let result = tc_visitor.visit_source();
 
+        if let Err(err) = result {
+            tc_visitor.diagnostics().add_error(err);
+        } else {
+            // Print the result if no errors
+            if let Ok(source_term) = result {
+                println!("{}", source_term.for_formatting(storage.global_storage()));
+            }
+        }
+
         // If there are diagnostics that were generated or the result itself returned
         // an error, then we should return those errors, otherwise print the inferred
         // term.
-        if tc_visitor.diagnostics().has_diagnostics() || result.is_err() {
-            if let Err(err) = result {
-                tc_visitor.diagnostics().add_error(err);
-            }
-
+        if tc_visitor.diagnostics().has_diagnostics() {
             return Err(tc_visitor.diagnostics().into_reports());
-        }
-
-        // Print the result if it was ok
-        if let Ok(source_term) = result {
-            println!("{}", source_term.for_formatting(storage.global_storage()));
         }
 
         Ok(())

--- a/tests/cases/semantics/type_annotations/missing_struct_field_annotations.hash
+++ b/tests/cases/semantics/type_annotations/missing_struct_field_annotations.hash
@@ -1,4 +1,4 @@
-// run=fail, stage=semantics
+// run=fail, stage=semantic
 Mux := struct(
     val,
 
@@ -12,7 +12,7 @@ Mux := struct(
 );
 
 
-// Function fields must either have a default value from which 
+// Function fields must either have a default value from which
 // a type can be inferred or a type annotation.
 bar := (val, max, bax = 4, bux: i32, mux: i32 = 7) -> () => {
     ()

--- a/tests/cases/typecheck/spread-pats/tuple-spread-pats.hash
+++ b/tests/cases/typecheck/spread-pats/tuple-spread-pats.hash
@@ -24,3 +24,11 @@ test_spread_empty := () -> () => {
     (name, value, ...rest) := x;
     rest
 };
+
+ensure := <T> => (t: T) => {};
+
+test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
+    (...t) := f;
+    ensure<(name: str, bax: char)>(t);
+    t
+};

--- a/tests/cases/typecheck/spread-pats/tuple-spread-pats.hash
+++ b/tests/cases/typecheck/spread-pats/tuple-spread-pats.hash
@@ -25,10 +25,7 @@ test_spread_empty := () -> () => {
     rest
 };
 
-ensure := <T> => (t: T) => {};
-
 test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
     (...t) := f;
-    ensure<(name: str, bax: char)>(t);
     t
 };

--- a/tests/cases/typecheck/spread-pats/tuple-spread-pats.stderr
+++ b/tests/cases/typecheck/spread-pats/tuple-spread-pats.stderr
@@ -1,0 +1,7 @@
+warn: named tuple is coerced into an un-named tuple
+  --> $DIR/tuple-spread-pats.hash:29:5
+28 |   test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
+29 |       (...t) := f;
+   |       ^^^^^^ the coercion occurs here
+30 |       t
+   = note: if a tuple type is declared as named, it's usually that field names are important and shouldn't be thrown away.


### PR DESCRIPTION
Something like:
```
test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
    (...t) := f;
    t
};
```
no longer errors with "Not runtime instantiable"