### PR TITLE
parser: remove `;` requirement after expressions

### DIFF
--- a/compiler/hash-parser/src/parser/mod.rs
+++ b/compiler/hash-parser/src/parser/mod.rs
@@ -306,18 +306,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         )
     }
 
-    /// Create an error at the current location and push it into the
-    /// diagnostics.
-    pub(crate) fn emit_err(
-        &mut self,
-        kind: ParseErrorKind,
-        expected: Option<TokenKindVector>,
-        received: Option<TokenKind>,
-    ) {
-        let err = self.make_err(kind, expected, received, None);
-        self.add_error(err);
-    }
-
     /// Create an error at the current location.
     pub(crate) fn err<T>(
         &self,
@@ -536,7 +524,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         let mut contents = vec![];
 
         while self.has_token() {
-            match self.parse_top_level_expr(true) {
+            match self.parse_top_level_expr() {
                 Ok(Some((_, expr))) => contents.push(expr),
                 Ok(_) => continue,
                 Err(err) => {

--- a/tests/cases/parser/literals/dangling_parenthesis.stderr
+++ b/tests/cases/parser/literals/dangling_parenthesis.stderr
@@ -1,6 +1,5 @@
-error: unexpectedly encountered a `)`
+error: expected an expression, however received a `)`
  --> $DIR/dangling_parenthesis.hash:3:17
 2 |   
 3 |   k := (a) + ((b)));
   |                   ^ 
-  = help: consider adding a `;`

--- a/tests/cases/parser/misc/malformed_access_name.hash
+++ b/tests/cases/parser/misc/malformed_access_name.hash
@@ -1,9 +1,0 @@
-// run=fail, stage=parse
-
-// Explanation:
-//
-// Here we fail because the declared pattern is `a::b` followed by a `:` denoting 
-// a type signature and then the type `c` which then encounters the parenthesis 
-// which is erronous.
-
-a::b:c()

--- a/tests/cases/parser/misc/malformed_access_name.stderr
+++ b/tests/cases/parser/misc/malformed_access_name.stderr
@@ -1,6 +1,0 @@
-error: unexpectedly encountered a `(...)`
- --> $DIR/malformed_access_name.hash:9:7
-8 |   
-9 |   a::b:c()
-  |         ^^ 
-  = help: consider adding a `;`

--- a/tests/cases/parser/misc/malformed_function_literal_arrow.stderr
+++ b/tests/cases/parser/misc/malformed_function_literal_arrow.stderr
@@ -1,6 +1,5 @@
-error: unexpectedly encountered a `=`
+error: expected an expression, however received a `=`
  --> $DIR/malformed_function_literal_arrow.hash:3:36
 2 |   
 3 |   str_eq: (str, str) -> str = (a, b) = a == b;
   |                                      ^ 
-  = help: consider adding a `;`

--- a/tests/cases/parser/types/malformed_function_type.stderr
+++ b/tests/cases/parser/types/malformed_function_type.stderr
@@ -1,6 +1,5 @@
-error: unexpectedly encountered a `>`
+error: expected an expression, however received a `>`
  --> $DIR/malformed_function_type.hash:3:20
 2 |   
 3 |   str_eq: (str, str) > str;
   |                      ^ 
-  = help: consider adding a `;`

--- a/tests/cases/parser/types/unclose_type_args.stderr
+++ b/tests/cases/parser/types/unclose_type_args.stderr
@@ -1,6 +1,5 @@
-error: expected an operator, however received a `:`
+error: expected an expression, however received a `:`
  --> $DIR/unclose_type_args.hash:3:5
 2 |   
 3 |   k<t := do_something();
   |       ^ 
-  = help: consider adding either `.`, `=`, or `;`


### PR DESCRIPTION
This patch removes the requirement for all expressions to have a `;` semi-colon present to signify the end of the expression. However, this does not mean that the parser does not support the semi-colon anymore. 

The semi-colon is still present and handled by the parser in order to terminate expressions. It is unclear if it should be removed entirely later, but it will be supported until there is some way to disambiguate unary operators and binary expressions.