### PR TITLE
pipeline: use general `CompilerStage` for representing compiler stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "hash-source",
  "hash-types",
  "index_vec",
+ "rayon",
 ]
 
 [[package]]
@@ -601,6 +602,7 @@ dependencies = [
  "itertools",
  "log",
  "num-bigint",
+ "rayon",
  "slotmap",
  "smallvec",
 ]
@@ -646,7 +648,9 @@ dependencies = [
  "hash-ast",
  "hash-pipeline",
  "hash-reporting",
+ "hash-source",
  "hash-utils",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "hash-ast",
  "hash-reporting",
  "hash-source",
+ "hash-types",
  "hash-utils",
  "log",
  "num_cpus",

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -3,10 +3,8 @@
 //! that later stages can work on it without having to operate on similar
 //! constructs and duplicating logic.
 
-use std::collections::HashSet;
-
 use hash_ast::{ast::OwnsAstNode, visitor::AstVisitorMut};
-use hash_pipeline::{sources::Workspace, traits::Desugar, CompilerResult};
+use hash_pipeline::{sources::Workspace, traits::Desugar};
 use hash_source::SourceId;
 use visitor::AstDesugaring;
 
@@ -16,12 +14,6 @@ mod visitor;
 pub struct AstDesugarer;
 
 impl<'pool> Desugar<'pool> for AstDesugarer {
-    type State = HashSet<SourceId>;
-
-    fn make_state(&mut self) -> CompilerResult<Self::State> {
-        Ok(HashSet::default())
-    }
-
     /// This function is used to lower all of the AST that is present within
     /// the modules to be compatible with the typechecking stage. This is
     /// essentially a pass that will transform the following structures
@@ -47,15 +39,16 @@ impl<'pool> Desugar<'pool> for AstDesugarer {
         &mut self,
         entry_point: SourceId,
         workspace: &mut Workspace,
-        state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> hash_pipeline::traits::CompilerResult<()> {
+        let desugared_modules = &mut workspace.desugared_modules;
+        let node_map = &mut workspace.node_map;
+
         pool.scope(|scope| {
             let source_map = &workspace.source_map;
-            let node_map = &mut workspace.node_map;
 
             // De-sugar the target if it isn't already de-sugared
-            if !state.contains(&entry_point) {
+            if !desugared_modules.contains(&entry_point) {
                 if let SourceId::Interactive(id) = entry_point {
                     let source = node_map.get_interactive_block_mut(id);
                     let mut desugarer = AstDesugaring::new(source_map, entry_point);
@@ -68,7 +61,7 @@ impl<'pool> Desugar<'pool> for AstDesugarer {
             // to the queue so it can be distributed over the threads
             for (id, module) in node_map.iter_mut_modules() {
                 // Skip any modules that have already been de-sugared
-                if state.contains(&SourceId::Module(*id)) {
+                if desugared_modules.contains(&SourceId::Module(*id)) {
                     continue;
                 }
 
@@ -90,8 +83,8 @@ impl<'pool> Desugar<'pool> for AstDesugarer {
         });
 
         // Add all of the ids into the cache
-        state.insert(entry_point);
-        state.extend(workspace.node_map().iter_modules().map(|(id, _)| SourceId::Module(*id)));
+        desugared_modules.insert(entry_point);
+        desugared_modules.extend(node_map.iter_modules().map(|(id, _)| SourceId::Module(*id)));
 
         Ok(())
     }

--- a/compiler/hash-ast-expand/Cargo.toml
+++ b/compiler/hash-ast-expand/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hash-ast-expand"
+version = "0.1.0"
+authors = ["The Hash Language authors"]
+edition = "2021"
+
+[dependencies]
+rayon = "1.5.0"
+
+hash-ast = {path = "../hash-ast" }
+hash-source = { path = "../hash-source" }
+hash-reporting = {path = "../hash-reporting" }
+hash-pipeline = { path = "../hash-pipeline" }
+hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -1,0 +1,64 @@
+//! Hash AST expanding passes crate. This crate holds an implementation for the
+//! visitor pattern on the AST in order to expand any directives or macros that need
+//! to run after the parsing stage. Currently this function does not have 
+
+use hash_ast::ast::{AstVisitor, OwnsAstNode};
+use hash_pipeline::{settings::CompilerStageKind, sources::Workspace, traits::CompilerStage};
+use hash_source::SourceId;
+use visitor::AstExpander;
+
+mod visitor;
+
+pub struct AstExpansionStage;
+
+impl<'pool> CompilerStage<'pool> for AstExpansionStage {
+    fn stage_kind(&self) -> CompilerStageKind {
+        CompilerStageKind::DeSugar
+    }
+
+    fn run_stage(
+        &mut self,
+        entry_point: SourceId,
+        workspace: &mut Workspace,
+        _: &'pool rayon::ThreadPool,
+    ) -> hash_pipeline::traits::CompilerResult<()> {
+        let desugared_modules = &mut workspace.desugared_modules;
+        let node_map = &mut workspace.node_map;
+
+        // De-sugar the target if it isn't already de-sugared
+        if !desugared_modules.contains(&entry_point) {
+            if let SourceId::Interactive(id) = entry_point {
+                let expander = AstExpander::new(&workspace.source_map, entry_point);
+                let source = node_map.get_interactive_block(id);
+
+                expander.visit_body_block(source.node_ref()).unwrap();
+            }
+        }
+
+
+        for (id, module) in node_map.iter_modules() {
+            let module_id = SourceId::Module(*id);
+            
+            // Skip any modules that have already been de-sugared
+            if desugared_modules.contains(&module_id) {
+                continue;
+            }
+
+            let expander = AstExpander::new(&workspace.source_map, module_id);
+            expander.visit_module(module.node_ref()).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn cleanup(
+        &self,
+        entry_point: SourceId,
+        workspace: &mut Workspace,
+        settings: &hash_pipeline::settings::CompilerSettings,
+    ) {
+        if settings.stage > CompilerStageKind::Parse && settings.dump_ast {
+            workspace.print_sources(entry_point);
+        }
+    }
+}

--- a/compiler/hash-ast-expand/src/visitor.rs
+++ b/compiler/hash-ast-expand/src/visitor.rs
@@ -1,0 +1,937 @@
+use std::convert::Infallible;
+
+use hash_ast::{visitor::{walk, AstVisitor}, tree::AstTreeGenerator};
+use hash_source::{identifier::IDENTS, SourceMap, SourceId, location::{SourceLocation, Span}};
+use hash_utils::tree_writing::TreeWriter;
+
+#[derive(Debug)]
+pub struct AstExpander<'s> {
+    /// The map of the current workspace sources.
+    pub(crate) source_map: &'s SourceMap,
+    /// The `id` of the module that is currently being checked
+    source_id: SourceId,
+}
+
+impl<'s> AstExpander<'s> {
+    /// Create a new [AstDesugaring]. Contains the [SourceMap] and the
+    /// current id of the source in reference.
+    pub fn new(source_map: &'s SourceMap, source_id: SourceId) -> Self {
+        Self { source_map, source_id }
+    }
+
+    /// Create a [SourceLocation] from a [Span]
+    pub(crate) fn source_location(&self, span: Span) -> SourceLocation {
+        SourceLocation { span, id: self.source_id }
+    }
+}
+
+impl<'s> AstVisitor for AstExpander<'s> {
+    type Error = Infallible;
+    type NameRet = ();
+
+    fn visit_name(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Name>,
+    ) -> Result<Self::NameRet, Self::Error> {
+        Ok(())
+    }
+
+    type LitRet = ();
+
+    fn visit_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Lit>,
+    ) -> Result<Self::LitRet, Self::Error> {
+        Ok(())
+    }
+
+    type MapLitRet = ();
+
+    fn visit_map_lit(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MapLit>,
+    ) -> Result<Self::MapLitRet, Self::Error> {
+        let _ = walk::walk_map_lit(self, node);
+        Ok(())
+    }
+
+    type MapLitEntryRet = ();
+
+    fn visit_map_lit_entry(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MapLitEntry>,
+    ) -> Result<Self::MapLitEntryRet, Self::Error> {
+        let _ = walk::walk_map_lit_entry(self, node);
+        Ok(())
+    }
+
+    type ListLitRet = ();
+
+    fn visit_list_lit(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ListLit>,
+    ) -> Result<Self::ListLitRet, Self::Error> {
+        let _ = walk::walk_list_lit(self, node);
+        Ok(())
+    }
+
+    type SetLitRet = ();
+
+    fn visit_set_lit(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::SetLit>,
+    ) -> Result<Self::SetLitRet, Self::Error> {
+        let _ = walk::walk_set_lit(self, node);
+        Ok(())
+    }
+
+    type TupleLitEntryRet = ();
+
+    fn visit_tuple_lit_entry(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::TupleLitEntry>,
+    ) -> Result<Self::TupleLitEntryRet, Self::Error> {
+        let _ = walk::walk_tuple_lit_entry(self, node);
+        Ok(())
+    }
+
+    type TupleLitRet = ();
+
+    fn visit_tuple_lit(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::TupleLit>,
+    ) -> Result<Self::TupleLitRet, Self::Error> {
+        let _ = walk::walk_tuple_lit(self, node);
+        Ok(())
+    }
+
+    type StrLitRet = ();
+
+    fn visit_str_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::StrLit>,
+    ) -> Result<Self::StrLitRet, Self::Error> {
+        Ok(())
+    }
+
+    type CharLitRet = ();
+
+    fn visit_char_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::CharLit>,
+    ) -> Result<Self::CharLitRet, Self::Error> {
+        Ok(())
+    }
+
+    type FloatLitRet = ();
+
+    fn visit_float_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::FloatLit>,
+    ) -> Result<Self::FloatLitRet, Self::Error> {
+        Ok(())
+    }
+
+    type BoolLitRet = ();
+
+    fn visit_bool_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::BoolLit>,
+    ) -> Result<Self::BoolLitRet, Self::Error> {
+        Ok(())
+    }
+
+    type IntLitRet = ();
+
+    fn visit_int_lit(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::IntLit>,
+    ) -> Result<Self::IntLitRet, Self::Error> {
+        Ok(())
+    }
+
+    type BinOpRet = ();
+
+    fn visit_bin_op(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::BinOp>,
+    ) -> Result<Self::BinOpRet, Self::Error> {
+        Ok(())
+    }
+
+    type UnOpRet = ();
+
+    fn visit_un_op(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::UnOp>,
+    ) -> Result<Self::UnOpRet, Self::Error> {
+        Ok(())
+    }
+
+    type ExprRet = ();
+
+    fn visit_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Expr>,
+    ) -> Result<Self::ExprRet, Self::Error> {
+        walk::walk_expr_same_children(self, node)
+    }
+
+    type VariableExprRet = ();
+
+    fn visit_variable_expr(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::VariableExpr>,
+    ) -> Result<Self::VariableExprRet, Self::Error> {
+        Ok(())
+    }
+
+    type DirectiveExprRet = ();
+
+    fn visit_directive_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::DirectiveExpr>,
+    ) -> Result<Self::DirectiveExprRet, Self::Error> {
+        let _ = walk::walk_directive_expr(self, node);
+
+       // for the `dump_ast` directive, we essentially "dump" the generated tree
+       // that the parser created. We emit this tree regardless of whether or not
+       // there will be errors later on in the compilation stage. 
+        if node.name.is(IDENTS.dump_ast) {
+            let tree = AstTreeGenerator.visit_expr(node.subject.ast_ref()).unwrap();
+            let name = self.source_map.canonicalised_path_by_id(self.source_id);
+
+            let location = self.source_location(node.subject.span());
+            let span = self.source_map.get_column_row_span_for(location);
+
+            
+            println!("AST for {}{} {}", name, span, TreeWriter::new(&tree));
+        }
+
+        Ok(())
+    }
+
+    type ConstructorCallArgRet = ();
+
+    fn visit_constructor_call_arg(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallArg>,
+    ) -> Result<Self::ConstructorCallArgRet, Self::Error> {
+        let _ = walk::walk_constructor_call_arg(self, node);
+        Ok(())
+    }
+
+    type ConstructorCallExprRet = ();
+
+    fn visit_constructor_call_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorCallExpr>,
+    ) -> Result<Self::ConstructorCallExprRet, Self::Error> {
+        let _ = walk::walk_constructor_call_expr(self, node);
+        Ok(())
+    }
+
+    type PropertyKindRet = ();
+
+    fn visit_property_kind(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::PropertyKind>,
+    ) -> Result<Self::PropertyKindRet, Self::Error> {
+        Ok(())
+    }
+
+    type AccessExprRet = ();
+
+    fn visit_access_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::AccessExpr>,
+    ) -> Result<Self::AccessExprRet, Self::Error> {
+        let _ = walk::walk_access_expr(self, node);
+        Ok(())
+    }
+
+    type AccessKindRet = ();
+
+    fn visit_access_kind(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::AccessKind>,
+    ) -> Result<Self::AccessKindRet, Self::Error> {
+        Ok(())
+    }
+
+    type RefExprRet = ();
+
+    fn visit_ref_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::RefExpr>,
+    ) -> Result<Self::RefExprRet, Self::Error> {
+        let _ = walk::walk_ref_expr(self, node);
+        Ok(())
+    }
+
+    type DerefExprRet = ();
+
+    fn visit_deref_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::DerefExpr>,
+    ) -> Result<Self::DerefExprRet, Self::Error> {
+        let _ = walk::walk_deref_expr(self, node);
+        Ok(())
+    }
+
+    type UnsafeExprRet = ();
+
+    fn visit_unsafe_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::UnsafeExpr>,
+    ) -> Result<Self::UnsafeExprRet, Self::Error> {
+        let _ = walk::walk_unsafe_expr(self, node);
+        Ok(())
+    }
+
+    type LitExprRet = ();
+
+    fn visit_lit_expr(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::LitExpr>,
+    ) -> Result<Self::LitExprRet, Self::Error> {
+        Ok(())
+    }
+
+    type CastExprRet = ();
+
+    fn visit_cast_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::CastExpr>,
+    ) -> Result<Self::CastExprRet, Self::Error> {
+        let _ = walk::walk_cast_expr(self, node);
+        Ok(())
+    }
+
+    type TyExprRet = ();
+
+    fn visit_ty_expr(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TyExpr>,
+    ) -> Result<Self::TyExprRet, Self::Error> {
+        Ok(())
+    }
+
+    type BlockExprRet = ();
+
+    #[inline]
+    fn visit_block_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::BlockExpr>,
+    ) -> Result<Self::BlockExprRet, Self::Error> {
+        let _ = walk::walk_block_expr(self, node)?;
+
+        Ok(())
+    }
+
+    type ImportRet = ();
+
+    fn visit_import(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Import>,
+    ) -> Result<Self::ImportRet, Self::Error> {
+        Ok(())
+    }
+
+    type ImportExprRet = ();
+
+    fn visit_import_expr(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ImportExpr>,
+    ) -> Result<Self::ImportExprRet, Self::Error> {
+        Ok(())
+    }
+
+    type TyRet = ();
+
+    fn visit_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Ty>,
+    ) -> Result<Self::TyRet, Self::Error> {
+        Ok(())
+    }
+
+    type TupleTyRet = ();
+
+    fn visit_tuple_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TupleTy>,
+    ) -> Result<Self::TupleTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type ListTyRet = ();
+
+    fn visit_list_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ListTy>,
+    ) -> Result<Self::ListTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type SetTyRet = ();
+
+    fn visit_set_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::SetTy>,
+    ) -> Result<Self::SetTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type MapTyRet = ();
+
+    fn visit_map_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::MapTy>,
+    ) -> Result<Self::MapTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type TyArgRet = ();
+
+    fn visit_ty_arg(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TyArg>,
+    ) -> Result<Self::TyArgRet, Self::Error> {
+        Ok(())
+    }
+
+    type FnTyRet = ();
+
+    fn visit_fn_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::FnTy>,
+    ) -> Result<Self::FnTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type TyFnRet = ();
+
+    fn visit_ty_fn(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TyFn>,
+    ) -> Result<Self::TyFnRet, Self::Error> {
+        Ok(())
+    }
+
+    type TyFnCallRet = ();
+
+    fn visit_ty_fn_call(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TyFnCall>,
+    ) -> Result<Self::TyFnCallRet, Self::Error> {
+        Ok(())
+    }
+
+    type NamedTyRet = ();
+    fn visit_named_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::NamedTy>,
+    ) -> Result<Self::NamedTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type AccessTyRet = ();
+
+    fn visit_access_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::AccessTy>,
+    ) -> Result<Self::AccessTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type RefTyRet = ();
+
+    fn visit_ref_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::RefTy>,
+    ) -> Result<Self::RefTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type MergeTyRet = ();
+
+    fn visit_merge_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeTy>,
+    ) -> Result<Self::MergeTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type UnionTyRet = ();
+
+    fn visit_union_ty(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::UnionTy>,
+    ) -> Result<Self::UnionTyRet, Self::Error> {
+        Ok(())
+    }
+
+    type TyFnDefRet = ();
+
+    fn visit_ty_fn_def(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::TyFnDef>,
+    ) -> Result<Self::TyFnDefRet, Self::Error> {
+        let _ = walk::walk_ty_fn_def(self, node);
+        Ok(())
+    }
+
+    type FnDefRet = ();
+
+    fn visit_fn_def(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::FnDef>,
+    ) -> Result<Self::FnDefRet, Self::Error> {
+        let _ = walk::walk_fn_def(self, node);
+        Ok(())
+    }
+
+    type ParamRet = ();
+
+    fn visit_param(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Param>,
+    ) -> Result<Self::ParamRet, Self::Error> {
+        let _ = walk::walk_param(self, node);
+        Ok(())
+    }
+
+    type BlockRet = ();
+
+    fn visit_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Block>,
+    ) -> Result<Self::BlockRet, Self::Error> {
+        // We still need to walk the block now
+        let _ = walk::walk_block(self, node);
+
+        Ok(())
+    }
+
+    type MatchCaseRet = ();
+
+    fn visit_match_case(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MatchCase>,
+    ) -> Result<Self::MatchCaseRet, Self::Error> {
+        let _ = walk::walk_match_case(self, node);
+        Ok(())
+    }
+
+    type MatchBlockRet = ();
+
+    fn visit_match_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MatchBlock>,
+    ) -> Result<Self::MatchBlockRet, Self::Error> {
+        let _ = walk::walk_match_block(self, node);
+        Ok(())
+    }
+
+    type LoopBlockRet = ();
+
+    fn visit_loop_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::LoopBlock>,
+    ) -> Result<Self::LoopBlockRet, Self::Error> {
+        let _ = walk::walk_loop_block(self, node);
+
+        Ok(())
+    }
+
+    type ForLoopBlockRet = ();
+
+    fn visit_for_loop_block(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ForLoopBlock>,
+    ) -> Result<Self::ForLoopBlockRet, Self::Error> {
+        // Specifically left empty since this should never fire!
+        Ok(())
+    }
+
+    type WhileLoopBlockRet = ();
+
+    fn visit_while_loop_block(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::WhileLoopBlock>,
+    ) -> Result<Self::WhileLoopBlockRet, Self::Error> {
+        // Specifically left empty since this should never fire!
+        Ok(())
+    }
+
+    type ModBlockRet = ();
+
+    fn visit_mod_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ModBlock>,
+    ) -> Result<Self::ModBlockRet, Self::Error> {
+        let _ = walk::walk_mod_block(self, node);
+        Ok(())
+    }
+
+    type ImplBlockRet = ();
+
+    fn visit_impl_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ImplBlock>,
+    ) -> Result<Self::ImplBlockRet, Self::Error> {
+        let _ = walk::walk_impl_block(self, node);
+        Ok(())
+    }
+
+    type IfClauseRet = ();
+
+    fn visit_if_clause(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::IfClause>,
+    ) -> Result<Self::IfClauseRet, Self::Error> {
+        // Specifically left empty since this should never fire!
+        Ok(())
+    }
+
+    type IfBlockRet = ();
+
+    fn visit_if_block(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::IfBlock>,
+    ) -> Result<Self::IfBlockRet, Self::Error> {
+        // Specifically left empty since this should never fire!
+        Ok(())
+    }
+
+    type BodyBlockRet = ();
+
+    fn visit_body_block(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::BodyBlock>,
+    ) -> Result<Self::BodyBlockRet, Self::Error> {
+        let _ = walk::walk_body_block(self, node);
+        Ok(())
+    }
+
+    type ReturnStatementRet = ();
+
+    fn visit_return_statement(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::ReturnStatement>,
+    ) -> Result<Self::ReturnStatementRet, Self::Error> {
+        let _ = walk::walk_return_statement(self, node);
+        Ok(())
+    }
+
+    type BreakStatementRet = ();
+
+    fn visit_break_statement(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::BreakStatement>,
+    ) -> Result<Self::BreakStatementRet, Self::Error> {
+        Ok(())
+    }
+
+    type ContinueStatementRet = ();
+
+    fn visit_continue_statement(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ContinueStatement>,
+    ) -> Result<Self::ContinueStatementRet, Self::Error> {
+        Ok(())
+    }
+
+    type VisibilityRet = ();
+
+    fn visit_visibility(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Visibility>,
+    ) -> Result<Self::VisibilityRet, Self::Error> {
+        Ok(())
+    }
+
+    type MutabilityRet = ();
+
+    fn visit_mutability(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Mutability>,
+    ) -> Result<Self::MutabilityRet, Self::Error> {
+        Ok(())
+    }
+
+    type RefKindRet = ();
+
+    fn visit_ref_kind(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::RefKind>,
+    ) -> Result<Self::RefKindRet, Self::Error> {
+        Ok(())
+    }
+
+    type DeclarationRet = ();
+
+    fn visit_declaration(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Declaration>,
+    ) -> Result<Self::DeclarationRet, Self::Error> {
+        let _ = walk::walk_declaration(self, node);
+        Ok(())
+    }
+
+    type MergeDeclarationRet = ();
+
+    fn visit_merge_declaration(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::MergeDeclaration>,
+    ) -> Result<Self::MergeDeclarationRet, Self::Error> {
+        // @@Note: We probably don't have to walk this??
+        let _ = walk::walk_merge_declaration(self, node);
+        Ok(())
+    }
+
+    type AssignExprRet = ();
+
+    fn visit_assign_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::AssignExpr>,
+    ) -> Result<Self::AssignExprRet, Self::Error> {
+        let _ = walk::walk_assign_expr(self, node);
+        Ok(())
+    }
+
+    type AssignOpExprRet = ();
+
+    fn visit_assign_op_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::AssignOpExpr>,
+    ) -> Result<Self::AssignOpExprRet, Self::Error> {
+        let _ = walk::walk_assign_op_expr(self, node);
+        Ok(())
+    }
+
+    type BinaryExprRet = ();
+
+    fn visit_binary_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::BinaryExpr>,
+    ) -> Result<Self::BinaryExprRet, Self::Error> {
+        let _ = walk::walk_binary_expr(self, node);
+        Ok(())
+    }
+
+    type UnaryExprRet = ();
+
+    fn visit_unary_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::UnaryExpr>,
+    ) -> Result<Self::UnaryExprRet, Self::Error> {
+        let _ = walk::walk_unary_expr(self, node);
+        Ok(())
+    }
+
+    type IndexExprRet = ();
+
+    fn visit_index_expr(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::IndexExpr>,
+    ) -> Result<Self::IndexExprRet, Self::Error> {
+        let _ = walk::walk_index_expr(self, node);
+        Ok(())
+    }
+
+    type StructDefRet = ();
+
+    fn visit_struct_def(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::StructDef>,
+    ) -> Result<Self::StructDefRet, Self::Error> {
+        let _ = walk::walk_struct_def(self, node);
+        Ok(())
+    }
+
+    type EnumDefEntryRet = ();
+
+    fn visit_enum_def_entry(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::EnumDefEntry>,
+    ) -> Result<Self::EnumDefEntryRet, Self::Error> {
+        Ok(())
+    }
+
+    type EnumDefRet = ();
+
+    fn visit_enum_def(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::EnumDef>,
+    ) -> Result<Self::EnumDefRet, Self::Error> {
+        Ok(())
+    }
+
+    type TraitDefRet = ();
+
+    fn visit_trait_def(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::TraitDef>,
+    ) -> Result<Self::TraitDefRet, Self::Error> {
+        let _ = walk::walk_trait_def(self, node);
+        Ok(())
+    }
+
+    type TraitImplRet = ();
+
+    fn visit_trait_impl(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::TraitImpl>,
+    ) -> Result<Self::TraitImplRet, Self::Error> {
+        let _ = walk::walk_trait_impl(self, node);
+        Ok(())
+    }
+
+    type PatRet = ();
+
+    fn visit_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::Pat>,
+    ) -> Result<Self::PatRet, Self::Error> {
+        Ok(())
+    }
+
+    type AccessPatRet = ();
+
+    fn visit_access_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::AccessPat>,
+    ) -> Result<Self::AccessPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type ConstructorPatRet = ();
+
+    fn visit_constructor_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ConstructorPat>,
+    ) -> Result<Self::ConstructorPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type TuplePatEntryRet = ();
+
+    fn visit_tuple_pat_entry(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TuplePatEntry>,
+    ) -> Result<Self::TuplePatEntryRet, Self::Error> {
+        Ok(())
+    }
+
+    type TuplePatRet = ();
+
+    fn visit_tuple_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::TuplePat>,
+    ) -> Result<Self::TuplePatRet, Self::Error> {
+        Ok(())
+    }
+
+    type ListPatRet = ();
+
+    fn visit_list_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ListPat>,
+    ) -> Result<Self::ListPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type SpreadPatRet = ();
+
+    fn visit_spread_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::SpreadPat>,
+    ) -> Result<Self::SpreadPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type LitPatRet = ();
+
+    fn visit_lit_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::LitPat>,
+    ) -> Result<Self::LitPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type RangePatRet = ();
+
+    fn visit_range_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::RangePat>,
+    ) -> Result<Self::RangePatRet, Self::Error> {
+        Ok(())
+    }
+
+    type OrPatRet = ();
+
+    fn visit_or_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::OrPat>,
+    ) -> Result<Self::OrPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type IfPatRet = ();
+
+    fn visit_if_pat(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::IfPat>,
+    ) -> Result<Self::IfPatRet, Self::Error> {
+        let _ = walk::walk_if_pat(self, node);
+        Ok(())
+    }
+
+    type BindingPatRet = ();
+
+    fn visit_binding_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::BindingPat>,
+    ) -> Result<Self::BindingPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type WildPatRet = ();
+
+    fn visit_wild_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::WildPat>,
+    ) -> Result<Self::WildPatRet, Self::Error> {
+        Ok(())
+    }
+
+    type ModulePatEntryRet = ();
+
+    fn visit_module_pat_entry(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ModulePatEntry>,
+    ) -> Result<Self::ModulePatEntryRet, Self::Error> {
+        Ok(())
+    }
+
+    type ModulePatRet = ();
+
+    fn visit_module_pat(
+        &self,
+        _: hash_ast::ast::AstNodeRef<hash_ast::ast::ModulePat>,
+    ) -> Result<Self::ModulePatRet, Self::Error> {
+        Ok(())
+    }
+
+    type ModuleRet = ();
+
+    fn visit_module(
+        &self,
+        node: hash_ast::ast::AstNodeRef<hash_ast::ast::Module>,
+    ) -> Result<Self::ModuleRet, Self::Error> {
+        let _ = walk::walk_module(self, node);
+        Ok(())
+    }
+}

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, L, V>(
     mut compiler: Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C>,
+    mut compiler_state: CompilerState,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -82,8 +82,8 @@ where
 fn execute<'c, 'pool, P, D, S, C, L, V>(
     input: &str,
     compiler: &mut Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C>,
-) -> CompilerState<'c, C>
+    mut compiler_state: CompilerState,
+) -> CompilerState
 where
     'pool: 'c,
     P: Parser<'pool>,

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, L, V>(
     mut compiler: Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, 'pool, D, S, C, L, V>,
+    mut compiler_state: CompilerState<'c, 'pool, D, C, L, V>,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -82,8 +82,8 @@ where
 fn execute<'c, 'pool, P, D, S, C, L, V>(
     input: &str,
     compiler: &mut Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, 'pool, D, S, C, L, V>,
-) -> CompilerState<'c, 'pool, D, S, C, L, V>
+    mut compiler_state: CompilerState<'c, 'pool, D, C, L, V>,
+) -> CompilerState<'c, 'pool, D, C, L, V>
 where
     'pool: 'c,
     P: Parser<'pool>,

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, L, V>(
     mut compiler: Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, 'pool, D, C, L, V>,
+    mut compiler_state: CompilerState<'c, C, L, V>,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -82,8 +82,8 @@ where
 fn execute<'c, 'pool, P, D, S, C, L, V>(
     input: &str,
     compiler: &mut Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, 'pool, D, C, L, V>,
-) -> CompilerState<'c, 'pool, D, C, L, V>
+    mut compiler_state: CompilerState<'c, C, L, V>,
+) -> CompilerState<'c, C, L, V>
 where
     'pool: 'c,
     P: Parser<'pool>,

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, L, V>(
     mut compiler: Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C, L, V>,
+    mut compiler_state: CompilerState<'c, C, V>,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -45,7 +45,7 @@ where
     D: Desugar<'pool>,
     S: SemanticPass<'pool>,
     C: Tc<'c>,
-    L: Lowering<'c>,
+    L: Lowering,
     V: VirtualMachine<'c>,
 {
     // Display the version on start-up
@@ -82,15 +82,15 @@ where
 fn execute<'c, 'pool, P, D, S, C, L, V>(
     input: &str,
     compiler: &mut Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C, L, V>,
-) -> CompilerState<'c, C, L, V>
+    mut compiler_state: CompilerState<'c, C, V>,
+) -> CompilerState<'c, C, V>
 where
     'pool: 'c,
     P: Parser<'pool>,
     D: Desugar<'pool>,
     S: SemanticPass<'pool>,
     C: Tc<'c>,
-    L: Lowering<'c>,
+    L: Lowering,
     V: VirtualMachine<'c>,
 {
     if input.is_empty() {

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn goodbye() {
 /// REPL.
 pub fn init<'c, 'pool, P, D, S, C, L, V>(
     mut compiler: Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C, V>,
+    mut compiler_state: CompilerState<'c, C>,
 ) -> CompilerResult<()>
 where
     'pool: 'c,
@@ -46,7 +46,7 @@ where
     S: SemanticPass<'pool>,
     C: Tc<'c>,
     L: Lowering,
-    V: VirtualMachine<'c>,
+    V: VirtualMachine,
 {
     // Display the version on start-up
     print_version();
@@ -82,8 +82,8 @@ where
 fn execute<'c, 'pool, P, D, S, C, L, V>(
     input: &str,
     compiler: &mut Compiler<'pool, P, D, S, C, L, V>,
-    mut compiler_state: CompilerState<'c, C, V>,
-) -> CompilerState<'c, C, V>
+    mut compiler_state: CompilerState<'c, C>,
+) -> CompilerState<'c, C>
 where
     'pool: 'c,
     P: Parser<'pool>,
@@ -91,7 +91,7 @@ where
     S: SemanticPass<'pool>,
     C: Tc<'c>,
     L: Lowering,
-    V: VirtualMachine<'c>,
+    V: VirtualMachine,
 {
     if input.is_empty() {
         return compiler_state;

--- a/compiler/hash-lower/Cargo.toml
+++ b/compiler/hash-lower/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 index_vec = "0.1.3"
+rayon = "1.5.0"
 
 hash-ir = {path = "../hash-ir" }
 hash-ast = {path = "../hash-ast" }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -10,7 +10,10 @@ mod cfg;
 mod visitor;
 
 use hash_ir::ir::Body;
-use hash_pipeline::traits::{CompilerResult, Lowering};
+use hash_pipeline::{
+    settings::CompilerStageKind,
+    traits::{CompilerResult, CompilerStage},
+};
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId,
@@ -23,41 +26,28 @@ use self::builder::Builder;
 /// through the source files.
 pub struct IrLowerer;
 
-pub struct IrLoweringState<'ir> {
-    interactive_body: Body<'ir>,
-}
-
-impl<'ir> Default for IrLoweringState<'ir> {
-    fn default() -> Self {
-        Self::new()
+impl<'pool> CompilerStage<'pool> for IrLowerer {
+    fn stage_kind(&self) -> CompilerStageKind {
+        CompilerStageKind::IrGen
     }
-}
 
-impl<'ir> IrLoweringState<'ir> {
-    pub fn new() -> Self {
-        let dummy_span = SourceLocation::new(Span::default(), SourceId::default());
-
-        Self { interactive_body: Body::new_uninitialised(dummy_span) }
-    }
-}
-
-impl Lowering for IrLowerer {
-    fn lower_interactive_block(
+    fn run_stage(
         &mut self,
-        _interactive_id: hash_source::InteractiveId,
-        _workspace: &hash_pipeline::sources::Workspace,
-    ) -> CompilerResult<()> {
-        Ok(())
-    }
-
-    fn lower_module(
-        &mut self,
-        _module_id: hash_source::ModuleId,
-        _workspace: &hash_pipeline::sources::Workspace,
+        entry_point: SourceId,
+        workspace: &mut hash_pipeline::sources::Workspace,
+        pool: &'pool rayon::ThreadPool,
     ) -> CompilerResult<()> {
         // We need to iterate all of the modules and essentially perform
         // a discovery process for what needs to be lowered...
 
         Ok(())
+    }
+
+    fn cleanup(
+        &self,
+        entry_point: SourceId,
+        workspace: &mut hash_pipeline::sources::Workspace,
+        settings: &hash_pipeline::settings::CompilerSettings,
+    ) {
     }
 }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -10,7 +10,7 @@ mod cfg;
 mod visitor;
 
 use hash_ir::ir::Body;
-use hash_pipeline::traits::Lowering;
+use hash_pipeline::traits::{Lowering, CompilerResult};
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId,
@@ -41,19 +41,12 @@ impl<'ir> IrLoweringState<'ir> {
     }
 }
 
-impl<'c> Lowering<'c> for IrLowerer {
-    type State = IrLoweringState<'c>;
-
-    fn make_state(&mut self) -> hash_pipeline::traits::CompilerResult<Self::State> {
-        Ok(IrLoweringState::new())
-    }
-
-    fn lower_interactive_block<'pool>(
-        &'pool mut self,
+impl Lowering for IrLowerer {
+    fn lower_interactive_block(
+        &mut self,
         _interactive_id: hash_source::InteractiveId,
         _workspace: &hash_pipeline::sources::Workspace,
-        _state: &mut Self::State,
-    ) -> hash_pipeline::traits::CompilerResult<()> {
+    ) -> CompilerResult<()> {
         Ok(())
     }
 
@@ -61,8 +54,7 @@ impl<'c> Lowering<'c> for IrLowerer {
         &mut self,
         _module_id: hash_source::ModuleId,
         _workspace: &hash_pipeline::sources::Workspace,
-        _state: &mut Self::State,
-    ) -> hash_pipeline::traits::CompilerResult<()> {
+    ) -> CompilerResult<()> {
         // We need to iterate all of the modules and essentially perform
         // a discovery process for what needs to be lowered...
 

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -10,7 +10,7 @@ mod cfg;
 mod visitor;
 
 use hash_ir::ir::Body;
-use hash_pipeline::traits::{Lowering, CompilerResult};
+use hash_pipeline::traits::{CompilerResult, Lowering};
 use hash_source::{
     location::{SourceLocation, Span},
     SourceId,

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -3,8 +3,8 @@
 
 use std::{borrow::Cow, path::PathBuf};
 
-use hash_pipeline::sources::Workspace;
-use hash_source::{InteractiveId, ModuleId, SourceId};
+use hash_pipeline::sources::NodeMap;
+use hash_source::{InteractiveId, ModuleId, SourceId, SourceMap};
 
 /// A [ParseSource] represents the pre-processed information before a module
 /// or an interactive block gets lexed and parsed. Logic related to
@@ -22,10 +22,9 @@ pub struct ParseSource {
 
 impl ParseSource {
     /// Create a new [ParseSource] from a [ModuleId].
-    pub fn from_module(module_id: ModuleId, workspace: &Workspace) -> Self {
-        let module = workspace.node_map().get_module(module_id);
-        let contents =
-            workspace.source_map().contents_by_id(SourceId::Module(module_id)).to_owned();
+    pub fn from_module(module_id: ModuleId, node_map: &NodeMap, source_map: &SourceMap) -> Self {
+        let module = node_map.get_module(module_id);
+        let contents = source_map.contents_by_id(SourceId::Module(module_id)).to_owned();
 
         Self {
             id: SourceId::Module(module_id),
@@ -36,22 +35,26 @@ impl ParseSource {
     /// Create a new [ParseSource] from a [InteractiveId].
     pub fn from_interactive(
         interactive_id: InteractiveId,
-        workspace: &Workspace,
+        source_map: &SourceMap,
         current_dir: PathBuf,
     ) -> Self {
-        let contents =
-            workspace.source_map().contents_by_id(SourceId::Interactive(interactive_id)).to_owned();
+        let contents = source_map.contents_by_id(SourceId::Interactive(interactive_id)).to_owned();
 
         Self { id: SourceId::Interactive(interactive_id), contents, path: current_dir }
     }
 
     /// Create a [ParseSource] from a general [SourceId]
-    pub fn from_source(source_id: SourceId, workspace: &Workspace, current_dir: PathBuf) -> Self {
+    pub fn from_source(
+        source_id: SourceId,
+        node_map: &NodeMap,
+        source_map: &SourceMap,
+        current_dir: PathBuf,
+    ) -> Self {
         match source_id {
             SourceId::Interactive(interactive_id) => {
-                Self::from_interactive(interactive_id, workspace, current_dir)
+                Self::from_interactive(interactive_id, source_map, current_dir)
             }
-            SourceId::Module(module_id) => Self::from_module(module_id, workspace),
+            SourceId::Module(module_id) => Self::from_module(module_id, node_map, source_map),
         }
     }
 

--- a/compiler/hash-pipeline/Cargo.toml
+++ b/compiler/hash-pipeline/Cargo.toml
@@ -12,6 +12,7 @@ rayon = "1.5.0"
 num_cpus = "1.13.0"
 
 hash-ast = { path = "../hash-ast" }
+hash-types = { path = "../hash-types" }
 hash-utils = { path = "../hash-utils" }
 hash-source = { path = "../hash-source" }
 hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -217,7 +217,7 @@ impl<'pool> Compiler<'pool> {
 
                 eprintln!(
                     "{}",
-                    ReportWriter::new(diagnostic, compiler_state.workspace.source_map())
+                    ReportWriter::new(diagnostic, &compiler_state.workspace.source_map)
                 );
             }
 
@@ -262,7 +262,7 @@ impl<'pool> Compiler<'pool> {
             if self.settings.emit_errors {
                 eprintln!(
                     "{}",
-                    ReportWriter::new(err.create_report(), compiler_state.workspace.source_map())
+                    ReportWriter::new(err.create_report(), &compiler_state.workspace.source_map)
                 );
             }
 
@@ -279,7 +279,7 @@ impl<'pool> Compiler<'pool> {
             if self.settings.emit_errors {
                 eprintln!(
                     "{}",
-                    ReportWriter::new(err.create_report(), compiler_state.workspace.source_map())
+                    ReportWriter::new(err.create_report(), &compiler_state.workspace.source_map)
                 );
             }
 

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -38,7 +38,7 @@ pub struct CompilerSettings {
 
     /// To what should the compiler run to, anywhere from parsing, typecheck, to
     /// code generation.
-    pub stage: CompilerMode,
+    pub stage: CompilerStageKind,
 }
 
 impl CompilerSettings {
@@ -59,8 +59,8 @@ impl CompilerSettings {
         self.emit_errors = value;
     }
 
-    /// Specify the [CompilerMode] the compiler should run to.
-    pub fn set_stage(&mut self, stage: CompilerMode) {
+    /// Specify the [CompilerStageKind] the compiler should run to.
+    pub fn set_stage(&mut self, stage: CompilerStageKind) {
         self.stage = stage;
     }
 }
@@ -74,7 +74,7 @@ impl Default for CompilerSettings {
             skip_prelude: false,
             emit_errors: true,
             dump_ast: false,
-            stage: CompilerMode::Full,
+            stage: CompilerStageKind::Full,
         }
     }
 }
@@ -82,7 +82,7 @@ impl Default for CompilerSettings {
 /// Enum representing what mode the compiler should run in. Specifically, if the
 /// compiler should only run up to a particular stage within the pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum CompilerMode {
+pub enum CompilerStageKind {
     Parse,
     DeSugar,
     SemanticPass,
@@ -92,22 +92,22 @@ pub enum CompilerMode {
     Full,
 }
 
-impl Default for CompilerMode {
+impl Default for CompilerStageKind {
     fn default() -> Self {
-        CompilerMode::Full
+        CompilerStageKind::Full
     }
 }
 
-impl Display for CompilerMode {
+impl Display for CompilerStageKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CompilerMode::Parse => write!(f, "parsing"),
-            CompilerMode::DeSugar => write!(f, "de-sugaring"),
-            CompilerMode::SemanticPass => write!(f, "semantic"),
-            CompilerMode::Typecheck => write!(f, "typecheck"),
-            CompilerMode::Lower => write!(f, "lowering"),
-            CompilerMode::IrGen => write!(f, "ir"),
-            CompilerMode::Full => write!(f, "total"),
+            CompilerStageKind::Parse => write!(f, "parsing"),
+            CompilerStageKind::DeSugar => write!(f, "de-sugaring"),
+            CompilerStageKind::SemanticPass => write!(f, "semantic"),
+            CompilerStageKind::Typecheck => write!(f, "typecheck"),
+            CompilerStageKind::Lower => write!(f, "lowering"),
+            CompilerStageKind::IrGen => write!(f, "ir"),
+            CompilerStageKind::Full => write!(f, "total"),
         }
     }
 }

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -195,6 +195,10 @@ pub struct Workspace {
     pub source_map: SourceMap,
     /// Stores all of the generated AST for modules and nodes
     pub node_map: NodeMap,
+
+    /// Modules that have already been semantically checked. This is needed in
+    /// order to avoid re-checking modules on re-evaluations of a workspace.
+    pub semantically_checked_modules: HashSet<SourceId>,
 }
 
 impl Workspace {
@@ -204,6 +208,7 @@ impl Workspace {
             node_map: NodeMap::new(),
             source_map: SourceMap::new(),
             dependencies: HashMap::new(),
+            semantically_checked_modules: HashSet::new(),
         }
     }
 

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -196,6 +196,8 @@ pub struct Workspace {
     /// Stores all of the generated AST for modules and nodes
     pub node_map: NodeMap,
 
+    pub desugared_modules: HashSet<SourceId>,
+
     /// Modules that have already been semantically checked. This is needed in
     /// order to avoid re-checking modules on re-evaluations of a workspace.
     pub semantically_checked_modules: HashSet<SourceId>,
@@ -208,6 +210,7 @@ impl Workspace {
             node_map: NodeMap::new(),
             source_map: SourceMap::new(),
             dependencies: HashMap::new(),
+            desugared_modules: HashSet::new(),
             semantically_checked_modules: HashSet::new(),
         }
     }

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -281,31 +281,6 @@ impl Workspace {
         self.dependencies.entry(source_id).or_insert_with(HashSet::new).insert(dependency);
     }
 
-    /// Get a reference to [SourceMap]
-    pub fn source_map(&self) -> &SourceMap {
-        &self.source_map
-    }
-
-    /// Get a mutable reference to [SourceMap]
-    pub fn source_map_mut(&mut self) -> &mut SourceMap {
-        &mut self.source_map
-    }
-
-    /// Get a reference to [NodeMap]
-    pub fn node_map(&self) -> &NodeMap {
-        &self.node_map
-    }
-
-    /// Get a mutable reference to [NodeMap]
-    pub fn node_map_mut(&mut self) -> &mut NodeMap {
-        &mut self.node_map
-    }
-
-    /// Get the [TyStorage] stored within the [Workspace].
-    pub fn ty_storage(&self) -> &TyStorage {
-        &self.ty_storage
-    }
-
     /// Utility function used by AST-like stages in order to print the
     /// current [self::sources::NodeMap].
     pub fn print_sources(&self, entry_point: SourceId) {
@@ -313,7 +288,7 @@ impl Workspace {
             SourceId::Interactive(id) => {
                 // If this is an interactive statement, we want to print the statement that was
                 // just parsed.
-                let source = self.node_map().get_interactive_block(id);
+                let source = self.node_map.get_interactive_block(id);
                 let tree = AstTreeGenerator.visit_body_block(source.node_ref()).unwrap();
 
                 println!("{}", TreeWriter::new(&tree));
@@ -321,7 +296,7 @@ impl Workspace {
             SourceId::Module(_) => {
                 // If this is a module, we want to print all of the generated modules from the
                 // parsing stage
-                for (_, generated_module) in self.node_map().iter_modules() {
+                for (_, generated_module) in self.node_map.iter_modules() {
                     let tree = AstTreeGenerator.visit_module(generated_module.node_ref()).unwrap();
 
                     println!(

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -27,17 +27,11 @@ pub trait Parser<'pool> {
 /// The [Desugar] represents an abstract parser that can parse all aspects of
 /// the Hash programming language.
 pub trait Desugar<'pool> {
-    type State;
-
-    /// Initialise [Desugar::State].
-    fn make_state(&mut self) -> CompilerResult<Self::State>;
-
     /// Perform a de-sugaring pass on the provided sources.
     fn desugar(
         &mut self,
         entry_point: SourceId,
         workspace: &mut Workspace,
-        state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> CompilerResult<()>;
 }

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -3,98 +3,48 @@
 //! provided sources into runnable/executable code.
 
 use hash_reporting::report::Report;
-use hash_source::{InteractiveId, ModuleId, SourceId};
+use hash_source::SourceId;
 
-use crate::sources::Workspace;
+use crate::{
+    settings::{CompilerSettings, CompilerStageKind},
+    sources::Workspace,
+};
 
 pub type CompilerResult<T> = Result<T, Vec<Report>>;
 
-/// The [Parser] represents an abstract parser that can parse all aspects of the
-/// Hash programming language.
-pub trait Parser<'pool> {
-    /// Given a [SourceId], parse the current job and append any parsed modules
-    /// to the provided sources parameter. On success, the function returns
-    /// nothing and on failure, the stage provides a generated diagnostics
-    /// [Report].
-    fn parse(
+/// [CompilerStage] represents an abstract stage within the compiler pipeline.
+/// Each stage has an associated [CompilerStageKind] which can be used by
+/// the pipeline which stages to run.
+pub trait CompilerStage<'pool> {
+    /// Run the stage, with an initial `entry_point` module. For most
+    /// stages this is irrelevant since the module dependency graph
+    /// is not relevant for the stage.
+    fn run_stage(
         &mut self,
         entry_point: SourceId,
         workspace: &mut Workspace,
         pool: &'pool rayon::ThreadPool,
     ) -> CompilerResult<()>;
-}
 
-/// The [Desugar] represents an abstract parser that can parse all aspects of
-/// the Hash programming language.
-pub trait Desugar<'pool> {
-    /// Perform a de-sugaring pass on the provided sources.
-    fn desugar(
-        &mut self,
-        entry_point: SourceId,
-        workspace: &mut Workspace,
-        pool: &'pool rayon::ThreadPool,
-    ) -> CompilerResult<()>;
-}
+    /// A function that is invoked after the stage completes successfully, this
+    /// might be needed to perform some additional operations when the stage
+    /// has completed.
+    ///
+    /// An example of this use case might be for the parser. The parser stage
+    /// checks whether the `--dump-ast` flag has been set within the
+    /// compiler settings, if the flag is specified, then the compiler must
+    /// emit the parsed AST. The parser does this by checking this condition
+    /// and then invoking a function to emit all of the ASTs for each module
+    /// within the workspace.
+    fn cleanup(
+        &self,
+        _entry_point: SourceId,
+        _workspace: &mut Workspace,
+        _settings: &CompilerSettings,
+    ) {
+    }
 
-/// The [SemanticPass] represents a stage within the compiler that performs
-/// various verifications on the generated AST from the [Parser] and the
-/// [Desugar] stage. The details of the checks that this pass performs is
-/// available within the `hash-ast-passes` crate. However, overall the checks
-/// that this stage should perform will be detailed within the specification of
-/// the language.
-pub trait SemanticPass<'pool> {
-    /// Perform a de-sugaring pass on the provided sources.
-    fn perform_pass(
-        &mut self,
-        entry_point: SourceId,
-        workspace: &mut Workspace,
-        pool: &'pool rayon::ThreadPool,
-    ) -> Result<(), Vec<Report>>;
-}
-
-/// The [Tc] represents an abstract type checker that implements all the
-/// specified typechecking methods and internally performs some kind of
-/// typechecking operations. The methods [Tc::check_module] and
-/// [Tc::check_interactive] will return a unit on success, or a generated
-/// diagnostic error report which can be displayed and printed by the user of
-/// the pipeline. Both functions modify the states of the checker and return
-/// them regardless of error, both states are considered to be the new states
-/// and should be set in the compiler pipeline.
-pub trait Tc<'c> {
-    /// Given a [InteractiveId], check the interactive statement with the
-    /// specific rules that are applied in interactive rules.
-    fn check_interactive(
-        &mut self,
-        interactive_id: InteractiveId,
-        workspace: &mut Workspace,
-    ) -> CompilerResult<()>;
-
-    /// Given a [ModuleId], check the module.
-    fn check_module(
-        &mut self,
-        module_id: ModuleId,
-        workspace: &mut Workspace,
-    ) -> CompilerResult<()>;
-}
-
-/// The IR lowering trait, converting typed AST into Hash IR
-pub trait Lowering {
-    /// Given a [InteractiveId], perform a lowering on the provided typed
-    /// body block whilst keeping state on previously specified interactive
-    /// blocks.
-    fn lower_interactive_block(
-        &mut self,
-        interactive_id: InteractiveId,
-        workspace: &Workspace,
-    ) -> CompilerResult<()>;
-
-    /// Perform a IR lowering pass on a module specified by a [ModuleId]. The
-    /// result is written to the [Workspace] IR store.
-    fn lower_module(&mut self, module_id: ModuleId, workspace: &Workspace) -> CompilerResult<()>;
-}
-
-/// The virtual machine trait
-pub trait VirtualMachine {
-    /// Run the currently generated VM
-    fn run(&mut self, workspace: &Workspace) -> CompilerResult<()>;
+    /// This function is used to to return the `stage` kind of
+    /// this [CompilerStage].
+    fn stage_kind(&self) -> CompilerStageKind;
 }

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -106,15 +106,7 @@ pub trait Lowering {
 }
 
 /// The virtual machine trait
-pub trait VirtualMachine<'c> {
-    /// The general [VirtualMachine] state. This is implementation specific to
-    /// the VM that implements this trait. The pipeline should have no
-    /// dealings with the actual state, except saving it.
-    type State;
-
-    /// Initialise [VirtualMachine::State].
-    fn make_state(&mut self) -> CompilerResult<Self::State>;
-
+pub trait VirtualMachine {
     /// Run the currently generated VM
-    fn run(&mut self, state: &mut Self::State) -> CompilerResult<()>;
+    fn run(&mut self, workspace: &Workspace) -> CompilerResult<()>;
 }

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -49,17 +49,11 @@ pub trait Desugar<'pool> {
 /// that this stage should perform will be detailed within the specification of
 /// the language.
 pub trait SemanticPass<'pool> {
-    type State;
-
-    /// Initialise [SemanticPass::State].
-    fn make_state(&mut self) -> CompilerResult<Self::State>;
-
     /// Perform a de-sugaring pass on the provided sources.
     fn perform_pass(
         &mut self,
         entry_point: SourceId,
         workspace: &mut Workspace,
-        state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> Result<(), Vec<Report>>;
 }

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -61,31 +61,19 @@ pub trait SemanticPass<'pool> {
 /// them regardless of error, both states are considered to be the new states
 /// and should be set in the compiler pipeline.
 pub trait Tc<'c> {
-    /// The [Tc] state. This is implementation specific to the
-    /// typechecker that implements this trait. The pipeline should have no
-    /// dealings with the actual state, except saving it.
-    type State;
-
-    /// Initialise [Tc::State].
-    fn make_state(&mut self) -> CompilerResult<Self::State>;
-
     /// Given a [InteractiveId], check the interactive statement with the
-    /// specific rules that are applied in interactive rules. The function
-    /// accepts the previous [Tc::State].
-    fn check_interactive<'pool>(
-        &'pool mut self,
+    /// specific rules that are applied in interactive rules.
+    fn check_interactive(
+        &mut self,
         interactive_id: InteractiveId,
-        workspace: &Workspace,
-        state: &mut Self::State,
+        workspace: &mut Workspace,
     ) -> CompilerResult<()>;
 
-    /// Given a [ModuleId], check the module. The function accepts the previous
-    /// [Tc::State].
+    /// Given a [ModuleId], check the module.
     fn check_module(
         &mut self,
         module_id: ModuleId,
-        workspace: &Workspace,
-        state: &mut Self::State,
+        workspace: &mut Workspace,
     ) -> CompilerResult<()>;
 }
 

--- a/compiler/hash-pipeline/src/traits.rs
+++ b/compiler/hash-pipeline/src/traits.rs
@@ -90,32 +90,19 @@ pub trait Tc<'c> {
 }
 
 /// The IR lowering trait, converting typed AST into Hash IR
-pub trait Lowering<'c> {
-    /// IR Lowering state, any temporary state that the IR Lowering requires
-    /// in order to lower the AST.
-    type State;
-
-    /// Initialise [Lowering::State].
-    fn make_state(&mut self) -> CompilerResult<Self::State>;
-
+pub trait Lowering {
     /// Given a [InteractiveId], perform a lowering on the provided typed
     /// body block whilst keeping state on previously specified interactive
     /// blocks.
-    fn lower_interactive_block<'pool>(
-        &'pool mut self,
+    fn lower_interactive_block(
+        &mut self,
         interactive_id: InteractiveId,
         workspace: &Workspace,
-        state: &mut Self::State,
     ) -> CompilerResult<()>;
 
     /// Perform a IR lowering pass on a module specified by a [ModuleId]. The
     /// result is written to the [Workspace] IR store.
-    fn lower_module(
-        &mut self,
-        module_id: ModuleId,
-        workspace: &Workspace,
-        state: &mut Self::State,
-    ) -> CompilerResult<()>;
+    fn lower_module(&mut self, module_id: ModuleId, workspace: &Workspace) -> CompilerResult<()>;
 }
 
 /// The virtual machine trait

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -163,7 +163,6 @@ core_idents! {
     ibig("ibig"),
     Index("index"),
     index("Index"),
-    intrinsics("intrinsics"),
     isize("isize"),
     K("K"),
     List("List"),
@@ -224,4 +223,9 @@ core_idents! {
     V("V"),
     value("value"),
     void("void"),
+
+    // Directives that are pre-defined within the language.
+    dump_ast("dump_ast"),
+    dump_ir("dump_ast"),
+    intrinsics("intrinsics"),
 }

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -12,6 +12,7 @@ itertools = "0.10"
 if_chain = "1.0.2"
 num-bigint = "0.4"
 smallvec = "1.9.0"
+rayon = "1.5.0"
 
 hash-ast = { path = "../hash-ast" }
 hash-alloc = { path = "../hash-alloc" }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -81,7 +81,7 @@ impl<'pool> CompilerStage<'pool> for Typechecker {
                 LocalStorage::new(&workspace.ty_storage.global, entry_point);
         }
 
-        let TyStorage { local, global } = workspace.ty_storage();
+        let TyStorage { local, global } = &workspace.ty_storage;
 
         // Instantiate a visitor with the source and visit the source, using the
         // previous local storage.
@@ -94,7 +94,7 @@ impl<'pool> CompilerStage<'pool> for Typechecker {
             diagnostics_store: &self.diagnostics_store,
             cache: &self.cache,
         };
-        let tc_visitor = TcVisitor::new_in_source(storage.storages(), workspace.node_map());
+        let tc_visitor = TcVisitor::new_in_source(storage.storages(), &workspace.node_map);
 
         match tc_visitor.visit_source() {
             Err(err) => {

--- a/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/warning.rs
@@ -5,7 +5,7 @@ use hash_reporting::{
     builder::ReportBuilder,
     report::{Report, ReportCodeBlock, ReportElement, ReportKind, ReportNote, ReportNoteKind},
 };
-use hash_source::{location::SourceLocation, SourceId};
+use hash_source::{identifier::Identifier, location::SourceLocation, SourceId};
 
 /// A [AnalysisWarning] is warning that can occur during the semantic pass
 pub struct AnalysisWarning {
@@ -34,7 +34,13 @@ impl AnalysisWarning {
 
 /// The kind of [AnalysisWarning] that can occur.
 pub(crate) enum AnalysisWarningKind {
+    /// When an expression is in a position that will have no effect.
     UselessExpression,
+
+    /// If a directive is specified that is not known to the compiler, this
+    /// is currently a warning but it will become a hard error when directives
+    /// are also subject to standard scoping rules.
+    UnknownDirective { name: Identifier },
 }
 
 impl From<AnalysisWarning> for Report {
@@ -53,6 +59,18 @@ impl From<AnalysisWarning> for Report {
                     .add_element(ReportElement::Note(ReportNote::new(
                         ReportNoteKind::Note,
                         "A constant expression in a body block that has no side-effects is redundant",
+                    )));
+            }
+            AnalysisWarningKind::UnknownDirective { name } => {
+                builder
+                    .with_message(format!("`{name}` is not a known directive"))
+                    .add_element(ReportElement::CodeBlock(ReportCodeBlock::new(
+                        warning.location,
+                        "",
+                    )))
+                    .add_element(ReportElement::Note(ReportNote::new(
+                        ReportNoteKind::Note,
+                        "unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.",
                     )));
             }
         }

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -7,27 +7,17 @@ pub mod analysis;
 pub(crate) mod diagnostics;
 pub mod visitor;
 
-use std::collections::HashSet;
-
 use analysis::SemanticAnalyser;
 use crossbeam_channel::unbounded;
 use diagnostics::AnalysisDiagnostic;
 use hash_ast::{ast::OwnsAstNode, visitor::AstVisitorMutSelf};
-use hash_pipeline::{sources::Workspace, traits::SemanticPass, CompilerResult};
+use hash_pipeline::{sources::Workspace, traits::SemanticPass};
 use hash_reporting::report::Report;
 use hash_source::SourceId;
 
 pub struct HashSemanticAnalysis;
 
 impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
-    /// A store representing modules that have already been analysed in the
-    /// current pipeline.
-    type State = HashSet<SourceId>;
-
-    fn make_state(&mut self) -> CompilerResult<Self::State> {
-        Ok(HashSet::default())
-    }
-
     /// This will perform a pass on the AST by checking the semantic rules that
     /// are within the language specification. The function will attempt to
     /// perform a pass on the `entry_point` which happens on the main
@@ -41,17 +31,17 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
         &mut self,
         entry_point: SourceId,
         workspace: &mut Workspace,
-        state: &mut Self::State,
         pool: &'pool rayon::ThreadPool,
     ) -> Result<(), Vec<Report>> {
         let (sender, receiver) = unbounded::<AnalysisDiagnostic>();
 
         let source_map = &workspace.source_map;
         let node_map = &mut workspace.node_map;
+        let checked_modules = &mut workspace.semantically_checked_modules;
 
         pool.scope(|scope| {
             // De-sugar the target if it isn't already de-sugared
-            if !state.contains(&entry_point) {
+            if !checked_modules.contains(&entry_point) {
                 if let SourceId::Interactive(id) = entry_point {
                     let source = node_map.get_interactive_block_mut(id);
 
@@ -69,7 +59,7 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
                 let source_id = SourceId::Module(*id);
 
                 // Skip any modules that have already been de-sugared
-                if state.contains(&source_id) {
+                if checked_modules.contains(&source_id) {
                     continue;
                 }
 
@@ -100,8 +90,8 @@ impl<'pool> SemanticPass<'pool> for HashSemanticAnalysis {
         });
 
         // Add all of the ids into the cache
-        state.insert(entry_point);
-        state.extend(workspace.node_map().iter_modules().map(|(id, _)| SourceId::Module(*id)));
+        checked_modules.insert(entry_point);
+        checked_modules.extend(node_map.iter_modules().map(|(id, _)| SourceId::Module(*id)));
 
         // Collect all of the errors
         drop(sender);

--- a/compiler/hash-vm/Cargo.toml
+++ b/compiler/hash-vm/Cargo.toml
@@ -5,8 +5,11 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
+rayon = "1.5.0"
+
 hash-alloc = {path = "../hash-alloc" }
-hash-utils = {path = "../hash-utils" }
 hash-ast = {path = "../hash-ast" }
-hash-reporting = {path = "../hash-reporting" }
 hash-pipeline = {path = "../hash-pipeline" }
+hash-reporting = {path = "../hash-reporting" }
+hash-source = { path = "../hash-source" }
+hash-utils = {path = "../hash-utils" }

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -2,7 +2,7 @@
 
 use std::cell::Cell;
 
-use hash_pipeline::traits::VirtualMachine;
+use hash_pipeline::{sources::Workspace, traits::VirtualMachine};
 use hash_reporting::report::Report;
 
 use crate::{
@@ -885,14 +885,8 @@ impl Interpreter {
     }
 }
 
-impl VirtualMachine<'_> for Interpreter {
-    type State = ();
-
-    fn make_state(&mut self) -> hash_pipeline::CompilerResult<Self::State> {
-        Ok(())
-    }
-
-    fn run(&mut self, _state: &mut Self::State) -> hash_pipeline::CompilerResult<()> {
+impl VirtualMachine for Interpreter {
+    fn run(&mut self, _workspace: &Workspace) -> hash_pipeline::CompilerResult<()> {
         self.run().map_err(|err| vec![Report::from(err)])
     }
 }

--- a/compiler/hash-vm/src/vm.rs
+++ b/compiler/hash-vm/src/vm.rs
@@ -2,8 +2,9 @@
 
 use std::cell::Cell;
 
-use hash_pipeline::{sources::Workspace, traits::VirtualMachine};
+use hash_pipeline::{settings::CompilerStageKind, sources::Workspace, traits::CompilerStage};
 use hash_reporting::report::Report;
+use hash_source::SourceId;
 
 use crate::{
     bytecode::Instruction,
@@ -885,8 +886,17 @@ impl Interpreter {
     }
 }
 
-impl VirtualMachine for Interpreter {
-    fn run(&mut self, _workspace: &Workspace) -> hash_pipeline::CompilerResult<()> {
+impl<'pool> CompilerStage<'pool> for Interpreter {
+    fn run_stage(
+        &mut self,
+        _entry_point: SourceId,
+        _workspace: &mut Workspace,
+        _pool: &'pool rayon::ThreadPool,
+    ) -> hash_pipeline::traits::CompilerResult<()> {
         self.run().map_err(|err| vec![Report::from(err)])
+    }
+
+    fn stage_kind(&self) -> CompilerStageKind {
+        CompilerStageKind::Full
     }
 }

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -1,7 +1,7 @@
 //! Hash Compiler arguments management.
 
 use clap::Parser as ClapParser;
-use hash_pipeline::settings::{CompilerMode, CompilerSettings};
+use hash_pipeline::settings::{CompilerSettings, CompilerStageKind};
 
 /// CompilerOptions is a structural representation of what arguments the
 /// compiler can take when running. Compiler options are well documented on the
@@ -52,12 +52,12 @@ pub(crate) struct CompilerOptions {
 impl From<CompilerOptions> for CompilerSettings {
     fn from(options: CompilerOptions) -> Self {
         let stage = match options.mode {
-            Some(SubCmd::AstGen { .. }) => CompilerMode::Parse,
-            Some(SubCmd::DeSugar { .. }) => CompilerMode::DeSugar,
+            Some(SubCmd::AstGen { .. }) => CompilerStageKind::Parse,
+            Some(SubCmd::DeSugar { .. }) => CompilerStageKind::DeSugar,
 
-            Some(SubCmd::Check { .. }) => CompilerMode::Typecheck,
-            Some(SubCmd::IrGen { .. }) => CompilerMode::IrGen,
-            _ => CompilerMode::Full,
+            Some(SubCmd::Check { .. }) => CompilerStageKind::Typecheck,
+            Some(SubCmd::IrGen { .. }) => CompilerStageKind::IrGen,
+            _ => CompilerStageKind::Full,
         };
 
         Self {

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -14,7 +14,7 @@ use hash_parser::HashParser;
 use hash_pipeline::{settings::CompilerSettings, Compiler};
 use hash_reporting::errors::CompilerError;
 use hash_source::ModuleKind;
-use hash_typecheck::TcImpl;
+use hash_typecheck::Typechecker;
 use hash_untyped_semantics::HashSemanticAnalysis;
 use hash_vm::vm::Interpreter;
 use log::LevelFilter;
@@ -79,7 +79,7 @@ fn main() {
     let parser = HashParser::new();
     let desugarer = AstDesugarer;
     let semantic_analyser = HashSemanticAnalysis;
-    let checker = TcImpl;
+    let checker = Typechecker::new();
     let lowerer = IrLowerer;
 
     // Create the vm

--- a/tests/cases/semantics/directives/unknown_directive.hash
+++ b/tests/cases/semantics/directives/unknown_directive.hash
@@ -1,12 +1,12 @@
 // run=pass, stage=semantic
 
 Bar := #erase trait<T> {
-    into_bar: (T) -> Self;
+    into_bar: (T) -> Self
 }
 
 
 Bar := #memoise () -> u32 => {
-    into_bar: (T) -> Self;
+    into_bar: (T) -> Self
 }
 
 main := () => {

--- a/tests/cases/semantics/directives/unknown_directive.hash
+++ b/tests/cases/semantics/directives/unknown_directive.hash
@@ -1,0 +1,17 @@
+// run=pass, stage=semantic
+
+Bar := #erase trait<T> {
+    into_bar: (T) -> Self;
+}
+
+
+Bar := #memoise () -> u32 => {
+    into_bar: (T) -> Self;
+}
+
+main := () => {
+    t := #dump_ast {
+        k := perform_operation()
+        unmerge(k)
+    }
+}

--- a/tests/cases/semantics/directives/unknown_directive.stderr
+++ b/tests/cases/semantics/directives/unknown_directive.stderr
@@ -3,7 +3,7 @@ warn: `erase` is not a known directive
 2 |   
 3 |   Bar := #erase trait<T> {
   |           ^^^^^ 
-4 |       into_bar: (T) -> Self;
+4 |       into_bar: (T) -> Self
   = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.
 
 warn: `memoise` is not a known directive
@@ -11,5 +11,5 @@ warn: `memoise` is not a known directive
 7 |   
 8 |   Bar := #memoise () -> u32 => {
   |           ^^^^^^^ 
-9 |       into_bar: (T) -> Self;
+9 |       into_bar: (T) -> Self
   = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.

--- a/tests/cases/semantics/directives/unknown_directive.stderr
+++ b/tests/cases/semantics/directives/unknown_directive.stderr
@@ -1,0 +1,15 @@
+warn: `erase` is not a known directive
+ --> $DIR/unknown_directive.hash:3:9
+2 |   
+3 |   Bar := #erase trait<T> {
+  |           ^^^^^ 
+4 |       into_bar: (T) -> Self;
+  = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.
+
+warn: `memoise` is not a known directive
+ --> $DIR/unknown_directive.hash:8:9
+7 |   
+8 |   Bar := #memoise () -> u32 => {
+  |           ^^^^^^^ 
+9 |       into_bar: (T) -> Self;
+  = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -37,7 +37,7 @@ use hash_testing_internal::{
     TestingInput,
 };
 use hash_testing_macros::generate_tests;
-use hash_typecheck::TcImpl;
+use hash_typecheck::Typechecker;
 use hash_untyped_semantics::HashSemanticAnalysis;
 use hash_vm::vm::Interpreter;
 use regex::Regex;
@@ -197,7 +197,7 @@ fn handle_test(input: TestingInput) {
     let parser = HashParser::new();
     let desugarer = AstDesugarer;
     let semantic_analyser = HashSemanticAnalysis;
-    let checker = TcImpl;
+    let checker = Typechecker::new();
     let lowerer = IrLowerer;
 
     // Create the vm

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -60,7 +60,7 @@ fn compare_emitted_diagnostics(
 ) -> std::io::Result<()> {
     let contents = diagnostics
         .into_iter()
-        .map(|report| format!("{}", ReportWriter::new(report, sources.source_map())))
+        .map(|report| format!("{}", ReportWriter::new(report, &sources.source_map)))
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -181,7 +181,7 @@ fn handle_pass_case(
             "\ntest case did not pass:\n{}",
             diagnostics
                 .into_iter()
-                .map(|report| format!("{}", ReportWriter::new(report, sources.source_map())))
+                .map(|report| format!("{}", ReportWriter::new(report, &sources.source_map)))
                 .collect::<Vec<_>>()
                 .join("\n")
         );

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -28,8 +28,10 @@ use std::{fs, io};
 
 use hash_ast_desugaring::AstDesugarer;
 use hash_lower::IrLowerer;
-use hash_parser::HashParser;
-use hash_pipeline::{settings::CompilerSettings, sources::Workspace, Compiler};
+use hash_parser::Parser;
+use hash_pipeline::{
+    settings::CompilerSettings, sources::Workspace, traits::CompilerStage, Compiler,
+};
 use hash_reporting::{report::Report, writer::ReportWriter};
 use hash_source::ModuleKind;
 use hash_testing_internal::{
@@ -38,11 +40,13 @@ use hash_testing_internal::{
 };
 use hash_testing_macros::generate_tests;
 use hash_typecheck::Typechecker;
-use hash_untyped_semantics::HashSemanticAnalysis;
+use hash_untyped_semantics::SemanticAnalysis;
 use hash_vm::vm::Interpreter;
 use regex::Regex;
 
 use crate::{ANSI_REGEX, REGENERATE_OUTPUT};
+
+const WORKER_COUNT: usize = 2;
 
 /// Given the testing input, and a pre-filtered [Vec<Report>] based on
 /// the testing input parameters, render the reports and compare them
@@ -193,18 +197,7 @@ fn handle_pass_case(
 
 /// Generic test handler in the event whether a case should pass or fail.
 fn handle_test(input: TestingInput) {
-    // Initialise the compiler pipeline
-    let parser = HashParser::new();
-    let desugarer = AstDesugarer;
-    let semantic_analyser = HashSemanticAnalysis;
-    let checker = Typechecker::new();
-    let lowerer = IrLowerer;
-
-    // Create the vm
-    let vm = Interpreter::new();
-
-    let worker_count = 2;
-    let mut compiler_settings = CompilerSettings::new(worker_count);
+    let mut compiler_settings = CompilerSettings::new(WORKER_COUNT);
     compiler_settings.set_skip_prelude(true);
     compiler_settings.set_emit_errors(false);
     compiler_settings.set_stage(input.metadata.stage);
@@ -213,21 +206,21 @@ fn handle_test(input: TestingInput) {
     // queue can run within a worker and any other jobs can run inside another
     // worker or workers.
     let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(worker_count)
+        .num_threads(WORKER_COUNT)
         .thread_name(|id| format!("compiler-worker-{}", id))
         .build()
         .unwrap();
 
-    let mut compiler = Compiler::new(
-        parser,
-        desugarer,
-        semantic_analyser,
-        checker,
-        lowerer,
-        vm,
-        &pool,
-        compiler_settings,
-    );
+    let compiler_stages: Vec<Box<dyn CompilerStage>> = vec![
+        Box::new(Parser::new()),
+        Box::new(AstDesugarer),
+        Box::new(SemanticAnalysis),
+        Box::new(Typechecker::new()),
+        Box::new(IrLowerer),
+        Box::new(Interpreter::new()),
+    ];
+
+    let mut compiler = Compiler::new(compiler_stages, &pool, compiler_settings);
     let mut compiler_state = compiler.bootstrap();
 
     // // Now parse the module and store the result

--- a/tests/testing-internal/src/metadata.rs
+++ b/tests/testing-internal/src/metadata.rs
@@ -8,7 +8,7 @@ use std::{
     path::PathBuf,
 };
 
-use hash_pipeline::settings::CompilerMode;
+use hash_pipeline::settings::CompilerStageKind;
 use itertools::{peek_nth, Itertools};
 use quote::{quote, ToTokens};
 
@@ -85,7 +85,7 @@ impl ToTokens for HandleWarnings {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TestMetadata {
     /// The compiler stage should the test reach before stopping.
-    pub stage: CompilerMode,
+    pub stage: CompilerStageKind,
     /// How should the test complete, pass or fail.
     pub completion: TestResult,
     /// If the test should ignore any emitted warnings.
@@ -108,7 +108,7 @@ impl ToTokens for TestMetadata {
 
         // Convert the stage into the `tokenised` stage...
         let stage: quote::__private::TokenStream =
-            format!("CompilerMode::{:?}", stage).parse().unwrap();
+            format!("CompilerStageKind::{:?}", stage).parse().unwrap();
 
         tokens.extend(
             quote! ( TestMetadata { completion: #completion, stage: #stage, warnings: #warnings  }),
@@ -119,7 +119,7 @@ impl ToTokens for TestMetadata {
 #[derive(Debug, Default)]
 pub struct TestMetadataBuilder {
     /// Stage that the test should run to
-    stage: Option<CompilerMode>,
+    stage: Option<CompilerStageKind>,
 
     /// Whether the test is expected to pass or fail.
     completion: Option<TestResult>,
@@ -135,7 +135,7 @@ impl TestMetadataBuilder {
     }
 
     /// Add a stage value to the test.
-    pub fn with_stage(&mut self, stage: CompilerMode) -> &mut Self {
+    pub fn with_stage(&mut self, stage: CompilerStageKind) -> &mut Self {
         self.stage = Some(stage);
         self
     }
@@ -207,7 +207,7 @@ pub struct ParsedMetadata {
 /// ```
 /// From the above example, this function will produce a [TestMetadata] that
 /// specifies that this test should `pass` and should only run up until the
-/// [CompilerMode::Parse].
+/// [CompilerStageKind::Parse].
 pub fn parse_test_case_metadata(path: &PathBuf) -> Result<ParsedMetadata, io::Error> {
     let mut source = String::new();
 
@@ -261,15 +261,15 @@ pub fn parse_test_case_metadata(path: &PathBuf) -> Result<ParsedMetadata, io::Er
                 }
                 "stage" => {
                     let stage = match value.as_str() {
-                        "parse" => CompilerMode::Parse,
-                        "semantic" => CompilerMode::SemanticPass,
-                        "typecheck" => CompilerMode::Typecheck,
-                        "ir" => CompilerMode::IrGen,
-                        "full" => CompilerMode::Full,
+                        "parse" => CompilerStageKind::Parse,
+                        "semantic" => CompilerStageKind::SemanticPass,
+                        "typecheck" => CompilerStageKind::Typecheck,
+                        "ir" => CompilerStageKind::IrGen,
+                        "full" => CompilerStageKind::Full,
                         // We always default to `full` here
                         _ => {
                             warnings.push(ParseWarning::new_unrecognised_value(key, value));
-                            CompilerMode::Full
+                            CompilerStageKind::Full
                         }
                     };
 

--- a/tests/testing-macros/src/lib.rs
+++ b/tests/testing-macros/src/lib.rs
@@ -234,7 +234,7 @@ pub fn generate_tests(input: TokenStream) -> TokenStream {
             #[test]
             fn #test_names() {
                 use hash_testing_internal::metadata::TestMetadata;
-                use hash_pipeline::settings::CompilerMode;
+                use hash_pipeline::settings::CompilerStageKind;
 
                 #test_func(TestingInput {
                     path: #paths.into(),


### PR DESCRIPTION
This patch moves away from the `Compiler` using traits that implement abstract `Stage` interfaces and just to a single `CompilerStage`. This significantly simplifies the pipeline code and makes it more standard per stage.