### PR TITLE
Add the ability to assign `ScopeId`s to AST nodes

### DIFF
--- a/compiler/hash-typecheck/src/traverse/scopes.rs
+++ b/compiler/hash-typecheck/src/traverse/scopes.rs
@@ -20,9 +20,10 @@ impl<'tc> TcVisitor<'tc> {
     /// The `scope_to_use` parameter is optional and is used to override the
     /// scope that is used to append all the members into. If not given, a new
     /// constant scope is created and used.
-    pub(crate) fn visit_constant_scope<'m>(
+    pub(crate) fn visit_constant_scope<'m, T>(
         &self,
         members: impl Iterator<Item = ast::AstNodeRef<'m, ast::Expr>>,
+        originating_node: ast::AstNodeRef<T>,
         scope_to_use: Option<ScopeId>,
         scope_kind: ScopeKind,
     ) -> TcResult<VisitConstantScope> {
@@ -43,6 +44,9 @@ impl<'tc> TcVisitor<'tc> {
             }
             Ok(())
         })?;
+
+        // Assign the scope to the target node
+        self.register_node_info(originating_node, scope_id);
 
         Ok(VisitConstantScope { scope_name, scope_id })
     }

--- a/compiler/hash-types/src/nodes.rs
+++ b/compiler/hash-types/src/nodes.rs
@@ -4,6 +4,7 @@ use hash_ast::ast::AstNodeId;
 use hash_utils::new_partial_store;
 
 use super::{pats::PatId, terms::TermId};
+use crate::scope::ScopeId;
 
 /// Enumerates all the possible informational data that can be associated with
 /// an AST node.
@@ -13,22 +14,35 @@ pub enum NodeInfoTarget {
     Term(TermId),
     /// The node corresponds to the pattern with the given [`PatId`].
     Pat(PatId),
+    /// The node corresponds to the scope with the given [`ScopeId`].
+    Scope(ScopeId),
 }
 
 impl NodeInfoTarget {
-    /// Returns the [`TermId`] associated with this node, if any.
+    /// Asserts that this node info target is a term, and returns its
+    /// [`TermId`].
     pub fn term_id(self) -> TermId {
         match self {
             NodeInfoTarget::Term(term_id) => term_id,
-            NodeInfoTarget::Pat(_) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 
-    /// Returns the [`PatId`] associated with this node, if any.
+    /// Asserts that this node info target is a pattern, and returns its
+    /// [`PatId`].
     pub fn pat_id(self) -> PatId {
         match self {
             NodeInfoTarget::Pat(pat_id) => pat_id,
-            NodeInfoTarget::Term(_) => unreachable!(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Asserts that this node info target is a scope, and returns its
+    /// [`ScopeId`].
+    pub fn scope_id(self) -> ScopeId {
+        match self {
+            NodeInfoTarget::Scope(scope_id) => scope_id,
+            _ => unreachable!(),
         }
     }
 }
@@ -42,6 +56,12 @@ impl From<TermId> for NodeInfoTarget {
 impl From<PatId> for NodeInfoTarget {
     fn from(pat: PatId) -> Self {
         Self::Pat(pat)
+    }
+}
+
+impl From<ScopeId> for NodeInfoTarget {
+    fn from(scope: ScopeId) -> Self {
+        Self::Scope(scope)
     }
 }
 


### PR DESCRIPTION
This PR adds the ability for AST nodes to have attached scopes, in the same way that they currently can have attached `TermId`s or `PatId`s. This is because scope information is required during code generation. The way to access `ScopeId`s is through the `NodeInfoStore` struct on `GlobalStorage`, by providing an `AstNodeId` as an input and retrieving a scope using the `scope_id` method on the resultant `NodeInfoTarget`.

The following nodes have scopes attached to them:
- `MatchCase`
- `BodyBlock`
- `TraitDef`
- `TraitImpl`
- `ModBlock`
- `ImplBlock`
- `Modules`

Therefore, it is only valid to call `scope_id` on `NodeInfoTarget`s accessed through an `AstNodeId` corresponding to one of the above AST nodes. (Otherwise there will be a panic.)

Closes #558 