### PR TITLE
IR: introduce `IrTy` to represent types at the IR level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,9 @@ dependencies = [
 name = "hash-ir"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "hash-alloc",
+ "hash-ast",
  "hash-source",
  "hash-types",
  "hash-utils",

--- a/compiler/hash-ir/Cargo.toml
+++ b/compiler/hash-ir/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 
 [dependencies]
 index_vec = "0.1.3"
+bitflags = "1.3.2"
 
+hash-ast = {path = "../hash-ast" }
 hash-utils = {path = "../hash-utils" }
 hash-alloc = {path = "../hash-alloc" }
 hash-source = {path = "../hash-source" }

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -1,31 +1,14 @@
 //! Hash Compiler Intermediate Representation (IR) crate.
 #![allow(clippy::too_many_arguments)]
 
-use hash_utils::{
-    new_store_key,
-    store::{DefaultStore, Store},
-};
-use ir::{Body, RValue};
-
 pub mod ir;
+pub mod ty;
 pub mod visitor;
 pub mod write;
 
-new_store_key!(pub RValueId);
-
-/// Stores all the used [RValue]s.
-///
-/// [Rvalue]s are accessed by an ID, of type [RValueId].
-#[derive(Debug, Default)]
-pub struct RValueStore {
-    data: DefaultStore<RValueId, RValue>,
-}
-
-impl Store<RValueId, RValue> for RValueStore {
-    fn internal_data(&self) -> &std::cell::RefCell<Vec<RValue>> {
-        self.data.internal_data()
-    }
-}
+use hash_utils::store::Store;
+use ir::{Body, RValue, RValueId, RValueStore};
+use ty::{AdtStore, TyListStore, TyStore};
 
 /// Storage that is used by the IR builder.
 pub struct IrStorage {
@@ -33,17 +16,55 @@ pub struct IrStorage {
     pub generated_bodies: Vec<Body>,
 
     /// The storage for all the [RValue]s.
-    pub store: RValueStore,
+    rvalue_store: ir::RValueStore,
+
+    /// The storage for all of the used types that are within the IR.
+    ty_store: ty::TyStore,
+
+    /// Storage for grouped types, ones that appear in a parent type, i.e. a
+    /// [`IrTy::Fn(...)`] type will use the `TyListStore` to store that
+    /// parameter types.
+    ty_list_store: ty::TyListStore,
+
+    /// Storage that is used to store all of the created ADTs that
+    /// are registered within the IR.
+    adt_store: ty::AdtStore,
 }
 
 impl IrStorage {
     pub fn new() -> Self {
-        Self { generated_bodies: Vec::new(), store: RValueStore::default() }
+        Self {
+            generated_bodies: Vec::new(),
+            rvalue_store: RValueStore::default(),
+            ty_store: TyStore::default(),
+            ty_list_store: TyListStore::default(),
+            adt_store: AdtStore::default(),
+        }
+    }
+
+    /// Get a reference to the [TyStore]
+    pub fn ty_store(&self) -> &TyStore {
+        &self.ty_store
+    }
+
+    /// Get a reference to the [TyListStore]
+    pub fn ty_list_store(&self) -> &TyListStore {
+        &self.ty_list_store
+    }
+
+    /// Get a reference to the [AdtStore]
+    pub fn adt_store(&self) -> &AdtStore {
+        &self.adt_store
+    }
+
+    /// Get a reference to the [RValueStore]
+    pub fn rvalue_store(&self) -> &RValueStore {
+        &self.rvalue_store
     }
 
     /// Push an [RValue] on the storage.
     pub fn push_rvalue(&mut self, rvalue: RValue) -> RValueId {
-        self.store.create(rvalue)
+        self.rvalue_store.create(rvalue)
     }
 
     /// Extend the IR storage with the given bodies.

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -1,0 +1,249 @@
+//! Simplified Hash type hierarchy. The [IrTy] is used a simplified
+//! variant of the available Hash [Term]s that are defined in the
+//! `hash-types` crate. This data structure is used to remove unnecessary
+//! complexity from types that are required for IR generation and
+//! analysis.
+
+use std::fmt;
+
+use hash_source::{
+    constant::{FloatTy, SIntTy, UIntTy},
+    identifier::Identifier,
+};
+use hash_utils::{
+    new_sequence_store_key, new_store_key,
+    store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, Store},
+};
+use index_vec::IndexVec;
+
+use crate::write::{ForFormatting, WriteTyIr};
+
+/// Mutability of a particular variable, reference, etc.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Mutability {
+    /// Mutable variable, reference, etc.
+    Mutable,
+    /// Immutable variable, reference, etc.
+    Immutable,
+}
+
+impl Mutability {
+    /// Returns true if the mutability is mutable.
+    pub fn is_mutable(&self) -> bool {
+        matches!(self, Mutability::Mutable)
+    }
+
+    /// Returns true if the mutability is immutable.
+    pub fn is_immutable(&self) -> bool {
+        matches!(self, Mutability::Immutable)
+    }
+
+    /// Get [Mutability] as a printable name
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Mutability::Mutable => "mut",
+            Mutability::Immutable => "",
+        }
+    }
+}
+
+impl fmt::Display for Mutability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Simplified type structure used by the IR and other stages to reason about
+/// Hash programs once types have been erased and simplified.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum IrTy {
+    /// A primitive signed integer type, e.g. `i32`.
+    Int(SIntTy),
+
+    /// A primitive unsigned integer type, e.g. `u32`.
+    UInt(UIntTy),
+
+    /// A primitive floating point type, e.g. `f32`.
+    Float(FloatTy),
+
+    /// String type.
+    Str,
+
+    /// Boolean type.
+    Bool,
+
+    /// Character type.
+    Char,
+
+    /// The never type
+    Never,
+
+    /// A reference type, referring to a another type, e.g. `&T`
+    Ref(IrTyId, Mutability),
+
+    /// A raw reference type, referring to a another type, e.g. `&raw T`
+    RawRef(IrTyId, Mutability),
+
+    /// A reference counted pointer type, e.g. `Rc<T>`
+    Rc(IrTyId, Mutability),
+
+    /// A tuple type
+    Tuple(IrTyListId),
+
+    /// A slice type
+    Slice(IrTyId),
+
+    /// An array type with a specified length, i.e. `[T; N]`
+    Array(IrTyId, u64),
+
+    /// An abstract data structure type, i.e a `struct` or `enum`, or any
+    /// other kind of type.
+    Adt(AdtId),
+
+    /// The first item is the interned parameter types to the function, and the
+    /// second item is the return type of the function. If the function has no
+    /// explicit return type, this will always be inferred at this stage.
+    Fn(IrTyListId, IrTyId),
+}
+
+index_vec::define_index_type! {
+    /// Index for [VariantIdx] stores within generated [Body]s.
+    pub struct VariantIdx = u32;
+
+    MAX_INDEX = i32::max_value() as usize;
+    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
+
+    DEBUG_FORMAT = "variant#{}";
+}
+
+#[derive(Clone)]
+pub struct AdtData {
+    /// The name of the ADT
+    pub name: Identifier,
+
+    /// All of the variants that are defined for this variant.
+    pub variants: IndexVec<VariantIdx, AdtVariant>,
+
+    // Flags which denote additional information about this specific
+    // data structure.
+    // pub flags: AdtFlags,
+    /// Options that are regarding the representation of the ADT
+    /// in memory.
+    pub representation: AdtRepresentation,
+}
+
+/// Options that are regarding the representation of the ADT. This includes
+/// options about alignment, padding, etc.
+///
+/// @@Future: add user configurable options for the ADT.
+///     - add `alignment` configuration
+///     - add `pack` configuration
+///     - add layout randomisation configuration
+///     - add `C` layout configuration
+#[derive(Clone)]
+pub struct AdtRepresentation {}
+
+#[derive(Clone)]
+pub struct AdtVariant {
+    /// The name of the variant, if this is a struct variant, this inherits
+    /// the name of the struct.
+    pub name: Identifier,
+
+    /// The fields that are defined for this variant.
+    pub fields: Vec<AdtField>,
+}
+
+#[derive(Clone)]
+pub struct AdtField {
+    /// The name of the field.
+    pub name: Identifier,
+
+    /// The type of the field.
+    pub ty: IrTyId,
+}
+
+new_store_key!(pub AdtId);
+
+/// Stores all the used [IrTy]s.
+///
+/// [Rvalue]s are accessed by an ID, of type [IrTyId].
+pub type AdtStore = DefaultStore<AdtId, AdtData>;
+
+impl fmt::Display for ForFormatting<'_, AdtId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let adt_name = self.storage.adt_store().map_fast(self.t, |item| item.name);
+
+        // We just write the name of the underlying ADT
+        write!(f, "{adt_name}")
+    }
+}
+
+new_store_key!(pub IrTyId);
+
+/// Stores all the used [IrTy]s.
+///
+/// [Rvalue]s are accessed by an ID, of type [IrTyId].
+pub type TyStore = DefaultStore<IrTyId, IrTy>;
+
+impl fmt::Display for ForFormatting<'_, IrTyId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ty = self.storage.ty_store().get(self.t);
+
+        match ty {
+            IrTy::Int(variant) => write!(f, "{variant}"),
+            IrTy::UInt(variant) => write!(f, "{variant}"),
+            IrTy::Float(variant) => write!(f, "{variant}"),
+            IrTy::Bool => write!(f, "bool"),
+            IrTy::Str => write!(f, "str"),
+            IrTy::Char => write!(f, "char"),
+            IrTy::Never => write!(f, "!"),
+            IrTy::Ref(inner, mutability) => {
+                write!(f, "&{mutability}{}", inner.for_fmt(self.storage))
+            }
+            IrTy::RawRef(inner, mutability) => {
+                write!(f, "&raw {mutability}{}", inner.for_fmt(self.storage))
+            }
+            IrTy::Rc(inner, mutability) => {
+                let name = match mutability {
+                    Mutability::Mutable => "Mut",
+                    Mutability::Immutable => "",
+                };
+
+                write!(f, "Rc{name}<{}>", inner.for_fmt(self.storage))
+            }
+            IrTy::Tuple(fields) => write!(f, "({})", fields.for_fmt(self.storage)),
+            IrTy::Adt(adt) => write!(f, "{}", adt.for_fmt(self.storage)),
+            IrTy::Fn(params, return_ty) => write!(
+                f,
+                "({}) -> {}",
+                params.for_fmt(self.storage),
+                return_ty.for_fmt(self.storage)
+            ),
+            IrTy::Slice(ty) => write!(f, "[{}]", ty.for_fmt(self.storage)),
+            IrTy::Array(ty, len) => write!(f, "[{}; {len}]", ty.for_fmt(self.storage)),
+        }
+    }
+}
+
+new_sequence_store_key!(pub IrTyListId);
+
+/// Define the [TyListStore], which is a sequence of [IrTy]s associated
+/// with a [IrTyListId].
+pub type TyListStore = DefaultSequenceStore<IrTyListId, IrTyId>;
+
+impl fmt::Display for ForFormatting<'_, IrTyListId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let items = self.storage.ty_list_store().get_vec(self.t);
+        let mut tys = items.iter();
+
+        if let Some(first) = tys.next() {
+            write!(f, "{first}", first = first.for_fmt(self.storage))?;
+
+            for ty in tys {
+                write!(f, ", {ty}", ty = ty.for_fmt(self.storage))?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -6,6 +6,7 @@ use hash_ast::ast::{AstNodeRef, Block, BodyBlock};
 use hash_ir::ir::{BasicBlock, Place};
 
 use super::{BlockAnd, BlockAndExtend, Builder};
+use crate::build::unpack;
 
 impl<'tcx> Builder<'tcx> {
     pub(crate) fn block_into_dest(
@@ -36,8 +37,8 @@ impl<'tcx> Builder<'tcx> {
     pub(crate) fn body_block_into_dest(
         &mut self,
         place: Place,
-        block: BasicBlock,
-        body: &BodyBlock,
+        mut block: BasicBlock,
+        body: &'tcx BodyBlock,
     ) -> BlockAnd<()> {
         // Essentially walk all of the statement in the block, and then set
         // the return type of this block as the last expression, or an empty
@@ -46,7 +47,9 @@ impl<'tcx> Builder<'tcx> {
 
         // If this block has an expression, we need to deal with it since
         // it might change the destination of this block.
-        if let Some(expr) = body.expr.as_ref() {}
+        if let Some(expr) = body.expr.as_ref() {
+            unpack!(block = self.expr_into_dest(place, block, expr.ast_ref()));
+        }
 
         block.unit()
     }

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -9,15 +9,15 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         place: Place,
         block: BasicBlock,
-        body: AstNodeRef<'tcx, Expr>,
+        expr: AstNodeRef<'tcx, Expr>,
     ) -> BlockAnd<()> {
-        let block_and = match body.body {
+        let block_and = match expr.body {
             // @@Todo: we need to determine if this is a method call, or
             // a constructor call, we should do this somewhere else
             Expr::ConstructorCall(..) => todo!(),
             Expr::Directive(expr) => self.expr_into_dest(place, block, expr.subject.ast_ref()),
             Expr::Variable(variable) => {
-                let term = self.tcx.node_info_store.get(body.id()).map(|f| f.term_id()).unwrap();
+                let term = self.get_term_of_ast_node(expr.id());
                 println!("term: {term:?}");
 
                 block.unit()
@@ -33,7 +33,7 @@ impl<'tcx> Builder<'tcx> {
             // For declarations, we have to perform some bookkeeping in regards
             // to locals..., but this expression should never return any value
             // so we should just return a unit block here
-            Expr::Declaration(decl) => self.handle_expr_declaration(place, block, body),
+            Expr::Declaration(decl) => self.handle_expr_declaration(place, block, expr),
 
             // Traverse the lhs of the cast, and then apply the cast
             // to the result... although this should be a no-op?

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -17,7 +17,7 @@ impl<'tcx> Builder<'tcx> {
             Expr::ConstructorCall(..) => todo!(),
             Expr::Directive(expr) => self.expr_into_dest(place, block, expr.subject.ast_ref()),
             Expr::Variable(variable) => {
-                let term = self.get_term_of_ast_node(expr.id());
+                let term = self.get_ty_of_node(expr.id());
                 println!("term: {term:?}");
 
                 block.unit()

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -99,17 +99,17 @@ impl BlockAndExtend for BasicBlock {
 
 /// Update a block pointer and return the value.
 /// Use it like `let x = unpack!(block = self.foo(block, foo))`.
-macro_rules! unpack {
+pub macro unpack {
     ($x:ident = $c:expr) => {{
         let BlockAnd(b, v) = $c;
         $x = b;
         v
-    }};
+    }},
 
     ($c:expr) => {{
         let BlockAnd(b, ()) = $c;
         b
-    }};
+    }}
 }
 
 /// The builder is responsible for lowering a body into the associated IR.
@@ -208,6 +208,15 @@ impl<'tcx> Builder<'tcx> {
     #[inline]
     fn get_term_id_of_ast_node(&self, id: AstNodeId) -> TermId {
         self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap()
+    }
+
+    /// Function to get the associated [Term] with the
+    /// provided [AstNodeId].
+    #[inline]
+    fn get_term_of_ast_node(&self, id: AstNodeId) -> Term {
+        let term_id = self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap();
+
+        self.tcx.term_store.get(term_id)
     }
 
     /// Function to get the associated [PatId] with the

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -12,6 +12,7 @@ use hash_ir::{
         BasicBlock, BasicBlockData, Body, FnSource, Local, LocalDecl, Place, Terminator,
         TerminatorKind, START_BLOCK,
     },
+    ty::{IrTy, IrTyId},
     IrStorage,
 };
 use hash_source::{
@@ -26,7 +27,7 @@ use hash_types::{
     storage::GlobalStorage,
     terms::{FnLit, FnTy, Level0Term, Level1Term, Term, TermId},
 };
-use hash_utils::store::{CloneStore, PartialStore, SequenceStoreKey};
+use hash_utils::store::{CloneStore, PartialStore, SequenceStore, SequenceStoreKey};
 use index_vec::IndexVec;
 
 use crate::cfg::ControlFlowGraph;
@@ -206,23 +207,29 @@ impl<'tcx> Builder<'tcx> {
     /// Function to get the associated [TermId] with the
     /// provided [AstNodeId].
     #[inline]
-    fn get_term_id_of_ast_node(&self, id: AstNodeId) -> TermId {
-        self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap()
+    fn get_ty_id_of_node(&self, id: AstNodeId) -> IrTyId {
+        let term_id = self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap();
+
+        // We need to try and look up the type within the cache, if not
+        // present then we create the type by converting the term into
+        // the type.
+
+        todo!()
     }
 
     /// Function to get the associated [Term] with the
     /// provided [AstNodeId].
     #[inline]
-    fn get_term_of_ast_node(&self, id: AstNodeId) -> Term {
+    fn get_ty_of_node(&self, id: AstNodeId) -> IrTy {
         let term_id = self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap();
 
-        self.tcx.term_store.get(term_id)
+        todo!()
     }
 
     /// Function to get the associated [PatId] with the
     /// provided [AstNodeId].
     #[inline]
-    fn get_pat_of_ast_node(&self, id: AstNodeId) -> Pat {
+    fn get_pat_id_of_node(&self, id: AstNodeId) -> Pat {
         let pat_id = self.tcx.node_info_store.get(id).map(|f| f.pat_id()).unwrap();
 
         self.tcx.pat_store.get(pat_id)
@@ -236,21 +243,23 @@ impl<'tcx> Builder<'tcx> {
         };
 
         let term = match self.item {
-            BuildItem::FnDef(node) => self.get_term_id_of_ast_node(node.id()),
-            BuildItem::Expr(node) => self.get_term_id_of_ast_node(node.id()),
+            BuildItem::FnDef(node) => self.get_ty_of_node(node.id()),
+            BuildItem::Expr(node) => self.get_ty_of_node(node.id()),
         };
 
-        let fn_ty = get_fn_ty_from_term(term, self.tcx);
+        let IrTy::Fn(params, ret_ty) = term else {
+            panic!("Expected a function type");
+        };
 
         // The first local declaration is used as the return type. The return local
         // declaration is always mutable because it will be set at some point in
         // the end, not the beginning.
-        self.declarations.push(LocalDecl::new_mutable(fn_ty.return_ty));
+        self.declarations.push(LocalDecl::new_mutable(ret_ty));
 
         // Deal with all the function parameters that are given to the function.
-        for param in self.tcx.params_store.get_owned_param_list(fn_ty.params).positional() {
+        for param in self.storage.ty_list_store().get_vec(params) {
             // @@Future: deal with parameter attributes that are mutable?
-            self.declarations.push(LocalDecl::new_immutable(param.ty));
+            self.declarations.push(LocalDecl::new_immutable(param));
         }
 
         // Now we begin by lowering the body of the function.

--- a/compiler/hash-lower/src/build/pat.rs
+++ b/compiler/hash-lower/src/build/pat.rs
@@ -1,5 +1,8 @@
 use hash_ast::ast::{self, AstNodeRef};
-use hash_ir::ir::{Local, LocalDecl};
+use hash_ir::{
+    ir::{Local, LocalDecl},
+    ty::IrTyId,
+};
 use hash_types::{pats::BindingPat, scope::Mutability, terms::TermId};
 
 use super::Builder;
@@ -13,10 +16,10 @@ impl<'tcx> Builder<'tcx> {
         match pat.body {
             ast::Pat::Binding(ast::BindingPat { name, visibility, mutability }) => {
                 // resolve the type of this binding
-                let pat = self.get_pat_of_ast_node(pat_id);
+                let pat = self.get_pat_id_of_node(pat_id);
                 let BindingPat { mutability, .. } = pat.into_bind().unwrap();
 
-                let ty = self.get_term_id_of_ast_node(pat_id);
+                let ty = self.get_ty_id_of_node(pat_id);
                 self.declare_binding(ty, mutability)
             }
             ast::Pat::Constructor(_) => todo!(),
@@ -41,7 +44,7 @@ impl<'tcx> Builder<'tcx> {
     }
 
     /// Declare a [Local] with the given metadata in the current builder.
-    pub(crate) fn declare_binding(&mut self, ty: TermId, mutability: Mutability) {
+    pub(crate) fn declare_binding(&mut self, ty: IrTyId, mutability: Mutability) {
         let local = LocalDecl::new(mutability, ty);
 
         self.declarations.push(local);

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -3,10 +3,10 @@
 
 use hash_ir::{
     ir::{
-        BasicBlock, BasicBlockData, Place, RValue, Statement, StatementKind, Terminator,
+        BasicBlock, BasicBlockData, Place, RValue, RValueId, Statement, StatementKind, Terminator,
         TerminatorKind,
     },
-    IrStorage, RValueId,
+    IrStorage,
 };
 use hash_source::location::Span;
 use index_vec::IndexVec;

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -293,45 +293,6 @@ impl<'a> AstVisitorMutSelf for LoweringVisitor<'a> {
         Ok(())
     }
 
-    type ModBlockRet = ();
-
-    fn visit_mod_block(
-        &mut self,
-        node: ast::AstNodeRef<ast::ModBlock>,
-    ) -> Result<Self::ModBlockRet, Self::Error> {
-        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Mod);
-        let _ = walk_mut_self::walk_mod_block(self, node);
-        self.current_block = old_block_origin;
-
-        Ok(())
-    }
-
-    type ImplBlockRet = ();
-
-    fn visit_impl_block(
-        &mut self,
-        node: ast::AstNodeRef<ast::ImplBlock>,
-    ) -> Result<Self::ImplBlockRet, Self::Error> {
-        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Impl);
-        let _ = walk_mut_self::walk_impl_block(self, node);
-        self.current_block = old_block_origin;
-        Ok(())
-    }
-
-    type BodyBlockRet = ();
-
-    fn visit_body_block(
-        &mut self,
-        node: ast::AstNodeRef<ast::BodyBlock>,
-    ) -> Result<Self::BodyBlockRet, Self::Error> {
-        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Body);
-
-        let _ = walk_mut_self::walk_body_block(self, node);
-
-        self.current_block = old_block_origin;
-        Ok(())
-    }
-
     type DeclarationRet = ();
 
     fn visit_declaration(
@@ -348,6 +309,18 @@ impl<'a> AstVisitorMutSelf for LoweringVisitor<'a> {
         self.bind_stack.extend(binds.into_iter().rev());
         let _ = walk_mut_self::walk_declaration(self, node);
 
+        Ok(())
+    }
+
+    type BodyBlockRet = ();
+
+    fn visit_body_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::BodyBlock>,
+    ) -> Result<Self::BodyBlockRet, Self::Error> {
+        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Body);
+        let _ = walk_mut_self::walk_body_block(self, node);
+        self.current_block = old_block_origin;
         Ok(())
     }
 
@@ -371,6 +344,31 @@ impl<'a> AstVisitorMutSelf for LoweringVisitor<'a> {
     ) -> Result<Self::TraitImplRet, Self::Error> {
         let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Impl);
         let _ = walk_mut_self::walk_trait_impl(self, node);
+        self.current_block = old_block_origin;
+        Ok(())
+    }
+
+    type ModBlockRet = ();
+
+    fn visit_mod_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::ModBlock>,
+    ) -> Result<Self::ModBlockRet, Self::Error> {
+        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Mod);
+        let _ = walk_mut_self::walk_mod_block(self, node);
+        self.current_block = old_block_origin;
+
+        Ok(())
+    }
+
+    type ImplBlockRet = ();
+
+    fn visit_impl_block(
+        &mut self,
+        node: ast::AstNodeRef<ast::ImplBlock>,
+    ) -> Result<Self::ImplBlockRet, Self::Error> {
+        let old_block_origin = mem::replace(&mut self.current_block, BlockOrigin::Impl);
+        let _ = walk_mut_self::walk_impl_block(self, node);
         self.current_block = old_block_origin;
         Ok(())
     }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -3,6 +3,7 @@
 //! the Hash IR builder crate contains implemented passes that will optimise the
 //! IR, performing optimisations such as constant folding or dead code
 //! elimination.
+#![feature(decl_macro)]
 #![allow(unused)] // @@TODO: remove this when the builder is complete
 
 mod build;
@@ -67,7 +68,7 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
             let stage_info = source_stage_info.get(source_id);
 
             // Skip any modules that have already been checked
-            if stage_info.is_semantics_checked() {
+            if stage_info.is_lowered() {
                 continue;
             }
 

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -75,28 +75,28 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
             let mut discoverer = LoweringVisitor::new(&ty_storage.global, ir_storage, source_id);
             discoverer.visit_module(module.node_ref());
 
-            // we need to check if any of the bodies have been marked for `dumping`
-            // and emit the IR that they have generated.
-            let bodies_to_dump = discoverer
-                .bodies
-                .iter()
-                .enumerate()
-                .filter(|(index, body)| body.needs_dumping())
-                .map(|(index, _)| index)
-                .collect::<Vec<_>>();
-
-            for (index, body_index) in bodies_to_dump.into_iter().enumerate() {
-                if index > 0 {
-                    println!();
-                }
-
-                let body = &discoverer.bodies[body_index];
-                println!("{}", IrWriter::new(&ty_storage.global, body));
-            }
-
             // We need to add all of the bodies to the global bodies
             // store.
             lowered_bodies.extend(discoverer.into_bodies());
+        }
+
+        // we need to check if any of the bodies have been marked for `dumping`
+        // and emit the IR that they have generated.
+        let bodies_to_dump = lowered_bodies
+            .iter()
+            .enumerate()
+            .filter(|(index, body)| body.needs_dumping())
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+
+        for (index, body_index) in bodies_to_dump.into_iter().enumerate() {
+            // Use a newline as a separator between each body
+            if index > 0 {
+                println!();
+            }
+
+            let body = &lowered_bodies[body_index];
+            println!("{}", IrWriter::new(ir_storage, body));
         }
 
         // Mark all modules now as lowered, and all generated

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -2,7 +2,7 @@
 //! logic that transforms tokens into an AST.
 use hash_ast::ast::*;
 use hash_source::{
-    constant::{IntConstant, CONSTANT_MAP},
+    constant::{FloatTy, IntConstant, IntTy, SIntTy, UIntTy, CONSTANT_MAP},
     identifier::{Identifier, IDENTS},
     location::Span,
 };
@@ -86,20 +86,20 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     /// Parse an integer literal suffix.
     fn parse_integer_suffix(&self, suffix: Identifier, span: Span) -> ParseResult<IntLitKind> {
         let ty = match suffix {
-            id if IDENTS.i8 == id => IntTy::I8,
-            id if IDENTS.i16 == id => IntTy::I16,
-            id if IDENTS.i32 == id => IntTy::I32,
-            id if IDENTS.i64 == id => IntTy::I64,
-            id if IDENTS.i128 == id => IntTy::I128,
-            id if IDENTS.isize == id => IntTy::ISize,
-            id if IDENTS.ibig == id => IntTy::IBig,
-            id if IDENTS.u8 == id => IntTy::U8,
-            id if IDENTS.u16 == id => IntTy::U16,
-            id if IDENTS.u32 == id => IntTy::U32,
-            id if IDENTS.u64 == id => IntTy::U64,
-            id if IDENTS.u128 == id => IntTy::U128,
-            id if IDENTS.usize == id => IntTy::USize,
-            id if IDENTS.ubig == id => IntTy::UBig,
+            id if IDENTS.i8 == id => IntTy::Int(SIntTy::I8),
+            id if IDENTS.i16 == id => IntTy::Int(SIntTy::I16),
+            id if IDENTS.i32 == id => IntTy::Int(SIntTy::I32),
+            id if IDENTS.i64 == id => IntTy::Int(SIntTy::I64),
+            id if IDENTS.i128 == id => IntTy::Int(SIntTy::I128),
+            id if IDENTS.isize == id => IntTy::Int(SIntTy::ISize),
+            id if IDENTS.ibig == id => IntTy::Int(SIntTy::IBig),
+            id if IDENTS.u8 == id => IntTy::UInt(UIntTy::U8),
+            id if IDENTS.u16 == id => IntTy::UInt(UIntTy::U16),
+            id if IDENTS.u32 == id => IntTy::UInt(UIntTy::U32),
+            id if IDENTS.u64 == id => IntTy::UInt(UIntTy::U64),
+            id if IDENTS.u128 == id => IntTy::UInt(UIntTy::U128),
+            id if IDENTS.usize == id => IntTy::UInt(UIntTy::USize),
+            id if IDENTS.ubig == id => IntTy::UInt(UIntTy::UBig),
             id => self.err_with_location(
                 ParseErrorKind::InvalidLitSuffix(NumericLitKind::Integer, id),
                 None,

--- a/compiler/hash-typecheck/src/exhaustiveness/constant.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/constant.rs
@@ -2,7 +2,7 @@
 //! to represent literals, and convert them into a `ConstantValue` which is
 //! used within the exhaustiveness sub-system to represent these values within
 //! a single data type.
-use hash_ast::ast::IntTy;
+use hash_source::constant::IntTy;
 use hash_types::terms::TermId;
 use num_bigint::BigInt;
 

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -3,7 +3,7 @@
 //! the `splitting` operation creates [DeconstructedCtor]s that represent
 //! the whole range of all possible values by the associated type
 //! to the constructor.
-use hash_ast::ast::{IntTy, RangeEnd};
+use hash_ast::ast::RangeEnd;
 use hash_types::{
     nominals::NominalDef,
     terms::{Level1Term, Term},
@@ -87,7 +87,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                 // @@Future: Maybe in the future, we can have a compiler setting/project
                 // setting that allows a user to say `it's ok to use the `target`
                 // pointer width`
-                IntTy::ISize | IntTy::USize | IntTy::UBig | IntTy::IBig => {
+                kind if kind.is_big_sized_integral() || kind.is_ptr_sized_integral() => {
                     smallvec![DeconstructedCtor::NonExhaustive]
                 }
                 kind if kind.is_signed() => {

--- a/compiler/hash-typecheck/src/ops/oracle.rs
+++ b/compiler/hash-typecheck/src/ops/oracle.rs
@@ -1,7 +1,10 @@
 //! Functionality related to determining properties about terms and other
 //! constructs.
-use hash_ast::ast::{IntTy, ParamOrigin};
-use hash_source::identifier::Identifier;
+use hash_ast::ast::ParamOrigin;
+use hash_source::{
+    constant::{IntTy, SIntTy, UIntTy},
+    identifier::Identifier,
+};
 use hash_types::{
     nominals::{
         EnumDef, EnumVariant, EnumVariantValue, NominalDef, NominalDefId, StructDef, UnitDef,
@@ -56,10 +59,10 @@ impl<'tc> Oracle<'tc> {
     /// If the term is an integer type, returns its [IntTy].
     pub fn term_as_int_ty(&self, term: TermId) -> Option<IntTy> {
         macro_rules! check_for_tys {
-            ($($ty:ident => $variant:ident),* $(,)?) => {
+            ($($ty:ident => $variant:expr),* $(,)?) => {
                 $(
                     if self.unifier().terms_are_equal(term, self.core_defs().$ty()) {
-                        return Some(IntTy::$variant);
+                        return Some($variant);
                     }
                 )*
             };
@@ -67,16 +70,16 @@ impl<'tc> Oracle<'tc> {
 
         // Check if it is each of the integer types.
         check_for_tys!(
-                i8_ty => I8,
-                i16_ty => I16,
-                i32_ty => I32,
-                i64_ty => I64,
-                isize_ty => ISize,
-                u8_ty => U8,
-                u16_ty => U16,
-                u32_ty => U32,
-                u64_ty => U64,
-                usize_ty => USize,
+                i8_ty => IntTy::Int(SIntTy::I8),
+                i16_ty => IntTy::Int(SIntTy::I16),
+                i32_ty => IntTy::Int(SIntTy::I32),
+                i64_ty => IntTy::Int(SIntTy::I64),
+                isize_ty => IntTy::Int(SIntTy::ISize),
+                u8_ty => IntTy::UInt(UIntTy::U8),
+                u16_ty => IntTy::UInt(UIntTy::U16),
+                u32_ty => IntTy::UInt(UIntTy::U32),
+                u64_ty => IntTy::UInt(UIntTy::U64),
+                usize_ty => IntTy::UInt(UIntTy::USize),
         );
 
         // Otherwise not an int

--- a/compiler/hash-types/src/terms.rs
+++ b/compiler/hash-types/src/terms.rs
@@ -5,9 +5,9 @@ use std::{
     fmt::{self, Display},
 };
 
-use hash_ast::ast::{IntLit, IntLitKind, IntTy};
+use hash_ast::ast::{IntLit, IntLitKind};
 use hash_source::{
-    constant::{InternedStr, CONSTANT_MAP},
+    constant::{IntTy, InternedStr, SIntTy, CONSTANT_MAP},
     identifier::Identifier,
 };
 use hash_utils::{
@@ -281,7 +281,9 @@ impl From<IntLit> for LitTerm {
 
         match lit.kind {
             IntLitKind::Suffixed(kind) => LitTerm::Int { value: value.to_big_int(), kind },
-            IntLitKind::Unsuffixed => LitTerm::Int { value: value.to_big_int(), kind: IntTy::I32 },
+            IntLitKind::Unsuffixed => {
+                LitTerm::Int { value: value.to_big_int(), kind: IntTy::Int(SIntTy::I32) }
+            }
         }
     }
 }


### PR DESCRIPTION
This patch introduces `IrTy` which is an enum that represents all of the types that can occur at the IR level. This enum is a simplified version of the `Term` structure that is used in the typechecking implementation.  This is introduced in order to avoid the complexities of dealing with the entire term structure during IR generation since only a part of the type term structure is present at the time of generation.