### PR TITLE
TC: Attach type information to nodes

### DIFF
--- a/compiler/hash-typecheck/src/storage/mod.rs
+++ b/compiler/hash-typecheck/src/storage/mod.rs
@@ -13,6 +13,7 @@ pub mod cache;
 pub mod deconstructed;
 pub mod location;
 pub mod mods;
+pub mod nodes;
 pub mod nominals;
 pub mod param_list;
 pub mod params;
@@ -34,6 +35,7 @@ use self::{
     deconstructed::{DeconstructedCtorStore, DeconstructedPatStore},
     location::LocationStore,
     mods::ModDefStore,
+    nodes::NodeInfoStore,
     nominals::NominalDefStore,
     params::ParamsStore,
     pats::{PatArgsStore, PatStore},
@@ -66,6 +68,7 @@ pub struct GlobalStorage {
     pub pat_store: PatStore,
     pub pat_args_store: PatArgsStore,
     pub checked_sources: CheckedSources,
+    pub node_info_store: NodeInfoStore,
 
     /// Storage for tc diagnostics
     pub diagnostics_store: DiagnosticsStore,
@@ -98,6 +101,7 @@ impl GlobalStorage {
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
             term_list_store: TermListStore::new(),
+            node_info_store: NodeInfoStore::new(),
             scope_store,
             diagnostics_store: DiagnosticsStore::default(),
             trt_def_store: TrtDefStore::new(),
@@ -195,6 +199,10 @@ pub trait AccessToStorage {
 
     fn term_list_store(&self) -> &TermListStore {
         &self.global_storage().term_list_store
+    }
+
+    fn node_info_store(&self) -> &NodeInfoStore {
+        &self.global_storage().node_info_store
     }
 
     fn cache(&self) -> &Cache {

--- a/compiler/hash-typecheck/src/storage/nodes.rs
+++ b/compiler/hash-typecheck/src/storage/nodes.rs
@@ -3,6 +3,28 @@
 use hash_ast::ast::AstNodeId;
 use hash_utils::new_partial_store;
 
-use super::terms::TermId;
+use super::{pats::PatId, terms::TermId};
 
-new_partial_store!(pub NodeInfoStore<AstNodeId, TermId>);
+/// Enumerates all the possible informational data that can be associated with
+/// an AST node.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NodeInfoTarget {
+    /// The node corresponds to the term with the given [`TermId`].
+    Term(TermId),
+    /// The node corresponds to the pattern with the given [`PatId`].
+    Pat(PatId),
+}
+
+impl From<TermId> for NodeInfoTarget {
+    fn from(term: TermId) -> Self {
+        Self::Term(term)
+    }
+}
+
+impl From<PatId> for NodeInfoTarget {
+    fn from(pat: PatId) -> Self {
+        Self::Pat(pat)
+    }
+}
+
+new_partial_store!(pub NodeInfoStore<AstNodeId, NodeInfoTarget>);

--- a/compiler/hash-typecheck/src/storage/nodes.rs
+++ b/compiler/hash-typecheck/src/storage/nodes.rs
@@ -1,0 +1,8 @@
+//! Storage that holds type information about AST nodes.
+
+use hash_ast::ast::AstNodeId;
+use hash_utils::new_partial_store;
+
+use super::terms::TermId;
+
+new_partial_store!(pub NodeInfoStore<AstNodeId, TermId>);

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -176,7 +176,9 @@ impl<'tc> TcVisitor<'tc> {
         node: AstNodeRef<T>,
         term: TermId,
     ) -> TcResult<TermId> {
+        // Copy location before so that validation errors point to the right location:
         self.copy_location_from_node_to_target(node, term);
+
         let simplified_term_id = self.validator().validate_term(term)?.simplified_term_id;
         self.node_info_store().insert(node.id(), NodeInfoTarget::Term(simplified_term_id));
         Ok(simplified_term_id)

--- a/tests/cases/typecheck/property_access/numeric_access_on_struct.stderr
+++ b/tests/cases/typecheck/property_access/numeric_access_on_struct.stderr
@@ -1,6 +1,6 @@
 error[0015]: the field `2` is not present within `Frobulate(data = 23_i32, other = 'c')`
- --> $DIR/numeric_access_on_struct.hash:8:1
-7 |   
-8 |   t := Frobulate(data = 23);
-  |   ^ `Frobulate(data = 23_i32, other = 'c')` does not contain the property `2`
-9 |   
+  --> $DIR/numeric_access_on_struct.hash:12:3
+11 |   main := () -> i32 => {
+12 |     t.2
+   |     ^ `Frobulate(data = 23_i32, other = 'c')` does not contain the property `2`
+13 |   };

--- a/tests/cases/typecheck/property_access/numeric_access_on_struct.stderr
+++ b/tests/cases/typecheck/property_access/numeric_access_on_struct.stderr
@@ -1,6 +1,6 @@
 error[0015]: the field `2` is not present within `Frobulate(data = 23_i32, other = 'c')`
- --> $DIR/numeric_access_on_struct.hash:8:6
+ --> $DIR/numeric_access_on_struct.hash:8:1
 7 |   
 8 |   t := Frobulate(data = 23);
-  |        ^^^^^^^^^^^^^^^^^^^^ `Frobulate(data = 23_i32, other = 'c')` does not contain the property `2`
+  |   ^ `Frobulate(data = 23_i32, other = 'c')` does not contain the property `2`
 9 |   

--- a/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
+++ b/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
@@ -1,6 +1,6 @@
 error[0015]: the field `2` is not present within `(1_i32, 2_i32)`
- --> $DIR/out_of_bounds_access.hash:2:6
+ --> $DIR/out_of_bounds_access.hash:2:1
 1 |   // run=fail
 2 |   t := (1, 2);
-  |        ^^^^^^ `(1_i32, 2_i32)` does not contain the property `2`
+  |   ^ `(1_i32, 2_i32)` does not contain the property `2`
 3 |   

--- a/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
+++ b/tests/cases/typecheck/property_access/out_of_bounds_access.stderr
@@ -1,6 +1,6 @@
 error[0015]: the field `2` is not present within `(1_i32, 2_i32)`
- --> $DIR/out_of_bounds_access.hash:2:1
-1 |   // run=fail
-2 |   t := (1, 2);
-  |   ^ `(1_i32, 2_i32)` does not contain the property `2`
-3 |   
+ --> $DIR/out_of_bounds_access.hash:6:3
+5 |   main := () -> i32 => {
+6 |     t.2
+  |     ^ `(1_i32, 2_i32)` does not contain the property `2`
+7 |   };

--- a/tests/cases/typecheck/spread-pats/tuple-spread-pats.stderr
+++ b/tests/cases/typecheck/spread-pats/tuple-spread-pats.stderr
@@ -2,6 +2,12 @@ warn: named tuple is coerced into an un-named tuple
   --> $DIR/tuple-spread-pats.hash:29:5
 28 |   test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
 29 |       (...t) := f;
+   |       ^^^^^^ the named tuple type `{value (name: str, bax: char)}` is being coerced into an un-named tuple
+30 |       t
+
+  --> $DIR/tuple-spread-pats.hash:29:5
+28 |   test_all_spread := (f: (name: str, bax: char)) -> (name: str, bax: char) => {
+29 |       (...t) := f;
    |       ^^^^^^ the coercion occurs here
 30 |       t
    = note: if a tuple type is declared as named, it's usually that field names are important and shouldn't be thrown away.

--- a/tests/cases/typecheck/structs/missing-fields.stderr
+++ b/tests/cases/typecheck/structs/missing-fields.stderr
@@ -1,12 +1,18 @@
 error[0017]: struct literal is missing the fields `age`, and `width`
- --> $DIR/missing-fields.hash:3:8
-2 |    
-3 |    Dog := struct(
-  |  _________-
-4 | |      name: str,
-5 | |      age: i32,
-6 | |      width: f32,
-7 | |      height: f32,
-8 | |  );
-  | |___- the struct is defined here
-9 |    
+  --> $DIR/missing-fields.hash:14:5
+13 |   
+14 |       Dog(name, height) := viktor;
+   |       ^^^^^^^^^^^^^^^^^ missing `age`, and `width`
+15 |   };
+
+  --> $DIR/missing-fields.hash:3:8
+ 2 |    
+ 3 |    Dog := struct(
+   |  _________-
+ 4 | |      name: str,
+ 5 | |      age: i32,
+ 6 | |      width: f32,
+ 7 | |      height: f32,
+ 8 | |  );
+   | |___- the struct is defined here
+ 9 |    

--- a/tests/cases/typecheck/structs/missing-fields.stderr
+++ b/tests/cases/typecheck/structs/missing-fields.stderr
@@ -1,18 +1,12 @@
 error[0017]: struct literal is missing the fields `age`, and `width`
-  --> $DIR/missing-fields.hash:14:5
-13 |   
-14 |       Dog(name, height) := viktor;
-   |       ^^^^^^^^^^^^^^^^^ missing `age`, and `width`
-15 |   };
-
-  --> $DIR/missing-fields.hash:3:8
- 2 |    
- 3 |    Dog := struct(
-   |  _________-
- 4 | |      name: str,
- 5 | |      age: i32,
- 6 | |      width: f32,
- 7 | |      height: f32,
- 8 | |  );
-   | |___- the struct is defined here
- 9 |    
+ --> $DIR/missing-fields.hash:3:8
+2 |    
+3 |    Dog := struct(
+  |  _________-
+4 | |      name: str,
+5 | |      age: i32,
+6 | |      width: f32,
+7 | |      height: f32,
+8 | |  );
+  | |___- the struct is defined here
+9 |    


### PR DESCRIPTION
This PR adds a store `NodeInfoStore` which maps `AstNodeId`s to `TermId`s and `PatId`s. It is a necessary step for implementing mono/lowering to IR, as well as any post-TC semantic stages.

Closes #240.