### PR TITLE
IR: lower `loop`, `break`, `continue` and `return` statements

### DIFF
--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -19,7 +19,7 @@ pub enum Const {
     /// Nothing, it has zero size.
     Zero,
 
-    /// Byte constant, essentially a boolean.
+    /// Byte constant, could a boolean.
     Byte(u8),
 
     /// Character constant
@@ -131,7 +131,13 @@ pub struct LocalDecl {
     /// with which variable and scope).
     pub name: Option<Identifier>,
 
-    /// Whether the local declaration is an auxiliary,
+    /// Whether the local declaration is an auxiliary. An auxiliary local
+    /// declaration is used to store a temporary result of an operation that
+    /// is used to store the result of expressions that return **nothing**,
+    /// or temporary variables that are needed during the lowering process to
+    /// lower edge case expressions. Auxiliary local declarations will be
+    /// eliminated during the lowering process, when the IR undergoes
+    /// optimisations.
     auxiliary: bool,
 }
 

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -485,9 +485,14 @@ impl Body {
         source: BodySource,
         span: Span,
         source_id: SourceId,
-        dump: bool,
     ) -> Self {
-        Self { blocks, name, declarations, arg_count, source, span, source_id, dump }
+        Self { blocks, name, declarations, arg_count, source, span, source_id, dump: false }
+    }
+
+    /// Set the `dump` flag to `true` so that the IR Body that is generated
+    /// will be printed when the generation process is finalised.
+    pub fn mark_to_dump(&mut self) {
+        self.dump = true;
     }
 
     /// Check if the [Body] needs to be dumped.

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -1,5 +1,6 @@
 //! Hash Compiler Intermediate Representation (IR) crate.
 #![allow(clippy::too_many_arguments)]
+#![feature(let_chains)]
 
 pub mod ir;
 pub mod ty;

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -13,11 +13,14 @@ use hash_source::{
 };
 use hash_utils::{
     new_sequence_store_key, new_store_key,
-    store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore},
+    store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, Store},
 };
-use index_vec::IndexVec;
+use index_vec::{index_vec, IndexVec};
 
-use crate::write::{ForFormatting, WriteTyIr};
+use crate::{
+    write::{ForFormatting, WriteTyIr},
+    IrStorage,
+};
 
 /// Mutability of a particular variable, reference, etc.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -102,6 +105,17 @@ pub enum IrTy {
     /// second item is the return type of the function. If the function has no
     /// explicit return type, this will always be inferred at this stage.
     Fn(IrTyListId, IrTyId),
+}
+
+impl IrTy {
+    /// Make a unit type, i.e. `()`
+    pub fn unit(ir_storage: &IrStorage) -> Self {
+        let variants = index_vec![AdtVariant { name: 0usize.into(), fields: vec![] }];
+        let adt = AdtData::new_with_flags("unit".into(), variants, AdtFlags::TUPLE);
+        let adt_id = ir_storage.adt_store().create(adt);
+
+        Self::Adt(adt_id)
+    }
 }
 
 index_vec::define_index_type! {

--- a/compiler/hash-ir/src/write.rs
+++ b/compiler/hash-ir/src/write.rs
@@ -104,7 +104,7 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
         for (local, decl) in declarations.skip(offset) {
             write!(f, "    {}{local:?}: {};", decl.mutability(), decl.ty().for_fmt(self.ctx))?;
 
-            if let Some(name) = decl.name {
+            if let Some(name) = decl.name && !decl.auxiliary() {
                 writeln!(f, "\t\t// parameter `{name}`")?;
             } else {
                 writeln!(f)?;

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -57,7 +57,7 @@ impl<'tcx> Builder<'tcx> {
             Block::For(..) | Block::While(..) | Block::If(..) => unreachable!(),
 
             // Lowering implementation blocks is a no-op because this is dealt with
-            // at a lower level, so we just want to skip this.
+            // at a higher level, so we just want to skip this.
             Block::Impl(..) | Block::Mod(..) => block.unit(),
         }
     }
@@ -116,29 +116,5 @@ impl<'tcx> Builder<'tcx> {
 
         self.loop_block_info = old_block_info;
         normal_exit_block
-
-        // match (normal_exit_block, loop_block) {
-        //     // The inner `f` returned a block to where it currently was...
-        //     // which means that we can continue and use this block as part
-        //     // of the building from here.
-        //     (Some(block), None) => block,
-
-        //     // No `normal_exit_block` means that we should go back to the
-        //     // loop block.
-        //     (None, Some(block)) => block.unit(),
-        //     (None, None) => self.control_flow_graph.start_new_block().unit(),
-        //     (Some(normal_exit_block), Some(break_block)) => {
-        //         let target = self.control_flow_graph.start_new_block();
-
-        //         // Terminate the `continue` and `break` blocks with a `goto`
-        // instruction.         // Then specify that the next block that
-        // should be used is the newly         // created `target`
-        // block.         self.control_flow_graph.goto(unpack!
-        // (normal_exit_block), target, span);         self.
-        // control_flow_graph.goto(break_block, target, span);
-
-        //         target.unit()
-        //     }
-        // }
     }
 }

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -2,11 +2,12 @@
 //! contains the process for lowering a body block and a loop block. The `match`
 //! block lowering logic is complicated enough to warrant its own module which
 //! is located in `matches.rs`.
-use hash_ast::ast::{AstNodeRef, Block, BodyBlock, Expr};
-use hash_ir::ir::{BasicBlock, Place};
-use hash_utils::store::PartialStore;
+use std::mem;
 
-use super::{BlockAnd, BlockAndExtend, Builder};
+use hash_ast::ast::{AstNodeRef, Block, BodyBlock, Expr, LoopBlock};
+use hash_ir::ir::{BasicBlock, Place};
+
+use super::{BlockAnd, BlockAndExtend, Builder, LoopBlockInfo};
 use crate::build::unpack;
 
 impl<'tcx> Builder<'tcx> {
@@ -14,27 +15,51 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         place: Place,
         block: BasicBlock,
-        body: AstNodeRef<'tcx, Block>,
+        ast_block: AstNodeRef<'tcx, Block>,
     ) -> BlockAnd<()> {
-        self.with_scope(body, |this| {
-            // Check which kind of block we are dealing with...
-            match body.body {
-                Block::Body(body) => this.body_block_into_dest(place, block, body),
+        let span = ast_block.span();
 
-                // Send this off into the `match` lowering logic
-                Block::Match(..) => todo!(),
-
-                // Send this off into the `loop` lowering logic
-                Block::Loop(..) => todo!(),
-
-                // These variants are removed during the de-sugaring stage
-                Block::For(..) | Block::While(..) | Block::If(..) => unreachable!(),
-
-                // Lowering implementation blocks is a no-op because this is dealt with
-                // at a lower level, so we just want to skip this.
-                Block::Impl(..) | Block::Mod(..) => block.unit(),
+        match ast_block.body {
+            Block::Body(body) => {
+                self.with_scope(ast_block, |this| this.body_block_into_dest(place, block, body))
             }
-        })
+
+            // Send this off into the `match` lowering logic
+            Block::Match(..) => todo!(),
+
+            Block::Loop(LoopBlock { contents }) => {
+                // Begin the loop block by connecting the previous block
+                // and terminating it with a `goto` instruction to this block
+                let loop_body = self.control_flow_graph.start_new_block();
+                self.control_flow_graph.goto(block, loop_body, span);
+
+                let next_block = self.control_flow_graph.start_new_block();
+
+                self.enter_breakable_block(loop_body, next_block, place, move |this| {
+                    // We need to create a temporary for the blocks return value which is
+                    // always going to be `()`
+                    let tmp_place = this.make_tmp_unit();
+
+                    let body_block_end =
+                        unpack!(this.block_into_dest(tmp_place, loop_body, contents.ast_ref()));
+
+                    // In the situation that we have the final statement in the loop, this
+                    // block should go back to the start of the loop...
+                    if !this.control_flow_graph.is_terminated(body_block_end) {
+                        this.control_flow_graph.goto(body_block_end, loop_body, ast_block.span());
+                    }
+
+                    next_block.unit()
+                })
+            }
+
+            // These variants are removed during the de-sugaring stage
+            Block::For(..) | Block::While(..) | Block::If(..) => unreachable!(),
+
+            // Lowering implementation blocks is a no-op because this is dealt with
+            // at a lower level, so we just want to skip this.
+            Block::Impl(..) | Block::Mod(..) => block.unit(),
+        }
     }
 
     pub(crate) fn body_block_into_dest(
@@ -47,23 +72,73 @@ impl<'tcx> Builder<'tcx> {
         // the return type of this block as the last expression, or an empty
         // unit if there is no expression.
         for statement in body.statements.iter() {
+            if self.reached_terminator {
+                break;
+            }
+
             // We need to handle declarations here specifically, otherwise
             // in order to not have to create a temporary for the declaration
             // which doesn't make sense because we are just declaring a local(s)
             if let Expr::Declaration(decl) = statement.body() {
                 unpack!(block = self.handle_expr_declaration(block, decl));
             } else {
-                // unpack!(block = self.expr_into_dest(place, block, statement.ast_ref()))
-                todo!() // @@Todo: put the statement in a temporary
+                // @@Investigate: do we need to deal with the temporary here?
+                unpack!(block = self.expr_into_temp(block, statement.ast_ref()));
             }
         }
 
         // If this block has an expression, we need to deal with it since
         // it might change the destination of this block.
-        if let Some(expr) = body.expr.as_ref() {
+        if let Some(expr) = body.expr.as_ref() && !self.reached_terminator {
             unpack!(block = self.expr_into_dest(place, block, expr.ast_ref()));
         }
 
         block.unit()
+    }
+
+    /// Function that handles the lowering of loop expressions. This function
+    /// takes in an inner closure which runs the operation of lowering the
+    /// inner body loop,
+    pub(crate) fn enter_breakable_block<F>(
+        &mut self,
+        loop_body: BasicBlock,
+        next_block: BasicBlock,
+        _break_destination: Place,
+        f: F,
+    ) -> BlockAnd<()>
+    where
+        F: FnOnce(&mut Builder<'tcx>) -> BlockAnd<()>,
+    {
+        let block_info = LoopBlockInfo { loop_body, next_block };
+        let old_block_info = mem::replace(&mut self.loop_block_info, Some(block_info));
+
+        let normal_exit_block = f(self);
+
+        self.loop_block_info = old_block_info;
+        normal_exit_block
+
+        // match (normal_exit_block, loop_block) {
+        //     // The inner `f` returned a block to where it currently was...
+        //     // which means that we can continue and use this block as part
+        //     // of the building from here.
+        //     (Some(block), None) => block,
+
+        //     // No `normal_exit_block` means that we should go back to the
+        //     // loop block.
+        //     (None, Some(block)) => block.unit(),
+        //     (None, None) => self.control_flow_graph.start_new_block().unit(),
+        //     (Some(normal_exit_block), Some(break_block)) => {
+        //         let target = self.control_flow_graph.start_new_block();
+
+        //         // Terminate the `continue` and `break` blocks with a `goto`
+        // instruction.         // Then specify that the next block that
+        // should be used is the newly         // created `target`
+        // block.         self.control_flow_graph.goto(unpack!
+        // (normal_exit_block), target, span);         self.
+        // control_flow_graph.goto(break_block, target, span);
+
+        //         target.unit()
+        //     }
+        // }
     }
 }

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -1,8 +1,8 @@
-use hash_ast::ast::{AstNodeRef, Expr, Lit};
+use hash_ast::ast::{AstNodeRef, Lit};
 use hash_ir::ir;
 use hash_reporting::macros::panic_on_span;
 
-use super::{unpack, BlockAnd, BlockAndExtend, Builder};
+use super::Builder;
 
 impl<'tcx> Builder<'tcx> {
     /// Lower a simple literal into an [ir::Const], this does not deal

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -156,10 +156,6 @@ pub(crate) struct Builder<'tcx> {
     /// The current scope stack that builder is in.
     scope_stack: Vec<ScopeId>,
 
-    /// If the body that is being built will need to be
-    /// dumped.
-    needs_dumping: bool,
-
     /// Information about the currently traversed [Block] in the AST. This
     /// value is used to determine when the block should be terminated by
     /// the builder. This is used to avoid lowering statements that occur
@@ -208,7 +204,6 @@ impl<'tcx> Builder<'tcx> {
         tcx: &'tcx GlobalStorage,
         storage: &'tcx mut IrStorage,
         source_map: &'tcx SourceMap,
-        needs_dumping: bool,
         dead_ends: &'tcx HashSet<AstNodeId>,
     ) -> Self {
         let arg_count = match item {
@@ -240,7 +235,6 @@ impl<'tcx> Builder<'tcx> {
             reached_terminator: false,
             loop_block_info: None,
             scope_stack: vec![],
-            needs_dumping,
             dead_ends,
             tmp_place: None,
         }
@@ -264,7 +258,6 @@ impl<'tcx> Builder<'tcx> {
             BodySource::Item,
             self.item.span(),
             self.source_id,
-            self.needs_dumping,
         )
     }
 

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -8,36 +8,21 @@ mod expr;
 mod matches;
 mod pat;
 mod place;
+mod rvalue;
+mod temp;
 mod ty;
 
-use std::{
-    cell::Cell,
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use hash_ast::ast::{AstNodeId, AstNodeRef, Expr, FnDef};
 use hash_ir::{
-    ir::{
-        BasicBlock, BasicBlockData, Body, BodySource, Local, LocalDecl, Place, Terminator,
-        TerminatorKind, START_BLOCK,
-    },
+    ir::{BasicBlock, Body, BodySource, Local, LocalDecl, Place, TerminatorKind, START_BLOCK},
     ty::{IrTy, IrTyId, Mutability},
     IrStorage,
 };
-use hash_source::{
-    identifier::Identifier,
-    location::{SourceLocation, Span},
-    SourceId, SourceMap,
-};
-use hash_types::{
-    fmt::PrepareForFormatting,
-    nodes::NodeInfoTarget,
-    pats::{Pat, PatId},
-    scope::ScopeId,
-    storage::GlobalStorage,
-    terms::{FnLit, FnTy, Level0Term, Level1Term, Term, TermId},
-};
-use hash_utils::store::{CloneStore, PartialStore, SequenceStore, SequenceStoreKey, Store};
+use hash_source::{identifier::Identifier, location::Span, SourceId, SourceMap};
+use hash_types::{pats::Pat, scope::ScopeId, storage::GlobalStorage};
+use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 use index_vec::IndexVec;
 
 use self::ty::{convert_term_into_ir_ty, get_fn_ty_from_term, lower_term};
@@ -115,8 +100,23 @@ pub macro unpack {
     }}
 }
 
-/// The builder is responsible for lowering a body into the associated IR.
+/// Information about the current `loop` context that is being lowered. When
+/// the [Builder] is lowering a loop, it will store the current loop body
+/// block, and the `next` block that the loop will jump to after the loop
+/// in order to correctly handle `break` and `continue` statements.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LoopBlockInfo {
+    /// Denotes where the index of the loop body that is being used
+    /// for `continue` statements. The loop body should finish the
+    /// current block by sending the **current** block to the loop body.
+    loop_body: BasicBlock,
 
+    /// Denotes where the index of the next block that is being used
+    /// for `break` statements should jump to...
+    next_block: BasicBlock,
+}
+
+/// The builder is responsible for lowering a body into the associated IR.
 pub(crate) struct Builder<'tcx> {
     /// The type storage needed for accessing the types of the traversed terms
     tcx: &'tcx GlobalStorage,
@@ -159,6 +159,23 @@ pub(crate) struct Builder<'tcx> {
     /// If the body that is being built will need to be
     /// dumped.
     needs_dumping: bool,
+
+    /// Information about the currently traversed [Block] in the AST. This
+    /// value is used to determine when the block should be terminated by
+    /// the builder. This is used to avoid lowering statements that occur
+    /// after a block terminator.
+    loop_block_info: Option<LoopBlockInfo>,
+
+    /// If the current [Block] has reached a terminating statement, i.e. a
+    /// statement that is typed as `!`. Examples of such statements are
+    /// `return`, `break`, `continue`, etc.
+    reached_terminator: bool,
+
+    /// A temporary [Place] that is used to throw away results from expressions
+    /// when we know that we don't need or want to store the result. If
+    /// `tmp_place` is [None], then we create a new temporary place and store
+    /// it in the field for later use.
+    tmp_place: Option<Place>,
 
     /// Declaration dead ends, this is to ensure that we don't try to
     /// lower a declaration that is not part of the function definition.
@@ -220,9 +237,12 @@ impl<'tcx> Builder<'tcx> {
             control_flow_graph: ControlFlowGraph::new(),
             declarations: IndexVec::new(),
             declaration_map: HashMap::new(),
+            reached_terminator: false,
+            loop_block_info: None,
             scope_stack: vec![],
             needs_dumping,
             dead_ends,
+            tmp_place: None,
         }
     }
 
@@ -279,6 +299,26 @@ impl<'tcx> Builder<'tcx> {
         self.tcx.pat_store.get(pat_id)
     }
 
+    /// Function to create a new [Place] that is used to ignore
+    /// the results of expressions, i.e. blocks.
+    pub(crate) fn make_tmp_unit(&mut self) -> Place {
+        match &self.tmp_place {
+            Some(tmp) => tmp.clone(),
+            None => {
+                let ty = IrTy::unit(self.storage);
+                let ty_id = self.storage.ty_store().create(ty);
+
+                let local = LocalDecl::new_auxiliary(ty_id, Mutability::Immutable);
+                let local_id = self.declarations.push(local);
+
+                let place = Place::from(local_id);
+                self.tmp_place = Some(place.clone());
+
+                place
+            }
+        }
+    }
+
     /// Run a lowering operation whilst entering a new scope which is derived
     /// from the provided [AstNodeRef<Expr>].
     ///
@@ -299,17 +339,25 @@ impl<'tcx> Builder<'tcx> {
         result
     }
 
+    /// Get the current [ScopeId] that is being used within the builder.
+    pub(crate) fn current_scope(&self) -> ScopeId {
+        *self.scope_stack.last().unwrap()
+    }
+
     /// Push a [LocalDecl] in the current [Builder] with the associated
     /// [ScopeId]. This will put the [LocalDecl] into the declarations, and
     /// create an entry in the lookup map so that the [Local] can be looked up
     /// via the name of the local and the scope that it is in.
     pub(crate) fn push_local(&mut self, decl: LocalDecl, scope: ScopeId) -> Local {
-        let decl_name = decl.name.unwrap();
+        let decl_name = decl.name;
         let index = self.declarations.push(decl);
 
-        // We assume that if this function is used to push
-        // a declaration, then the `LocalDecl` has an associated name.
-        self.declaration_map.insert((scope, decl_name), index);
+        // If the declaration has a name i.e. not an auxiliary local, then
+        // we can push it into the `declaration_map`.
+        if let Some(name) = decl_name {
+            self.declaration_map.insert((scope, name), index);
+        }
+
         index
     }
 
@@ -343,7 +391,7 @@ impl<'tcx> Builder<'tcx> {
 
         // We need to get the underlying `FnTy` so that we can read the parameters
         let fn_term = match self.item {
-            BuildItem::FnDef(node) => get_fn_ty_from_term(term_id, self.tcx),
+            BuildItem::FnDef(_node) => get_fn_ty_from_term(term_id, self.tcx),
             BuildItem::Expr(_) => unreachable!(),
         };
         let fn_params =
@@ -356,7 +404,7 @@ impl<'tcx> Builder<'tcx> {
         // The first local declaration is used as the return type. The return local
         // declaration is always mutable because it will be set at some point in
         // the end, not the beginning.
-        let ret_local = LocalDecl { name: None, ty: ret_ty, mutability: Mutability::Mutable };
+        let ret_local = LocalDecl::new_auxiliary(ret_ty, Mutability::Mutable);
         self.declarations.push(ret_local);
 
         // Deal with all the function parameters that are given to the function.
@@ -374,13 +422,13 @@ impl<'tcx> Builder<'tcx> {
         let start = self.control_flow_graph.start_new_block();
         debug_assert!(start == START_BLOCK);
 
-        let return_block =
-            unpack!(self.expr_into_dest(Place::return_place(), start, node.body.fn_body.ast_ref()));
-
         // Now that we have built the inner body block, we then need to terminate
         // the current basis block with a return terminator.
         let ret_span = node.span(); // @@Fixme: this should be the span of the ending part of the function body
                                     // span!
+
+        let return_block =
+            unpack!(self.expr_into_dest(Place::return_place(), start, node.body.fn_body.ast_ref()));
 
         self.control_flow_graph.terminate(return_block, ret_span, TerminatorKind::Return)
     }
@@ -392,5 +440,5 @@ impl<'tcx> Builder<'tcx> {
     ///
     /// This is a different concept from `compile-time` since in the future we
     /// will allow compile time expressions to run any arbitrary code.
-    fn build_const(&mut self, _node: AstNodeRef<Expr>) {}
+    fn _build_const(&mut self, _node: AstNodeRef<Expr>) {}
 }

--- a/compiler/hash-lower/src/build/pat.rs
+++ b/compiler/hash-lower/src/build/pat.rs
@@ -1,10 +1,10 @@
 use hash_ast::ast::{self, AstNodeRef};
 use hash_ir::{
-    ir::{BasicBlock, Local, LocalDecl, Place},
+    ir::{BasicBlock, LocalDecl, Place},
     ty::{IrTyId, Mutability},
 };
 use hash_source::identifier::Identifier;
-use hash_types::{pats::BindingPat, terms::TermId};
+use hash_types::pats::BindingPat;
 
 use super::{BlockAnd, Builder};
 use crate::build::{unpack, BlockAndExtend};
@@ -16,7 +16,7 @@ impl<'tcx> Builder<'tcx> {
         let node_id = pat.id();
 
         match pat.body {
-            ast::Pat::Binding(ast::BindingPat { name, visibility, mutability }) => {
+            ast::Pat::Binding(ast::BindingPat { name: _, visibility: _, mutability: _ }) => {
                 // resolve the type of this binding
                 let pat = self.get_pat_id_of_node(node_id);
                 let BindingPat { mutability, name, .. } = pat.into_bind().unwrap();

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -1,3 +1,6 @@
+//! Utilities for dealing with [Place]s when building up Hash IR.
+#![allow(unused)]
+
 use hash_ast::ast::{AstNodeRef, Expr};
 use hash_ir::ir::{BasicBlock, Local, Place, PlaceProjection};
 
@@ -69,7 +72,7 @@ impl<'tcx> Builder<'tcx> {
 
     pub(crate) fn as_place_builder(
         &mut self,
-        mut block: BasicBlock,
+        block: BasicBlock,
         expr: AstNodeRef<'tcx, Expr>,
     ) -> BlockAnd<PlaceBuilder> {
         match expr.body {
@@ -112,7 +115,6 @@ impl<'tcx> Builder<'tcx> {
             | Expr::Return(_)
             | Expr::Break(_)
             | Expr::Continue(_)
-            | Expr::Index(_)
             | Expr::Assign(_)
             | Expr::AssignOp(_)
             | Expr::BinaryExpr(_)

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -1,0 +1,25 @@
+use hash_ast::ast::{AstNodeRef, Expr};
+use hash_ir::ir::{BasicBlock, RValueId};
+use hash_utils::store::Store;
+
+use super::{BlockAnd, BlockAndExtend, Builder};
+
+impl<'tcx> Builder<'tcx> {
+    /// Construct an [RValue] from the given [Expr] and return the [RValueId].
+    pub(crate) fn as_rvalue(
+        &mut self,
+        block: BasicBlock,
+        expr: AstNodeRef<'tcx, Expr>,
+    ) -> BlockAnd<RValueId> {
+        // @@Todo: use a notion of `categories` to determine if we should
+        // lower it as a constant or else, the `category` is derived from
+        // the expression itself,
+        let rvalue = match expr.body {
+            Expr::Lit(lit) => self.as_constant(lit.data.ast_ref()).into(),
+            _ => unimplemented!(),
+        };
+
+        let rvalue_id = self.storage.rvalue_store().create(rvalue);
+        block.and(rvalue_id)
+    }
+}

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -1,0 +1,31 @@
+//! Lowering logic for compiling an [Expr] into a temporary [Local].
+
+use hash_ast::ast::{AstNodeRef, Expr};
+use hash_ir::{
+    ir::{BasicBlock, Local, LocalDecl, Place},
+    ty::Mutability,
+};
+
+use super::{BlockAnd, Builder};
+use crate::build::{unpack, BlockAndExtend};
+
+impl<'tcx> Builder<'tcx> {
+    /// Compile an [Expr] into a freshly created temporary [Place].
+    pub(crate) fn expr_into_temp(
+        &mut self,
+        mut block: BasicBlock,
+        expr: AstNodeRef<'tcx, Expr>,
+    ) -> BlockAnd<Local> {
+        let temp = {
+            let ty = self.get_ty_id_of_node(expr.id());
+            let local = LocalDecl::new_auxiliary(ty, Mutability::Immutable);
+            let scope = self.current_scope();
+
+            self.push_local(local, scope)
+        };
+        let temp_place = Place::from(temp);
+
+        unpack!(block = self.expr_into_dest(temp_place, block, expr));
+        block.and(temp)
+    }
+}

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -32,11 +32,6 @@ pub(super) fn get_fn_ty_from_term(term: TermId, tcx: &GlobalStorage) -> FnTy {
     }
 }
 
-// pub(super) fn create_tuple_ty(tcx: &GlobalStorage, ir_ctx: &IrStorage) ->
-// IrTy {
-
-// }
-
 /// Get the [IrTy] from a given [TermId].
 pub(super) fn lower_term(term: TermId, tcx: &GlobalStorage, ir_ctx: &IrStorage) -> IrTy {
     let term = tcx.term_store.get(term);

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -1,12 +1,9 @@
 //! Data structure representing the Control-Flow-Graph(CFG) that is used to
 //! represent lowered functions or constant blocks.
 
-use hash_ir::{
-    ir::{
-        BasicBlock, BasicBlockData, Place, RValue, RValueId, Statement, StatementKind, Terminator,
-        TerminatorKind,
-    },
-    IrStorage,
+use hash_ir::ir::{
+    BasicBlock, BasicBlockData, Place, RValueId, Statement, StatementKind, Terminator,
+    TerminatorKind,
 };
 use hash_source::location::Span;
 use index_vec::IndexVec;
@@ -37,6 +34,15 @@ impl ControlFlowGraph {
         self.basic_blocks.push(BasicBlockData::new(None))
     }
 
+    /// Create a [BasicBlock] that is terminated by a [TerminatorKind::Return]
+    /// and has no other present statements.
+    pub(crate) fn make_return_block(&mut self) -> BasicBlock {
+        let block = self.start_new_block();
+        self.block_data_mut(block).terminator =
+            Some(Terminator { kind: TerminatorKind::Return, span: Span::default() });
+        block
+    }
+
     /// Function to terminate a particular [BasicBlock] provided that it has not
     /// been already terminated.
     pub(crate) fn terminate(&mut self, block: BasicBlock, span: Span, kind: TerminatorKind) {
@@ -48,6 +54,11 @@ impl ControlFlowGraph {
         );
 
         self.block_data_mut(block).terminator = Some(Terminator { span, kind });
+    }
+
+    /// Check whether a block has been terminated or not.
+    pub(crate) fn is_terminated(&self, block: BasicBlock) -> bool {
+        self.block_data(block).terminator.is_some()
     }
 
     /// Add a [Statement] to the specified [BasicBlock]

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -244,11 +244,19 @@ impl<'a> AstVisitorMutSelf for LoweringVisitor<'a> {
             self.tcx,
             self.storage,
             self.source_map,
-            self.in_dump_ir_directive,
             &self.dead_ends,
         );
         builder.build_fn();
-        self.bodies.push(builder.finish());
+
+        let mut generated_body = builder.finish();
+
+        // If we are in the `dump_ir` directive, then we need to
+        // mark the generated body as needing to be dumped.
+        if self.in_dump_ir_directive {
+            generated_body.mark_to_dump();
+        }
+
+        self.bodies.push(generated_body);
 
         // We want to clear the dead ends after we have finished lowering the particular
         // function and then add this ID to the dead ends

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -14,11 +14,9 @@ use hash_ast::{
 use hash_ir::{ir::Body, IrStorage};
 use hash_source::{
     identifier::{Identifier, IDENTS},
-    location::{SourceLocation, Span},
     SourceId, SourceMap,
 };
-use hash_types::{fmt::PrepareForFormatting, nodes::NodeInfoTarget, storage::GlobalStorage};
-use hash_utils::store::{CloneStore, PartialStore};
+use hash_types::storage::GlobalStorage;
 
 use crate::build::Builder;
 
@@ -66,7 +64,7 @@ fn extract_binds_from_bind(pat: ast::AstNodeRef<ast::Pat>, binds: &mut Vec<Bindi
         }
         ast::Pat::List(ast::ListPat { fields }) => {
             for entry in fields.iter() {
-                extract_binds_from_bind(pat, binds);
+                extract_binds_from_bind(entry.ast_ref(), binds);
             }
         }
         ast::Pat::Or(ast::OrPat { variants }) => {
@@ -152,12 +150,6 @@ impl<'ir> LoweringVisitor<'ir> {
             bind_stack: Vec::new(),
             dead_ends: HashSet::new(),
         }
-    }
-
-    /// Create a [SourceLocation] from a given span using the current
-    /// [SourceId].
-    fn source_location(&self, span: Span) -> SourceLocation {
-        SourceLocation { span, id: self.source_id }
     }
 
     pub(crate) fn into_bodies(self) -> Vec<Body> {


### PR DESCRIPTION
This PR implements the lowering process for the following items:
- loops and constructs related to loops.
- return statements
- constant literal values

closes #581 
closes #576 