### PR TITLE
ast-expand: `#dump_ast` directive now allows user to dump the AST for a particular expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "clap",
  "hash-alloc",
  "hash-ast-desugaring",
+ "hash-ast-expand",
  "hash-interactive",
  "hash-lower",
  "hash-parser",
@@ -398,6 +399,18 @@ dependencies = [
  "hash-pipeline",
  "hash-reporting",
  "hash-source",
+ "rayon",
+]
+
+[[package]]
+name = "hash-ast-expand"
+version = "0.1.0"
+dependencies = [
+ "hash-ast",
+ "hash-pipeline",
+ "hash-reporting",
+ "hash-source",
+ "hash-utils",
  "rayon",
 ]
 
@@ -544,6 +557,7 @@ version = "0.1.0"
 dependencies = [
  "hash-ast",
  "hash-ast-desugaring",
+ "hash-ast-expand",
  "hash-lexer",
  "hash-lower",
  "hash-parser",
@@ -591,7 +605,6 @@ dependencies = [
  "dashmap",
  "hash-alloc",
  "hash-ast",
- "hash-ast-desugaring",
  "hash-error-codes",
  "hash-pipeline",
  "hash-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "compiler/hash-alloc",
   "compiler/hash-ast-desugaring",
+  "compiler/hash-ast-expand",
   "compiler/hash-ast",
   "compiler/hash-error-codes",
   "compiler/hash-interactive",

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -1,6 +1,6 @@
 //! Hash AST expanding passes crate. This crate holds an implementation for the
-//! visitor pattern on the AST in order to expand any directives or macros that need
-//! to run after the parsing stage. Currently this function does not have 
+//! visitor pattern on the AST in order to expand any directives or macros that
+//! need to run after the parsing stage. Currently this function does not have
 
 use hash_ast::ast::{AstVisitor, OwnsAstNode};
 use hash_pipeline::{settings::CompilerStageKind, sources::Workspace, traits::CompilerStage};
@@ -9,9 +9,9 @@ use visitor::AstExpander;
 
 mod visitor;
 
-pub struct AstExpansionStage;
+pub struct AstExpansionPass;
 
-impl<'pool> CompilerStage<'pool> for AstExpansionStage {
+impl<'pool> CompilerStage<'pool> for AstExpansionPass {
     fn stage_kind(&self) -> CompilerStageKind {
         CompilerStageKind::DeSugar
     }
@@ -35,10 +35,9 @@ impl<'pool> CompilerStage<'pool> for AstExpansionStage {
             }
         }
 
-
         for (id, module) in node_map.iter_modules() {
             let module_id = SourceId::Module(*id);
-            
+
             // Skip any modules that have already been de-sugared
             if desugared_modules.contains(&module_id) {
                 continue;

--- a/compiler/hash-ast-expand/src/visitor.rs
+++ b/compiler/hash-ast-expand/src/visitor.rs
@@ -1,7 +1,14 @@
 use std::convert::Infallible;
 
-use hash_ast::{visitor::{walk, AstVisitor}, tree::AstTreeGenerator};
-use hash_source::{identifier::IDENTS, SourceMap, SourceId, location::{SourceLocation, Span}};
+use hash_ast::{
+    tree::AstTreeGenerator,
+    visitor::{walk, AstVisitor},
+};
+use hash_source::{
+    identifier::IDENTS,
+    location::{SourceLocation, Span},
+    SourceId, SourceMap,
+};
 use hash_utils::tree_writing::TreeWriter;
 
 #[derive(Debug)]
@@ -194,9 +201,9 @@ impl<'s> AstVisitor for AstExpander<'s> {
     ) -> Result<Self::DirectiveExprRet, Self::Error> {
         let _ = walk::walk_directive_expr(self, node);
 
-       // for the `dump_ast` directive, we essentially "dump" the generated tree
-       // that the parser created. We emit this tree regardless of whether or not
-       // there will be errors later on in the compilation stage. 
+        // for the `dump_ast` directive, we essentially "dump" the generated tree
+        // that the parser created. We emit this tree regardless of whether or not
+        // there will be errors later on in the compilation stage.
         if node.name.is(IDENTS.dump_ast) {
             let tree = AstTreeGenerator.visit_expr(node.subject.ast_ref()).unwrap();
             let name = self.source_map.canonicalised_path_by_id(self.source_id);
@@ -204,8 +211,7 @@ impl<'s> AstVisitor for AstExpander<'s> {
             let location = self.source_location(node.subject.span());
             let span = self.source_map.get_column_row_span_for(location);
 
-            
-            println!("AST for {}{} {}", name, span, TreeWriter::new(&tree));
+            println!("AST for {}:{}\n{}", name, span, TreeWriter::new(&tree));
         }
 
         Ok(())

--- a/compiler/hash-pipeline/src/sources.rs
+++ b/compiler/hash-pipeline/src/sources.rs
@@ -78,6 +78,11 @@ impl Module {
         &self.path
     }
 
+    /// Get the canonicalised `path` from the [Module].
+    pub fn canonicalised_path(&self) -> String {
+        adjust_canonicalisation(self.path())
+    }
+
     /// Set the `node` for given [Module]
     pub fn set_node(&mut self, node: ast::AstNode<ast::Module>) {
         self.node = Some(node);
@@ -215,6 +220,12 @@ pub struct Workspace {
     /// Stores all of the generated AST for modules and nodes
     pub node_map: NodeMap,
 
+    /// Sources that have passed from the `expansion` stage of the compiler.
+    /// @@Todo: Use bit-flags to represent which module has been
+    /// expanded/desugared/semantically checked/type checked.
+    pub expanded_sources: HashSet<SourceId>,
+
+    /// Sources that have passed from the `desugaring` stage of the compiler.
     pub desugared_modules: HashSet<SourceId>,
 
     /// Modules that have already been semantically checked. This is needed in
@@ -240,6 +251,7 @@ impl Workspace {
             ty_storage: TyStorage { global, local },
             node_map: NodeMap::new(),
             source_map: SourceMap::new(),
+            expanded_sources: HashSet::new(),
             dependencies: HashMap::new(),
             desugared_modules: HashSet::new(),
             semantically_checked_modules: HashSet::new(),
@@ -300,8 +312,8 @@ impl Workspace {
                     let tree = AstTreeGenerator.visit_module(generated_module.node_ref()).unwrap();
 
                     println!(
-                        "Tree for `{}`:\n{}",
-                        adjust_canonicalisation(generated_module.path()),
+                        "AST for `{}`:\n{}",
+                        generated_module.canonicalised_path(),
                         TreeWriter::new(&tree)
                     );
                 }

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -13,8 +13,10 @@ use std::{
     iter::{once, repeat},
 };
 
-use hash_source::{location::SourceLocation, SourceMap};
-use hash_utils::path::adjust_canonicalisation;
+use hash_source::{
+    location::{compute_row_col_from_offset, RowCol, RowColSpan, SourceLocation},
+    SourceMap,
+};
 
 use crate::{
     highlight::{highlight, Colour, Modifier},
@@ -33,56 +35,6 @@ const DIAGNOSTIC_CONNECTING_CHAR: &str = "|";
 /// The maximum number of lines a block display can use before the lines in the
 /// center of the block are skipped.
 const LINE_SKIP_THRESHOLD: usize = 6;
-
-/// Struct to represent the column and row offset produced from converting a
-/// [hash_source::location::Span].
-pub(crate) struct ColRowOffset {
-    /// The column offset.
-    col: usize,
-    /// The row offset.
-    row: usize,
-}
-
-/// Function to compute a row and column number from a given source string
-/// and an offset within the source. This will take into account the number
-/// of encountered newlines and characters per line in order to compute
-/// precise row and column numbers of the span.
-pub(crate) fn offset_col_row(offset: usize, source: &str, non_inclusive: bool) -> ColRowOffset {
-    let source_lines = source.split('\n');
-
-    let mut bytes_skipped = 0;
-    let mut total_lines: usize = 0;
-    let mut last_line_len = 0;
-
-    let mut line_index = None;
-    for (line_idx, line) in source_lines.enumerate() {
-        // One byte for the newline
-        let skip_width = line.len() + 1;
-
-        // Here, we don't want an inclusive range because we don't want to get the last
-        // byte because that will always point to the newline character and this
-        // isn't necessary to be included when selecting a span for printing.
-        let range = if non_inclusive {
-            bytes_skipped..bytes_skipped + skip_width
-        } else {
-            bytes_skipped..bytes_skipped + skip_width + 1
-        };
-
-        if range.contains(&offset) {
-            line_index = Some(ColRowOffset { col: offset - bytes_skipped, row: line_idx });
-            break;
-        }
-
-        bytes_skipped += skip_width;
-        total_lines += 1;
-        last_line_len = line.len();
-    }
-
-    line_index.unwrap_or(ColRowOffset {
-        col: last_line_len.saturating_sub(1),
-        row: total_lines.saturating_sub(1),
-    })
-}
 
 /// This function holds inner rules for calculating what the selected top
 /// and bottom buffer sizes should be.
@@ -121,14 +73,14 @@ impl ReportCodeBlock {
                 let source = sources.contents_by_id(source_id);
 
                 // Compute offset rows and columns from the provided span
-                let ColRowOffset { col: start_col, row: start_row } =
-                    offset_col_row(span.start(), source, true);
+                let start @ RowCol { row: start_row, .. } =
+                    compute_row_col_from_offset(span.start(), source, true);
 
-                let ColRowOffset { col: end_col, row: end_row } =
-                    offset_col_row(span.end(), source, false);
+                let end @ RowCol { row: end_row, .. } =
+                    compute_row_col_from_offset(span.end(), source, false);
 
-                let ColRowOffset { row: last_row, .. } =
-                    offset_col_row(source.len(), source, false);
+                let RowCol { row: last_row, .. } =
+                    compute_row_col_from_offset(source.len(), source, false);
 
                 // Compute the selected span outside of the diagnostic span
                 let (top_buf, bottom_buf) = compute_buffers(start_row, end_row);
@@ -140,8 +92,8 @@ impl ReportCodeBlock {
                     .chars()
                     .count();
 
-                let info =
-                    ReportCodeBlockInfo { indent_width, start_col, start_row, end_col, end_row };
+                let span = RowColSpan::new(start, end);
+                let info = ReportCodeBlockInfo { indent_width, span };
 
                 self.info.replace(Some(info));
                 info
@@ -159,7 +111,8 @@ impl ReportCodeBlock {
         let source_id = self.source_location.id;
         let source = modules.contents_by_id(source_id);
 
-        let ReportCodeBlockInfo { start_row, end_row, .. } = self.info(modules);
+        let ReportCodeBlockInfo { span, .. } = self.info(modules);
+        let (start_row, end_row) = span.rows();
 
         let (top_buffer, bottom_buffer) = compute_buffers(start_row, end_row);
 
@@ -194,7 +147,10 @@ impl ReportCodeBlock {
     ) -> fmt::Result {
         let error_view = self.get_source_view(modules);
 
-        let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
+        let ReportCodeBlockInfo { span, .. } = self.info(modules);
+
+        let (start_row, end_row) = span.rows();
+        let (start_column, end_column) = span.columns();
 
         // Print each selected line with the line number
         for (index, line) in error_view {
@@ -211,18 +167,18 @@ impl ReportCodeBlock {
             if (start_row..=end_row).contains(&index) && !line.is_empty() {
                 let dashes: String = repeat(LINE_DIAGNOSTIC_MARKER)
                     .take(if index == start_row && start_row == end_row {
-                        end_col - start_col
+                        end_column - start_column
                     } else if index == start_row {
-                        line.len().saturating_sub(start_col)
+                        line.len().saturating_sub(start_column)
                     } else if index == end_row {
-                        end_col
+                        end_column
                     } else {
                         line.len()
                     })
                     .collect();
 
                 let mut code_note: String = repeat(" ")
-                    .take(if index == start_row { start_col } else { 0 })
+                    .take(if index == start_row { start_column } else { 0 })
                     .chain(once(dashes.as_str()))
                     .collect();
 
@@ -277,11 +233,14 @@ impl ReportCodeBlock {
     ) -> fmt::Result {
         let error_view = self.get_source_view(modules);
 
-        let ReportCodeBlockInfo { start_row, end_row, start_col, end_col, .. } = self.info(modules);
+        let ReportCodeBlockInfo { span, .. } = self.info(modules);
 
         // If the difference between the rows is longer than `LINE_SKIP_THRESHOLD`
         // lines, then we essentially begin to collapse the view by using `...`
         // as the filler for those lines...
+        let (start_row, end_row) = span.rows();
+        let (start_column, end_column) = span.columns();
+
         let skip_lines_range = if end_row - start_row > LINE_SKIP_THRESHOLD {
             let mid = LINE_SKIP_THRESHOLD / 2;
             Some((start_row + mid)..=(end_row - mid))
@@ -351,8 +310,10 @@ impl ReportCodeBlock {
             // If this is th first row of the diagnostic span, then we want to draw an arrow
             // leading up to it
             if index == start_row {
-                let arrow: String =
-                    repeat('_').take(start_col + 2).chain(once(BLOCK_DIAGNOSTIC_MARKER)).collect();
+                let arrow: String = repeat('_')
+                    .take(start_column + 2)
+                    .chain(once(BLOCK_DIAGNOSTIC_MARKER))
+                    .collect();
 
                 writeln!(
                     f,
@@ -367,7 +328,7 @@ impl ReportCodeBlock {
             // and of course we write the note at the end of the span.
             if index == end_row {
                 let arrow: String = once('|')
-                    .chain(repeat('_').take(end_col + 1))
+                    .chain(repeat('_').take(end_column + 1))
                     .chain(format!("{BLOCK_DIAGNOSTIC_MARKER} ").chars())
                     .chain(self.code_message.as_str().chars())
                     .collect();
@@ -390,12 +351,12 @@ impl ReportCodeBlock {
     pub(crate) fn render(
         &self,
         f: &mut fmt::Formatter,
-        modules: &SourceMap,
+        source_map: &SourceMap,
         longest_indent_width: usize,
         report_kind: ReportKind,
     ) -> fmt::Result {
         let source_id = self.source_location.id;
-        let ReportCodeBlockInfo { start_row, end_row, start_col, .. } = self.info(modules);
+        let ReportCodeBlockInfo { span, .. } = self.info(source_map);
 
         // Print the filename of the code block...
         writeln!(
@@ -412,10 +373,12 @@ impl ReportCodeBlock {
         // Now we can determine whether we want to use the `block` or the `line` view.
         // The block view is for displaying large spans for multiple lines,
         // whilst the line view is for a single line span.
+        let (start_row, end_row) = span.rows();
+
         if start_row == end_row {
-            self.render_line_view(f, modules, longest_indent_width, report_kind)
+            self.render_line_view(f, source_map, longest_indent_width, report_kind)
         } else {
-            self.render_block_view(f, modules, longest_indent_width, report_kind)
+            self.render_block_view(f, source_map, longest_indent_width, report_kind)
         }
     }
 }
@@ -453,21 +416,5 @@ impl ReportElement {
             }
             ReportElement::Note(note) => note.render(f, longest_indent_width),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn offset_test() {
-        let contents = "Hello, world!\nGoodbye, world, it has been fun.";
-
-        let ColRowOffset { col, row } = offset_col_row(contents.len() - 1, contents, false);
-        assert_eq!((col, row), (31, 1));
-
-        let ColRowOffset { col, row } = offset_col_row(contents.len() + 3, contents, false);
-        assert_eq!((col, row), (31, 1));
     }
 }

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -405,12 +405,7 @@ impl ReportCodeBlock {
             highlight(Colour::Blue, "-->"),
             highlight(
                 Modifier::Underline,
-                format!(
-                    "{}:{}:{}",
-                    adjust_canonicalisation(modules.path_by_id(source_id)),
-                    start_row + 1,
-                    start_col + 1,
-                )
+                format!("{}:{}", source_map.canonicalised_path_by_id(source_id), span.start)
             )
         )?;
 

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -2,7 +2,7 @@
 use std::{cell::Cell, convert::Infallible, fmt, io};
 
 use hash_error_codes::error_codes::HashErrorCode;
-use hash_source::location::SourceLocation;
+use hash_source::location::{RowColSpan, SourceLocation};
 
 use crate::{
     builder::ReportBuilder,
@@ -15,14 +15,9 @@ use crate::{
 pub struct ReportCodeBlockInfo {
     /// How many characters should be used for line numbers on the side.
     pub indent_width: usize,
-    /// The beginning column of the code block.
-    pub start_col: usize,
-    /// The beginning row of the code block.
-    pub start_row: usize,
-    /// The end column of the code block.
-    pub end_col: usize,
-    /// The end row of the code block.
-    pub end_row: usize,
+
+    /// The span of the code block but using row and column indices.
+    pub span: RowColSpan,
 }
 
 /// Enumeration describing the kind of [Report]; either being a warning, info or

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 use bimap::BiMap;
+use hash_utils::path::adjust_canonicalisation;
+use location::{compute_row_col_from_offset, RowColSpan, SourceLocation};
 use slotmap::{new_key_type, Key, SlotMap};
 
 pub mod constant;
@@ -176,5 +178,16 @@ impl SourceMap {
     /// Add an interactive block to the [SourceMap]
     pub fn add_interactive_block(&mut self, contents: String) -> InteractiveId {
         self.interactive_content_map.insert(contents)
+    }
+
+    /// Function to get a friendly representation of the [SourceLocation] in
+    /// terms of row and column positions.
+    pub fn get_column_row_span_for(&self, location: SourceLocation) -> RowColSpan {
+        let source = self.contents_by_id(location.id);
+
+        let start = compute_row_col_from_offset(location.span.start(), source, true);
+        let end = compute_row_col_from_offset(location.span.end(), source, false);
+
+        RowColSpan { start, end }
     }
 }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -100,6 +100,16 @@ impl SourceMap {
         }
     }
 
+    /// Get a canonicalised version of a [Path] for a [SourceId]. If it is
+    /// interactive, the path is always set as `<interactive>`. The function
+    /// automatically converts the value into a string.
+    pub fn canonicalised_path_by_id(&self, source_id: SourceId) -> String {
+        match source_id {
+            SourceId::Interactive(_) => String::from("<interactive>"),
+            SourceId::Module(_) => adjust_canonicalisation(self.path_by_id(source_id)),
+        }
+    }
+
     /// Get the name of a [SourceId] by extracting the path and further
     /// retrieving the stem of the filename as the name of the module. This
     /// function adheres to the rules of module naming conventions which are

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -177,7 +177,12 @@ pub fn compute_row_col_from_offset(offset: usize, source: &str, non_inclusive: b
 
     let mut line_index = None;
     for (line_idx, line) in source_lines.enumerate() {
-        // One byte for the newline
+        // @@Future: rather than *assuming* that the newline will always be a single
+        // byte, we should perform a `normalisation` operation when the source
+        // file is first read, so that we can deal with any line ending
+        // regardless of the current environment.
+        //
+        // Add a single byte for the `\n`...
         let skip_width = line.len() + 1;
 
         // Here, we don't want an inclusive range because we don't want to get the last

--- a/compiler/hash-typecheck/Cargo.toml
+++ b/compiler/hash-typecheck/Cargo.toml
@@ -16,7 +16,6 @@ rayon = "1.5.0"
 
 hash-ast = { path = "../hash-ast" }
 hash-alloc = { path = "../hash-alloc" }
-hash-ast-desugaring = { path = "../hash-ast-desugaring" }
 hash-error-codes = { path = "../hash-error-codes" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash/Cargo.toml
+++ b/compiler/hash/Cargo.toml
@@ -26,6 +26,7 @@ hash-tree-def = { path = "../hash-tree-def" }
 # Various stages that the pipeline interfaces with...
 hash-parser = { path = "../hash-parser" }
 hash-ast-desugaring = { path = "../hash-ast-desugaring" }
+hash-ast-expand = { path = "../hash-ast-expand" }
 hash-untyped-semantics = { path = "../hash-untyped-semantics" }
 hash-typecheck = { path = "../hash-typecheck" }
 hash-lower = { path = "../hash-lower" }

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -9,6 +9,7 @@ use std::{num::NonZeroUsize, panic};
 
 use clap::Parser as ClapParser;
 use hash_ast_desugaring::AstDesugarer;
+use hash_ast_expand::AstExpansionPass;
 use hash_lower::IrLowerer;
 use hash_parser::Parser;
 use hash_pipeline::{settings::CompilerSettings, traits::CompilerStage, Compiler};
@@ -87,6 +88,7 @@ fn main() {
     let compiler_settings: CompilerSettings = opts.into();
     let compiler_stages: Vec<Box<dyn CompilerStage>> = vec![
         Box::new(Parser::new()),
+        Box::new(AstExpansionPass),
         Box::new(AstDesugarer),
         Box::new(SemanticAnalysis),
         Box::new(Typechecker::new()),

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,7 @@ hash-reporting = {path = "../compiler/hash-reporting" }
 hash-lexer = {path = "../compiler/hash-lexer" }
 hash-parser = {path = "../compiler/hash-parser" }
 hash-ast-desugaring = { path = "../compiler/hash-ast-desugaring" }
+hash-ast-expand = { path = "../compiler/hash-ast-expand" }
 hash-untyped-semantics = { path = "../compiler/hash-untyped-semantics" }
 hash-typecheck = { path = "../compiler/hash-typecheck" }
 hash-lower = { path = "../compiler/hash-lower" }

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -27,6 +27,7 @@
 use std::{fs, io};
 
 use hash_ast_desugaring::AstDesugarer;
+use hash_ast_expand::AstExpansionPass;
 use hash_lower::IrLowerer;
 use hash_parser::Parser;
 use hash_pipeline::{
@@ -214,6 +215,7 @@ fn handle_test(input: TestingInput) {
     let compiler_stages: Vec<Box<dyn CompilerStage>> = vec![
         Box::new(Parser::new()),
         Box::new(AstDesugarer),
+        Box::new(AstExpansionPass),
         Box::new(SemanticAnalysis),
         Box::new(Typechecker::new()),
         Box::new(IrLowerer),


### PR DESCRIPTION
This patch adds a new stage to the compiler called `hash-ast-expand` which will perform any expansions that need to happen for macros (which will be added in the future) or directives which are essentially a superset of macros, but allow the user to perform more powerful metaprogramming operations.

Addditionally, this patch refactors how line/column numbers are calculated, and where the logic is housed for this:

> Previously, when the compiler needed to convert `SourceLocation`s
and `Span`s into their respective row and columns values for line
number information, it was being done as a second thought in the
reporting sub-system.

> Now that there has been the need to access this logic from other crates,
it has been decided that this logic should live in `hash-source` and
be accessible by everyone who requires converting locations into
row and column values. This means that:

> - computing `row` and `column` values logic now lives in `hash-source`.
> - `RowColSpan` is a structure that represents a `Span` but with row
and column values.
> - `RowCol` is a single unit data structure to group a `row` and
`column` value.


closes #541 