### PR TITLE
ir: add initial support for the `#dump_ir` directive

### DIFF
--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -49,15 +49,4 @@ impl<'pool> CompilerStage<'pool> for AstExpansionPass {
 
         Ok(())
     }
-
-    fn cleanup(
-        &self,
-        entry_point: SourceId,
-        workspace: &mut Workspace,
-        settings: &hash_pipeline::settings::CompilerSettings,
-    ) {
-        if settings.stage > CompilerStageKind::Parse && settings.dump_ast {
-            workspace.print_sources(entry_point);
-        }
-    }
 }

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -99,12 +99,12 @@ impl<T> AstNode<T> {
 #[derive(Debug)]
 pub struct AstNodeRef<'t, T> {
     /// A reference to the body of the [AstNode].
-    body: &'t T,
+    pub body: &'t T,
     /// The [Span] of the node.
-    span: Span,
+    pub span: Span,
     /// The [AstNodeId] of the node, representing a unique identifier within
     /// the AST, useful for performing fast comparisons of trees.
-    id: AstNodeId,
+    pub id: AstNodeId,
 }
 
 impl<T> Clone for AstNodeRef<'_, T> {

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -42,12 +42,4 @@ impl<'pool> CompilerStage<'pool> for IrLowerer {
 
         Ok(())
     }
-
-    fn cleanup(
-        &self,
-        entry_point: SourceId,
-        workspace: &mut hash_pipeline::sources::Workspace,
-        settings: &hash_pipeline::settings::CompilerSettings,
-    ) {
-    }
 }

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -647,13 +647,22 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 // First get the directive subject, and expect a possible singular expression
                 // followed by the directive.
                 let name = self.parse_name()?;
-                let subject = self.parse_expr()?;
 
-                // create the subject node
-                return Ok(self.node_with_joined_span(
-                    Expr::Directive(DirectiveExpr { name, subject }),
-                    start,
-                ));
+                // Continue attempting to parse a 'top level' expression since directives
+                // can accept the whole set of expressions.
+                loop {
+                    let expr = self.parse_top_level_expr()?;
+
+                    if let Some(subject) = expr {
+                        // create the subject node
+                        return Ok(self.node_with_joined_span(
+                            Expr::Directive(DirectiveExpr { name, subject }),
+                            start,
+                        ));
+                    }
+
+                    continue;
+                }
             }
             TokenKind::Keyword(Keyword::Unsafe) => {
                 let arg = self.parse_expr()?;

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -302,6 +302,7 @@ impl<'pool> Compiler<'pool> {
         };
 
         // Create the entry point and run!
+
         let entry_point =
             compiler_state.workspace.add_module(contents.unwrap(), Module::new(filename), kind);
 

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -226,6 +226,6 @@ core_idents! {
 
     // Directives that are pre-defined within the language.
     dump_ast("dump_ast"),
-    dump_ir("dump_ast"),
+    dump_ir("dump_ir"),
     intrinsics("intrinsics"),
 }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -100,7 +100,9 @@ impl<'pool> CompilerStage<'pool> for Typechecker {
             Err(err) => {
                 tc_visitor.diagnostics().add_error(err);
             }
-            Ok(source_term) if !tc_visitor.diagnostics().has_errors() => {
+            Ok(source_term)
+                if !tc_visitor.diagnostics().has_errors() && entry_point.is_interactive() =>
+            {
                 // @@Cmdline: make this a configurable behaviour through a cmd-arg.
                 // Print the result if no errors
                 println!("{}", source_term.for_formatting(storage.global_storage()));

--- a/compiler/hash-untyped-semantics/src/diagnostics/directives.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/directives.rs
@@ -15,10 +15,15 @@ use hash_ast::ast::{Block, BlockExpr, Expr};
 /// expanded into the [DirectiveArgument] variants as their own standalone
 /// variants.
 pub enum DirectiveArgument {
+    /// Some function call, or a constructor initialisation.
     ConstructorCall,
+    /// A directive expression.
     Directive,
+    /// A declaration.
     Declaration,
+    /// Unsafe block expression
     Unsafe,
+    /// Literal expression.
     LitExpr,
     Cast,
     /// Since the AST is de-sugared at this point, it should be that `for`,
@@ -33,19 +38,32 @@ pub enum DirectiveArgument {
     ModBlock,
     /// The [hash_ast::ast::Block::Body] variant
     Block,
+    /// An `import` statement.
     Import,
+    /// A `struct` definition.
     StructDef,
+    /// An `enum` definition.
     EnumDef,
+    /// A type function definition.
     TyFnDef,
+    /// A `trait` definition as the argument to the function.
     TraitDef,
+    /// A function definition, regardless of the position.
     FnDef,
+    /// A type.
     Ty,
+    /// A `return` expression.
     Return,
+    /// A `break` expression.
     Break,
+    /// A `continue` expression.
     Continue,
+    /// A merge declaration.
     MergeDeclaration,
+    /// A trait implementation block e.g. `impl T {}`.
     TraitImpl,
-    /// General expression
+    /// General expression, this is used when it expected any variant of an
+    /// expression, but did not receive one.
     Expr,
 }
 

--- a/compiler/hash-untyped-semantics/src/diagnostics/origins.rs
+++ b/compiler/hash-untyped-semantics/src/diagnostics/origins.rs
@@ -61,6 +61,9 @@ pub(crate) enum BlockOrigin {
     Impl,
     /// Block is a body of some kind.
     Body,
+    /// A dummy [BlockOrigin] kind, only used for error
+    /// reporting and grouping `constant` blocks together.
+    Const,
 }
 
 impl BlockOrigin {
@@ -72,6 +75,7 @@ impl BlockOrigin {
             BlockOrigin::Impl => "impl",
             BlockOrigin::Body => "body",
             BlockOrigin::Trait => "trait",
+            BlockOrigin::Const => "constant",
         }
     }
 }

--- a/tests/cases/parser/misc/expresionless_directive.stderr
+++ b/tests/cases/parser/misc/expresionless_directive.stderr
@@ -1,5 +1,11 @@
-error: expected an expression, however received a `;`
+error: expected an expression
+ --> $DIR/expresionless_directive.hash:4:12
+3 |   // This directive does not have an expression
+4 |   k := #dump;
+  |              ^ 
+
+warn: unnecessary trailing semicolon
  --> $DIR/expresionless_directive.hash:4:11
 3 |   // This directive does not have an expression
 4 |   k := #dump;
-  |             ^ 
+  |             ^ remove this semicolon

--- a/tests/cases/semantics/directives/dump_ir.hash
+++ b/tests/cases/semantics/directives/dump_ir.hash
@@ -1,0 +1,16 @@
+// run=fail, stage=semantic
+
+#dump_ir foo := 2
+
+// FAIL: `#dump_ir` only accepts declarations as an argument.
+mux := #dump_ir 2
+
+
+#dump_ir bux := () => {
+
+    // FAIL: This is not allowed since `#dump_ir` calls should be within constant 
+    // blocks only, not body blocks...
+
+    #dump_ir m := 2
+}
+

--- a/tests/cases/semantics/directives/dump_ir.hash
+++ b/tests/cases/semantics/directives/dump_ir.hash
@@ -14,3 +14,6 @@ mux := #dump_ir 2
     #dump_ir m := 2
 }
 
+
+// Allowed: multiple nested directives
+#dump_ast #dump_ir brux := 2

--- a/tests/cases/semantics/directives/dump_ir.stderr
+++ b/tests/cases/semantics/directives/dump_ir.stderr
@@ -1,0 +1,13 @@
+error: the `dump_ir` directive expects a declaration as an argument
+ --> $DIR/dump_ir.hash:6:17
+5 |   // FAIL: `#dump_ir` only accepts declarations as an argument.
+6 |   mux := #dump_ir 2
+  |                   ^ a literal cannot be given to the `dump_ir` directive
+7 |   
+
+error: the `dump_ir` directive is must be within a constant block
+  --> $DIR/dump_ir.hash:14:14
+13 |   
+14 |       #dump_ir m := 2
+   |                ^ `dump_ir` cannot be used within body block
+15 |   }


### PR DESCRIPTION
Initial work towards #146 