### PR TITLE
typechecker: introduce workaround for currently broken trait resolution

### DIFF
--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -148,8 +148,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                             NominalDef::Struct(_) => smallvec![DeconstructedCtor::Single],
                             NominalDef::Enum(enum_def) => {
                                 // The exception is if the pattern is at the top level, because we
-                                // want empty matches to be
-                                // considered exhaustive.
+                                // want empty matches to be considered exhaustive.
                                 let is_secretly_empty =
                                     enum_def.variants.is_empty() && !ctx.is_top_level;
 


### PR DESCRIPTION
Currently, the typechecker cannot properly check the types of binary and unary expressions because the trait resolution system is not working properly and that the `prelude` does not contain trait definitions for these types. Once the new typechecking system is introduced by @kontheocharis, this issue will be fixed and this hack will be removed.

Relevant issue: https://github.com/hash-org/lang/issues/419

This patch is needed to implement: #574, #582