### PR TITLE
pipeline: simplify pipeline settings and job parameter handling

### DIFF
--- a/compiler/hash-interactive/src/command.rs
+++ b/compiler/hash-interactive/src/command.rs
@@ -1,6 +1,5 @@
 //! Hash interactive mode commands.
 
-use hash_pipeline::settings::{CompilerJobParams, CompilerMode};
 use hash_reporting::errors::InteractiveCommandError;
 
 #[derive(Debug, Clone)]
@@ -17,19 +16,6 @@ pub enum InteractiveCommand<'i> {
     Version,
     /// A string representing a statement that will be executed
     Code(&'i str),
-}
-
-impl From<&InteractiveCommand<'_>> for CompilerJobParams {
-    fn from(command: &InteractiveCommand<'_>) -> Self {
-        // Here, we don't care about all of the other modes except `Type` and `Display`
-        // since these will either be pre-emptively handled by the REPL, or it will
-        // execute the full stage.
-        match command {
-            InteractiveCommand::Display(_) => CompilerJobParams::new(CompilerMode::Parse, true),
-            InteractiveCommand::Type(_) => CompilerJobParams::new(CompilerMode::Typecheck, true),
-            _ => CompilerJobParams::default(),
-        }
-    }
 }
 
 struct CommandDelegator<'i> {

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -6,7 +6,6 @@ use std::{env, process::exit};
 
 use command::InteractiveCommand;
 use hash_pipeline::{
-    settings::CompilerJobParams,
     sources::InteractiveBlock,
     traits::{Desugar, Lowering, Parser, SemanticPass, Tc, VirtualMachine},
     Compiler, CompilerState,
@@ -112,7 +111,7 @@ where
         }
         Ok(InteractiveCommand::Version) => print_version(),
         Ok(
-            ref inner @ (InteractiveCommand::Type(expr)
+            ref _inner @ (InteractiveCommand::Type(expr)
             | InteractiveCommand::Display(expr)
             | InteractiveCommand::Code(expr)),
         ) => {
@@ -121,15 +120,10 @@ where
                 .workspace
                 .add_interactive_block(expr.to_string(), InteractiveBlock::new());
 
-            // Compute the mode of the job based on provided arguments via the interactive
-            // command
-            let settings: CompilerJobParams = inner.into();
-
             // We don't want the old diagnostics
             // @@Refactor: we don't want to leak the diagnostics here..
             compiler_state.diagnostics.clear();
-            let new_state =
-                compiler.run(SourceId::Interactive(interactive_id), compiler_state, settings);
+            let new_state = compiler.run(SourceId::Interactive(interactive_id), compiler_state);
             return new_state;
         }
         Err(e) => CompilerError::from(e).report(),

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -53,7 +53,6 @@ impl<'c> Lowering<'c> for IrLowerer {
         _interactive_id: hash_source::InteractiveId,
         _workspace: &hash_pipeline::sources::Workspace,
         _state: &mut Self::State,
-        _job_params: &hash_pipeline::settings::CompilerJobParams,
     ) -> hash_pipeline::traits::CompilerResult<()> {
         Ok(())
     }
@@ -63,7 +62,6 @@ impl<'c> Lowering<'c> for IrLowerer {
         _module_id: hash_source::ModuleId,
         _workspace: &hash_pipeline::sources::Workspace,
         _state: &mut Self::State,
-        _job_params: &hash_pipeline::settings::CompilerJobParams,
     ) -> hash_pipeline::traits::CompilerResult<()> {
         // We need to iterate all of the modules and essentially perform
         // a discovery process for what needs to be lowered...

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -5,7 +5,7 @@
 use hash_reporting::report::Report;
 use hash_source::{InteractiveId, ModuleId, SourceId};
 
-use crate::{settings::CompilerJobParams, sources::Workspace};
+use crate::sources::Workspace;
 
 pub type CompilerResult<T> = Result<T, Vec<Report>>;
 
@@ -89,7 +89,6 @@ pub trait Tc<'c> {
         interactive_id: InteractiveId,
         workspace: &Workspace,
         state: &mut Self::State,
-        job_params: &CompilerJobParams,
     ) -> CompilerResult<()>;
 
     /// Given a [ModuleId], check the module. The function accepts the previous
@@ -99,7 +98,6 @@ pub trait Tc<'c> {
         module_id: ModuleId,
         workspace: &Workspace,
         state: &mut Self::State,
-        job_params: &CompilerJobParams,
     ) -> CompilerResult<()>;
 }
 
@@ -120,7 +118,6 @@ pub trait Lowering<'c> {
         interactive_id: InteractiveId,
         workspace: &Workspace,
         state: &mut Self::State,
-        job_params: &CompilerJobParams,
     ) -> CompilerResult<()>;
 
     /// Perform a IR lowering pass on a module specified by a [ModuleId]. The
@@ -130,7 +127,6 @@ pub trait Lowering<'c> {
         module_id: ModuleId,
         workspace: &Workspace,
         state: &mut Self::State,
-        job_params: &CompilerJobParams,
     ) -> CompilerResult<()>;
 }
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -94,7 +94,6 @@ impl Tc<'_> for TcImpl {
         id: hash_source::InteractiveId,
         workspace: &hash_pipeline::sources::Workspace,
         state: &mut Self::State,
-        _job_params: &hash_pipeline::settings::CompilerJobParams,
     ) -> CompilerResult<()> {
         // We need to set the interactive-id to update the current local-storage `id`
         // value
@@ -140,7 +139,6 @@ impl Tc<'_> for TcImpl {
         id: hash_source::ModuleId,
         sources: &hash_pipeline::sources::Workspace,
         state: &mut Self::State,
-        _job_params: &hash_pipeline::settings::CompilerJobParams,
     ) -> CompilerResult<()> {
         // Instantiate a visitor with the source and visit the source, using a new local
         // storage.

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -12,23 +12,7 @@ use crate::{
     stack::Stack,
 };
 
-/// Options specified to the Interpreter
-pub struct InterpreterOptions {
-    /// The stack size of the interpreter
-    stack_size: usize,
-}
-
-impl InterpreterOptions {
-    pub fn new(stack_size: usize) -> Self {
-        Self { stack_size }
-    }
-}
-
-impl Default for InterpreterOptions {
-    fn default() -> Self {
-        Self { stack_size: 10000 }
-    }
-}
+const DEFAULT_STACK_SIZE: usize = 10_000;
 
 /// Interpreter flags represent generated context from the current
 /// execution. This flags store information about the last executed
@@ -62,11 +46,17 @@ pub struct Interpreter {
     // stack heap: Heap,
 }
 
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Interpreter {
     #[must_use]
-    pub fn new(options: InterpreterOptions) -> Self {
+    pub fn new() -> Self {
         Self {
-            stack: Stack::new(options.stack_size),
+            stack: Stack::new(DEFAULT_STACK_SIZE),
             instructions: Vec::new(),
             registers: RegisterSet::default(),
             flags: InterpreterFlags::default(),

--- a/compiler/hash-vm/tests/vm.rs
+++ b/compiler/hash-vm/tests/vm.rs
@@ -1,9 +1,6 @@
 //! Hash Compiler VM tests.
 use hash_vm::{
-    bytecode::Instruction,
-    bytecode_builder::BytecodeBuilder,
-    register::Register,
-    vm::{Interpreter, InterpreterOptions},
+    bytecode::Instruction, bytecode_builder::BytecodeBuilder, register::Register, vm::Interpreter,
 };
 
 #[test]
@@ -15,7 +12,7 @@ fn push_two_and_add() {
 
     builder.add_instruction(Instruction::Add16 { l1, l2 });
 
-    let mut vm = Interpreter::new(InterpreterOptions::default());
+    let mut vm = Interpreter::new();
     vm.set_program(builder.into());
 
     // set registers l1 and l2 to appropriate values...


### PR DESCRIPTION
- VM: remove `InterpreterOptions` which are not currently needed.
- pipeline: remove `CompilerJobParams`, and propagate pipeline parameters via the pipeline settings.
- add `--dump-ast` for emitting the generated AST from the semantics/parser.