### PR TITLE
IR: lower primitive literal constants and declarations

### DIFF
--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -16,6 +16,7 @@ use crate::ty::{IrTyId, Mutability};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Const {
+    Byte(u8),
     /// Character constant
     Char(char),
     /// Integer constant that is defined within the program source.
@@ -31,6 +32,18 @@ pub enum Const {
     /// str := struct(data: &raw u8, len: usize);
     /// ```
     Str(InternedStr),
+}
+
+impl fmt::Display for Const {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Byte(b) => write!(f, "{b}"),
+            Self::Char(c) => write!(f, "{c}"),
+            Self::Int(i) => write!(f, "{i}"),
+            Self::Float(flt) => write!(f, "{flt}"),
+            Self::Str(s) => write!(f, "{s}"),
+        }
+    }
 }
 
 /// A collection of operations that are constant and must run during the
@@ -183,6 +196,12 @@ impl Place {
     /// Create a [Place] that points to the return `place` of a lowered  body.
     pub fn return_place() -> Self {
         Self { local: RETURN_PLACE, projections: Vec::new() }
+    }
+}
+
+impl From<Local> for Place {
+    fn from(value: Local) -> Self {
+        Self { local: value, projections: Vec::new() }
     }
 }
 

--- a/compiler/hash-ir/src/write.rs
+++ b/compiler/hash-ir/src/write.rs
@@ -102,7 +102,13 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
         let offset = 1 + self.body.arg_count;
 
         for (local, decl) in declarations.skip(offset) {
-            writeln!(f, "    {}{local:?}:{};", decl.mutability(), decl.ty().for_fmt(self.ctx))?;
+            write!(f, "    {}{local:?}: {};", decl.mutability(), decl.ty().for_fmt(self.ctx))?;
+
+            if let Some(name) = decl.name {
+                writeln!(f, "\t\t// parameter `{name}`")?;
+            } else {
+                writeln!(f)?;
+            }
         }
 
         // Print all of the basic blocks
@@ -157,7 +163,7 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
 
         match rvalue {
             RValue::Use(place) => write!(f, "{place}"),
-            RValue::Const(operand) => write!(f, "const {operand:?}"),
+            RValue::Const(operand) => write!(f, "const {operand}"),
             RValue::BinaryOp(op, lhs, rhs) => write!(f, "{lhs:?} {op:?} {rhs:?}"),
             RValue::UnaryOp(op, operand) => write!(f, "{op:?}({operand:?})"),
             RValue::ConstOp(op, operand) => write!(f, "{op:?}({operand:?})"),

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -2,7 +2,7 @@
 //! contains the process for lowering a body block and a loop block. The `match`
 //! block lowering logic is complicated enough to warrant its own module which
 //! is located in `matches.rs`.
-use hash_ast::ast::{AstNodeRef, Block, BodyBlock};
+use hash_ast::ast::{AstNodeRef, Block, BodyBlock, Expr};
 use hash_ir::ir::{BasicBlock, Place};
 use hash_utils::store::PartialStore;
 
@@ -46,7 +46,17 @@ impl<'tcx> Builder<'tcx> {
         // Essentially walk all of the statement in the block, and then set
         // the return type of this block as the last expression, or an empty
         // unit if there is no expression.
-        for statement in body.statements.iter() {}
+        for statement in body.statements.iter() {
+            // We need to handle declarations here specifically, otherwise
+            // in order to not have to create a temporary for the declaration
+            // which doesn't make sense because we are just declaring a local(s)
+            if let Expr::Declaration(..) = statement.body() {
+                unpack!(block = self.handle_expr_declaration(block, statement.ast_ref()));
+            } else {
+                // unpack!(block = self.expr_into_dest(place, block, statement.ast_ref()))
+                todo!() // @@Todo: put the statement in a temporary
+            }
+        }
 
         // If this block has an expression, we need to deal with it since
         // it might change the destination of this block.

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -50,8 +50,8 @@ impl<'tcx> Builder<'tcx> {
             // We need to handle declarations here specifically, otherwise
             // in order to not have to create a temporary for the declaration
             // which doesn't make sense because we are just declaring a local(s)
-            if let Expr::Declaration(..) = statement.body() {
-                unpack!(block = self.handle_expr_declaration(block, statement.ast_ref()));
+            if let Expr::Declaration(decl) = statement.body() {
+                unpack!(block = self.handle_expr_declaration(block, decl));
             } else {
                 // unpack!(block = self.expr_into_dest(place, block, statement.ast_ref()))
                 todo!() // @@Todo: put the statement in a temporary

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -1,0 +1,26 @@
+use hash_ast::ast::{AstNodeRef, Expr, Lit};
+use hash_ir::ir;
+use hash_reporting::macros::panic_on_span;
+
+use super::{unpack, BlockAnd, BlockAndExtend, Builder};
+
+impl<'tcx> Builder<'tcx> {
+    /// Lower a simple literal into an [ir::Const], this does not deal
+    /// with literals that are arrays or other compound data structures.
+    pub(crate) fn as_constant(&mut self, lit: AstNodeRef<'tcx, Lit>) -> ir::Const {
+        match lit.body {
+            Lit::Str(literal) => ir::Const::Str(literal.data),
+            Lit::Char(literal) => ir::Const::Char(literal.data),
+            Lit::Int(literal) => ir::Const::Int(literal.value),
+            Lit::Float(literal) => ir::Const::Float(literal.value),
+            Lit::Bool(literal) => ir::Const::Byte(literal.data.into()),
+            Lit::Set(_) | Lit::Map(_) | Lit::List(_) | Lit::Tuple(_) => {
+                panic_on_span!(
+                    lit.span().into_location(self.source_id),
+                    self.source_map,
+                    "cannot lower compound literal into constant"
+                )
+            }
+        }
+    }
+}

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -172,7 +172,8 @@ pub(crate) struct Builder<'tcx> {
     /// Then we don't want to add `foo` as a declaration to the body of `bar`
     /// because it is a free standing function that will be lowered by
     /// another builder. However, this does not occur when the function is
-    /// not free standing, for example: ```ignore
+    /// not free standing, for example:
+    /// ```ignore
     /// bar := (x: i32) => {
     ///     foo := () => { 1 + x };   
     /// }

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -1,14 +1,19 @@
 //! Defines a IR Builder for function blocks. This is essentially a builder
 //! pattern for lowering declarations into the associated IR.
+#![allow(clippy::too_many_arguments)]
 
 mod block;
+mod constant;
 mod expr;
 mod matches;
 mod pat;
 mod place;
 mod ty;
 
-use std::{cell::Cell, collections::HashMap};
+use std::{
+    cell::Cell,
+    collections::{HashMap, HashSet},
+};
 
 use hash_ast::ast::{AstNodeId, AstNodeRef, Expr, FnDef};
 use hash_ir::{
@@ -22,7 +27,7 @@ use hash_ir::{
 use hash_source::{
     identifier::Identifier,
     location::{SourceLocation, Span},
-    SourceId,
+    SourceId, SourceMap,
 };
 use hash_types::{
     fmt::PrepareForFormatting,
@@ -119,6 +124,12 @@ pub(crate) struct Builder<'tcx> {
     /// The IR storage needed for storing all of the created values and bodies
     storage: &'tcx mut IrStorage,
 
+    /// The sources of the current program, this is only used
+    /// to give more contextual panics when the compiler unexpectedly
+    /// encounters an unexpected AST node, and thus it will emit a
+    /// span when the compiler panics.
+    source_map: &'tcx SourceMap,
+
     /// The name with the associated body that this is building.
     name: Identifier,
 
@@ -148,6 +159,27 @@ pub(crate) struct Builder<'tcx> {
     /// If the body that is being built will need to be
     /// dumped.
     needs_dumping: bool,
+
+    /// Declaration dead ends, this is to ensure that we don't try to
+    /// lower a declaration that is not part of the function definition.
+    /// For example, if the function `foo` is declared in `bar` like this:
+    /// ```ignore
+    /// bar := () => {
+    ///     foo := () => { 1 };   
+    /// }
+    /// ```
+    ///
+    /// Then we don't want to add `foo` as a declaration to the body of `bar`
+    /// because it is a free standing function that will be lowered by
+    /// another builder. However, this does not occur when the function is
+    /// not free standing, for example: ```ignore
+    /// bar := (x: i32) => {
+    ///     foo := () => { 1 + x };   
+    /// }
+    /// ```
+    /// The function `foo` is no longer free in `bar` because it captures `x`,
+    /// therefore making it a closure of `foo`.
+    dead_ends: &'tcx HashSet<AstNodeId>,
 }
 
 impl<'tcx> Builder<'tcx> {
@@ -157,7 +189,9 @@ impl<'tcx> Builder<'tcx> {
         source_id: SourceId,
         tcx: &'tcx GlobalStorage,
         storage: &'tcx mut IrStorage,
+        source_map: &'tcx SourceMap,
         needs_dumping: bool,
+        dead_ends: &'tcx HashSet<AstNodeId>,
     ) -> Self {
         let arg_count = match item {
             BuildItem::FnDef(node) => {
@@ -165,7 +199,8 @@ impl<'tcx> Builder<'tcx> {
                 // figure out how many arguments there will be passed in
                 // and how many locals we need to allocate.
 
-                let term = tcx.node_info_store.get(node.id()).map(|info| info.term_id()).unwrap();
+                let term =
+                    tcx.node_info_store.node_info(node.id()).map(|info| info.term_id()).unwrap();
                 let fn_ty = get_fn_ty_from_term(term, tcx);
 
                 fn_ty.params.len()
@@ -177,6 +212,7 @@ impl<'tcx> Builder<'tcx> {
             item,
             tcx,
             storage,
+            source_map,
             name,
             arg_count,
             source_id,
@@ -185,6 +221,7 @@ impl<'tcx> Builder<'tcx> {
             declaration_map: HashMap::new(),
             scope_stack: vec![],
             needs_dumping,
+            dead_ends,
         }
     }
 
@@ -214,7 +251,7 @@ impl<'tcx> Builder<'tcx> {
     /// provided [AstNodeId].
     #[inline]
     fn get_ty_id_of_node(&self, id: AstNodeId) -> IrTyId {
-        let term_id = self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap();
+        let term_id = self.tcx.node_info_store.node_info(id).map(|f| f.term_id()).unwrap();
 
         // We need to try and look up the type within the cache, if not
         // present then we create the type by converting the term into
@@ -227,7 +264,7 @@ impl<'tcx> Builder<'tcx> {
     /// provided [AstNodeId].
     #[inline]
     fn get_ty_of_node(&self, id: AstNodeId) -> IrTy {
-        let term_id = self.tcx.node_info_store.get(id).map(|f| f.term_id()).unwrap();
+        let term_id = self.tcx.node_info_store.node_info(id).map(|f| f.term_id()).unwrap();
 
         lower_term(term_id, self.tcx, self.storage)
     }
@@ -236,7 +273,7 @@ impl<'tcx> Builder<'tcx> {
     /// provided [AstNodeId].
     #[inline]
     fn get_pat_id_of_node(&self, id: AstNodeId) -> Pat {
-        let pat_id = self.tcx.node_info_store.get(id).map(|f| f.pat_id()).unwrap();
+        let pat_id = self.tcx.node_info_store.node_info(id).map(|f| f.pat_id()).unwrap();
 
         self.tcx.pat_store.get(pat_id)
     }
@@ -250,7 +287,7 @@ impl<'tcx> Builder<'tcx> {
         expr: AstNodeRef<U>,
         f: impl FnOnce(&mut Self) -> T,
     ) -> T {
-        let scope_id = self.tcx.node_info_store.get(expr.id()).map(|f| f.scope_id()).unwrap();
+        let scope_id = self.tcx.node_info_store.node_info(expr.id()).map(|f| f.scope_id()).unwrap();
         self.scope_stack.push(scope_id);
 
         let result = f(self);
@@ -301,7 +338,7 @@ impl<'tcx> Builder<'tcx> {
             BuildItem::Expr(_) => unreachable!(),
         };
 
-        let term_id = self.tcx.node_info_store.get(node.id()).map(|f| f.term_id()).unwrap();
+        let term_id = self.tcx.node_info_store.node_info(node.id()).map(|f| f.term_id()).unwrap();
 
         // We need to get the underlying `FnTy` so that we can read the parameters
         let fn_term = match self.item {
@@ -322,7 +359,8 @@ impl<'tcx> Builder<'tcx> {
         self.declarations.push(ret_local);
 
         // Deal with all the function parameters that are given to the function.
-        let param_scope = self.tcx.node_info_store.get(node.id()).map(|f| f.scope_id()).unwrap();
+        let param_scope =
+            self.tcx.node_info_store.node_info(node.id()).map(|f| f.scope_id()).unwrap();
         self.scope_stack.push(param_scope);
 
         // @@Future: deal with parameter attributes that are mutable?

--- a/compiler/hash-lower/src/build/pat.rs
+++ b/compiler/hash-lower/src/build/pat.rs
@@ -1,23 +1,24 @@
 use hash_ast::ast::{self, AstNodeRef};
 use hash_ir::{
-    ir::{Local, LocalDecl},
+    ir::{BasicBlock, Local, LocalDecl, Place},
     ty::{IrTyId, Mutability},
 };
 use hash_source::identifier::Identifier;
 use hash_types::{pats::BindingPat, terms::TermId};
 
-use super::Builder;
+use super::{BlockAnd, Builder};
+use crate::build::{unpack, BlockAndExtend};
 
 impl<'tcx> Builder<'tcx> {
     /// Visit all of the bindings that are declared in the current pattern, and
     /// add them to the current builder declarations.
     pub(crate) fn visit_bindings(&mut self, pat: AstNodeRef<'tcx, ast::Pat>) {
-        let pat_id = pat.id();
+        let node_id = pat.id();
 
         match pat.body {
             ast::Pat::Binding(ast::BindingPat { name, visibility, mutability }) => {
                 // resolve the type of this binding
-                let pat = self.get_pat_id_of_node(pat_id);
+                let pat = self.get_pat_id_of_node(node_id);
                 let BindingPat { mutability, name, .. } = pat.into_bind().unwrap();
 
                 // @@Fugly: convert the provided mutability into **our** mutability
@@ -26,7 +27,7 @@ impl<'tcx> Builder<'tcx> {
                     hash_types::scope::Mutability::Mutable => Mutability::Mutable,
                 };
 
-                let ty = self.get_ty_id_of_node(pat_id);
+                let ty = self.get_ty_id_of_node(node_id);
                 self.declare_binding(name, ty, mutability)
             }
             ast::Pat::Constructor(_) => todo!(),
@@ -56,5 +57,33 @@ impl<'tcx> Builder<'tcx> {
         let scope_id = self.scope_stack.last().unwrap();
 
         self.push_local(local, *scope_id);
+    }
+
+    /// Put the right-hand side expression into the provided irrefutable
+    /// pattern.
+    pub(super) fn expr_into_pat(
+        &mut self,
+        mut block: BasicBlock,
+        irrefutable_pat: AstNodeRef<'tcx, ast::Pat>,
+        rvalue: AstNodeRef<'tcx, ast::Expr>,
+    ) -> BlockAnd<()> {
+        match irrefutable_pat.body {
+            // The simple case of a just writing into the binding, we can
+            // directly assign into the binding that is provided.
+            ast::Pat::Binding(ast::BindingPat { name, .. }) => {
+                let place = Place::from(self.lookup_local(name.ident).unwrap());
+                unpack!(block = self.expr_into_dest(place, block, rvalue));
+                block.unit()
+            }
+            ast::Pat::Wild(_) => todo!(),
+            ast::Pat::Constructor(_) => todo!(),
+            ast::Pat::Tuple(_) => todo!(),
+            ast::Pat::List(_) => todo!(),
+            ast::Pat::Lit(_) => todo!(),
+            ast::Pat::Or(_) => todo!(),
+            pat => {
+                panic!("reached irrefutable pattern: {pat:?} in `expr_into_pat`");
+            }
+        }
     }
 }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -73,7 +73,8 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
                 continue;
             }
 
-            let mut discoverer = LoweringVisitor::new(&ty_storage.global, ir_storage, source_id);
+            let mut discoverer =
+                LoweringVisitor::new(&ty_storage.global, ir_storage, source_map, source_id);
             discoverer.visit_module(module.node_ref());
 
             // We need to add all of the bodies to the global bodies

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -69,6 +69,11 @@ impl Span {
     pub fn is_empty(&self) -> bool {
         self.start() == self.end()
     }
+
+    /// Convert the [Span] into a [SourceLocation].
+    pub fn into_location(self, source_id: SourceId) -> SourceLocation {
+        SourceLocation::new(self, source_id)
+    }
 }
 
 impl Default for Span {

--- a/compiler/hash-typecheck/src/ops/pats.rs
+++ b/compiler/hash-typecheck/src/ops/pats.rs
@@ -876,6 +876,17 @@ impl<'tc> PatMatcher<'tc> {
         if let Some(members) = bound_members {
             self.verify_members_are_bound_once(&members)?;
 
+            // Here, we for each member, we register an associated `TermId` with the node
+            // that corresponds to `AstNodeId` of the pattern. This is used
+            // during IR generation when querying the types of the patterns.
+            members.iter().for_each(|member| {
+                let PatMember { member, pat } = member;
+
+                if let Some(id) = self.node_info_store().pat_to_node_id(*pat) {
+                    self.node_info_store().update_or_insert(id, member.ty().into())
+                }
+            });
+
             Ok(Some(members))
         } else {
             Ok(None)

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -2059,6 +2059,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
             },
         );
 
+        // Copy the location of this node to the pat_id
         self.register_node_info_and_location(node, pat);
         Ok(pat)
     }


### PR DESCRIPTION
This patch implements IR lowering for constant literals such as integers, floats, etc. Additionally, this patch also implements the handling of declarations that appear within body blocks.