### PR TITLE
Add substitution and hole definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "indexmap",
  "log",
  "num-bigint",
+ "smallvec",
 ]
 
 [[package]]

--- a/compiler/hash-types/Cargo.toml
+++ b/compiler/hash-types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 log = "0.4"
 num-bigint = "0.4"
 indexmap = "1.9"
+smallvec = "1.9"
 
 hash-ast = { path = "../hash-ast" }
 hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-types/src/new/access.rs
+++ b/compiler/hash-types/src/new/access.rs
@@ -9,12 +9,12 @@ pub enum AccessKind {
     CtorField,
     /// Accessing a tuple field, like `f := (2, 3); f.0`.
     TupleField,
-    /// Accessing a module member, like `X := mod { y := 3 }; X.y`.
+    /// Accessing a module member, like `X := mod { y := 3 }; X::y`.
     ModMember,
     /// Accessing a trait member, like `T := trait { y := 3; z := self.y }`
     TrtMember,
     /// Accessing a datatype constructor, like `Colour := enum(Red, Green,
-    /// Blue); Colour.Red`
+    /// Blue); Colour::Red`
     Ctor,
 }
 

--- a/compiler/hash-types/src/new/holes.rs
+++ b/compiler/hash-types/src/new/holes.rs
@@ -1,4 +1,24 @@
 //! Definitions related to type and term holes.
 
-// @@Todo
-pub struct Hole {}
+use hash_utils::{new_store_key, store::DefaultStore};
+
+/// The kind of the hole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HoleKind {
+    /// The hole is a type hole
+    Ty,
+    /// The hole is a term hole
+    Term,
+}
+
+/// A hole, which represents a type or term that is not yet known.
+pub struct Hole {
+    /// The ID of the hole.
+    pub id: HoleId,
+    /// Whether the hole is a type hole or a term hole
+    pub kind: HoleKind,
+    // @@Todo: do we need any additional data here?
+}
+
+new_store_key!(pub HoleId);
+pub type HoleStore = DefaultStore<HoleId, Hole>;

--- a/compiler/hash-types/src/new/mod.rs
+++ b/compiler/hash-types/src/new/mod.rs
@@ -16,6 +16,7 @@ pub mod params;
 pub mod pats;
 pub mod refs;
 pub mod scopes;
+pub mod subs;
 pub mod symbols;
 pub mod terms;
 pub mod trts;

--- a/compiler/hash-types/src/new/subs.rs
+++ b/compiler/hash-types/src/new/subs.rs
@@ -1,0 +1,126 @@
+//! Definitions related to substitutions.
+use smallvec::SmallVec;
+
+use super::{holes::HoleId, symbols::Symbol, terms::TermId};
+
+/// The subject of a substitution
+///
+/// This is either a symbolic variable, or hole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubSubject {
+    /// A variable subject.
+    ///
+    /// For example, ((x) => x)(3) will form the substitution x ~> 3
+    Var(Symbol),
+    /// A hole subject.
+    ///
+    /// For example, x := 3, where x: U1, will form the substitution U1 ~> i32
+    Hole(HoleId),
+}
+
+impl PartialEq<Symbol> for SubSubject {
+    fn eq(&self, other: &Symbol) -> bool {
+        match self {
+            SubSubject::Var(s) => s == other,
+            SubSubject::Hole(_) => false,
+        }
+    }
+}
+
+impl PartialEq<HoleId> for SubSubject {
+    fn eq(&self, other: &HoleId) -> bool {
+        match self {
+            SubSubject::Var(_) => false,
+            SubSubject::Hole(h) => h == other,
+        }
+    }
+}
+
+/// An entry in a substitution.
+///
+/// This is a pair of a subject and a term to replace the subject with.
+#[derive(Debug, Clone, Copy)]
+pub struct SubEntry {
+    pub from: SubSubject,
+    pub to: TermId,
+}
+
+/// A substitution, which replaces variables in terms, by other terms.
+#[derive(Debug, Clone)]
+pub struct Sub {
+    data: SmallVec<[SubEntry; 4]>,
+}
+
+impl Sub {
+    /// Create an empty substitution.
+    pub fn identity() -> Self {
+        Self { data: SmallVec::new() }
+    }
+
+    /// Create a substitution from pairs of ([`SubSubject`], [`TermId`]).
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (SubSubject, TermId)>) -> Self {
+        Self { data: pairs.into_iter().map(|(from, to)| SubEntry { from, to }).collect() }
+    }
+
+    /// Get the substitution for the given [`SubSubject`], if any.
+    pub fn get_sub_for(&self, subject: SubSubject) -> Option<TermId> {
+        self.data.iter().find(|entry| entry.from == subject).map(|entry| entry.to)
+    }
+
+    /// Get all the subjects (i.e. the domain) of the substitution as an
+    /// iterator.
+    pub fn domain(&self) -> impl Iterator<Item = SubSubject> + '_ {
+        self.data.iter().map(|entry| entry.from)
+    }
+
+    /// Get all the targets (i.e. the range) of the substitution as an iterator.
+    pub fn range(&self) -> impl Iterator<Item = TermId> + '_ {
+        self.data.iter().map(|entry| entry.to)
+    }
+
+    /// Get the pairs of the substitution as an iterator.
+    pub fn iter(&self) -> impl Iterator<Item = (SubSubject, TermId)> + '_ {
+        self.data.iter().map(|entry| (entry.from, entry.to))
+    }
+
+    /// Whether the substitution is empty (i.e. identity).
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Get the number of substitutions.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Add a variable substitution.
+    pub fn insert(&mut self, from: SubSubject, to: TermId) {
+        self.data.push(SubEntry { from, to })
+    }
+
+    /// Add variable substitutions from the given [`Sub`].
+    pub fn extend(&mut self, other: &Sub) {
+        self.data.extend(other.data.iter().copied())
+    }
+
+    /// Add variable substitutions from the iterator of pairs.
+    pub fn extend_from_pairs(&mut self, pairs: impl IntoIterator<Item = (SubSubject, TermId)>) {
+        self.data.extend(pairs.into_iter().map(|(from, to)| SubEntry { from, to }))
+    }
+
+    /// Remove the substitution for the given variable.
+    pub fn remove(&mut self, from: SubSubject) -> Option<TermId> {
+        self.data.iter().position(|entry| entry.from == from).map(|i| self.data.swap_remove(i).to)
+    }
+
+    /// Clear the substitution. (i.e. make it identity)
+    pub fn clear(&mut self) {
+        self.data.clear()
+    }
+}
+
+impl Default for Sub {
+    fn default() -> Self {
+        Self::identity()
+    }
+}

--- a/compiler/hash-types/src/new/terms.rs
+++ b/compiler/hash-types/src/new/terms.rs
@@ -7,6 +7,7 @@ use hash_utils::{
 
 use super::{
     casting::{CastTerm, CoerceTerm},
+    holes::HoleId,
     lits::LitTerm,
     symbols::Symbol,
     tys::TypeOfTerm,
@@ -103,6 +104,13 @@ pub enum Term {
     // References
     Ref(RefTerm),
     Deref(DerefTerm),
+
+    /// Term hole
+    ///
+    /// Invariant: `hole.kind == HoleKind::Term`
+    // @@Reconsider: this invariant might need to be broken sometimes if types are used in expr
+    // context.
+    Hole(HoleId),
 }
 
 new_store_key!(pub TermId);

--- a/compiler/hash-types/src/new/tys.rs
+++ b/compiler/hash-types/src/new/tys.rs
@@ -2,6 +2,7 @@
 
 use hash_utils::{new_store_key, store::DefaultStore};
 
+use super::holes::HoleId;
 use crate::new::{
     data::DataTy, fns::FnTy, refs::RefTy, terms::TermId, trts::TrtBoundsId, tuples::TupleTy,
     unions::UnionTy,
@@ -42,13 +43,34 @@ pub enum Ty {
     /// A term which evaluates to a type.
     Eval(TermId),
 
+    /// Type hole.
+    ///
+    /// Invariant: `hole.kind == HoleKind::Ty`
+    Hole(HoleId),
+
+    /// Type variable
+    Var(TyId),
+
+    /// Union type
     Union(UnionTy),
+
+    /// Tuple type
     Tuple(TupleTy),
+
+    /// Function type
     Fn(FnTy),
-    Data(DataTy),
-    Universe(UniverseTy),
-    Meta(MetaTy),
+
+    /// Reference type
     Ref(RefTy),
+
+    /// A user-defined data type
+    Data(DataTy),
+
+    /// The universe type
+    Universe(UniverseTy),
+
+    /// Meta type: type of definitions
+    Meta(MetaTy),
 }
 
 new_store_key!(pub TyId);


### PR DESCRIPTION
This PR adds definitions for type/term holes (before were `UnresolvedVar`s) and for substitutions. The substitution implementation is almost the same as before, but it uses a smallvec rather than a map to keep track of the substitution pairs. This is because most of the time the substitutions will only contain a couple of mappings, and in this case it would be slower to allocate and lookup in a `HashMap`.

Closes #569, #567 