### PR TITLE
Collapse ExprKind AST node to Expr

### DIFF
--- a/compiler/hash-ast-desugaring/src/desugaring.rs
+++ b/compiler/hash-ast-desugaring/src/desugaring.rs
@@ -3,9 +3,9 @@
 use hash_ast::{
     ast::{
         AstNode, AstNodes, BindingPat, Block, BlockExpr, BodyBlock, BoolLit, BreakStatement,
-        ConstructorCallArg, ConstructorCallExpr, ConstructorPat, Expr, ExprKind, ForLoopBlock,
-        IfBlock, IfClause, IfPat, Lit, LitExpr, LitPat, LoopBlock, MatchBlock, MatchCase,
-        MatchOrigin, Name, Pat, TuplePatEntry, VariableExpr, WhileLoopBlock, WildPat,
+        ConstructorCallArg, ConstructorCallExpr, ConstructorPat, Expr, ForLoopBlock, IfBlock,
+        IfClause, IfPat, Lit, LitExpr, LitPat, LoopBlock, MatchBlock, MatchCase, MatchOrigin, Name,
+        Pat, TuplePatEntry, VariableExpr, WhileLoopBlock, WildPat,
     },
     ast_nodes,
 };
@@ -85,10 +85,7 @@ impl<'s> AstDesugaring<'s> {
             AstNode::new(
                 MatchCase {
                     pat,
-                    expr: AstNode::new(
-                        Expr::new(ExprKind::Block(BlockExpr { data: body })),
-                        body_span
-                    )
+                    expr: AstNode::new(Expr::Block(BlockExpr { data: body }), body_span)
                 },
                 pat_span
             ),
@@ -101,7 +98,7 @@ impl<'s> AstDesugaring<'s> {
                         },),
                         pat_span
                     ),
-                    expr: AstNode::new(Expr::new(ExprKind::Break(BreakStatement {})), body_span),
+                    expr: AstNode::new(Expr::Break(BreakStatement {}), body_span),
                 },
                 pat_span
             ),
@@ -112,18 +109,18 @@ impl<'s> AstDesugaring<'s> {
             contents: AstNode::new(
                 Block::Match(MatchBlock {
                     subject: AstNode::new(
-                        Expr::new(ExprKind::ConstructorCall(ConstructorCallExpr {
+                        Expr::ConstructorCall(ConstructorCallExpr {
                             subject: AstNode::new(
-                                Expr::new(ExprKind::Variable(VariableExpr {
+                                Expr::Variable(VariableExpr {
                                     name: AstNode::new(Name { ident: "next".into() }, iter_span),
-                                })),
+                                }),
                                 iter_span,
                             ),
                             args: ast_nodes![AstNode::new(
                                 ConstructorCallArg { name: None, value: iterator },
                                 iter_span
                             )],
-                        })),
+                        }),
                         body_span,
                     ),
                     cases: match_cases,
@@ -196,7 +193,7 @@ impl<'s> AstDesugaring<'s> {
                                     condition_span
                                 ),
                                 expr: AstNode::new(
-                                    Expr::new(ExprKind::Block(BlockExpr { data: body })),
+                                    Expr::Block(BlockExpr { data: body }),
                                     body_span
                                 ),
                             },
@@ -213,10 +210,7 @@ impl<'s> AstDesugaring<'s> {
                                     }),
                                     condition_span
                                 ),
-                                expr: AstNode::new(
-                                    Expr::new(ExprKind::Break(BreakStatement {})),
-                                    condition_span
-                                )
+                                expr: AstNode::new(Expr::Break(BreakStatement {}), condition_span)
                             },
                             condition_span
                         ),
@@ -265,7 +259,7 @@ impl<'s> AstDesugaring<'s> {
                     }),
                     branch_span,
                 ),
-                expr: AstNode::new(Expr::new(ExprKind::Block(BlockExpr { data: body })), body_span),
+                expr: AstNode::new(Expr::Block(BlockExpr { data: body }), body_span),
             },
             branch_span,
         )
@@ -366,10 +360,7 @@ impl<'s> AstDesugaring<'s> {
             AstNode::new(
                 MatchCase {
                     pat: AstNode::new(Pat::Wild(WildPat {}), else_block_span),
-                    expr: AstNode::new(
-                        Expr::new(ExprKind::Block(BlockExpr { data: block })),
-                        else_block_span,
-                    ),
+                    expr: AstNode::new(Expr::Block(BlockExpr { data: block }), else_block_span),
                 },
                 else_block_span,
             )
@@ -384,7 +375,7 @@ impl<'s> AstDesugaring<'s> {
                 MatchCase {
                     pat: AstNode::new(Pat::Wild(WildPat {}), parent_span),
                     expr: AstNode::new(
-                        Expr::new(ExprKind::Block(BlockExpr {
+                        Expr::Block(BlockExpr {
                             data: AstNode::new(
                                 Block::Body(BodyBlock {
                                     statements: AstNodes::empty(),
@@ -392,7 +383,7 @@ impl<'s> AstDesugaring<'s> {
                                 }),
                                 parent_span,
                             ),
-                        })),
+                        }),
                         parent_span,
                     ),
                 },
@@ -406,9 +397,9 @@ impl<'s> AstDesugaring<'s> {
 
         Block::Match(MatchBlock {
             subject: AstNode::new(
-                Expr::new(ExprKind::LitExpr(LitExpr {
+                Expr::LitExpr(LitExpr {
                     data: AstNode::new(Lit::Bool(BoolLit { data: true }), parent_span),
-                })),
+                }),
                 parent_span,
             ),
             cases: AstNodes::new(clauses, clauses_span),

--- a/compiler/hash-ast-desugaring/src/visitor.rs
+++ b/compiler/hash-ast-desugaring/src/visitor.rs
@@ -177,17 +177,7 @@ impl<'s> AstVisitorMut for AstDesugaring<'s> {
         &mut self,
         node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::Expr>,
     ) -> Result<Self::ExprRet, Self::Error> {
-        let _ = walk_mut::walk_expr(self, node);
-        Ok(())
-    }
-
-    type ExprKindRet = ();
-
-    fn visit_expr_kind(
-        &mut self,
-        node: hash_ast::ast::AstNodeRefMut<hash_ast::ast::ExprKind>,
-    ) -> Result<Self::ExprKindRet, Self::Error> {
-        walk_mut::walk_expr_kind_same_children(self, node)
+        walk_mut::walk_expr_same_children(self, node)
     }
 
     type VariableExprRet = ();

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -830,8 +830,8 @@ define_tree! {
         /// literal is constant in the minimal time possible.
         pub fn is_constant(&self) -> bool {
             let is_expr_lit_and_const = |expr: &AstNode<Expr>| -> bool {
-                match expr.kind() {
-                    ExprKind::LitExpr(LitExpr { data: lit }) => lit.is_constant(),
+                match expr.body() {
+                    Expr::LitExpr(LitExpr { data: lit }) => lit.is_constant(),
                     _ => false,
                 }
             };
@@ -1967,10 +1967,10 @@ define_tree! {
         pub index_expr: Child!(Expr),
     }
 
-    /// The kind of an expression.
+    /// An expression.
     #[derive(Debug, PartialEq, Clone)]
     #[node]
-    pub enum ExprKind {
+    pub enum Expr {
         /// A constructor call which could be a struct/enum initialisation or a
         /// function call e.g. `foo(5)`.
         ConstructorCall(ConstructorCallExpr),
@@ -2032,36 +2032,6 @@ define_tree! {
         BinaryExpr(BinaryExpr),
         /// Unary Expression composed of a unary operator and an expression
         UnaryExpr(UnaryExpr),
-    }
-
-    /// An expression.
-    #[derive(Debug, PartialEq, Clone)]
-    #[node]
-    pub struct Expr {
-        /// The kind of the expression
-        pub kind: ExprKind,
-    }
-
-    impl Expr {
-        /// Create a new [Expr] with a specific [ExprKind].
-        pub fn new(kind: ExprKind) -> Self {
-            Self { kind }
-        }
-
-        /// Convert the [Expr] into an [ExprKind]
-        pub fn into_kind(self) -> ExprKind {
-            self.kind
-        }
-
-        /// Get the [ExprKind] of the expression
-        pub fn kind(&self) -> &ExprKind {
-            &self.kind
-        }
-
-        /// Get the [ExprKind] of the expression
-        pub fn kind_mut(&mut self) -> &mut ExprKind {
-            &mut self.kind
-        }
     }
 
     /// A module.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -156,7 +156,7 @@ impl AstVisitor for AstTreeGenerator {
 
     type ExprRet = TreeNode;
     fn visit_expr(&self, node: ast::AstNodeRef<ast::Expr>) -> Result<Self::ExprRet, Self::Error> {
-        Ok(walk::walk_expr(self, node)?.kind)
+        walk::walk_expr_same_children(self, node)
     }
 
     type VariableExprRet = TreeNode;
@@ -1151,13 +1151,5 @@ impl AstVisitor for AstTreeGenerator {
     ) -> Result<Self::ModuleRet, Self::Error> {
         let walk::Module { contents } = walk::walk_module(self, node)?;
         Ok(TreeNode::branch("module", contents))
-    }
-
-    type ExprKindRet = TreeNode;
-    fn visit_expr_kind(
-        &self,
-        node: ast::AstNodeRef<ast::ExprKind>,
-    ) -> Result<Self::ExprKindRet, Self::Error> {
-        walk::walk_expr_kind_same_children(self, node)
     }
 }

--- a/compiler/hash-parser/src/diagnostics/warning.rs
+++ b/compiler/hash-parser/src/diagnostics/warning.rs
@@ -4,7 +4,7 @@
 use std::fmt::Display;
 
 use derive_more::Constructor;
-use hash_ast::ast::ExprKind;
+use hash_ast::ast::Expr;
 use hash_reporting::{
     builder::ReportBuilder,
     report::{Report, ReportCodeBlock, ReportElement, ReportKind},
@@ -40,11 +40,11 @@ pub enum SubjectKind {
     Expr,
 }
 
-impl From<&ExprKind> for SubjectKind {
-    fn from(kind: &ExprKind) -> Self {
+impl From<&Expr> for SubjectKind {
+    fn from(kind: &Expr) -> Self {
         match kind {
-            ExprKind::LitExpr(_) => SubjectKind::Lit,
-            ExprKind::Block(_) => SubjectKind::Block,
+            Expr::LitExpr(_) => SubjectKind::Lit,
+            Expr::Block(_) => SubjectKind::Block,
             _ => SubjectKind::Expr,
         }
     }

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -166,7 +166,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 ty,
                 default: default.map(|node| {
                     let span = node.span();
-                    self.node_with_span(Expr::new(ExprKind::Ty(TyExpr { ty: node })), span)
+                    self.node_with_span(Expr::Ty(TyExpr { ty: node }), span)
                 }),
                 origin: ParamOrigin::TyFn,
             },

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -228,9 +228,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
 
         Ok(gen.node_with_span(
-            Expr::new(ExprKind::LitExpr(LitExpr {
+            Expr::LitExpr(LitExpr {
                 data: gen.node_with_span(Lit::List(ListLit { elements }), span),
-            })),
+            }),
             span,
         ))
     }

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -154,7 +154,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
                     Ty::TyFnCall(TyFnCall {
                         subject: self.node_with_joined_span(
-                            Expr::new(ExprKind::Ty(TyExpr { ty: self.node_with_joined_span(ty, span) })),
+                            Expr::Ty(TyExpr { ty: self.node_with_joined_span(ty, span) }),
                             span,
                         ),
                         args: self.parse_ty_args(true)?,
@@ -356,7 +356,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     ty,
                     default: default.map(|node| {
                         let span = node.span();
-                        self.node_with_span(Expr::new(ExprKind::Ty(TyExpr { ty: node })), span)
+                        self.node_with_span(Expr::Ty(TyExpr { ty: node }), span)
                     }),
                     origin: ParamOrigin::TyFn,
                 },

--- a/compiler/hash-typecheck/src/traverse/coerce.rs
+++ b/compiler/hash-typecheck/src/traverse/coerce.rs
@@ -28,7 +28,7 @@ impl<'tc> Coercing<'tc> {
     pub fn potentially_coerce_as_value(
         &self,
         term_id: TermId,
-        originating_node: AstNodeRef<ast::ExprKind>,
+        originating_node: AstNodeRef<ast::Expr>,
     ) -> TermId {
         self.coerce_as_value(term_id, originating_node).unwrap_or(term_id)
     }
@@ -40,7 +40,7 @@ impl<'tc> Coercing<'tc> {
     pub fn coerce_as_value(
         &self,
         term_id: TermId,
-        originating_node: AstNodeRef<ast::ExprKind>,
+        originating_node: AstNodeRef<ast::Expr>,
     ) -> Option<TermId> {
         // @@Future: Currently the only purpose of this function is to coerce
         // unit types into unit values, but in the future it can be used to wrap
@@ -49,7 +49,7 @@ impl<'tc> Coercing<'tc> {
         if let (Some(nominal_def_id), true) =
             (self.oracle().term_as_nominal_def_id(term_id), self.oracle().term_is_unit_def(term_id))
         {
-            if let ast::ExprKind::Cast(_) = originating_node.body() {
+            if let ast::Expr::Cast(_) = originating_node.body() {
                 // We don't want to do this if the unit expression is directly cast as a type
                 None
             } else {

--- a/compiler/hash-untyped-semantics/src/analysis/block.rs
+++ b/compiler/hash-untyped-semantics/src/analysis/block.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashSet, mem};
 
 use hash_ast::{
-    ast::{AstNodeRef, BodyBlock, Expr, ExprKind},
+    ast::{AstNodeRef, BodyBlock, Expr},
     visitor::AstVisitorMutSelf,
 };
 
@@ -29,8 +29,7 @@ impl SemanticAnalyser<'_> {
         let mut error_indices = HashSet::new();
 
         for (index, statement) in members.enumerate() {
-            if !matches!(statement.kind(), ExprKind::Declaration(_) | ExprKind::MergeDeclaration(_))
-            {
+            if !matches!(statement.body(), Expr::Declaration(_) | Expr::MergeDeclaration(_)) {
                 self.append_error(
                     AnalysisErrorKind::NonDeclarativeExpression { origin },
                     statement,

--- a/compiler/hash-untyped-semantics/src/diagnostics/directives.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/directives.rs
@@ -3,15 +3,15 @@
 
 use std::fmt::Display;
 
-use hash_ast::ast::{Block, BlockExpr, ExprKind};
+use hash_ast::ast::{Block, BlockExpr, Expr};
 
-/// [DirectiveArgument] is a mapping between [ExprKind] to a simplified
+/// [DirectiveArgument] is a mapping between [Expr] to a simplified
 /// version for reporting on if a directive received the 'wrong' kind of
-/// argument. Some variants of [ExprKind] are collapsed into the general
+/// argument. Some variants of [Expr] are collapsed into the general
 /// [DirectiveArgument::Expr] because it is irrelevant from the context of
 /// directive what the expression is.
 ///
-/// Additionally, some of the inner variants of [ExprKind::Block] are
+/// Additionally, some of the inner variants of [Expr::Block] are
 /// expanded into the [DirectiveArgument] variants as their own standalone
 /// variants.
 pub enum DirectiveArgument {
@@ -49,34 +49,34 @@ pub enum DirectiveArgument {
     Expr,
 }
 
-impl From<&ExprKind> for DirectiveArgument {
-    fn from(expr: &ExprKind) -> Self {
+impl From<&Expr> for DirectiveArgument {
+    fn from(expr: &Expr) -> Self {
         match expr {
-            ExprKind::ConstructorCall(_) => DirectiveArgument::ConstructorCall,
-            ExprKind::Directive(_) => DirectiveArgument::Directive,
-            ExprKind::Declaration(_) => DirectiveArgument::Declaration,
-            ExprKind::Unsafe(_) => DirectiveArgument::Unsafe,
-            ExprKind::LitExpr(_) => DirectiveArgument::LitExpr,
-            ExprKind::Cast(_) => DirectiveArgument::Cast,
-            ExprKind::Block(BlockExpr { data: block }) => match block.body() {
+            Expr::ConstructorCall(_) => DirectiveArgument::ConstructorCall,
+            Expr::Directive(_) => DirectiveArgument::Directive,
+            Expr::Declaration(_) => DirectiveArgument::Declaration,
+            Expr::Unsafe(_) => DirectiveArgument::Unsafe,
+            Expr::LitExpr(_) => DirectiveArgument::LitExpr,
+            Expr::Cast(_) => DirectiveArgument::Cast,
+            Expr::Block(BlockExpr { data: block }) => match block.body() {
                 Block::Loop(_) | Block::While(_) | Block::For(_) => DirectiveArgument::Loop,
                 Block::Match(_) | Block::If(_) => DirectiveArgument::Match,
                 Block::Mod(_) => DirectiveArgument::ModBlock,
                 Block::Body(_) => DirectiveArgument::Block,
                 Block::Impl(_) => DirectiveArgument::ImplBlock,
             },
-            ExprKind::Import(_) => DirectiveArgument::Import,
-            ExprKind::StructDef(_) => DirectiveArgument::StructDef,
-            ExprKind::EnumDef(_) => DirectiveArgument::EnumDef,
-            ExprKind::TyFnDef(_) => DirectiveArgument::TyFnDef,
-            ExprKind::TraitDef(_) => DirectiveArgument::TraitDef,
-            ExprKind::FnDef(_) => DirectiveArgument::FnDef,
-            ExprKind::Ty(_) => DirectiveArgument::Ty,
-            ExprKind::Return(_) => DirectiveArgument::Return,
-            ExprKind::Break(_) => DirectiveArgument::Break,
-            ExprKind::Continue(_) => DirectiveArgument::Continue,
-            ExprKind::MergeDeclaration(_) => DirectiveArgument::MergeDeclaration,
-            ExprKind::TraitImpl(_) => DirectiveArgument::TraitImpl,
+            Expr::Import(_) => DirectiveArgument::Import,
+            Expr::StructDef(_) => DirectiveArgument::StructDef,
+            Expr::EnumDef(_) => DirectiveArgument::EnumDef,
+            Expr::TyFnDef(_) => DirectiveArgument::TyFnDef,
+            Expr::TraitDef(_) => DirectiveArgument::TraitDef,
+            Expr::FnDef(_) => DirectiveArgument::FnDef,
+            Expr::Ty(_) => DirectiveArgument::Ty,
+            Expr::Return(_) => DirectiveArgument::Return,
+            Expr::Break(_) => DirectiveArgument::Break,
+            Expr::Continue(_) => DirectiveArgument::Continue,
+            Expr::MergeDeclaration(_) => DirectiveArgument::MergeDeclaration,
+            Expr::TraitImpl(_) => DirectiveArgument::TraitImpl,
             _ => DirectiveArgument::Expr,
         }
     }


### PR DESCRIPTION
This is since Expr only contains an ExprKind field.