### PR TITLE
lang: support type parameters on `{nominal:trait} defns, {impl:mod} blocks`

### DIFF
--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -727,8 +727,17 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::ModBlock>,
     ) -> Result<Self::ModBlockRet, Self::Error> {
-        let walk::ModBlock(inner) = walk::walk_mod_block(self, ctx, node)?;
-        Ok(TreeNode::branch("module", inner.children))
+        let walk::ModBlock { block, ty_params } = walk::walk_mod_block(self, ctx, node)?;
+
+        let children = {
+            if ty_params.is_empty() {
+                vec![block]
+            } else {
+                vec![TreeNode::branch("ty_params", ty_params), block]
+            }
+        };
+
+        Ok(TreeNode::branch("mod", children))
     }
 
     type ImplBlockRet = TreeNode;
@@ -737,8 +746,17 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::ImplBlock>,
     ) -> Result<Self::ImplBlockRet, Self::Error> {
-        let walk::ImplBlock(inner) = walk::walk_impl_block(self, ctx, node)?;
-        Ok(TreeNode::branch("impl", inner.children))
+        let walk::ImplBlock { block, ty_params } = walk::walk_impl_block(self, ctx, node)?;
+
+        let children = {
+            if ty_params.is_empty() {
+                vec![block]
+            } else {
+                vec![TreeNode::branch("ty_params", ty_params), block]
+            }
+        };
+
+        Ok(TreeNode::branch("impl", children))
     }
 
     type IfClauseRet = TreeNode;
@@ -963,11 +981,17 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::StructDef>,
     ) -> Result<Self::StructDefRet, Self::Error> {
-        let walk::StructDef { entries } = walk::walk_struct_def(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            "struct_def",
-            iter::once(TreeNode::branch("fields", entries)).collect(),
-        ))
+        let walk::StructDef { fields, ty_params } = walk::walk_struct_def(self, ctx, node)?;
+
+        let children = {
+            if ty_params.is_empty() {
+                vec![TreeNode::branch("fields", fields)]
+            } else {
+                vec![TreeNode::branch("ty_params", ty_params), TreeNode::branch("fields", fields)]
+            }
+        };
+
+        Ok(TreeNode::branch("struct_def", children))
     }
 
     type EnumDefEntryRet = TreeNode;
@@ -989,11 +1013,20 @@ impl AstVisitor for AstTreeGenerator {
         ctx: &Self::Ctx,
         node: ast::AstNodeRef<ast::EnumDef>,
     ) -> Result<Self::EnumDefRet, Self::Error> {
-        let walk::EnumDef { entries } = walk::walk_enum_def(self, ctx, node)?;
-        Ok(TreeNode::branch(
-            "enum_def",
-            iter::once(TreeNode::branch("variants", entries)).collect(),
-        ))
+        let walk::EnumDef { entries, ty_params } = walk::walk_enum_def(self, ctx, node)?;
+
+        let children = {
+            if ty_params.is_empty() {
+                vec![TreeNode::branch("variants", entries)]
+            } else {
+                vec![
+                    TreeNode::branch("ty_params", ty_params),
+                    TreeNode::branch("variants", entries),
+                ]
+            }
+        };
+
+        Ok(TreeNode::branch("enum_def", children))
     }
 
     type TraitDefRet = TreeNode;

--- a/compiler/hash-parser/src/diagnostics/error.rs
+++ b/compiler/hash-parser/src/diagnostics/error.rs
@@ -145,7 +145,7 @@ impl From<ParseError> for Report {
             ParseErrorKind::Block => "expected block body, which begins with a `{`".to_string(),
             ParseErrorKind::ReAssignmentOp => "expected a re-assignment operator".to_string(),
             ParseErrorKind::TypeDefinition(ty) => {
-                format!("expected {ty} definition entries here which begin with a `(`")
+                format!("expected {ty} definition entries here which begin with a `<` or `(`")
             }
             ParseErrorKind::ExpectedValueAfterTyAnnotation => {
                 "expected value assignment after type annotation within named tuple".to_string()

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -16,24 +16,28 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub fn parse_struct_def(&mut self) -> ParseResult<StructDef> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Struct)));
 
+        let ty_params = self.parse_optional_ty_params()?;
+
         let mut gen = self.parse_delim_tree(
             Delimiter::Paren,
             Some(ParseErrorKind::TypeDefinition(TyArgumentKind::Struct)),
         )?;
 
-        let entries = gen.parse_separated_fn(
+        let fields = gen.parse_separated_fn(
             |g| g.parse_nominal_def_param(ParamOrigin::Struct),
             |g| g.parse_token(TokenKind::Comma),
         );
         self.consume_gen(gen);
 
-        Ok(StructDef { fields: entries })
+        Ok(StructDef { ty_params, fields })
     }
 
     /// Parse an [EnumDef]. The keyword `enum` begins the construct and is
     /// followed by parentheses with inner enum fields defined.
     pub fn parse_enum_def(&mut self) -> ParseResult<EnumDef> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Enum)));
+
+        let ty_params = self.parse_optional_ty_params()?;
 
         let mut gen = self.parse_delim_tree(
             Delimiter::Paren,
@@ -44,7 +48,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             .parse_separated_fn(|g| g.parse_enum_def_entry(), |g| g.parse_token(TokenKind::Comma));
         self.consume_gen(gen);
 
-        Ok(EnumDef { entries })
+        Ok(EnumDef { ty_params, entries })
     }
 
     /// Parse an [EnumDefEntry].
@@ -114,42 +118,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// level on expressions such as struct, enum, function, and trait
     /// definitions.
     pub fn parse_ty_fn_def(&mut self) -> ParseResult<TyFnDef> {
-        let mut params = AstNodes::empty();
+        debug_assert!(self.current_token().has_kind(TokenKind::Lt));
 
-        // Flag denoting that we were able to parse the ending `>` within the function
-        // def arg
-        let mut arg_ending = false;
-
-        while let Some(param) = self.peek_resultant_fn_mut(|g| g.parse_ty_fn_def_param()) {
-            params.nodes.push(param);
-
-            match self.peek() {
-                Some(token) if token.has_kind(TokenKind::Comma) => {
-                    self.skip_token();
-                }
-                Some(token) if token.has_kind(TokenKind::Gt) => {
-                    self.skip_token();
-                    arg_ending = true;
-                    break;
-                }
-                token => self.err_with_location(
-                    ParseErrorKind::Expected,
-                    Some(TokenKindVector::from_vec(smallvec![TokenKind::Comma, TokenKind::Gt])),
-                    token.map(|t| t.kind),
-                    token.map_or_else(|| self.next_location(), |t| t.span),
-                )?,
-            }
-        }
-
-        // So if we failed to parse even a `>` we should report this...
-        if !arg_ending {
-            self.err_with_location(
-                ParseErrorKind::Expected,
-                Some(TokenKindVector::singleton(TokenKind::Gt)),
-                self.peek().map(|tok| tok.kind),
-                self.next_location(),
-            )?;
-        }
+        let params = self.parse_ty_params()?;
 
         // see if we need to add a return ty...
         let return_ty = match self.peek_resultant_fn(|g| g.parse_thin_arrow()) {
@@ -206,6 +177,64 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     pub fn parse_trait_def(&mut self) -> ParseResult<TraitDef> {
         debug_assert!(self.current_token().has_kind(TokenKind::Keyword(Keyword::Trait)));
 
-        Ok(TraitDef { members: self.parse_exprs_from_braces()? })
+        let ty_params = self.parse_optional_ty_params()?;
+
+        Ok(TraitDef { members: self.parse_exprs_from_braces()?, ty_params })
+    }
+
+    /// Parse optional type [Param]s, if the next token is not a
+    /// `<`, the function will return an empty [AstNodes<Param>].
+    #[inline]
+    pub(crate) fn parse_optional_ty_params(&mut self) -> ParseResult<AstNodes<Param>> {
+        match self.peek() {
+            Some(tok) if tok.has_kind(TokenKind::Lt) => {
+                self.skip_token();
+                self.parse_ty_params()
+            }
+            _ => Ok(AstNodes::new(vec![], None)),
+        }
+    }
+
+    /// Parse a collection of type [Param]s which can appear on nominal
+    /// definitions, and trait definitions.
+    fn parse_ty_params(&mut self) -> ParseResult<AstNodes<Param>> {
+        let mut params = AstNodes::empty();
+
+        // Flag denoting that we were able to parse the ending `>` within the function
+        // def arg
+        let mut param_ending = false;
+
+        while let Some(param) = self.peek_resultant_fn_mut(|g| g.parse_ty_fn_def_param()) {
+            params.nodes.push(param);
+
+            match self.peek() {
+                Some(token) if token.has_kind(TokenKind::Comma) => {
+                    self.skip_token();
+                }
+                Some(token) if token.has_kind(TokenKind::Gt) => {
+                    self.skip_token();
+                    param_ending = true;
+                    break;
+                }
+                token => self.err_with_location(
+                    ParseErrorKind::Expected,
+                    Some(TokenKindVector::from_vec(smallvec![TokenKind::Comma, TokenKind::Gt])),
+                    token.map(|t| t.kind),
+                    token.map_or_else(|| self.next_location(), |t| t.span),
+                )?,
+            }
+        }
+
+        // So if we failed to parse even a `>` we should report this...
+        if !param_ending {
+            self.err_with_location(
+                ParseErrorKind::Expected,
+                Some(TokenKindVector::singleton(TokenKind::Gt)),
+                self.peek().map(|tok| tok.kind),
+                self.next_location(),
+            )?;
+        }
+
+        Ok(params)
     }
 }

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -227,12 +227,18 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
         // So if we failed to parse even a `>` we should report this...
         if !param_ending {
-            self.err_with_location(
-                ParseErrorKind::Expected,
-                Some(TokenKindVector::singleton(TokenKind::Gt)),
-                self.peek().map(|tok| tok.kind),
-                self.next_location(),
-            )?;
+            // Here we encountered a trailing comma, so now we have to account for
+            // the `>` being after
+            if matches!(self.peek(), Some(tok) if tok.has_kind(TokenKind::Gt)) {
+                self.skip_token();
+            } else {
+                self.err_with_location(
+                    ParseErrorKind::Expected,
+                    Some(TokenKindVector::singleton(TokenKind::Gt)),
+                    self.peek().map(|tok| tok.kind),
+                    self.next_location(),
+                )?;
+            }
         }
 
         Ok(params)

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -100,8 +100,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         Ok(Some((has_semi, expr)))
     }
 
-    /// Function to eat a collection of trailing semi-colons and produce
-    /// a resultant [ExprKind::Empty].
+    /// Function to eat a collection of trailing semi-colons.
     pub(crate) fn eat_trailing_semis(&mut self) {
         let tok = self.current_token();
         debug_assert!(tok.has_kind(TokenKind::Semi));

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -207,14 +207,8 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     }
                     TokenKind::Keyword(Keyword::If) => self.parse_if_block()?,
                     TokenKind::Keyword(Keyword::Match) => self.parse_match_block()?,
-                    TokenKind::Keyword(Keyword::Mod) => {
-                        let block = self.parse_body_block()?;
-                        self.node_with_joined_span(Block::Mod(ModBlock(block)), start)
-                    }
-                    TokenKind::Keyword(Keyword::Impl) => {
-                        let block = self.parse_body_block()?;
-                        self.node_with_joined_span(Block::Impl(ImplBlock(block)), start)
-                    }
+                    TokenKind::Keyword(Keyword::Mod) => self.parse_mod_block()?,
+                    TokenKind::Keyword(Keyword::Impl) => self.parse_impl_block()?,
                     _ => unreachable!(),
                 };
 

--- a/compiler/hash-tree-def/src/definitions.rs
+++ b/compiler/hash-tree-def/src/definitions.rs
@@ -1,5 +1,5 @@
 //! Data types for storing the parsed tree definition given to the
-//! [`super::define_tree`] macro.
+//! [`super::define_tree!`] macro.
 
 use std::collections::HashMap;
 

--- a/compiler/hash-tree-def/src/lib.rs
+++ b/compiler/hash-tree-def/src/lib.rs
@@ -1,6 +1,6 @@
-//! This crate defines a macro [`define_tree`] that can be used to define a tree
-//! structure comprised of nodes. The macro will generate visitor and walker
-//! implementations for the given tree.
+//! This crate defines a macro [`define_tree!`] that can be used to define a
+//! tree structure comprised of nodes. The macro will generate visitor and
+//! walker implementations for the given tree.
 
 mod definitions;
 mod emitting;

--- a/compiler/hash-typecheck/src/ops/scope.rs
+++ b/compiler/hash-typecheck/src/ops/scope.rs
@@ -302,7 +302,7 @@ impl<'tc> ScopeManager<'tc> {
         })
     }
 
-    /// Get the [ScopeKind] of the current [Scope]
+    /// Get the [ScopeKind] of the current scope.
     pub fn current_scope_kind(&self) -> ScopeKind {
         let id = self.scopes().current_scope();
         self.scope_store().map_fast(id, |scope| scope.kind)

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -1300,7 +1300,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
     ) -> Result<Self::ModBlockRet, Self::Error> {
         // create a scope for the module definition
         let VisitConstantScope { scope_name, scope_id, .. } =
-            self.visit_constant_scope(ctx, node.0.members(), None, ScopeKind::Mod)?;
+            self.visit_constant_scope(ctx, node.block.members(), None, ScopeKind::Mod)?;
 
         // @@Todo: bound variables
         let mod_def = self.builder().create_mod_def(scope_name, ModDefOrigin::Mod, scope_id);
@@ -1323,7 +1323,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
     ) -> Result<Self::ImplBlockRet, Self::Error> {
         // create a scope for the module definition
         let VisitConstantScope { scope_name, scope_id, .. } =
-            self.visit_constant_scope(ctx, node.0.members(), None, ScopeKind::Impl)?;
+            self.visit_constant_scope(ctx, node.block.members(), None, ScopeKind::Impl)?;
 
         // @@Todo: bound variables
         let mod_def = self.builder().create_mod_def(scope_name, ModDefOrigin::AnonImpl, scope_id);
@@ -1778,10 +1778,10 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::StructDef>,
     ) -> Result<Self::StructDefRet, Self::Error> {
-        let walk::StructDef { entries } = walk::walk_struct_def(self, ctx, node)?;
+        let walk::StructDef { fields, .. } = walk::walk_struct_def(self, ctx, node)?;
 
         // create the params
-        let fields = self.builder().create_params(entries, ParamOrigin::Struct);
+        let fields = self.builder().create_params(fields, ParamOrigin::Struct);
 
         // add the location of each parameter
         self.copy_location_from_nodes_to_targets(node.fields.ast_ref_iter(), fields);
@@ -1839,7 +1839,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         ctx: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::EnumDef>,
     ) -> Result<Self::EnumDefRet, Self::Error> {
-        let walk::EnumDef { entries } = walk::walk_enum_def(self, ctx, node)?;
+        let walk::EnumDef { entries, .. } = walk::walk_enum_def(self, ctx, node)?;
 
         let builder = self.builder();
         let enum_variant_union = builder.create_union_term(

--- a/compiler/hash-types/src/lib.rs
+++ b/compiler/hash-types/src/lib.rs
@@ -93,7 +93,7 @@ pub struct VariableMember {
 
 /// A constant scope member.
 ///
-/// Should be part of a [ScopeKind::Constant] or [ScopeKind::Variable].
+/// Should be part of a constant [ScopeKind] or [ScopeKind::Variable].
 ///
 /// Has a flag as to whether the member is closed (can be substituted by its
 /// value -- think referential transparency).

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -713,7 +713,7 @@ impl AstVisitor for SemanticAnalyser<'_> {
         _: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ModBlock>,
     ) -> Result<Self::ModBlockRet, Self::Error> {
-        self.check_constant_body_block(&node.body().0, BlockOrigin::Mod);
+        self.check_constant_body_block(&node.body().block, BlockOrigin::Mod);
         Ok(())
     }
 
@@ -724,7 +724,7 @@ impl AstVisitor for SemanticAnalyser<'_> {
         _: &Self::Ctx,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::ImplBlock>,
     ) -> Result<Self::ImplBlockRet, Self::Error> {
-        self.check_constant_body_block(&node.body().0, BlockOrigin::Impl);
+        self.check_constant_body_block(&node.body().block, BlockOrigin::Impl);
         Ok(())
     }
 

--- a/tests/cases/parser/types/enum_with_ty_params.hash
+++ b/tests/cases/parser/types/enum_with_ty_params.hash
@@ -1,0 +1,31 @@
+// run=pass, stage=parse
+
+Foo := enum<T, U, Mux> (
+    One(
+        foo: U,
+        bar: T,
+        mu: Mux
+    )
+);
+
+T := enum<U,> (
+     Beep(T),
+     Name(T, char),
+     Traverse(T, str, u32, Vec<f32>),
+
+     // @@Todo: the syntax `T -> U` should be allowed
+     Transcend((T) -> U),
+);
+
+Foo := enum<T = i32, U, Mux: Hash ~ Eq> (
+    ContaintorOf(U), 
+    DetainorOf(T), 
+    MapOf(
+        items: { Mux: T }
+    )
+);
+
+Foo := enum<T = i32, K := Mux ~ Universe, U: Type, Mux: Hash ~ Eq> (
+    With(U), 
+    Or(T), 
+);

--- a/tests/cases/parser/types/incomplete_ty_params.hash
+++ b/tests/cases/parser/types/incomplete_ty_params.hash
@@ -1,0 +1,32 @@
+// run=fail, stage=parse
+
+{
+    T := struct<U, (
+        beep: T,
+    );
+};
+
+{
+    T := struct U,> (
+        beep: T,
+    );
+};
+
+{
+    T := enum <,> (
+        beep: T,
+    );
+};
+
+{
+    // @@Todo: make a warning
+    T := trait <> {
+        mux: () -> char;
+    };
+};
+
+{
+    T := trait < { // missing `>`
+        mux: () -> char;
+    };
+};

--- a/tests/cases/parser/types/incomplete_ty_params.stderr
+++ b/tests/cases/parser/types/incomplete_ty_params.stderr
@@ -1,0 +1,40 @@
+error: unexpectedly encountered a `(...)`
+ --> $DIR/incomplete_ty_params.hash:4:20
+2 |    
+3 |    {
+4 |        T := struct<U, (
+  |  _____________________-
+5 | |          beep: T,
+6 | |      );
+  | |_______- 
+7 |    };
+8 |    
+  = help: consider adding a `>`
+
+error: expected struct definition entries here which begin with a `<` or `(`, however received the identifier `U`
+  --> $DIR/incomplete_ty_params.hash:10:17
+ 9 |   {
+10 |       T := struct U,> (
+   |                   ^ 
+11 |           beep: T,
+   = help: consider adding a `(`
+
+error: unexpectedly encountered a `,`
+  --> $DIR/incomplete_ty_params.hash:16:16
+15 |   {
+16 |       T := enum <,> (
+   |                  ^ 
+17 |           beep: T,
+   = help: consider adding a `>`
+
+error: unexpectedly encountered a `{...}`
+  --> $DIR/incomplete_ty_params.hash:29:18
+27 |    
+28 |    {
+29 |        T := trait < { // missing `>`
+   |  ___________________-
+30 | |          mux: () -> char;
+31 | |      };
+   | |_______- 
+32 |    };
+   = help: consider adding a `>`

--- a/tests/cases/parser/types/struct_with_ty_params.hash
+++ b/tests/cases/parser/types/struct_with_ty_params.hash
@@ -1,0 +1,23 @@
+// run=pass, stage=parse
+
+Foo := struct<T, U, Mux> (
+    foo: U,
+    bar: T,
+    mu: Mux
+);
+
+T := struct<U,> (
+     beep: T,
+);
+
+Foo := struct<T = i32, U, Mux: Hash ~ Eq> (
+    U, 
+    T, 
+    { Mux: T }
+);
+
+Foo := struct<T = i32, K := Mux ~ Universe, U: Type, Mux: Hash ~ Eq> (
+    U, 
+    T, 
+    { Mux: T }
+);


### PR DESCRIPTION
This pr enables the parser to accept the newly introduced syntax on the following constructs:
- nominal definitions, such as `struct`, `struct<T> { field: T }`
- trait definitions,
- `impl` blocks
- `mod` blocks

Additionally, this patch fixes a bug with the `parse_ty_params` not accounting for the "trailing comma" edge case.

Furthermore, this patch brings some missing documentation and fixes the recently introduced broken documentation links.