### PR TITLE
tc: Implement traversal for assigning with operands

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1081,7 +1081,7 @@ impl Display for UnOp {
 }
 
 /// Binary operators that are defined within the core of the language.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOp {
     /// '=='
     EqEq,
@@ -1197,6 +1197,20 @@ impl BinOp {
                 | BinOp::Div
                 | BinOp::Mod
         )
+    }
+
+    /// Checks whether this operator is a ordering comparison operator, i.e. `<`
+    /// `<=`, `>`, etc.
+    pub fn is_ordering_comparator(&self) -> bool {
+        matches!(self, BinOp::Gt | BinOp::GtEq | BinOp::Lt | BinOp::LtEq)
+    }
+
+    /// Checks whether this operator is a `lazy` operator, as in it is possible
+    /// that only the first operand is evaluated before ever evaluating the
+    /// second operand. Lazy operators are the logical operators `&&` and `||`
+    /// that short-circuit.
+    pub fn is_lazy(&self) -> bool {
+        matches!(self, BinOp::And | BinOp::Or)
     }
 }
 

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -7,6 +7,7 @@ error_codes! {
     UsingContinueOutsideLoop = 3,
     UsingReturnOutsideFn = 4,
     ItemIsImmutable = 5,
+    ItemMustBeImmutable = 6,
 
     // Name spacing and symbol errors
     UnresolvedSymbol = 10,

--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -6,7 +6,7 @@ error_codes! {
     UsingBreakOutsideLoop = 2,
     UsingContinueOutsideLoop = 3,
     UsingReturnOutsideFn = 4,
-    // 5: un-used
+    ItemIsImmutable = 5,
 
     // Name spacing and symbol errors
     UnresolvedSymbol = 10,

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -86,6 +86,9 @@ pub struct IdentifierMap<'c> {
 }
 
 /// Holds some default identifiers in order to avoid map lookups.
+///
+/// @@Todo: Create a macro that creates a mod block with all of these
+/// as constants.
 #[allow(non_snake_case)]
 pub struct CoreIdentifiers {
     pub underscore: Identifier,
@@ -139,6 +142,41 @@ pub struct CoreIdentifiers {
     pub b: Identifier,
     pub K: Identifier,
     pub V: Identifier,
+
+    /// Operator traits
+    pub trt_eq: Identifier,
+    pub trt_neq: Identifier,
+    pub trt_ord: Identifier,
+    pub trt_gt: Identifier,
+    pub trt_gt_eq: Identifier,
+    pub trt_lt: Identifier,
+    pub trt_lt_eq: Identifier,
+
+    /// Arithmetic operator traits
+    pub trt_bit_or_eq: Identifier,
+    pub trt_bit_or: Identifier,
+    pub trt_or: Identifier,
+    pub trt_bit_and_eq: Identifier,
+    pub trt_bit_and: Identifier,
+    pub trt_and: Identifier,
+    pub trt_bit_xor_eq: Identifier,
+    pub trt_bit_xor: Identifier,
+    pub trt_bit_exp_eq: Identifier,
+    pub trt_bit_exp: Identifier,
+    pub trt_shr_eq: Identifier,
+    pub trt_shr: Identifier,
+    pub trt_shl_eq: Identifier,
+    pub trt_shl: Identifier,
+    pub trt_add_eq: Identifier,
+    pub trt_add: Identifier,
+    pub trt_sub: Identifier,
+    pub trt_sub_eq: Identifier,
+    pub trt_mul_eq: Identifier,
+    pub trt_mul: Identifier,
+    pub trt_div_eq: Identifier,
+    pub trt_div: Identifier,
+    pub trt_mod_eq: Identifier,
+    pub trt_mod: Identifier,
 }
 
 impl CoreIdentifiers {
@@ -194,6 +232,40 @@ impl CoreIdentifiers {
             b: ident_map.create_ident("b"),
             isize: ident_map.create_ident("isize"),
             usize: ident_map.create_ident("usize"),
+
+            trt_eq: ident_map.create_ident("eq"),
+            trt_ord: ident_map.create_ident("ord"),
+            trt_neq: ident_map.create_ident("neq"),
+            trt_gt: ident_map.create_ident("trt_gt"),
+            trt_gt_eq: ident_map.create_ident("trt_gt_eq"),
+            trt_lt: ident_map.create_ident("trt_lt"),
+            trt_lt_eq: ident_map.create_ident("trt_lt_eq"),
+
+            /// Arithmetic trait operators
+            trt_bit_or_eq: ident_map.create_ident("bit_or_eq"),
+            trt_bit_or: ident_map.create_ident("bit_or"),
+            trt_or: ident_map.create_ident("or"),
+            trt_bit_and_eq: ident_map.create_ident("bit_and_eq"),
+            trt_bit_and: ident_map.create_ident("bit_and"),
+            trt_and: ident_map.create_ident("and"),
+            trt_bit_xor_eq: ident_map.create_ident("bit_xor_eq"),
+            trt_bit_xor: ident_map.create_ident("bit_xor"),
+            trt_bit_exp_eq: ident_map.create_ident("bit_exp_eq"),
+            trt_bit_exp: ident_map.create_ident("bit_exp"),
+            trt_shr_eq: ident_map.create_ident("shr_eq"),
+            trt_shr: ident_map.create_ident("shr"),
+            trt_shl_eq: ident_map.create_ident("shl_eq"),
+            trt_shl: ident_map.create_ident("shl"),
+            trt_add_eq: ident_map.create_ident("add_eq"),
+            trt_add: ident_map.create_ident("add"),
+            trt_sub: ident_map.create_ident("sub"),
+            trt_sub_eq: ident_map.create_ident("sub_eq"),
+            trt_mul_eq: ident_map.create_ident("mul_eq"),
+            trt_mul: ident_map.create_ident("mul"),
+            trt_div_eq: ident_map.create_ident("div_eq"),
+            trt_div: ident_map.create_ident("div"),
+            trt_mod_eq: ident_map.create_ident("mod_eq"),
+            trt_mod: ident_map.create_ident("mod"),
         }
     }
 }

--- a/compiler/hash-typecheck/src/exhaustiveness/lower.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/lower.rs
@@ -8,7 +8,7 @@ use hash_types::{
     pats::{PatArgsId, PatId},
     terms::TermId,
     AccessPat, ConstPat, ConstructorPat, IfPat, Level0Term, Level1Term, ListPat, LitTerm, ModDef,
-    ModPat, NominalDef, Pat, PatArg, RangePat, ScopeKind, SpreadPat, StructFields, Term, TupleTy,
+    ModPat, NominalDef, Pat, PatArg, RangePat, SpreadPat, StructFields, Term, TupleTy,
 };
 use hash_utils::store::Store;
 use if_chain::if_chain;
@@ -79,7 +79,7 @@ impl<'tc> LowerPatOps<'tc> {
                         let ModDef { members, .. } = reader.get_mod_def(id);
                         self.scope_store().map_fast(members, |scope| {
                             // We should be in a constant scope
-                            assert!(scope.kind == ScopeKind::Constant);
+                            assert!(scope.kind.is_constant());
                             (
                                 members,
                                 scope

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -301,4 +301,10 @@ impl<'tc> ScopeManager<'tc> {
             err.map_or(Ok(()), Err)
         })
     }
+
+    /// Get the [ScopeKind] of the current [Scope]
+    pub fn current_scope_kind(&self) -> ScopeKind {
+        let id = self.scopes().current_scope();
+        self.scope_store().map_fast(id, |scope| scope.kind)
+    }
 }

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -3,8 +3,8 @@
 use hash_reporting::diagnostic::Diagnostics;
 use hash_source::identifier::Identifier;
 use hash_types::{
-    arguments::ArgsId, params::ParamsId, scope::ScopeId, terms::TermId, BoundVar, Member,
-    Mutability, ScopeKind, ScopeMember, ScopeVar,
+    arguments::ArgsId, location::LocationTarget, params::ParamsId, scope::ScopeId, terms::TermId,
+    BoundVar, Member, Mutability, ScopeKind, ScopeMember, ScopeVar,
 };
 use hash_utils::store::Store;
 use itertools::Itertools;
@@ -240,15 +240,35 @@ impl<'tc> ScopeManager<'tc> {
     /// This will unify the value with the index, decrement the
     /// `assignments_until_closed` counter for the member, and will panic if
     /// the counter is zero already.
-    pub fn assign_member(&self, scope_id: ScopeId, index: usize, value: TermId) -> TcResult<()> {
+    pub fn assign_member(
+        &self,
+        scope_id: ScopeId,
+        index: usize,
+        value: TermId,
+        site: impl Into<LocationTarget>,
+    ) -> TcResult<()> {
         let member = self.scope_store().map_fast(scope_id, |scope| scope.get_by_index(index));
 
         // Unify types:
         let rhs_ty = self.typer().infer_ty_of_term(value)?;
-        let _ = self.unifier().unify_terms(rhs_ty, member.ty())?;
+
+        let mut err = None;
+
+        if let Err(tc_err) = self.unifier().unify_terms(rhs_ty, member.ty()) {
+            err = Some(tc_err);
+        }
 
         self.scope_store().modify_fast(scope_id, |scope| {
             let member = scope.get_mut_by_index(index);
+            let member_name = member.name();
+
+            let mut append_err = |tc_err| {
+                if err.is_some() {
+                    self.diagnostics().add_error(tc_err);
+                } else {
+                    err = Some(tc_err);
+                }
+            };
 
             // @@Todo: add back once this is property implemented
             // if member.is_closed() {
@@ -257,20 +277,28 @@ impl<'tc> ScopeManager<'tc> {
             match member {
                 Member::Bound(_) | Member::SetBound(_) => {
                     // @@Todo: refine this error
-                    Err(TcError::InvalidAssignSubject { location: (scope_id, index).into() })
+                    append_err(TcError::InvalidAssignSubject { location: (scope_id, index).into() })
                 }
                 Member::Variable(variable) => {
-                    // Assign
-                    // @@Todo: check if mutable
-                    variable.value = value;
-                    Ok(())
+                    // Check that the member is declared as being mutable...
+                    if matches!(variable.mutability, Mutability::Immutable) {
+                        append_err(TcError::MemberIsImmutable {
+                            name: member_name,
+                            site: site.into(),
+                            decl: (scope_id, index),
+                        });
+                    } else {
+                        // Assign
+                        variable.value = value;
+                    }
                 }
                 Member::Constant(constant) => {
                     // @@Todo implement this properly
                     constant.set_value(value);
-                    Ok(())
                 }
-            }
+            };
+
+            err.map_or(Ok(()), Err)
         })
     }
 }

--- a/compiler/hash-typecheck/src/traverse/mod.rs
+++ b/compiler/hash-typecheck/src/traverse/mod.rs
@@ -4,6 +4,7 @@ use self::coerce::Coercing;
 use crate::storage::AccessToStorage;
 
 pub mod coerce;
+pub(crate) mod operators;
 pub mod params;
 pub mod scopes;
 pub mod visitor;

--- a/compiler/hash-typecheck/src/traverse/operators.rs
+++ b/compiler/hash-typecheck/src/traverse/operators.rs
@@ -1,0 +1,125 @@
+use hash_ast::ast::{AstNodeRef, BinOp, ParamOrigin};
+use hash_source::identifier::{Identifier, CORE_IDENTIFIERS};
+use hash_types::terms::TermId;
+
+use super::visitor::TcVisitor;
+use crate::{diagnostics::error::TcResult, ops::AccessToOps};
+
+impl<'tc> TcVisitor<'tc> {
+    /// Creates the basic type which is resultant from an [BinOp]. This
+    /// operation is required for primitive and non-primitive types.
+    pub(crate) fn create_operator_fn(
+        &self,
+        lhs: TermId,
+        rhs: TermId,
+        op: AstNodeRef<BinOp>,
+        assigning: bool,
+    ) -> TermId {
+        let bin_op = *op.body();
+        let trt_name = self.convert_bin_op_into_trt_name(bin_op, assigning);
+
+        let prop_access = self.builder().create_prop_access(lhs, trt_name);
+        self.copy_location_from_node_to_target(op, prop_access);
+
+        let builder = self.builder();
+        builder.create_fn_call_term(
+            prop_access,
+            builder.create_args([builder.create_nameless_arg(rhs)], ParamOrigin::Fn),
+        )
+    }
+
+    /// This creates the appropriate type for a lazy (short-circuiting) operator
+    /// such as the logical `and` and `or` operators. These [BinOp]s have
+    /// differing requirements in the way they are evaluated by those
+    /// functions, this is why `create_operator_fn` cannot be used for these
+    /// operators.
+    pub(crate) fn create_lazy_operator_fn(
+        &self,
+        lhs: TermId,
+        rhs: TermId,
+        op: BinOp,
+    ) -> TcResult<TermId> {
+        let trt_name = match op {
+            BinOp::And => "and",
+            BinOp::Or => "or",
+            // All other operators are not lazy and thus should not be used here...
+            _ => unreachable!(),
+        };
+
+        let lhs_ty = self.typer().infer_ty_of_term(lhs)?;
+        let rhs_ty = self.typer().infer_ty_of_term(rhs)?;
+
+        let builder = self.builder();
+
+        // () => lhs
+        let fn_ty = builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), lhs_ty);
+        let lhs = builder.create_fn_lit_term(fn_ty, lhs);
+
+        // () => rhs
+        let fn_ty = builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), rhs_ty);
+        let rhs = builder.create_fn_lit_term(fn_ty, rhs);
+
+        // (() => lhs).trait_name()
+        let prop_access = builder.create_prop_access(lhs, trt_name);
+
+        // (() => lhs).trait_name(() => rhs)
+        Ok(builder.create_fn_call_term(
+            prop_access,
+            builder.create_args([builder.create_nameless_arg(rhs)], ParamOrigin::Fn),
+        ))
+    }
+
+    /// Convert a [BinOp] into the appropriate trait name symbol. This function
+    /// also takes into account whether or not this operator is assigning. Some
+    /// [BinOp]s don't have assigning variants which means that  `assigning`
+    /// flag is ignored when it does not make a difference.
+    ///
+    /// ##Panics
+    ///
+    /// - If the passed [BinOp] has no trait name equivalent, these [BinOp]s are
+    /// either [BinOp::As] or [BinOp::Merge].
+    fn convert_bin_op_into_trt_name(&self, op: BinOp, assigning: bool) -> Identifier {
+        match (op, assigning) {
+            // Equality, ordering operators don't have assigning variants
+            // so no need to handle this case
+            (BinOp::EqEq, _) => CORE_IDENTIFIERS.trt_eq,
+            (BinOp::NotEq, _) => CORE_IDENTIFIERS.trt_neq,
+            (BinOp::Gt, _) => CORE_IDENTIFIERS.trt_gt,
+            (BinOp::GtEq, _) => CORE_IDENTIFIERS.trt_gt_eq,
+            (BinOp::Lt, _) => CORE_IDENTIFIERS.trt_lt,
+            (BinOp::LtEq, _) => CORE_IDENTIFIERS.trt_lt_eq,
+
+            // Lazy operators don't have assigning variants
+            (BinOp::Or, _) => CORE_IDENTIFIERS.trt_or,
+            (BinOp::And, _) => CORE_IDENTIFIERS.trt_and,
+
+            // Arithmetic operators
+            (BinOp::BitOr, true) => CORE_IDENTIFIERS.trt_bit_or_eq,
+            (BinOp::BitOr, false) => CORE_IDENTIFIERS.trt_bit_or,
+            (BinOp::BitAnd, true) => CORE_IDENTIFIERS.trt_bit_and_eq,
+            (BinOp::BitAnd, false) => CORE_IDENTIFIERS.trt_bit_and,
+            (BinOp::BitXor, true) => CORE_IDENTIFIERS.trt_bit_xor_eq,
+            (BinOp::BitXor, false) => CORE_IDENTIFIERS.trt_bit_xor,
+            (BinOp::Exp, true) => CORE_IDENTIFIERS.trt_bit_exp_eq,
+            (BinOp::Exp, false) => CORE_IDENTIFIERS.trt_bit_exp,
+            (BinOp::Shr, true) => CORE_IDENTIFIERS.trt_shr_eq,
+            (BinOp::Shr, false) => CORE_IDENTIFIERS.trt_shr,
+            (BinOp::Shl, true) => CORE_IDENTIFIERS.trt_shl_eq,
+            (BinOp::Shl, false) => CORE_IDENTIFIERS.trt_shl,
+            (BinOp::Add, true) => CORE_IDENTIFIERS.trt_add_eq,
+            (BinOp::Add, false) => CORE_IDENTIFIERS.trt_add,
+            (BinOp::Sub, true) => CORE_IDENTIFIERS.trt_sub,
+            (BinOp::Sub, false) => CORE_IDENTIFIERS.trt_sub_eq,
+            (BinOp::Mul, true) => CORE_IDENTIFIERS.trt_mul_eq,
+            (BinOp::Mul, false) => CORE_IDENTIFIERS.trt_mul,
+            (BinOp::Div, true) => CORE_IDENTIFIERS.trt_div_eq,
+            (BinOp::Div, false) => CORE_IDENTIFIERS.trt_div,
+            (BinOp::Mod, true) => CORE_IDENTIFIERS.trt_mod_eq,
+            (BinOp::Mod, false) => CORE_IDENTIFIERS.trt_mod,
+
+            // These should be dealt with before or completely erased at this
+            // point.
+            (BinOp::Merge | BinOp::As, _) => unreachable!(),
+        }
+    }
+}

--- a/compiler/hash-typecheck/src/traverse/scopes.rs
+++ b/compiler/hash-typecheck/src/traverse/scopes.rs
@@ -28,10 +28,10 @@ impl<'tc> TcVisitor<'tc> {
         ctx: &<Self as AstVisitor>::Ctx,
         members: impl Iterator<Item = ast::AstNodeRef<'m, ast::Expr>>,
         scope_to_use: Option<ScopeId>,
+        scope_kind: ScopeKind,
     ) -> TcResult<VisitConstantScope> {
         // Create a scope and enter it, for adding all the members:
-        let scope_id =
-            scope_to_use.unwrap_or_else(|| self.builder().create_scope(ScopeKind::Constant, []));
+        let scope_id = scope_to_use.unwrap_or_else(|| self.builder().create_scope(scope_kind, []));
 
         // Get the name of the scope from the surrounding declaration hint, if any.
         // This is only useful for mod/impl/trait blocks

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -1679,7 +1679,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
 
         // We want to create the type that represents this operation, and then
         // ensure that it typechecks...
-        let ty = self.create_operator_fn(member.ty(), rhs, node.operator.ast_ref(), true);
+        let ty = self.create_operator_fn(var_term, rhs, node.operator.ast_ref(), true);
         let _ = self.validate_and_register_simplified_term(node, ty)?;
 
         // Now check that the declared local item is declared as mutable

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -25,7 +25,7 @@ use hash_types::{
     storage::LocalStorage,
     terms::TermId,
     AccessOp, Arg, BindingPat, ConstPat, Field, Member, ModDefOrigin, Mutability, Param, Pat,
-    PatArg, RangePat, ScopeKind, SpreadPat, Sub, Visibility,
+    PatArg, RangePat, ScopeKind, ScopeMember, SpreadPat, Sub, Visibility,
 };
 use hash_utils::store::{PartialStore, Store};
 use itertools::Itertools;
@@ -1614,23 +1614,23 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::AssignExpr>,
     ) -> Result<Self::AssignExprRet, Self::Error> {
         let rhs = self.visit_expr(ctx, node.rhs.ast_ref())?;
+        let site: LocationTarget = self.source_location_at_node(node).into();
 
         // Try to resolve the variable in scopes; if it is not found, it is an error. If
         // it is found, then set it to its new term.
         let name = match node.lhs.kind() {
             ast::ExprKind::Variable(name) => name.name.ident,
             _ => {
-                return Err(TcError::InvalidAssignSubject {
-                    location: self.source_location_at_node(node).into(),
-                });
+                return Err(TcError::InvalidAssignSubject { location: site });
             }
         };
+
         let var_term = self.builder().create_var_term(name);
         self.copy_location_from_node_to_target(node, var_term);
-        let member = self.scope_manager().resolve_name_in_scopes(name, var_term)?;
+        let scope_item = self.scope_manager().resolve_name_in_scopes(name, var_term)?;
 
         // Set the value to the member:
-        self.scope_manager().assign_member(member.scope_id, member.index, rhs)?;
+        self.scope_manager().assign_member(scope_item.scope_id, scope_item.index, rhs, site)?;
 
         let term = self.builder().create_void_term();
         self.validate_and_register_simplified_term(node, term)
@@ -1640,10 +1640,48 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
 
     fn visit_assign_op_expr(
         &mut self,
-        _ctx: &Self::Ctx,
-        _node: hash_ast::ast::AstNodeRef<hash_ast::ast::AssignOpExpr>,
+        ctx: &Self::Ctx,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::AssignOpExpr>,
     ) -> Result<Self::AssignOpExprRet, Self::Error> {
-        todo!()
+        debug_assert!(node.operator.is_re_assignable());
+
+        let rhs = self.visit_expr(ctx, node.rhs.ast_ref())?;
+
+        let name = match node.lhs.kind() {
+            ast::ExprKind::Variable(name) => name.name.ident,
+            // @@Incomplete: what about tuples, or array indices?
+            _ => {
+                return Err(TcError::InvalidAssignSubject {
+                    location: self.source_location_at_node(node).into(),
+                });
+            }
+        };
+
+        let var_term = self.builder().create_var_term(name);
+        self.copy_location_from_node_to_target(node, var_term);
+
+        let ScopeMember { member, scope_id, index } =
+            self.scope_manager().resolve_name_in_scopes(name, var_term)?;
+
+        // We want to create the type that represents this operation, and then
+        // ensure that it typechecks...
+        let ty = self.create_operator_fn(member.ty(), rhs, node.operator.ast_ref(), true);
+        let _ = self.validate_and_register_simplified_term(node, ty)?;
+
+        // Now check that the declared local item is declared as mutable
+
+        let site: LocationTarget = self.source_location_at_node(node).into();
+
+        if matches!(member.mutability(), Mutability::Immutable) {
+            self.diagnostics().add_error(TcError::MemberIsImmutable {
+                name: member.name(),
+                site,
+                decl: (scope_id, index),
+            })
+        }
+
+        let term = self.builder().create_void_term();
+        self.validate_and_register_simplified_term(node, term)
     }
 
     type BinaryExprRet = TermId;
@@ -1655,65 +1693,12 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
     ) -> Result<Self::BinaryExprRet, Self::Error> {
         let walk::BinaryExpr { lhs, rhs, .. } = walk::walk_binary_expr(self, ctx, node)?;
 
-        let operator_fn = |trait_fn_name: &str| {
-            let prop_access = self.builder().create_prop_access(lhs, trait_fn_name);
-            self.copy_location_from_node_to_target(node.operator.ast_ref(), prop_access);
-
-            let builder = self.builder();
-            builder.create_fn_call_term(
-                prop_access,
-                builder.create_args([builder.create_nameless_arg(rhs)], ParamOrigin::Fn),
-            )
-        };
-
-        let lazy_operator_fn = |visitor: &mut Self, trait_name: &str| -> TcResult<TermId> {
-            let lhs_ty = visitor.typer().infer_ty_of_term(lhs)?;
-            let rhs_ty = visitor.typer().infer_ty_of_term(rhs)?;
-
-            let builder = visitor.builder();
-
-            // () => lhs
-            let fn_ty =
-                builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), lhs_ty);
-            let lhs = builder.create_fn_lit_term(fn_ty, lhs);
-
-            // () => rhs
-            let fn_ty =
-                builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), rhs_ty);
-            let rhs = builder.create_fn_lit_term(fn_ty, rhs);
-
-            // (() => lhs).trait_name()
-            let prop_access = builder.create_prop_access(lhs, trait_name);
-
-            // (() => lhs).trait_name(() => rhs)
-            Ok(builder.create_fn_call_term(
-                prop_access,
-                builder.create_args([builder.create_nameless_arg(rhs)], ParamOrigin::Fn),
-            ))
-        };
-
-        let term = match node.operator.body() {
-            BinOp::Merge => self.builder().create_merge_term([lhs, rhs]),
-            BinOp::As => unreachable!(),
-            BinOp::EqEq => operator_fn("eq"),
-            BinOp::NotEq => operator_fn("not_eq"),
-            BinOp::BitOr => operator_fn("bit_or"),
-            BinOp::Or => operator_fn("or"),
-            BinOp::BitAnd => operator_fn("bit_and"),
-            BinOp::And => operator_fn("and"),
-            BinOp::BitXor => operator_fn("bit_xor"),
-            BinOp::Exp => operator_fn("exp"),
-            BinOp::Shr => operator_fn("bit_shr"),
-            BinOp::Shl => operator_fn("bit_shl"),
-            BinOp::Add => operator_fn("add"),
-            BinOp::Sub => operator_fn("sub"),
-            BinOp::Mul => operator_fn("mul"),
-            BinOp::Div => operator_fn("div"),
-            BinOp::Mod => operator_fn("modulo"),
-            BinOp::Gt => lazy_operator_fn(self, "gt")?,
-            BinOp::GtEq => lazy_operator_fn(self, "gt_eq")?,
-            BinOp::Lt => lazy_operator_fn(self, "lt")?,
-            BinOp::LtEq => lazy_operator_fn(self, "lt_eq")?,
+        let term = if matches!(node.operator.body(), BinOp::Merge) {
+            self.builder().create_merge_term([lhs, rhs])
+        } else if node.operator.is_lazy() {
+            self.create_lazy_operator_fn(lhs, rhs, *node.operator.body())?
+        } else {
+            self.create_operator_fn(lhs, rhs, node.operator.ast_ref(), false)
         };
 
         self.validate_and_register_simplified_term(node, term)

--- a/compiler/hash-types/src/bootstrap.rs
+++ b/compiler/hash-types/src/bootstrap.rs
@@ -140,7 +140,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     let hash_trt = builder.create_trt_def(
         Some(CORE_IDENTIFIERS.Hash),
         builder.create_scope(
-            ScopeKind::Constant,
+            ScopeKind::Trait,
             [
                 Member::uninitialised_constant(
                     CORE_IDENTIFIERS.Self_i,
@@ -167,7 +167,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     let eq_trt = builder.create_trt_def(
         Some(CORE_IDENTIFIERS.Eq),
         builder.create_scope(
-            ScopeKind::Constant,
+            ScopeKind::Trait,
             [
                 Member::uninitialised_constant(
                     CORE_IDENTIFIERS.Self_i,
@@ -202,7 +202,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     let index_trt = builder.create_trt_def(
         Some(CORE_IDENTIFIERS.Index),
         builder.create_scope(
-            ScopeKind::Constant,
+            ScopeKind::Trait,
             [
                 Member::uninitialised_constant(
                     CORE_IDENTIFIERS.Self_i,
@@ -248,7 +248,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     let list_index_impl = builder.create_nameless_mod_def(
         ModDefOrigin::TrtImpl(index_trt_term),
         builder.create_scope(
-            ScopeKind::Constant,
+            ScopeKind::Impl,
             [
                 Member::open_constant(
                     CORE_IDENTIFIERS.Self_i,

--- a/compiler/hash-types/src/builder.rs
+++ b/compiler/hash-types/src/builder.rs
@@ -456,7 +456,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a trait definition with no name, and the given members.
     pub fn create_nameless_trt_def(&self, members: impl Iterator<Item = Member>) -> TrtDefId {
-        let members = self.create_scope(ScopeKind::Constant, members);
+        let members = self.create_scope(ScopeKind::Trait, members);
 
         self.gs.trt_def_store.create(TrtDef { name: None, members })
     }

--- a/compiler/hash-types/src/lib.rs
+++ b/compiler/hash-types/src/lib.rs
@@ -309,14 +309,20 @@ pub enum ScopeKind {
     /// - Block expression scope
     /// - Function parameter scope
     Variable,
-    /// A constant scope.
+
+    /// Module scope is a constant scope.
     ///
-    /// Can be:
+    /// Could be:
     /// - The root scope
     /// - Module block scope
-    /// - Trait block scope
-    /// - Impl block scope
-    Constant,
+    Mod,
+
+    /// An `impl` scope kind.
+    Impl,
+
+    /// A trait scope is a constant scope,
+    Trait,
+
     /// A bound scope.
     ///
     /// Can be:
@@ -327,6 +333,12 @@ pub enum ScopeKind {
     /// Can be:
     /// - Type function "argument" scope.
     SetBound,
+}
+
+impl ScopeKind {
+    pub fn is_constant(&self) -> bool {
+        matches!(self, ScopeKind::Mod | ScopeKind::Trait | ScopeKind::Impl)
+    }
 }
 
 /// Stores a list of members, indexed by the members' names.

--- a/compiler/hash-types/src/lib.rs
+++ b/compiler/hash-types/src/lib.rs
@@ -152,6 +152,14 @@ impl Member {
         }
     }
 
+    /// Get the mutability of the particular member, if any.
+    pub fn mutability(&self) -> Mutability {
+        match self {
+            Member::Variable(VariableMember { mutability, .. }) => *mutability,
+            _ => Mutability::Immutable,
+        }
+    }
+
     /// Get [LocationTarget]s referencing to the
     /// value of the declaration.
     pub fn location(&self) -> LocationTarget {

--- a/compiler/hash-types/src/storage.rs
+++ b/compiler/hash-types/src/storage.rs
@@ -77,7 +77,7 @@ impl GlobalStorage {
     /// Create a new, empty [GlobalStorage].
     pub fn new() -> Self {
         let scope_store = ScopeStore::new();
-        let root_scope = scope_store.create(Scope::empty(ScopeKind::Constant));
+        let root_scope = scope_store.create(Scope::empty(ScopeKind::Mod));
         let gs = Self {
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
@@ -121,7 +121,7 @@ impl LocalStorage {
                 // First the root scope
                 gs.root_scope,
                 // Then the scope for the source
-                gs.scope_store.create(Scope::empty(ScopeKind::Constant)),
+                gs.scope_store.create(Scope::empty(ScopeKind::Mod)),
             ]),
             id: Cell::new(id),
         }


### PR DESCRIPTION
- split `SkopeKind::Constant` into each specific variant of a constant scope kind. This is needed for checking the initialisation rules of declarations within constant scopes.
- verify that items cannot be declared as `mut` within constant blocks.
- verify that variables must be declared as `mut` for assign operations, and assigning operations with operators.
- closes #498 