### PR TITLE
TC: Add unit nominal primitive

### DIFF
--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -166,6 +166,9 @@ pub enum TcError {
     /// Cannot find a constructor for the given type
     NoConstructorOnType { subject: TermId },
 
+    /// The subject does not have a callable constructor (i.e. it is constant).
+    NoCallableConstructorOnType { subject: TermId },
+
     /// When a bind within a pattern is declared more than one
     IdentifierBoundMultipleTimes { name: Identifier, pat: PatId },
 
@@ -1304,6 +1307,19 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
                 if let Some(location) = ctx.location_store().get_location(subject) {
                     builder
                         .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(location, "")));
+                }
+            }
+            TcError::NoCallableConstructorOnType { subject } => {
+                builder.with_message(format!(
+                    "type `{}` has a constant constructor, not a callable one",
+                    subject.for_formatting(ctx.global_storage())
+                ));
+
+                if let Some(location) = ctx.location_store().get_location(subject) {
+                    builder.add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        location,
+                        "try to remove the argument list here",
+                    )));
                 }
             }
             TcError::IdentifierBoundMultipleTimes { name, pat } => {

--- a/compiler/hash-typecheck/src/exhaustiveness/construct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/construct.rs
@@ -149,6 +149,7 @@ impl<'tc> ConstructorOps<'tc> {
                                 }
                                 StructFields::Opaque => 0,
                             },
+                            NominalDef::Unit(_) => 0,
                             // @@EnumToUnion: remove this
                             NominalDef::Enum(_) => unreachable!(),
                         }

--- a/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/deconstruct.rs
@@ -230,6 +230,11 @@ impl Debug for ForFormatting<'_, DeconstructedPatId> {
                                     write!(f, "{}", name)?;
                                 }
                             }
+                            NominalDef::Unit(unit_def) => {
+                                if let Some(name) = unit_def.name {
+                                    write!(f, "{}", name)?;
+                                }
+                            }
                             // @@EnumToUnion: remove and replace
                             NominalDef::Enum(_) => unreachable!(),
                         }

--- a/compiler/hash-typecheck/src/exhaustiveness/fields.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/fields.rs
@@ -120,6 +120,9 @@ impl<'tc> FieldOps<'tc> {
                                     self.for_fmt(ctx.ty),
                                 ),
                             },
+                            NominalDef::Unit(_) => {
+                                Fields::empty()
+                            },
                             // @@EnumToUnion: when enums aren't represented as this anymore
                             NominalDef::Enum(_) => unreachable!(),
                         }

--- a/compiler/hash-typecheck/src/exhaustiveness/lower.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/lower.rs
@@ -26,9 +26,9 @@ use crate::{
         params::ParamsId,
         pats::{PatArgsId, PatId},
         primitives::{
-            AccessPat, ConstructorPat, IfPat, Level0Term, Level1Term, ListPat, LitTerm, ModDef,
-            ModPat, NominalDef, Pat, PatArg, RangePat, ScopeKind, SpreadPat, StructFields, Term,
-            TupleTy,
+            AccessPat, ConstPat, ConstructorPat, IfPat, Level0Term, Level1Term, ListPat, LitTerm,
+            ModDef, ModPat, NominalDef, Pat, PatArg, RangePat, ScopeKind, SpreadPat, StructFields,
+            Term, TupleTy,
         },
         terms::TermId,
         AccessToStorage, StorageRef,
@@ -180,36 +180,43 @@ impl<'tc> LowerPatOps<'tc> {
             Pat::Constructor(ConstructorPat { args, .. }) => {
                 match reader.get_term(ty) {
                     Term::Level1(Level1Term::NominalDef(nominal_def)) => {
+                        // @@Todo: deal with variants
                         let (ctor, members) = match reader.get_nominal_def(nominal_def) {
                             NominalDef::Struct(struct_def) => match struct_def.fields {
                                 StructFields::Explicit(members) => {
-                                    (DeconstructedCtor::Single, members)
+                                    (DeconstructedCtor::Single, Some(members))
                                 }
                                 StructFields::Opaque => {
                                     panic!("got unexpected opaque struct-def here")
                                 }
                             },
+                            NominalDef::Unit(_) => (DeconstructedCtor::Single, None),
                             // @@EnumToUnion: when enums aren't a thing, do this with a union
                             NominalDef::Enum(_) => unreachable!(),
                         };
 
-                        // Lower the fields by resolving what positions the actual fields are
-                        // with the reference of the constructor's type...
-                        let fields = self.pat_lowerer().deconstruct_pat_fields(args, members);
+                        if let Some(members) = members {
+                            // Lower the fields by resolving what positions the actual fields are
+                            // with the reference of the constructor's type...
+                            let fields = self.pat_lowerer().deconstruct_pat_fields(args, members);
 
-                        let args = reader.get_params_owned(members);
-                        let tys = args.positional().iter().map(|param| param.ty);
+                            let args = reader.get_params_owned(members);
+                            let tys = args.positional().iter().map(|param| param.ty);
 
-                        let mut wilds: SmallVec<[_; 2]> =
-                            tys.map(|ty| self.deconstruct_pat_ops().wildcard(ty)).collect();
+                            let mut wilds: SmallVec<[_; 2]> =
+                                tys.map(|ty| self.deconstruct_pat_ops().wildcard(ty)).collect();
 
-                        // For each provided field, we want to recurse and lower the pattern further
-                        for field in fields {
-                            wilds[field.index] =
-                                self.deconstruct_pat(wilds[field.index].ty, field.pat);
+                            // For each provided field, we want to recurse and lower the pattern
+                            // further
+                            for field in fields {
+                                wilds[field.index] =
+                                    self.deconstruct_pat(wilds[field.index].ty, field.pat);
+                            }
+
+                            (ctor, wilds.to_vec())
+                        } else {
+                            (ctor, vec![])
                         }
-
-                        (ctor, wilds.to_vec())
                     }
                     _ => tc_panic!(
                         ty,
@@ -327,48 +334,51 @@ impl<'tc> LowerPatOps<'tc> {
                         Pat::Tuple(args)
                     }
                     Term::Level1(Level1Term::NominalDef(nom_def)) => {
-                        let tys = match reader.get_nominal_def(nom_def) {
+                        match reader.get_nominal_def(nom_def) {
                             NominalDef::Struct(struct_def) => {
-                                match struct_def.fields {
+                                let tys = match struct_def.fields {
                                     StructFields::Explicit(fields) => {
                                         reader.get_params_owned(fields)
                                     },
                                     StructFields::Opaque => unreachable!(),
-                                }
+                                };
+
+                                // Construct the inner arguments to the constructor by iterating over the
+                                // pattern fields within the pattern. If possible, lookup the name of the
+                                // field by using the nominal definition attached to the pattern.
+                                let children = pat.fields.iter_patterns().enumerate()
+                                    .filter(|(_, p)| {
+                                        !reader.get_deconstructed_pat_ctor(*p).is_wildcard()
+                                    })
+                                    .map(|(index, p)| {
+                                        PatArg {
+                                            name: tys.positional().get(index).and_then(|param| param.name),
+                                            pat: self.construct_pat(p)
+                                        }
+                                    }).collect_vec();
+
+                                // We collapse all fields that are specified as `wildcards` within
+                                // these construct patterns in order to represent them visually in a clearer
+                                // way. If a construct has 20 fields that 18 are specified as wildcards, and the
+                                // rest have user specified patterns, then we only want to print those and the
+                                // rest is denoted as `...`.
+                                let args = if pat.fields.len() != children.len() {
+                                    let dummy = Pat::Spread(SpreadPat { name: None  });
+                                    let arg = PatArg { pat: self.pat_store().create(dummy), name: None };
+
+                                    self.builder().create_pat_args(children.into_iter().chain(once(arg)), ParamOrigin::ListPat)
+                                }  else {
+                                    self.builder().create_pat_args(children, ParamOrigin::ListPat)
+                                };
+
+                                Pat::Constructor(ConstructorPat { subject: pat.ty, args })
                             },
+                            NominalDef::Unit(_) => {
+                                Pat::Const(ConstPat { term: self.builder().create_unit_term(nom_def) })
+                            }
                             NominalDef::Enum(_) => unreachable!(),
-                        };
+                        }
 
-
-                        // Construct the inner arguments to the constructor by iterating over the
-                        // pattern fields within the pattern. If possible, lookup the name of the
-                        // field by using the nominal definition attached to the pattern.
-                        let children = pat.fields.iter_patterns().enumerate()
-                            .filter(|(_, p)| {
-                                !reader.get_deconstructed_pat_ctor(*p).is_wildcard()
-                            })
-                            .map(|(index, p)| {
-                                PatArg {
-                                    name: tys.positional().get(index).and_then(|param| param.name),
-                                    pat: self.construct_pat(p)
-                                }
-                            }).collect_vec();
-
-                        // We collapse all fields that are specified as `wildcards` within
-                        // these construct patterns in order to represent them visually in a clearer
-                        // way. If a construct has 20 fields that 18 are specified as wildcards, and the
-                        // rest have user specified patterns, then we only want to print those and the
-                        // rest is denoted as `...`.
-                        let args = if pat.fields.len() != children.len() {
-                            let dummy = Pat::Spread(SpreadPat { name: None  });
-                            let arg = PatArg { pat: self.pat_store().create(dummy), name: None };
-
-                            self.builder().create_pat_args(children.into_iter().chain(once(arg)), ParamOrigin::ListPat)
-                        }  else {
-                            self.builder().create_pat_args(children, ParamOrigin::ListPat)
-                        };
-
-                        Pat::Constructor(ConstructorPat { subject: pat.ty, args })
                     }
                     _ => tc_panic!(
                         pat.ty,

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -82,94 +82,99 @@ impl<'tc> SplitWildcardOps<'tc> {
         // we need make sure to omit constructors that are statically impossible. E.g.,
         // for `Option<!>`, we do not include `Some(_)` in the returned list of
         // constructors.
-        let all_ctors = match ctx.ty {
-            ty if let Some(int_kind) = self.oracle().term_as_int_ty(ty) => {
-                match int_kind {
-                    // @@Future: Maybe in the future, we can have a compiler setting/project
-                    // setting that allows a user to say `it's ok to use the `target` pointer width`
-                    IntTy::ISize | IntTy::USize | IntTy::UBig | IntTy::IBig => {
-                        smallvec![DeconstructedCtor::NonExhaustive]
-                    }
-                    kind if kind.is_signed() => {
-                        // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                        let size = kind.size().unwrap();
-                        let bits = (size * 8) as u128;
-
-                        let min = 1u128 << (bits - 1);
-                        let max = min - 1;
-
-                        // i_kind::MIN..=_kind::MAX
-                        smallvec![make_range(min, max)]
-                    }
-                    kind => {
-                        // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                        let size = kind.size().unwrap();
-                        let bits = size * 8;
-
-                        let shift = 128 - bits;
-
-                        // Truncate (shift left to drop out leftover values, shift right to fill with
-                        // zeroes).
-                        let max = (u128::MAX << shift) >> shift;
-
-                        smallvec![make_range(0, max)]
-                    }
-                }
-            }
-            ty if self.oracle().term_as_list_ty(ty).is_some() => {
-                // For lists, we just default to a variable length list
-                smallvec![DeconstructedCtor::List(List { kind: ListKind::Var(0, 0) })]
-            }
-            ty if self.oracle().term_is_char_ty(ty) => {
-                smallvec![
-                    // The valid Unicode Scalar Value ranges.
-                    make_range('\u{0000}' as u128, '\u{D7FF}' as u128),
-                    make_range('\u{E000}' as u128, '\u{10FFFF}' as u128),
-                ]
-            }
-            ty if self.oracle().term_is_never_ty(ty) => {
-                // If our subject is the never type, we cannot
-                // expose its emptiness. The exception is if the pattern
-                // is at the top level, because we want empty matches
-                // to be considered exhaustive.
-                if !ctx.is_top_level {
+        let all_ctors = if let Some(int_kind) = self.oracle().term_as_int_ty(ctx.ty) {
+            match int_kind {
+                // @@Future: Maybe in the future, we can have a compiler setting/project
+                // setting that allows a user to say `it's ok to use the `target`
+                // pointer width`
+                IntTy::ISize | IntTy::USize | IntTy::UBig | IntTy::IBig => {
                     smallvec![DeconstructedCtor::NonExhaustive]
-                } else {
-                    smallvec![]
+                }
+                kind if kind.is_signed() => {
+                    // Safe to unwrap since we deal with `ibig` and `ubig` variants...
+                    let size = kind.size().unwrap();
+                    let bits = (size * 8) as u128;
+
+                    let min = 1u128 << (bits - 1);
+                    let max = min - 1;
+
+                    // i_kind::MIN..=_kind::MAX
+                    smallvec![make_range(min, max)]
+                }
+                kind => {
+                    // Safe to unwrap since we deal with `ibig` and `ubig` variants...
+                    let size = kind.size().unwrap();
+                    let bits = size * 8;
+
+                    let shift = 128 - bits;
+
+                    // Truncate (shift left to drop out leftover values, shift right to
+                    // fill with zeroes).
+                    let max = (u128::MAX << shift) >> shift;
+
+                    smallvec![make_range(0, max)]
                 }
             }
-            ty if self.oracle().term_is_str_ty(ty) => {
-                smallvec![DeconstructedCtor::NonExhaustive]
-            }
-            ty => match reader.get_term(ty) {
-                Term::Level1(Level1Term::NominalDef(def)) => {
-                    match reader.get_nominal_def(def) {
-                        NominalDef::Struct(_) => smallvec![DeconstructedCtor::Single],
-                        NominalDef::Enum(enum_def) => {
-                            // The exception is if the pattern is at the top level, because we
-                            // want empty matches to be
-                            // considered exhaustive.
-                            let is_secretly_empty =
-                                enum_def.variants.is_empty() && !ctx.is_top_level;
+        } else {
+            match ctx.ty {
+                ty if self.oracle().term_as_list_ty(ty).is_some() => {
+                    // For lists, we just default to a variable length list
+                    smallvec![DeconstructedCtor::List(List { kind: ListKind::Var(0, 0) })]
+                }
+                ty if self.oracle().term_is_char_ty(ty) => {
+                    smallvec![
+                        // The valid Unicode Scalar Value ranges.
+                        make_range('\u{0000}' as u128, '\u{D7FF}' as u128),
+                        make_range('\u{E000}' as u128, '\u{10FFFF}' as u128),
+                    ]
+                }
+                ty if self.oracle().term_is_never_ty(ty) => {
+                    // If our subject is the never type, we cannot
+                    // expose its emptiness. The exception is if the pattern
+                    // is at the top level, because we want empty matches
+                    // to be considered exhaustive.
+                    if !ctx.is_top_level {
+                        smallvec![DeconstructedCtor::NonExhaustive]
+                    } else {
+                        smallvec![]
+                    }
+                }
+                ty if self.oracle().term_is_str_ty(ty) => {
+                    smallvec![DeconstructedCtor::NonExhaustive]
+                }
+                ty => match reader.get_term(ty) {
+                    Term::Level1(Level1Term::NominalDef(def)) => {
+                        match reader.get_nominal_def(def) {
+                            NominalDef::Struct(_) => smallvec![DeconstructedCtor::Single],
+                            NominalDef::Enum(enum_def) => {
+                                // The exception is if the pattern is at the top level, because we
+                                // want empty matches to be
+                                // considered exhaustive.
+                                let is_secretly_empty =
+                                    enum_def.variants.is_empty() && !ctx.is_top_level;
 
-                            let mut ctors: SmallVec<[_; 1]> = enum_def
-                                .variants
-                                .iter()
-                                .enumerate()
-                                .map(|(index, _)| DeconstructedCtor::Variant(index))
-                                .collect();
+                                let mut ctors: SmallVec<[_; 1]> = enum_def
+                                    .variants
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(index, _)| DeconstructedCtor::Variant(index))
+                                    .collect();
 
-                            if is_secretly_empty {
-                                ctors.push(DeconstructedCtor::NonExhaustive);
+                                if is_secretly_empty {
+                                    ctors.push(DeconstructedCtor::NonExhaustive);
+                                }
+
+                                ctors
                             }
-
-                            ctors
+                            NominalDef::Unit(_) => {
+                                smallvec![DeconstructedCtor::Single]
+                            }
                         }
                     }
-                }
-                Term::Level1(Level1Term::Tuple(_)) => smallvec![DeconstructedCtor::Single],
-                _ => smallvec![DeconstructedCtor::NonExhaustive],
-            },
+                    Term::Level1(Level1Term::Tuple(_)) => smallvec![DeconstructedCtor::Single],
+                    _ => smallvec![DeconstructedCtor::NonExhaustive],
+                },
+            }
         };
 
         // Now we have to allocate `all_ctors` into storage

--- a/compiler/hash-typecheck/src/fmt.rs
+++ b/compiler/hash-typecheck/src/fmt.rs
@@ -14,7 +14,7 @@ use crate::storage::{
     primitives::{
         AccessOp, AccessPat, BoundVar, ConstPat, ConstructedTerm, EnumDef, Level0Term, Level1Term,
         Level2Term, Level3Term, ListPat, LitTerm, Member, ModDefOrigin, ModPat, Mutability,
-        NominalDef, Pat, RangePat, ScopeVar, SpreadPat, StructDef, Sub, SubVar, Term,
+        NominalDef, Pat, RangePat, ScopeVar, SpreadPat, StructDef, Sub, SubVar, Term, UnitDef,
         UnresolvedTerm, Var, Visibility,
     },
     scope::ScopeId,
@@ -287,6 +287,10 @@ impl<'gs> TcFormatter<'gs> {
                     members.for_formatting(self.global_storage)
                 )
             }
+            Level0Term::Unit(def_id) => {
+                opts.is_atomic.set(true);
+                write!(f, "{}", def_id.for_formatting(self.global_storage),)
+            }
         }
     }
 
@@ -532,6 +536,7 @@ impl<'gs> TcFormatter<'gs> {
         match self.global_storage.nominal_def_store.get(nominal_def_id) {
             NominalDef::Struct(StructDef { name: Some(name), .. })
             | NominalDef::Enum(EnumDef { name: Some(name), .. })
+            | NominalDef::Unit(UnitDef { name: Some(name) })
                 if !opts.expand =>
             {
                 write!(f, "{}", name)
@@ -544,6 +549,9 @@ impl<'gs> TcFormatter<'gs> {
             }
             NominalDef::Enum(_) => {
                 write!(f, "enum(..)")
+            }
+            NominalDef::Unit(_) => {
+                write!(f, "unit()")
             }
         }
     }

--- a/compiler/hash-typecheck/src/ops/building.rs
+++ b/compiler/hash-typecheck/src/ops/building.rs
@@ -319,6 +319,11 @@ impl<'gs> PrimitiveBuilder<'gs> {
         self.create_term(Term::Union(terms))
     }
 
+    /// Create a term [Level0Term::Unit] from the given nominal definition ID.
+    pub fn create_unit_term(&self, unit_id: NominalDefId) -> TermId {
+        self.create_term(Term::Level0(Level0Term::Unit(unit_id)))
+    }
+
     /// Create the void type term: [Level1Term::Tuple] with no members.
     pub fn create_void_ty_term(&self) -> TermId {
         self.create_term(Term::Level1(Level1Term::Tuple(TupleTy {

--- a/compiler/hash-typecheck/src/ops/discover.rs
+++ b/compiler/hash-typecheck/src/ops/discover.rs
@@ -95,7 +95,7 @@ impl<'tc> Discoverer<'tc> {
                 self.add_free_sub_vars_in_term_to_set(constructed.subject, result);
                 self.add_free_sub_vars_in_args_to_set(constructed.members, result);
             }
-            Level0Term::EnumVariant(_) | Level0Term::Lit(_) => {}
+            Level0Term::EnumVariant(_) | Level0Term::Lit(_) | Level0Term::Unit(_) => {}
         }
     }
 
@@ -312,7 +312,7 @@ impl<'tc> Discoverer<'tc> {
                 self.add_free_bound_vars_in_term_to_set(constructed.subject, result);
                 self.add_free_bound_vars_in_args_to_set(constructed.members, result);
             }
-            Level0Term::EnumVariant(_) | Level0Term::Lit(_) => {}
+            Level0Term::EnumVariant(_) | Level0Term::Lit(_) | Level0Term::Unit(_) => {}
         }
     }
 
@@ -356,10 +356,9 @@ impl<'tc> Discoverer<'tc> {
                         ..
                     }) => self.add_free_bound_vars_in_params_to_set(fields, result),
                     // @@Todo: add bound vars to opaque structs
-                    NominalDef::Struct(_) => {}
-                    NominalDef::Enum(_) => {
-                        // @@Remove: enums will be removed anyway.
-                    }
+                    NominalDef::Struct(_) | NominalDef::Unit(_) => {}
+                    // @@Remove: enums will be removed anyway.
+                    NominalDef::Enum(_) => {}
                 }
             }
             Level1Term::Tuple(tuple_ty) => {
@@ -1046,6 +1045,7 @@ impl<'tc> Discoverer<'tc> {
                         Ok(Some(self.builder().create_constructed_term(subject, members)))
                     }
                 }
+                Level0Term::Unit(_) => Ok(None),
             },
             Term::Level1(Level1Term::ModDef(_))
             | Term::Level1(Level1Term::NominalDef(_))

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -240,6 +240,7 @@ impl<'tc> PatMatcher<'tc> {
         // @@Todo: deal with enum variants
         let subject_members = match self.oracle().term_as_struct_def(subject).unwrap().fields {
             StructFields::Explicit(fields) => fields,
+            // @@ErrorReporting: this should be a tc panic
             _ => unreachable!(),
         };
 

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -359,7 +359,7 @@ impl<'tc> Simplifier<'tc> {
                     }
                 }
             },
-            Level0Term::Lit(_) => {
+            Level0Term::Unit(_) | Level0Term::Lit(_) => {
                 // Create an Rt(..) of the value wrapped, and use that as the subject.
                 let term_value = Level0Term::Rt(self.typer().infer_ty_of_term(originating_term)?);
                 let term = self.builder().create_term(Term::Level0(term_value.clone()));
@@ -426,6 +426,7 @@ impl<'tc> Simplifier<'tc> {
                             None => name_not_found(access_term),
                         }
                     }
+                    NominalDef::Unit(_) => todo!(),
                 }
             }
             Level1Term::Tuple(_tuple_ty) => does_not_support_access(access_term),
@@ -818,7 +819,9 @@ impl<'tc> Simplifier<'tc> {
 
                         Ok(ConstructedTerm { subject: term_id, members })
                     }
+                    // @@Remove
                     NominalDef::Enum(_) => cannot_use_as_call_subject(),
+                    NominalDef::Unit(_) => cannot_use_as_call_subject(),
                 }
             }
             _ => cannot_use_as_call_subject(),
@@ -953,6 +956,7 @@ impl<'tc> Simplifier<'tc> {
                     Level0Term::Lit(_) => cannot_use_as_fn_call_subject(),
                     Level0Term::Tuple(_) => cannot_use_as_fn_call_subject(),
                     Level0Term::Constructed(_) => cannot_use_as_fn_call_subject(),
+                    Level0Term::Unit(_) => cannot_use_as_fn_call_subject(),
                 }
             }
 
@@ -1066,6 +1070,7 @@ impl<'tc> Simplifier<'tc> {
                     Ok(None)
                 }
             }
+            Level0Term::Unit(_) => Ok(None),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -137,7 +137,7 @@ impl<'tc> Substituter<'tc> {
         &self,
         sub: &Sub,
         term: Level0Term,
-        original_term: TermId,
+        _original_term: TermId,
     ) -> TermId {
         match term {
             Level0Term::Rt(ty_term_id) => {
@@ -167,7 +167,7 @@ impl<'tc> Substituter<'tc> {
 
                 self.builder().create_constructed_term(subbed_subject, subbed_args)
             }
-            Level0Term::Lit(_) | Level0Term::EnumVariant(_) => original_term,
+            Level0Term::Lit(_) | Level0Term::EnumVariant(_) | Level0Term::Unit(_) => todo!(),
         }
     }
 

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -244,6 +244,10 @@ impl<'tc> Typer<'tc> {
                         };
                         Ok(self.simplifier().potentially_simplify_term(term)?)
                     }
+                    Level0Term::Unit(def_id) => {
+                        // The inner member stores the def ID of the unit
+                        Ok(self.builder().create_nominal_def_term(def_id))
+                    }
                 }
             }
             Term::BoundVar(bound_var) => {

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -365,6 +365,7 @@ impl<'tc> Validator<'tc> {
 
                 Ok(())
             }
+            NominalDef::Unit(_) => Ok(()), // nothing to do
         }
     }
 
@@ -837,6 +838,11 @@ impl<'tc> Validator<'tc> {
                     self.validate_term(term_ty_id)?;
                     Ok(result)
                 }
+                Level0Term::Unit(_) => {
+                    // Non-unit def ID inside here would be a compiler error,
+                    // not a user error, so we don't need to check it as part of validation.
+                    Ok(result)
+                }
             },
 
             // Access
@@ -1067,9 +1073,11 @@ impl<'tc> Validator<'tc> {
                         "Function call in checking for type function return validity should have been simplified!"
                     )
                     }
-                    Level0Term::Lit(_) | Level0Term::Tuple(_) | Level0Term::Constructed(_) => {
-                        Ok(false)
-                    }
+                    // @@Future: could support these in certain cases.
+                    Level0Term::Unit(_)
+                    | Level0Term::Lit(_)
+                    | Level0Term::Tuple(_)
+                    | Level0Term::Constructed(_) => Ok(false),
                 }
             }
             _ => Ok(true),
@@ -1351,6 +1359,7 @@ impl<'tc> Validator<'tc> {
                 StructFields::Explicit(fields) => (true, fields),
                 StructFields::Opaque => return Err(TcError::NoConstructorOnType { subject }),
             },
+            NominalDef::Unit(_) => return Err(TcError::NoCallableConstructorOnType { subject }),
             NominalDef::Enum(_) => unreachable!(),
         };
 

--- a/compiler/hash-typecheck/src/storage/primitives.rs
+++ b/compiler/hash-typecheck/src/storage/primitives.rs
@@ -513,7 +513,7 @@ pub struct ModDef {
 }
 
 /// The fields of a struct.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum StructFields {
     /// An explicit set of fields, as a set of parameters.
     Explicit(ParamsId),
@@ -525,7 +525,7 @@ pub enum StructFields {
 }
 
 /// A struct definition, containing a binding name and a set of fields.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct StructDef {
     pub name: Option<Identifier>,
     pub fields: StructFields,
@@ -550,17 +550,29 @@ pub struct EnumDef {
 }
 
 /// A trait definition, containing a binding name and a set of constant members.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TrtDef {
     pub name: Option<Identifier>,
     pub members: ScopeId,
 }
 
-/// A nominal definition, which for now is either a struct or an enum.
+/// A unit definition.
+///
+/// This is a nominal type with a single constant constructor.
+#[derive(Debug, Clone, Copy)]
+pub struct UnitDef {
+    pub name: Option<Identifier>,
+}
+
+/// A nominal definition, which for now is either a struct, an enum, or a unit.
 #[derive(Debug, Clone)]
 pub enum NominalDef {
+    /// A struct definition.
     Struct(StructDef),
+    /// @@Todo: delete
     Enum(EnumDef),
+    /// A unit definition.
+    Unit(UnitDef),
 }
 
 impl NominalDef {
@@ -569,6 +581,7 @@ impl NominalDef {
         match self {
             NominalDef::Struct(def) => def.name,
             NominalDef::Enum(def) => def.name,
+            NominalDef::Unit(def) => def.name,
         }
     }
 }
@@ -978,6 +991,10 @@ pub enum Level0Term {
 
     /// An enum variant, which is either a constant term or a function value.
     EnumVariant(EnumVariantValue),
+
+    /// A unit value, of the given unit type definition (inner `NominalDefId`
+    /// should point to a unit).
+    Unit(NominalDefId),
 
     /// Tuple literal.
     Tuple(TupleLit),


### PR DESCRIPTION
This PR adds `NominalDef::Unit`. This is meant to be to constant enum variants what structs are to enum variants with data. Hopefully that makes sense. It is equivalent in spirit to a struct with an empty field list, or a simply a unit struct in rust `struct Foo;`.

In subsequent commits, this will be used to replace enums; enum variants will become either structs or units, depending on whether they have data members or not.

Closes #501.