### PR TITLE
reporting: minimalise report code blocks

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1039,7 +1039,7 @@ pub struct Declaration {
 }
 
 /// A merge declaration (adding implementations to traits/structs), e.g. `x ~=
-/// impl { ... };`.
+/// impl T { ... };`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct MergeDeclaration {
     /// The expression to bind the right-hand side to.
@@ -1808,7 +1808,7 @@ pub enum ExprKind {
     /// the application of a binary operator, such as `x += 3`.
     AssignOp(AssignOpExpr),
     /// A merge declaration is one that adds an implementation for a particular
-    /// trait/struct to an already declared item, such as `x ~= impl { ... }`
+    /// trait/struct to an already declared item, such as `x ~= impl T { ... }`
     MergeDeclaration(MergeDeclaration),
     /// Trait implementation e.g. `impl Clone { ... }`
     TraitImpl(TraitImpl),

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -29,6 +29,7 @@ error_codes! {
     NonRuntimeInstantiable = 25,
     UnsupportedTyFnApplication = 26,
     TypeIsNotTrait = 27,
+    InvalidUnionElement = 28,
 
     // Errors in regard to parameter lists
     ParameterLengthMismatch = 35,
@@ -44,7 +45,7 @@ error_codes! {
     NoMatchingTraitImplementations = 53,
     InvalidPropertyAccessOfNonMethod = 54,
     TraitImplMissingMember = 55,
-    InvalidUnionElement = 56,
+    MethodNotAMemberOfTrait = 56,
 
     // Pattern errors
     IdentifierBoundMultipleTimes = 80,

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -279,11 +279,12 @@ impl ReportCodeBlock {
 
         let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
 
-        // If the difference between the rows is longer than 5 lines, then we
-        // essentially begin to collapse the view by using `...` as the filler
-        // for those lines...
+        // If the difference between the rows is longer than `LINE_SKIP_THRESHOLD`
+        // lines, then we essentially begin to collapse the view by using `...`
+        // as the filler for those lines...
         let skip_lines_range = if end_row - start_row > LINE_SKIP_THRESHOLD {
-            Some((start_row + 3)..=(end_row - 3))
+            let mid = LINE_SKIP_THRESHOLD / 2;
+            Some((start_row + mid)..=(end_row - mid))
         } else {
             None
         };

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -30,6 +30,10 @@ const BLOCK_DIAGNOSTIC_MARKER: char = '-';
 /// Character used to connect block views
 const DIAGNOSTIC_CONNECTING_CHAR: &str = "|";
 
+/// The maximum number of lines a block display can use before the lines in the
+/// center of the block are skipped.
+const LINE_SKIP_THRESHOLD: usize = 6;
+
 /// Struct to represent the column and row offset produced from converting a
 /// [hash_source::location::Span].
 pub(crate) struct ColRowOffset {
@@ -275,6 +279,15 @@ impl ReportCodeBlock {
 
         let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
 
+        // If the difference between the rows is longer than 5 lines, then we
+        // essentially begin to collapse the view by using `...` as the filler
+        // for those lines...
+        let skip_lines_range = if end_row - start_row > LINE_SKIP_THRESHOLD {
+            Some((start_row + 3)..=(end_row - 3))
+        } else {
+            None
+        };
+
         // So here, we want to iterate over all of the line and on the starting line, we
         // want to draw an arrow from the left hand-side up until the beginning
         // which then points up, on lines that are in the middle, we just want
@@ -282,7 +295,7 @@ impl ReportCodeBlock {
         // below the final line we want to draw an arrow leading up until
         // the end of the span.
         for (index, line) in error_view {
-            let index_str = format!("{:>pad_width$}", index + 1, pad_width = longest_indent_width);
+            let index_str = format!("{:<pad_width$}", index + 1, pad_width = longest_indent_width);
 
             let line_number = if (start_row..=end_row).contains(&index) {
                 highlight(report_kind.as_colour(), &index_str)
@@ -299,6 +312,31 @@ impl ReportCodeBlock {
             } else {
                 " "
             };
+
+            // So if we're at the start of the 'skip' range, use '...' instead
+            if let Some(range) = skip_lines_range.clone() {
+                if *range.start() == index {
+                    let range_line_number = format!(
+                        "{:<pad_width$}",
+                        ".".repeat(3),
+                        pad_width = longest_indent_width + 2
+                    );
+
+                    // Write the skipped lines as `...` and then the rest of the components that are
+                    // required for the error display
+                    writeln!(
+                        f,
+                        "{} {}",
+                        highlight(report_kind.as_colour(), range_line_number),
+                        highlight(report_kind.as_colour(), connector),
+                    )?;
+                }
+
+                // Skip the lines
+                if range.contains(&index) {
+                    continue;
+                }
+            }
 
             writeln!(
                 f,

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -94,3 +94,14 @@ pub struct SourceLocation {
     /// The id of the source that the span is referencing.
     pub id: SourceId,
 }
+
+impl SourceLocation {
+    /// Join the span of a [SourceLocation] with another [SourceLocation].
+    ///
+    /// *Note*: the `id` of both [SourceLocation]s must be the same.
+    pub fn join(self, other: Self) -> Self {
+        assert!(self.id == other.id);
+
+        Self { id: self.id, span: self.span.join(other.span) }
+    }
+}

--- a/compiler/hash-typecheck/src/storage/location.rs
+++ b/compiler/hash-typecheck/src/storage/location.rs
@@ -304,4 +304,27 @@ impl LocationStore {
             self.add_location_to_target(dest.into(), origin);
         }
     }
+
+    /// Merge the given [LocationTarget]s into a single [LocationTarget]
+    /// provided that they can be merged in terms of order. All `ids` of the
+    /// [SourceLocation]s must match.
+    ///
+    /// **Note**: At least one of the [LocationTarget]s must have an associated
+    /// [SourceLocation].
+    pub fn merge_locations(
+        &self,
+        locations: impl Iterator<Item = LocationTarget>,
+    ) -> LocationTarget {
+        let mut locations = locations.skip_while(|loc| self.get_location(loc).is_none());
+        let mut initial_span = locations.next().map(|loc| self.get_location(loc).unwrap()).unwrap();
+
+        // Iterate over the locations and then join them with the initial one
+        for location in locations {
+            if let Some(other) = self.get_location(location) {
+                initial_span = initial_span.join(other);
+            }
+        }
+
+        initial_span.into()
+    }
 }

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -16,6 +16,7 @@ use num_bigint::BigInt;
 
 use super::{
     arguments::ArgsId,
+    location::LocationTarget,
     mods::ModDefId,
     nominals::NominalDefId,
     params::ParamsId,
@@ -131,6 +132,12 @@ impl Member {
             | Member::Variable(VariableMember { name, .. })
             | Member::Constant(ConstantMember { name, .. }) => *name,
         }
+    }
+
+    /// Get [LocationTarget]s referencing to the
+    /// value of the declaration.
+    pub fn location(&self) -> LocationTarget {
+        self.value_or_ty().into()
     }
 
     /// Get the type of the member
@@ -324,15 +331,16 @@ impl Scope {
         index
     }
 
-    /// Get a member by name.
-    pub fn get(&self, member_name: Identifier) -> Option<(Member, usize)> {
-        let index = self.member_names.get(&member_name).copied()?;
+    /// Get a [Member] by name, returning the the [Member] and the index
+    /// of the [Member] in the scope.
+    pub fn get(&self, name: Identifier) -> Option<(Member, usize)> {
+        let index = self.member_names.get(&name).copied()?;
         Some((self.members[index], index))
     }
 
     /// Whether the scope contains a member with the given name.
-    pub fn contains(&self, member_name: Identifier) -> bool {
-        self.member_names.contains_key(&member_name)
+    pub fn contains(&self, name: Identifier) -> bool {
+        self.member_names.contains_key(&name)
     }
 
     /// Get a member by index, asserting that it exists.

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -1663,10 +1663,16 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
 
     fn visit_merge_declaration(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeDeclaration>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeDeclaration>,
     ) -> Result<Self::MergeDeclarationRet, Self::Error> {
-        todo!()
+        let walk::MergeDeclaration { decl, value } = walk::walk_merge_declaration(self, ctx, node)?;
+
+        let merge_term = self.builder().create_merge_term(vec![decl, value]);
+
+        // Add location
+        self.copy_location_from_node_to_target(node, merge_term);
+        Ok(self.validator().validate_term(merge_term)?.simplified_term_id)
     }
 
     type AssignExprRet = TermId;

--- a/compiler/hash-typecheck/src/traverse/scopes.rs
+++ b/compiler/hash-typecheck/src/traverse/scopes.rs
@@ -33,6 +33,10 @@ impl<'tc> TcVisitor<'tc> {
         let scope_id =
             scope_to_use.unwrap_or_else(|| self.builder().create_scope(ScopeKind::Constant, []));
 
+        // Get the name of the scope from the surrounding declaration hint, if any.
+        // This is only useful for mod/impl/trait blocks
+        let scope_name = self.state.declaration_name_hint.take();
+
         ScopeManager::enter_scope_with(self, scope_id, |this| {
             // @@Todo: deal with recursive declarations
 
@@ -46,10 +50,6 @@ impl<'tc> TcVisitor<'tc> {
             }
             Ok(())
         })?;
-
-        // Get the name of the scope from the surrounding declaration hint, if any.
-        // This is only useful for mod/impl/trait blocks
-        let scope_name = self.state.declaration_name_hint.take();
 
         Ok(VisitConstantScope { scope_name, scope_id })
     }

--- a/tests/cases/typecheck/structs/missing-fields.stderr
+++ b/tests/cases/typecheck/structs/missing-fields.stderr
@@ -6,13 +6,13 @@ error[0017]: struct literal is missing the fields `age`, and `width`
 15 |   };
 
   --> $DIR/missing-fields.hash:3:8
- 2 |    
- 3 |    Dog := struct(
+2  |    
+3  |    Dog := struct(
    |  _________-
- 4 | |      name: str,
- 5 | |      age: i32,
- 6 | |      width: f32,
- 7 | |      height: f32,
- 8 | |  );
+4  | |      name: str,
+5  | |      age: i32,
+6  | |      width: f32,
+7  | |      height: f32,
+8  | |  );
    | |___- the struct is defined here
- 9 |    
+9  |    

--- a/tests/cases/typecheck/traits/unspecified_member.hash
+++ b/tests/cases/typecheck/traits/unspecified_member.hash
@@ -1,0 +1,38 @@
+// run=fail
+Mux := struct(val := 3, bal := 'c');
+
+Foo := trait {
+  // Self: Type;
+  
+  bax : () -> u32;
+
+  bux : (a: i32) -> Mux; 
+};
+
+Frobulate := struct(
+  data: i32,
+  other: char = 'c',
+);
+
+
+Frobulate ~= impl Foo {
+  bax := () -> u32 => {
+    1u32
+  };
+
+  // So: also change type annotation checking in functions 
+  bux := (a: i32) -> Mux => {
+      Mux(val = a)
+  }; 
+
+  member_not_on_trt := (a: i32, b: char) -> Mux => {
+      match a {
+        0..10 => Mux(val = 1);
+        11..20 => Mux(val = 2);
+        21..30 => Mux(val = 3);
+        31..40 => Mux(val = 4);
+        _ => Mux(val = 17);
+      }
+  };
+};
+

--- a/tests/cases/typecheck/traits/unspecified_member.stderr
+++ b/tests/cases/typecheck/traits/unspecified_member.stderr
@@ -1,0 +1,15 @@
+error[0056]: method `member_not_on_trt` is not a member of trait `Foo`
+  --> $DIR/unspecified_member.hash:28:3
+27 |    
+28 |      member_not_on_trt := (a: i32, b: char) -> Mux => {
+   |  ____-
+29 | |        match a {
+30 | |          0..10 => Mux(val = 1);
+31 | |          11..20 => Mux(val = 2);
+32 | |          21..30 => Mux(val = 3);
+33 | |          31..40 => Mux(val = 4);
+34 | |          _ => Mux(val = 17);
+35 | |        }
+36 | |    };
+   | |_____- not a member of trait `Foo`
+37 |    };

--- a/tests/cases/typecheck/traits/unspecified_member.stderr
+++ b/tests/cases/typecheck/traits/unspecified_member.stderr
@@ -5,9 +5,7 @@ error[0056]: method `member_not_on_trt` is not a member of trait `Foo`
    |  ____-
 29 | |        match a {
 30 | |          0..10 => Mux(val = 1);
-31 | |          11..20 => Mux(val = 2);
-32 | |          21..30 => Mux(val = 3);
-33 | |          31..40 => Mux(val = 4);
+...  |
 34 | |          _ => Mux(val = 17);
 35 | |        }
 36 | |    };


### PR DESCRIPTION
This patch improves the printing of large code blocks by collapsing intermediate lines with a `...`. This was initially entailed in #290 and is now implemented with this PR.

In order to test the implementation, the trait implementation validation logic was partially implemented, specifically the detection of methods present in the trait implementation that are not defined in the trait definition. partially completes #389 

This also fixes a bug with `visit_constant_scope` trying to take the declaration hint after it visits children which meant that the parent declaration hint was overwritten by the children before it could be used by the parent.