### PR TITLE
Add patterns and literals to the new term structure.

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -583,14 +583,14 @@ define_tree! {
     }
 
     /// A string literal.
-    #[derive(Debug, PartialEq, Eq, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     #[node]
     pub struct StrLit {
         pub data: InternedStr
     }
 
     /// A character literal.
-    #[derive(Debug, PartialEq, Eq, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     #[node]
     pub struct CharLit {
         pub data: char
@@ -739,7 +739,7 @@ define_tree! {
     }
 
     /// An integer literal.
-    #[derive(Debug, PartialEq, Eq, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     #[node]
     pub struct IntLit {
         /// The raw value of the literal
@@ -783,7 +783,7 @@ define_tree! {
     }
 
     /// A float literal.
-    #[derive(Debug, PartialEq, Eq, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     #[node]
     pub struct FloatLit {
         /// Raw value of the literal

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -396,7 +396,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         &self,
         node: hash_ast::ast::AstNodeRef<hash_ast::ast::IntLit>,
     ) -> Result<Self::IntLitRet, Self::Error> {
-        let term = self.builder().create_lit_term(node.body().clone());
+        let term = self.builder().create_lit_term(*node.body());
         self.register_node_info_and_location(node, term);
         Ok(term)
     }

--- a/compiler/hash-types/src/new/access.rs
+++ b/compiler/hash-types/src/new/access.rs
@@ -1,0 +1,17 @@
+//! Definitions related to access operations.
+
+use super::{symbols::Symbol, terms::TermId};
+
+/// The kind of an access.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub enum AccessKind {
+    Numeric(usize),
+    Named(Symbol),
+}
+
+/// Term to access a nested value.
+#[derive(Debug, Clone, Copy)]
+pub struct AccessTerm {
+    pub subject: TermId,
+    pub access_kind: AccessKind,
+}

--- a/compiler/hash-types/src/new/args.rs
+++ b/compiler/hash-types/src/new/args.rs
@@ -3,6 +3,7 @@
 
 use hash_utils::{new_sequence_store_key, store::DefaultSequenceStore};
 
+use super::pats::PatId;
 use crate::new::{symbols::Symbol, terms::TermId};
 
 /// An argument to a parameter.
@@ -19,3 +20,15 @@ pub struct Arg {
 
 new_sequence_store_key!(pub ArgsId);
 pub type ArgsStore = DefaultSequenceStore<ArgsId, Arg>;
+
+/// A pattern argument to a parameter
+///
+/// This might be used for constructor patterns like `C(true, x)`.
+#[derive(Clone, Debug, Copy)]
+pub struct PatArg {
+    pub name: Option<Symbol>,
+    pub pat: PatId,
+}
+
+new_sequence_store_key!(pub PatArgsId);
+pub type PatArgsStore = DefaultSequenceStore<PatArgsId, PatArg>;

--- a/compiler/hash-types/src/new/control.rs
+++ b/compiler/hash-types/src/new/control.rs
@@ -55,14 +55,28 @@ pub enum LoopControlTerm {
 }
 
 /// A conditional pattern, containing a pattern and an condition.
+///
+/// This is `A if c` in its most general form, where `A` is a pattern and `c` is
+/// a boolean-valued term.
+///
+/// This pattern matches iff `A` matches and `c` is met.
 #[derive(Clone, Debug, Copy)]
 pub struct IfPat {
+    /// The subject pattern `A`.
     pub pat: PatId,
+    /// The condition `c`.
     pub condition: TermId,
 }
 
-/// Represents a list of alternative patterns (A | B | C).
+/// A list of alternative patterns.
+///
+/// This is `A | B | C | ...` in its most general form, where `A`, `B`, `C`,
+/// ..., are patterns.
+///
+/// This pattern matches iff at least one of the patterns in the sequence
+/// matches.
 #[derive(Copy, Clone, Debug)]
 pub struct OrPat {
+    /// The sequence of alternative patterns.
     pub alternatives: PatListId,
 }

--- a/compiler/hash-types/src/new/control.rs
+++ b/compiler/hash-types/src/new/control.rs
@@ -1,6 +1,6 @@
 //! Definitions related to control flow.
 
-use super::pats::PatListId;
+use super::pats::{PatId, PatListId};
 use crate::new::{
     scopes::BlockTerm,
     terms::{TermId, TermListId},
@@ -52,4 +52,17 @@ pub struct ReturnTerm {
 pub enum LoopControlTerm {
     Break,
     Continue,
+}
+
+/// A conditional pattern, containing a pattern and an condition.
+#[derive(Clone, Debug, Copy)]
+pub struct IfPat {
+    pub pat: PatId,
+    pub condition: TermId,
+}
+
+/// Represents a list of alternative patterns (A | B | C).
+#[derive(Copy, Clone, Debug)]
+pub struct OrPat {
+    pub alternatives: PatListId,
 }

--- a/compiler/hash-types/src/new/data.rs
+++ b/compiler/hash-types/src/new/data.rs
@@ -5,6 +5,7 @@ use hash_utils::{
     store::{DefaultSequenceStore, DefaultStore},
 };
 
+use super::defs::DefPatArgsId;
 use crate::new::{
     defs::{DefArgsId, DefParamsId},
     symbols::Symbol,
@@ -56,6 +57,17 @@ pub struct CtorTerm {
     pub ctor: CtorDefId,
     /// The arguments to the constructor.
     pub args: DefArgsId,
+}
+
+/// A constructor pattern.
+///
+/// This is a pattern matching a constructor, for example `Some(_)`.
+#[derive(Debug, Clone, Copy)]
+pub struct CtorPat {
+    /// The constructor definition that this pattern references.
+    pub ctor: CtorDefId,
+    /// The pattern arguments to the constructor.
+    pub args: DefPatArgsId,
 }
 
 /// A data-type definition.

--- a/compiler/hash-types/src/new/defs.rs
+++ b/compiler/hash-types/src/new/defs.rs
@@ -2,6 +2,7 @@
 
 use hash_utils::{new_sequence_store_key, store::DefaultSequenceStore};
 
+use super::{args::PatArgsId, pats::Spread};
 use crate::new::{args::ArgsId, params::ParamsId, symbols::Symbol, terms::TermId, tys::TyId};
 
 /// A group of definition parameters
@@ -29,6 +30,21 @@ pub struct DefArgGroup {
 new_sequence_store_key!(pub DefArgsId);
 pub type DefArgsStore = DefaultSequenceStore<DefArgsId, DefArgGroup>;
 pub type DefArgGroupId = (DefArgsId, usize);
+
+/// A group of definition pattern arguments
+///
+/// This contains the original parameter group of the definition, as well as
+/// set of pattern arguments for it, ordered by the original parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct DefPatArgGroup {
+    pub param_group: DefParamGroupId,
+    pub pat_args: PatArgsId,
+    /// The spread in this group of patterns, if any.
+    pub spread: Option<Spread>,
+}
+new_sequence_store_key!(pub DefPatArgsId);
+pub type DefPatArgsStore = DefaultSequenceStore<DefPatArgsId, DefPatArgGroup>;
+pub type DefPatArgGroupId = (DefPatArgsId, usize);
 
 /// A member of a definition.
 ///

--- a/compiler/hash-types/src/new/lits.rs
+++ b/compiler/hash-types/src/new/lits.rs
@@ -1,0 +1,53 @@
+//! Contains structures related to literals, like numbers, strings, etc.
+use hash_ast::ast;
+
+/// An integer literal.
+///
+/// Uses the `ast` representation.
+#[derive(Copy, Clone, Debug)]
+pub struct IntLit {
+    pub underlying: ast::IntLit,
+}
+
+/// A string literal.
+///
+/// Uses the `ast` representation.
+#[derive(Copy, Clone, Debug)]
+pub struct StrLit {
+    pub underlying: ast::StrLit,
+}
+
+/// A float literal.
+///
+/// Uses the `ast` representation.
+#[derive(Copy, Clone, Debug)]
+pub struct FloatLit {
+    pub underlying: ast::FloatLit,
+}
+
+/// A character literal.
+///
+/// Uses the `ast` representation.
+#[derive(Copy, Clone, Debug)]
+pub struct CharLit {
+    pub underlying: ast::CharLit,
+}
+
+/// A literal pattern
+///
+/// Floats are not valid patterns, so they are not included here.
+#[derive(Copy, Clone, Debug)]
+pub enum LitPat {
+    Int(IntLit),
+    Str(StrLit),
+    Char(CharLit),
+}
+
+/// A literal term
+#[derive(Copy, Clone, Debug)]
+pub enum LitTerm {
+    Int(IntLit),
+    Str(StrLit),
+    Char(CharLit),
+    Float(FloatLit),
+}

--- a/compiler/hash-types/src/new/mod.rs
+++ b/compiler/hash-types/src/new/mod.rs
@@ -1,12 +1,14 @@
 //! Contains definitions that are relevant to the typed semantic analysis stage
 //! of the compiler (in other words, typechecking).
 
+pub mod access;
 pub mod args;
 pub mod control;
 pub mod data;
 pub mod defs;
 pub mod fns;
 pub mod holes;
+pub mod lits;
 pub mod mods;
 pub mod params;
 pub mod pats;

--- a/compiler/hash-types/src/new/pats.rs
+++ b/compiler/hash-types/src/new/pats.rs
@@ -1,5 +1,6 @@
 //! Definitions related to patterns.
 
+use hash_ast::ast::RangeEnd;
 use hash_utils::{new_sequence_store_key, new_store, new_store_key, store::DefaultSequenceStore};
 
 use super::{
@@ -46,10 +47,7 @@ pub struct RangePat {
     /// The end of the range.
     pub end: LitPat,
     /// If the range includes the `end` or not.
-    ///
-    /// If `true`, this is the pattern `start..<end`, otherwise it is
-    /// `start..end`.
-    pub end_exclusive: bool,
+    pub range_end: RangeEnd,
 }
 
 /// Represents a pattern.

--- a/compiler/hash-types/src/new/pats.rs
+++ b/compiler/hash-types/src/new/pats.rs
@@ -2,12 +2,73 @@
 
 use hash_utils::{new_sequence_store_key, new_store, new_store_key, store::DefaultSequenceStore};
 
-// @@Todo
-#[derive(Debug, Clone, Copy)]
-pub enum Pat {}
+use super::{
+    control::{IfPat, OrPat},
+    data::CtorPat,
+    lits::LitPat,
+    scopes::BindingPat,
+    symbols::Symbol,
+    tuples::TuplePat,
+};
 
-new_sequence_store_key!(pub PatListId);
-pub type PatListStore = DefaultSequenceStore<PatListId, PatId>;
+/// A spread "pattern" (not part of [`Pat`]), which can appear in list patterns,
+/// tuple patterns, and constructor patterns.
+#[derive(Copy, Clone, Debug)]
+pub struct Spread {
+    /// The name of the spread bind.
+    /// If `name` does not map to a specific `Identifier` name, it means
+    /// that the bind is actually nameless.
+    pub name: Symbol,
+    /// The index in the sequence of target patterns, of this spread pattern.
+    pub index: usize,
+}
+
+/// A list pattern.
+///
+/// This is in the form `[x_1,...,x_n]`, with an optional spread `...(name?)` at
+/// some position.
+#[derive(Copy, Clone, Debug)]
+pub struct ListPat {
+    /// The sequence of patterns in the list pattern.
+    pub pats: PatListId,
+    /// The spread pattern, if any.
+    pub spread: Option<Spread>,
+}
+
+/// A range pattern containing two bounds `start` and `end`.
+///
+/// The `start` and `end` values must be either both [`LitPat::Int`], or both
+/// [`LitPat::Char`].
+#[derive(Copy, Clone, Debug)]
+pub struct RangePat {
+    /// The beginning of the range.
+    pub start: LitPat,
+    /// The end of the range.
+    pub end: LitPat,
+    /// If the range includes the `end` or not.
+    ///
+    /// If `true`, this is the pattern `start..<end`, otherwise it is
+    /// `start..end`.
+    pub end_exclusive: bool,
+}
+
+/// Represents a pattern.
+///
+/// Check the documentation of each member for more information.
+#[derive(Copy, Clone, Debug)]
+pub enum Pat {
+    Binding(BindingPat),
+    Range(RangePat),
+    Lit(LitPat),
+    Tuple(TuplePat),
+    Ctor(CtorPat),
+    List(ListPat),
+    Or(OrPat),
+    If(IfPat),
+}
 
 new_store_key!(pub PatId);
 new_store!(pub PatStore<PatId, Pat>);
+
+new_sequence_store_key!(pub PatListId);
+pub type PatListStore = DefaultSequenceStore<PatListId, PatId>;

--- a/compiler/hash-types/src/new/scopes.rs
+++ b/compiler/hash-types/src/new/scopes.rs
@@ -12,6 +12,17 @@ use crate::new::{
     tys::TyId,
 };
 
+/// A binding pattern, which is essentially a declaration left-hand side.
+#[derive(Clone, Debug, Copy)]
+pub struct BindingPat {
+    /// The name of the bind.
+    /// If `name` does not map to a specific `Identifier` name, it means
+    /// that the pattern is actually a wildcard `_`.
+    pub name: Symbol,
+    /// Whether the binding is declared as mutable.
+    pub is_mutable: bool,
+}
+
 // @@Todo: examples
 
 /// Term to declare new variable(s) in the current stack scope.
@@ -20,7 +31,6 @@ use crate::new::{
 /// multiple variables.
 #[derive(Debug, Clone, Copy)]
 pub struct DeclStackMemberTerm {
-    pub is_mutable: bool,
     pub bind_pat: PatId,
     pub ty: TyId,
     pub value: Option<TermId>,

--- a/compiler/hash-types/src/new/terms.rs
+++ b/compiler/hash-types/src/new/terms.rs
@@ -5,6 +5,7 @@ use hash_utils::{
     store::{DefaultSequenceStore, DefaultStore},
 };
 
+use super::lits::LitTerm;
 use crate::new::{
     args::ArgsId,
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
@@ -78,6 +79,9 @@ pub enum Term {
     Tuple(TupleTerm),
     TypeOf(TypeOfTerm),
     Ctor(CtorTerm),
+
+    // Literals
+    Lit(LitTerm),
 
     /// Infer the term from the surrounding context.
     Infer,

--- a/compiler/hash-types/src/new/tuples.rs
+++ b/compiler/hash-types/src/new/tuples.rs
@@ -1,5 +1,6 @@
 //! Definitions related to tuples.
 
+use super::{args::PatArgsId, pats::Spread};
 use crate::new::{args::ArgsId, params::ParamsId};
 
 /// A tuple type.
@@ -38,4 +39,36 @@ pub struct TupleTerm {
     /// will eventually be unified with the original type when the latter is
     /// resolved.
     pub conditions: ArgsId,
+}
+
+/// A tuple pattern
+///
+/// This is, in its most general form, `(a_1:A_1 = s_1,...,a_n:A_n = s_n) where
+/// (p_1:P_1 = q_1,...p_m:P_m = q_m)`.
+#[derive(Debug, Clone, Copy)]
+pub struct TuplePat {
+    /// The original tuple type, if known or given as part of the literal (might
+    /// contain holes).
+    pub original_ty: Option<TupleTy>,
+
+    /// The pattern arguments given for the tuple, `(s_1,...,s_n)`
+    ///
+    /// If the original type is present, then this is sorted in the order of the
+    /// parameters.
+    pub data: PatArgsId,
+
+    /// The spread in the data patterns, if any.
+    pub data_spread: Option<Spread>,
+
+    /// Condition pattern arguments, if given, `where (p_1,...,p_m)`.
+    ///
+    /// This should be present if `original_ty` is present (even if it is an
+    /// empty tuple).
+    /// It could also be present if `original_ty` is not present, but then they
+    /// will eventually be unified with the original type when the latter is
+    /// resolved.
+    pub conditions: PatArgsId,
+
+    /// The spread in the condition patterns, if any.
+    pub conditions_spread: Option<Spread>,
 }


### PR DESCRIPTION
This PR completes the `pats` module of the new term structure. The pattern structure is simplified compared to the old structure. The notable differences are:

- The `Mod` pattern kind is not used anymore. Instead, module destructuring statements at constant scope level will be resolved to actual members during an AST traversal pass, so they do not need to be present in the term structure. This also removes the need to have `visibility` on `BindingPat`.
- The `Spread` pattern kind is not used anymore. Instead, list, tuple and constructor patterns have an optional `spread` field which records an index position and an optional name. It denotes that a spread pattern is present at the given position, with the given name. This is possible due to the invariant that spread patterns can only appear at most once in a sequence of patterns. (It is possible that in the future this restriction can be relaxed for tuples and constructors but for now it is kept to make things simple.)
- The `Lit` pattern does not store any `TermId` anymore, but rather stores the exact literal being matched. To complement this, a new module called `lits` is added, which contains pattern and term literal types. For now these use the definitions from `hash_ast` because they would just be duplicated otherwise.
- The `Range` pattern again uses literals for its interval endpoints.

Closes #560.