### PR TITLE
TC: fix error reporting for non-equal compound pattern variable bounds

### DIFF
--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -1356,7 +1356,8 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Report {
             }
             TcError::MissingPatternBounds { pat, bounds } => {
                 builder.with_error_code(HashErrorCode::MissingPatternBounds).with_message(format!(
-                    "variables {} are not declared in all patterns",
+                    "variable{} {} are not declared in all patterns",
+                    pluralise!(bounds.len()),
                     SequenceDisplay::all(bounds.as_slice())
                 ));
 

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -45,6 +45,17 @@ impl<'tc> AccessToStorage for PatMatcher<'tc> {
     }
 }
 
+/// A pattern that occurs in a position within a declaration or some
+/// other binding structure. The [PatMember] represents the relation
+/// between the underlying [Pat] and the scope [Member].
+#[derive(Debug, Clone)]
+struct PatMember {
+    /// The id of the pattern.
+    pat: PatId,
+    /// The member that the pattern is bound to.
+    member: Member,
+}
+
 impl<'tc> PatMatcher<'tc> {
     /// Create a new [PatMatcher].
     pub fn new(storage: StorageRef<'tc>) -> Self {
@@ -53,10 +64,10 @@ impl<'tc> PatMatcher<'tc> {
 
     /// Verify that the given set of members corresponding to the given
     /// patterns, all bind distinct names.
-    pub fn verify_members_are_bound_once(&self, members: &[(Member, PatId)]) -> TcResult<()> {
+    fn verify_members_are_bound_once(&self, members: &[PatMember]) -> TcResult<()> {
         let mut names: HashSet<Identifier> = HashSet::new();
 
-        for (member, pat) in members.iter() {
+        for PatMember { member, pat } in members.iter() {
             if names.contains(&member.name()) {
                 return Err(TcError::IdentifierBoundMultipleTimes {
                     name: member.name(),
@@ -78,9 +89,12 @@ impl<'tc> PatMatcher<'tc> {
     /// been checked before creating the map.
     fn map_variables_to_terms(
         &self,
-        members: &[(Member, PatId)],
+        members: &[PatMember],
     ) -> HashMap<Identifier, (TermId, PatId)> {
-        members.iter().map(|(member, pat)| (member.name(), (member.ty(), *pat))).collect()
+        members
+            .iter()
+            .map(|PatMember { member, pat }| (member.name(), (member.ty(), *pat)))
+            .collect()
     }
 
     /// Function to check that the inner patterns of a [Pat::Or] adhere to the
@@ -88,7 +102,7 @@ impl<'tc> PatMatcher<'tc> {
     ///
     /// - For every inner pattern, the resultant members must be equivalent in
     ///   terms of name and type.
-    fn pat_members_match(&self, members: &[(Vec<(Member, PatId)>, PatId)]) -> TcResult<()> {
+    fn pat_members_match(&self, members: &[(Vec<PatMember>, PatId)]) -> TcResult<()> {
         let member_maps = members
             .iter()
             .map(|(members, pat)| (self.map_variables_to_terms(members), pat))
@@ -156,7 +170,7 @@ impl<'tc> PatMatcher<'tc> {
         items: Vec<(PatArg, TermId, Option<TermId>)>,
         name: Identifier,
         original_id: PatId,
-    ) -> TcResult<Option<(Member, PatId)>> {
+    ) -> TcResult<Option<PatMember>> {
         let members = self.builder().create_args(
             items.iter().map(|(member, ty, value)| Arg {
                 name: member.name,
@@ -176,7 +190,10 @@ impl<'tc> PatMatcher<'tc> {
         // this one so in-case it is used for error reporting purposes...
         self.location_store().copy_location(original_id, id);
 
-        Ok(Some((Member::variable(name, Mutability::Immutable, inferred_term, inferred_term), id)))
+        Ok(Some(PatMember {
+            member: Member::variable(name, Mutability::Immutable, inferred_term, inferred_term),
+            pat: id,
+        }))
     }
 
     /// Find a spread pattern within the provided [PatArgsId].
@@ -241,7 +258,7 @@ impl<'tc> PatMatcher<'tc> {
         &self,
         pat: PatId,
         ConstructorPat { args, subject }: ConstructorPat,
-    ) -> TcResult<Option<(Member, PatId)>> {
+    ) -> TcResult<Option<PatMember>> {
         let reader = self.reader();
 
         // Utility for creating a wildcard pattern since this is a
@@ -315,7 +332,7 @@ impl<'tc> PatMatcher<'tc> {
         pat: PatId,
         members: PatArgsId,
         subject: TermId,
-    ) -> TcResult<Option<(Member, PatId)>> {
+    ) -> TcResult<Option<PatMember>> {
         let reader = self.reader();
 
         // Utility for creating a wildcard pattern since this is a
@@ -530,7 +547,7 @@ impl<'tc> PatMatcher<'tc> {
         pat: PatId,
         members: PatArgsId,
         subject: TermId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         // Get the term of the tuple and try to unify it with the subject:
         let tuple_term = self.typer().get_term_of_pat(pat)?;
 
@@ -551,7 +568,7 @@ impl<'tc> PatMatcher<'tc> {
     fn match_constructor_pat_with_term(
         &self,
         ConstructorPat { args, subject }: ConstructorPat,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         // get the subject params
         let possible_subject_params = self.typer().infer_constructor_of_nominal_term(subject)?;
 
@@ -570,7 +587,7 @@ impl<'tc> PatMatcher<'tc> {
         &self,
         pat_args_id: PatArgsId,
         subject_params_id: ParamsId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         let subject_params = self.reader().get_params_owned(subject_params_id);
         let pat_args = self.reader().get_pat_args_owned(pat_args_id);
 
@@ -595,10 +612,10 @@ impl<'tc> PatMatcher<'tc> {
             // setting the name, so that we don't add it twice then add the name
             // to the scope.
             if let Some(name) = arg.name && !self.reader().get_pat(arg.pat).is_bind() {
-                bound_members.push((
-                    Member::variable(name, Mutability::Immutable, param.ty, param_value),
-                    arg.pat,
-                ));
+                bound_members.push(PatMember {
+                    member: Member::variable(name, Mutability::Immutable, param.ty, param_value),
+                    pat: arg.pat,
+                });
             }
 
             bound_members.extend(
@@ -620,7 +637,7 @@ impl<'tc> PatMatcher<'tc> {
     fn match_list_pat_with_term(
         &self,
         ListPat { list_element_ty, element_pats }: ListPat,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         // We need to collect all of the binds from the inner patterns of
         // the list
         let params = self.reader().get_pat_args_owned(element_pats).clone();
@@ -649,7 +666,7 @@ impl<'tc> PatMatcher<'tc> {
         id: PatId,
         SpreadPat { name }: SpreadPat,
         subject_ty: TermId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         match name {
             Some(name) => {
                 // Since `pat_ty` will be `List<T = Unresolved>`, we need to create a new
@@ -668,10 +685,15 @@ impl<'tc> PatMatcher<'tc> {
                 let TermValidation { simplified_term_id, term_ty_id } =
                     self.validator().validate_term(rt_term)?;
 
-                Ok(Some(vec![(
-                    Member::variable(name, Mutability::Immutable, term_ty_id, simplified_term_id),
-                    id,
-                )]))
+                Ok(Some(vec![PatMember {
+                    member: Member::variable(
+                        name,
+                        Mutability::Immutable,
+                        term_ty_id,
+                        simplified_term_id,
+                    ),
+                    pat: id,
+                }]))
             }
             _ => Ok(Some(vec![])),
         }
@@ -683,7 +705,7 @@ impl<'tc> PatMatcher<'tc> {
         &self,
         ModPat { members }: ModPat,
         subject: TermId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         let members = self.reader().get_pat_args_owned(members).clone();
 
         let mut bound_members = vec![];
@@ -714,7 +736,7 @@ impl<'tc> PatMatcher<'tc> {
         &self,
         pats: &[PatId],
         subject: TermId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         // Traverse all of the inner patterns within the `or` pattern, create a
         // map between the member names that are produced and the type of the
         // pattern... Then we want to ensure all of them are equal
@@ -750,7 +772,7 @@ impl<'tc> PatMatcher<'tc> {
         &self,
         pat_id: PatId,
         term_id: TermId,
-    ) -> TcResult<Option<Vec<(Member, PatId)>>> {
+    ) -> TcResult<Option<Vec<PatMember>>> {
         let TermValidation { simplified_term_id, term_ty_id } =
             self.validator().validate_term(term_id)?;
 
@@ -775,10 +797,15 @@ impl<'tc> PatMatcher<'tc> {
 
         let mut bound_members = match pat {
             // Binding: Add the binding as a member
-            Pat::Binding(binding) => Ok(Some(vec![(
-                Member::variable(binding.name, binding.mutability, term_ty_id, simplified_term_id),
-                pat_id,
-            )])),
+            Pat::Binding(binding) => Ok(Some(vec![PatMember {
+                member: Member::variable(
+                    binding.name,
+                    binding.mutability,
+                    term_ty_id,
+                    simplified_term_id,
+                ),
+                pat: pat_id,
+            }])),
 
             // We don't actually do anything here with the spread pattern since this should happen
             // at either the `list`, `tuple` or `constructor level. If it does not, then this
@@ -857,7 +884,8 @@ impl<'tc> PatMatcher<'tc> {
         pat_id: PatId,
         term_id: TermId,
     ) -> TcResult<Option<Vec<Member>>> {
-        self.match_pat_with_term_and_extract_binds(pat_id, term_id)
-            .map(|members| members.map(|inner| inner.into_iter().map(|(m, _)| m).collect()))
+        self.match_pat_with_term_and_extract_binds(pat_id, term_id).map(|members| {
+            members.map(|inner| inner.into_iter().map(|pat_member| pat_member.member).collect())
+        })
     }
 }

--- a/tests/cases/patterns/548.hash
+++ b/tests/cases/patterns/548.hash
@@ -1,0 +1,7 @@
+// run=fail, stage=typecheck
+
+main := () => {
+    // ~ERROR: variable `c` not declared in all patterns
+    // ~ERROR: variable `d` not declared in all patterns
+    (c | d) := 2;    
+}

--- a/tests/cases/patterns/548.stderr
+++ b/tests/cases/patterns/548.stderr
@@ -1,11 +1,11 @@
-error[0081]: variables `d` are not declared in all patterns
+error[0081]: variable `d` are not declared in all patterns
  --> $DIR/548.hash:6:6
 5 |       // ~ERROR: variable `d` not declared in all patterns
 6 |       (c | d) := 2;    
   |        ^ pattern doesn't bind `d`
 7 |   }
 
-error[0081]: variables `c` are not declared in all patterns
+error[0081]: variable `c` are not declared in all patterns
  --> $DIR/548.hash:6:10
 5 |       // ~ERROR: variable `d` not declared in all patterns
 6 |       (c | d) := 2;    

--- a/tests/cases/patterns/548.stderr
+++ b/tests/cases/patterns/548.stderr
@@ -1,3 +1,10 @@
+error[0081]: variables `d` are not declared in all patterns
+ --> $DIR/548.hash:6:6
+5 |       // ~ERROR: variable `d` not declared in all patterns
+6 |       (c | d) := 2;    
+  |        ^ pattern doesn't bind `d`
+7 |   }
+
 error[0081]: variables `c` are not declared in all patterns
  --> $DIR/548.hash:6:10
 5 |       // ~ERROR: variable `d` not declared in all patterns

--- a/tests/cases/patterns/548.stderr
+++ b/tests/cases/patterns/548.stderr
@@ -1,0 +1,6 @@
+error[0081]: variables `c` are not declared in all patterns
+ --> $DIR/548.hash:6:10
+5 |       // ~ERROR: variable `d` not declared in all patterns
+6 |       (c | d) := 2;    
+  |            ^ pattern doesn't bind `c`
+7 |   }

--- a/tests/cases/patterns/multiple_invalid_binds.hash
+++ b/tests/cases/patterns/multiple_invalid_binds.hash
@@ -1,0 +1,11 @@
+// run=fail, stage=typecheck
+
+main := () => {
+    // ~ERROR: variable `c` not declared in all patterns
+    // ~ERROR: variable `d` not declared in all patterns
+    // ~ERROR: variable `k` not declared in all patterns
+    // ~ERROR: variable `m` not declared in all patterns
+    // ~ERROR: variable `a` not declared in all patterns
+    // ~ERROR: variable ` b` not declared in all patterns
+    ((c, m) | (d, k), (a, b)) := (2, 1);    
+}

--- a/tests/cases/patterns/multiple_invalid_binds.stderr
+++ b/tests/cases/patterns/multiple_invalid_binds.stderr
@@ -1,0 +1,12 @@
+error[0020]: types mismatch, wanted `i32`, but got `(typeof(U_4), typeof(U_5))`
+  --> $DIR/multiple_invalid_binds.hash:10:38
+ 9 |       // ~ERROR: variable ` b` not declared in all patterns
+10 |       ((c, m) | (d, k), (a, b)) := (2, 1);    
+   |                                        ^ this expects the type `i32`
+11 |   }
+
+  --> $DIR/multiple_invalid_binds.hash:10:6
+ 9 |       // ~ERROR: variable ` b` not declared in all patterns
+10 |       ((c, m) | (d, k), (a, b)) := (2, 1);    
+   |        ^^^^^^ ...but this is of type `(typeof(U_4), typeof(U_5))`
+11 |   }


### PR DESCRIPTION
This patch fixes a problem with the error reporting for compound patterns that don't bind the same variables. This patch fixes this problem and improves the checking function to accumulate all errors in an instance and report them.

fixes #548 