### PR TITLE
pipeline: introduce `Target` to denote what compilation target the compiler is compiling to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "hash-reporting",
  "hash-session",
  "hash-source",
+ "hash-target",
  "hash-tree-def",
  "hash-typecheck",
  "hash-untyped-semantics",
@@ -498,6 +499,7 @@ dependencies = [
  "hash-ast",
  "hash-reporting",
  "hash-source",
+ "hash-target",
  "hash-types",
  "hash-utils",
  "log",
@@ -555,6 +557,10 @@ dependencies = [
  "num-bigint",
  "slotmap",
 ]
+
+[[package]]
+name = "hash-target"
+version = "0.1.0"
 
 [[package]]
 name = "hash-testing-internal"
@@ -658,6 +664,7 @@ version = "0.1.0"
 dependencies = [
  "hash-ast",
  "hash-source",
+ "hash-target",
  "hash-utils",
  "log",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "compiler/hash-reporting",
   "compiler/hash-session",
   "compiler/hash-source",
+  "compiler/hash-target",
   "compiler/hash-token",
   "compiler/hash-typecheck",
   "compiler/hash-types",

--- a/compiler/hash-pipeline/Cargo.toml
+++ b/compiler/hash-pipeline/Cargo.toml
@@ -16,3 +16,4 @@ hash-types = { path = "../hash-types" }
 hash-utils = { path = "../hash-utils" }
 hash-source = { path = "../hash-source" }
 hash-reporting = { path = "../hash-reporting" }
+hash-target = { path = "../hash-target" }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -3,9 +3,11 @@
 //! to the Compiler pipeline.
 use std::fmt::Display;
 
+use hash_target::TargetInfo;
+
 /// Various settings that are present on the compiler pipeline when initially
 /// launching.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct CompilerSettings {
     /// Print metrics about each stage when the entire pipeline has completed.
     ///
@@ -36,13 +38,15 @@ pub struct CompilerSettings {
     /// dump the ast for a particular expression.
     pub dump_ast: bool,
 
-    /// Which target the compiler should compile for, this affects various
-    /// settings within the compiler, notably the pointer size.
-    pub target: CompilationTarget,
-
     /// To what should the compiler run to, anywhere from parsing, typecheck, to
     /// code generation.
     pub stage: CompilerStageKind,
+
+    /// Information about the current "session" that the compiler is running
+    /// in. This contains information about which target the compiler is
+    /// compiling for, and other information that is used by the compiler
+    /// to determine how to compile the source code.
+    pub target_info: TargetInfo,
 }
 
 impl CompilerSettings {
@@ -72,7 +76,7 @@ impl CompilerSettings {
 impl Default for CompilerSettings {
     fn default() -> Self {
         Self {
-            target: CompilationTarget::default(),
+            target_info: TargetInfo::default(),
             output_stage_results: false,
             output_metrics: false,
             worker_count: num_cpus::get(),
@@ -80,36 +84,6 @@ impl Default for CompilerSettings {
             emit_errors: true,
             dump_ast: false,
             stage: CompilerStageKind::Full,
-        }
-    }
-}
-
-/// The target that the compiler should compile for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CompilationTarget {
-    /// The target is a 32-bit system.
-    X86,
-
-    /// The target is a 64-bit system.
-    X86_64,
-}
-
-impl Default for CompilationTarget {
-    fn default() -> Self {
-        match std::env::consts::ARCH {
-            "x86" => Self::X86,
-            "x86_64" => Self::X86_64,
-            _ => panic!("Unsupported target architecture"),
-        }
-    }
-}
-
-impl CompilationTarget {
-    /// Get the size of a pointer for the target in bytes.
-    pub fn pointer_size(&self) -> usize {
-        match self {
-            Self::X86 => 4,
-            Self::X86_64 => 8,
         }
     }
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -10,7 +10,7 @@ pub struct CompilerSettings {
     /// Print metrics about each stage when the entire pipeline has completed.
     ///
     /// N.B: This flag has no effect if the compiler is not specified to run in
-    ///       debug mode!
+    ///      debug mode!
     pub output_metrics: bool,
 
     /// Whether to output of each stage result.
@@ -35,6 +35,10 @@ pub struct CompilerSettings {
     /// dumped, or this could be achieved with using some kind of directive to
     /// dump the ast for a particular expression.
     pub dump_ast: bool,
+
+    /// Which target the compiler should compile for, this affects various
+    /// settings within the compiler, notably the pointer size.
+    pub target: CompilationTarget,
 
     /// To what should the compiler run to, anywhere from parsing, typecheck, to
     /// code generation.
@@ -68,6 +72,7 @@ impl CompilerSettings {
 impl Default for CompilerSettings {
     fn default() -> Self {
         Self {
+            target: CompilationTarget::default(),
             output_stage_results: false,
             output_metrics: false,
             worker_count: num_cpus::get(),
@@ -75,6 +80,36 @@ impl Default for CompilerSettings {
             emit_errors: true,
             dump_ast: false,
             stage: CompilerStageKind::Full,
+        }
+    }
+}
+
+/// The target that the compiler should compile for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompilationTarget {
+    /// The target is a 32-bit system.
+    X86,
+
+    /// The target is a 64-bit system.
+    X86_64,
+}
+
+impl Default for CompilationTarget {
+    fn default() -> Self {
+        match std::env::consts::ARCH {
+            "x86" => Self::X86,
+            "x86_64" => Self::X86_64,
+            _ => panic!("Unsupported target architecture"),
+        }
+    }
+}
+
+impl CompilationTarget {
+    /// Get the size of a pointer for the target in bytes.
+    pub fn pointer_size(&self) -> usize {
+        match self {
+            Self::X86 => 4,
+            Self::X86_64 => 8,
         }
     }
 }

--- a/compiler/hash-reporting/src/errors.rs
+++ b/compiler/hash-reporting/src/errors.rs
@@ -30,6 +30,9 @@ pub enum InteractiveCommandError {
 /// program.
 #[derive(Debug, Error)]
 pub enum CompilerError {
+    #[error("invalid compiler target `{0}` specified, available targets are: `x86_64` and `x86`")]
+    /// Invalid target was passed to the compiler.
+    InvalidTarget(String),
     /// Generic IO error.
     #[error("{0}")]
     IoError(#[from] io::Error),

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -66,8 +66,9 @@ pub struct CompilerSession {
 }
 
 impl CompilerSession {
+    /// Create a new [CompilerSession].
     pub fn new(workspace: Workspace, pool: rayon::ThreadPool, settings: CompilerSettings) -> Self {
-        let global = GlobalStorage::new();
+        let global = GlobalStorage::new(settings.target_info.target());
         let local = LocalStorage::new(&global, SourceId::default());
 
         Self {

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -113,14 +113,13 @@ pub enum UIntTy {
 impl UIntTy {
     /// Get the size of [IntTy] in bytes. Returns [None] for
     /// [UIntTy::UBig] variants
-    pub const fn size(&self) -> Option<u64> {
+    pub const fn size(&self, ptr_width: usize) -> Option<u64> {
         match self {
             UIntTy::U8 => Some(1),
             UIntTy::U16 => Some(2),
             UIntTy::U32 => Some(4),
             UIntTy::U64 => Some(8),
-            // @@Todo: actually get the target pointer size, don't default to 64bit pointers.
-            UIntTy::USize => Some(8),
+            UIntTy::USize => Some(ptr_width as u64),
             UIntTy::U128 => Some(16),
             UIntTy::UBig => None,
         }
@@ -129,14 +128,17 @@ impl UIntTy {
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
         match self {
-            UIntTy::U8 => Some(BigInt::from(i8::MAX)),
-            UIntTy::U16 => Some(BigInt::from(i16::MAX)),
-            UIntTy::U32 => Some(BigInt::from(i32::MAX)),
-            UIntTy::U64 => Some(BigInt::from(i64::MAX)),
-            UIntTy::U128 => Some(BigInt::from(i128::MAX)),
-            UIntTy::USize => Some(BigInt::from(isize::MAX)),
+            UIntTy::U8 => Some(BigInt::from(u8::MAX)),
+            UIntTy::U16 => Some(BigInt::from(u16::MAX)),
+            UIntTy::U32 => Some(BigInt::from(u32::MAX)),
+            UIntTy::U64 => Some(BigInt::from(u64::MAX)),
+            UIntTy::U128 => Some(BigInt::from(u128::MAX)),
+            UIntTy::USize => {
+                let max = !0u64 >> (64 - (ptr_width * 8));
+                Some(BigInt::from(max))
+            }
             UIntTy::UBig => None,
         }
     }
@@ -182,14 +184,13 @@ pub enum SIntTy {
 impl SIntTy {
     /// Get the size of [IntTy] in bytes. Returns [None] for
     /// [UIntTy::UBig] variants
-    pub const fn size(&self) -> Option<u64> {
+    pub const fn size(&self, ptr_width: usize) -> Option<u64> {
         match self {
             SIntTy::I8 => Some(1),
             SIntTy::I16 => Some(2),
             SIntTy::I32 => Some(4),
             SIntTy::I64 => Some(8),
-            // @@Todo: actually get the target pointer size, don't default to 64bit pointers.
-            SIntTy::ISize => Some(8),
+            SIntTy::ISize => Some(ptr_width as u64),
             SIntTy::I128 => Some(16),
             SIntTy::IBig => None,
         }
@@ -198,14 +199,18 @@ impl SIntTy {
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
         match self {
             SIntTy::I8 => Some(BigInt::from(i8::MAX)),
             SIntTy::I16 => Some(BigInt::from(i16::MAX)),
             SIntTy::I32 => Some(BigInt::from(i32::MAX)),
             SIntTy::I64 => Some(BigInt::from(i64::MAX)),
             SIntTy::I128 => Some(BigInt::from(i128::MAX)),
-            SIntTy::ISize => Some(BigInt::from(isize::MAX)),
+            SIntTy::ISize => {
+                // convert the size to a signed integer
+                let max = (1u64 << (ptr_width * 8 - 1)) - 1;
+                Some(BigInt::from(max))
+            }
             SIntTy::IBig => None,
         }
     }
@@ -213,14 +218,17 @@ impl SIntTy {
     /// Function to get the most minimum integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined minimum and so the
     /// function returns [None].
-    pub fn min(&self) -> Option<BigInt> {
+    pub fn min(&self, ptr_width: usize) -> Option<BigInt> {
         match self {
             SIntTy::I8 => Some(BigInt::from(i8::MIN)),
             SIntTy::I16 => Some(BigInt::from(i16::MIN)),
             SIntTy::I32 => Some(BigInt::from(i32::MIN)),
             SIntTy::I64 => Some(BigInt::from(i64::MIN)),
             SIntTy::I128 => Some(BigInt::from(i128::MIN)),
-            SIntTy::ISize => Some(BigInt::from(isize::MIN)),
+            SIntTy::ISize => {
+                let min = (i64::MAX) << ((ptr_width * 8) - 1);
+                Some(BigInt::from(min))
+            }
             SIntTy::IBig => None,
         }
     }
@@ -266,28 +274,28 @@ impl IntTy {
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
-    pub fn max(&self) -> Option<BigInt> {
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
         match self {
-            IntTy::Int(ty) => ty.max(),
-            IntTy::UInt(ty) => ty.max(),
+            IntTy::Int(ty) => ty.max(ptr_width),
+            IntTy::UInt(ty) => ty.max(ptr_width),
         }
     }
 
     /// Function to get the most minimum integer represented within this
     /// type. For sizes `ibig` there is no defined minimum and so the
     /// function returns [None].
-    pub fn min(&self) -> Option<BigInt> {
+    pub fn min(&self, ptr_width: usize) -> Option<BigInt> {
         match self {
-            IntTy::Int(ty) => ty.min(),
+            IntTy::Int(ty) => ty.min(ptr_width),
             IntTy::UInt(ty) => Some(ty.min()),
         }
     }
 
     /// Function to get the size of the integer type in bytes.
-    pub fn size(&self) -> Option<u64> {
+    pub fn size(&self, ptr_width: usize) -> Option<u64> {
         match self {
-            IntTy::Int(ty) => ty.size(),
-            IntTy::UInt(ty) => ty.size(),
+            IntTy::Int(ty) => ty.size(ptr_width),
+            IntTy::UInt(ty) => ty.size(ptr_width),
         }
     }
 

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -614,3 +614,37 @@ impl ConstantMap {
         self.int_table.alter(&id, |_, value| value.negate());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigInt;
+
+    use super::SIntTy;
+    use crate::constant::UIntTy;
+
+    #[test]
+    fn test_max_signed_int_value() {
+        // Pointer width is always described using a number of bytes
+        assert_eq!(SIntTy::ISize.max(8), Some(BigInt::from(isize::MAX)));
+        assert_eq!(SIntTy::ISize.min(8), Some(BigInt::from(isize::MIN)));
+
+        assert_eq!(SIntTy::ISize.max(4), Some(BigInt::from(i32::MAX)));
+        assert_eq!(SIntTy::ISize.min(4), Some(BigInt::from(i32::MIN)));
+
+        // Check that computing the size of each type with pointer widths
+        // is consistent.
+        assert_eq!(SIntTy::ISize.size(8), Some(8));
+        assert_eq!(SIntTy::ISize.size(4), Some(4));
+    }
+
+    #[test]
+    fn test_max_unsigned_int_value() {
+        // We don't check `min()` for unsigned since this always
+        // returns 0.
+        assert_eq!(UIntTy::USize.max(8), Some(BigInt::from(usize::MAX)));
+        assert_eq!(UIntTy::USize.max(4), Some(BigInt::from(u32::MAX)));
+
+        assert_eq!(UIntTy::USize.size(8), Some(8));
+        assert_eq!(UIntTy::USize.size(4), Some(4));
+    }
+}

--- a/compiler/hash-target/Cargo.toml
+++ b/compiler/hash-target/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hash-target"
+version = "0.1.0"
+authors = ["The Hash Language authors"]
+edition = "2021"
+
+[dependencies]

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -1,0 +1,64 @@
+//! Definitions to describe the target of Hash compilation.
+
+/// The target that the compiler should compile for.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Target {
+    /// The size of the pointer for the target in bytes.
+    pub pointer_width: usize,
+
+    /// The name of the target
+    pub name: String,
+}
+
+impl Target {
+    /// Create a new target from the given name and pointer width.
+    pub fn new(name: String, pointer_width: usize) -> Self {
+        Self { name, pointer_width }
+    }
+
+    /// Create a new target from the given name and pointer width.
+    pub fn from_string(name: String) -> Option<Self> {
+        match name.as_str() {
+            "x86_64" => Some(Self::new(name, 8)),
+            "x86" => Some(Self::new(name, 4)),
+            "aarch64" => Some(Self::new(name, 8)),
+            "arm" => Some(Self::new(name, 4)),
+            _ => None,
+        }
+    }
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Self { pointer_width: 8, name: "x86_64".into() }
+    }
+}
+
+/// Holds information about various targets that are currently used by the
+/// compiler.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TargetInfo {
+    /// The target value of the host that the compiler is running
+    /// for.
+    host: Target,
+
+    /// The target that the compiler is compiling for.
+    target: Target,
+}
+
+impl TargetInfo {
+    /// Create a new target info from the given host and target.
+    pub fn new(host: Target, target: Target) -> Self {
+        Self { host, target }
+    }
+
+    /// Get the target that the compiler is compiling for.
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
+
+    /// Get the host target that the compiler is running on.
+    pub fn host(&self) -> &Target {
+        &self.host
+    }
+}

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -1,28 +1,81 @@
 //! Definitions to describe the target of Hash compilation.
 
+use std::{
+    env::consts::ARCH,
+    fmt::{Display, Formatter},
+};
+
 /// The target that the compiler should compile for.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Target {
     /// The size of the pointer for the target in bytes.
+    ///
+    /// N.B. It is an invariant for the pointer size to be
+    /// larger than 8, there is no current host system that
+    /// supports a pointer size larger than 8 bytes.
     pub pointer_width: usize,
 
-    /// The name of the target
-    pub name: String,
+    /// The name of the target.
+    pub name: TargetName,
+}
+
+/// Represents the available targets that the compiler can compiler for.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TargetName {
+    /// x86 32-bit target architecture.
+    X86,
+
+    /// x86 64-bit target architecture.
+    X86_64,
+
+    /// ARM 64-bit target architecture.
+    Aarch64,
+
+    /// ARM 32-bit target architecture.
+    Arm,
+
+    /// Used for when the target name is not known, but can
+    /// still be compiled for.
+    Unknown,
+}
+
+impl TargetName {
+    pub fn from_system() -> Self {
+        match ARCH {
+            "x86" => Self::X86,
+            "x86_64" => Self::X86_64,
+            "aarch64" => Self::Aarch64,
+            "arm" => Self::Arm,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl Display for TargetName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TargetName::X86 => write!(f, "x86"),
+            TargetName::X86_64 => write!(f, "x86_64"),
+            TargetName::Aarch64 => write!(f, "aarch64"),
+            TargetName::Arm => write!(f, "arm"),
+            TargetName::Unknown => write!(f, "unknown"),
+        }
+    }
 }
 
 impl Target {
     /// Create a new target from the given name and pointer width.
-    pub fn new(name: String, pointer_width: usize) -> Self {
+    pub fn new(name: TargetName, pointer_width: usize) -> Self {
         Self { name, pointer_width }
     }
 
-    /// Create a new target from the given name and pointer width.
+    /// Create a new target from the given string.
     pub fn from_string(name: String) -> Option<Self> {
         match name.as_str() {
-            "x86_64" => Some(Self::new(name, 8)),
-            "x86" => Some(Self::new(name, 4)),
-            "aarch64" => Some(Self::new(name, 8)),
-            "arm" => Some(Self::new(name, 4)),
+            "x86" => Some(Self::new(TargetName::X86, 4)),
+            "x86_64" => Some(Self::new(TargetName::X86_64, 8)),
+            "arm" => Some(Self::new(TargetName::Arm, 4)),
+            "aarch64" => Some(Self::new(TargetName::Aarch64, 8)),
             _ => None,
         }
     }
@@ -30,7 +83,11 @@ impl Target {
 
 impl Default for Target {
     fn default() -> Self {
-        Self { pointer_width: 8, name: "x86_64".into() }
+        // get the size of the pointer for the current system
+        let pointer_width = std::mem::size_of::<usize>();
+        let name = TargetName::from_system();
+
+        Self { pointer_width, name }
     }
 }
 

--- a/compiler/hash-typecheck/src/exhaustiveness/constant.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/constant.rs
@@ -30,7 +30,7 @@ impl Constant {
     /// constraint is that it can fit into a [u128], otherwise the
     /// function will currently panic.
     pub fn from_int(int: BigInt, kind: IntTy, ty: TermId, ptr_width: usize) -> Self {
-        let size = kind.size(ptr_width).unwrap_or_else(|| int.bits());
+        let size = kind.size(ptr_width).map(|size| size * 8).unwrap_or_else(|| int.bits());
         assert!(size < 128);
 
         // @@Hack: this should be done in some better way or tidied up!

--- a/compiler/hash-typecheck/src/exhaustiveness/constant.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/constant.rs
@@ -29,8 +29,8 @@ impl Constant {
     /// Function to convert a [BigInt] into a [Constant]. The only
     /// constraint is that it can fit into a [u128], otherwise the
     /// function will currently panic.
-    pub fn from_int(int: BigInt, kind: IntTy, ty: TermId) -> Self {
-        let size = kind.size().unwrap_or_else(|| int.bits());
+    pub fn from_int(int: BigInt, kind: IntTy, ty: TermId, ptr_width: usize) -> Self {
+        let size = kind.size(ptr_width).unwrap_or_else(|| int.bits());
         assert!(size < 128);
 
         // @@Hack: this should be done in some better way or tidied up!
@@ -44,7 +44,7 @@ impl Constant {
 
             // memset the upper 16-kind.size() bytes to zero since they aren't
             // necessary.
-            data[0..(16 - kind.size().unwrap() as usize)].fill(0);
+            data[0..(16 - kind.size(ptr_width).unwrap() as usize)].fill(0);
 
             Constant { data: u128::from_be_bytes(data), ty }
         } else {

--- a/compiler/hash-typecheck/src/exhaustiveness/range.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/range.rs
@@ -269,7 +269,8 @@ impl<'tc> IntRangeOps<'tc> {
         let bias: u128 = match reader.get_term(constant.ty) {
             Term::Level0(Level0Term::Lit(lit)) => match lit {
                 LitTerm::Int { kind, .. } if kind.is_signed() => {
-                    let size = kind.size().unwrap();
+                    let ptr_width = self.global_storage().target_pointer_width;
+                    let size = kind.size(ptr_width).unwrap();
                     1u128 << (size * 8 - 1)
                 }
                 LitTerm::Char(_) | LitTerm::Int { .. } => 0,
@@ -308,7 +309,8 @@ impl<'tc> IntRangeOps<'tc> {
     /// last byte is that identifies the sign.
     fn signed_bias(&self, ty: TermId) -> u128 {
         if let Some(ty) = self.oracle().term_as_int_ty(ty) {
-            if let Some(size) = ty.size() && ty.is_signed()  {
+            let ptr_width = self.global_storage().target_pointer_width;
+            if let Some(size) = ty.size(ptr_width) && ty.is_signed()  {
                 let bits = (size * 8) as u128;
                 return 1u128 << (bits - 1);
             }

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -92,7 +92,8 @@ impl<'tc> SplitWildcardOps<'tc> {
                 }
                 kind if kind.is_signed() => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                    let size = kind.size().unwrap();
+                    let ptr_width = self.global_storage().target_pointer_width;
+                    let size = kind.size(ptr_width).unwrap();
                     let bits = (size * 8) as u128;
 
                     let min = 1u128 << (bits - 1);
@@ -103,7 +104,8 @@ impl<'tc> SplitWildcardOps<'tc> {
                 }
                 kind => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                    let size = kind.size().unwrap();
+                    let ptr_width = self.global_storage().target_pointer_width;
+                    let size = kind.size(ptr_width).unwrap();
                     let bits = size * 8;
 
                     let shift = 128 - bits;

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -1216,11 +1216,13 @@ impl<'tc> Validator<'tc> {
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: lhs, kind: lhs_kind })),
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs, kind: rhs_kind })),
             ) => {
+                let ptr_width = self.global_storage().target_pointer_width;
+
                 // Check that the integer type is sized, if it is not then we currently
                 // say that this is not supported...
-                if lhs_kind.size().is_none() || rhs_kind.size().is_none() {
+                if lhs_kind.size(ptr_width).is_none() || rhs_kind.size(ptr_width).is_none() {
                     return Err(TcError::UnsupportedRangePatTy {
-                        term: lhs_kind.size().map_or(lo, |_| hi),
+                        term: lhs_kind.size(ptr_width).map_or(lo, |_| hi),
                     });
                 }
 

--- a/compiler/hash-types/Cargo.toml
+++ b/compiler/hash-types/Cargo.toml
@@ -11,3 +11,4 @@ num-bigint = "0.4"
 hash-ast = { path = "../hash-ast" }
 hash-utils = { path = "../hash-utils" }
 hash-source = { path = "../hash-source" }
+hash-target = { path = "../hash-target" }

--- a/compiler/hash-types/src/storage.rs
+++ b/compiler/hash-types/src/storage.rs
@@ -6,6 +6,7 @@
 use std::cell::Cell;
 
 use hash_source::SourceId;
+use hash_target::Target;
 use hash_utils::store::Store;
 
 use crate::{
@@ -70,14 +71,19 @@ pub struct GlobalStorage {
     /// directly queried, but rather the [LocalStorage] scopes should be
     /// queried.
     pub root_scope: ScopeId,
+
+    /// The pointer width on the current target architecture.
+    pub target_pointer_width: usize,
 }
 
 impl GlobalStorage {
     /// Create a new, empty [GlobalStorage].
-    pub fn new() -> Self {
+    pub fn new(target: &Target) -> Self {
         let scope_store = ScopeStore::new();
         let root_scope = scope_store.create(Scope::empty(ScopeKind::Mod));
+
         let gs = Self {
+            target_pointer_width: target.pointer_width,
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
             term_list_store: TermListStore::new(),
@@ -92,14 +98,9 @@ impl GlobalStorage {
             params_store: ParamsStore::new(),
             args_store: ArgsStore::new(),
         };
+
         create_core_defs_in(&gs);
         gs
-    }
-}
-
-impl Default for GlobalStorage {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/compiler/hash-types/src/terms.rs
+++ b/compiler/hash-types/src/terms.rs
@@ -751,14 +751,16 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                         write!(f, "\"{str}\"")
                     }
                     LitTerm::Int { value, kind } => {
+                        let pointer_width = self.global_storage.target_pointer_width;
+
                         // It's often the case that users don't include the range of the entire
                         // integer and so we will write `-2147483648..x` and
                         // same for max, what we want to do is write `MIN`
                         // and `MAX for these situations since it is easier for the
                         // user to understand the problem
-                        if let Some(min) = kind.min() && min == *value {
+                        if let Some(min) = kind.min(pointer_width) && min == *value {
                             write!(f, "{kind}::MIN")
-                        } else if let Some(max) = kind.max() && max == *value {
+                        } else if let Some(max) = kind.max(pointer_width) && max == *value {
                             write!(f, "{kind}::MAX")
                         } else {
                             write!(f, "{value}_{kind}")

--- a/compiler/hash/Cargo.toml
+++ b/compiler/hash/Cargo.toml
@@ -21,7 +21,7 @@ hash-source = { path = "../hash-source" }
 hash-interactive = { path = "../hash-interactive" }
 hash-reporting = { path = "../hash-reporting" }
 hash-tree-def = { path = "../hash-tree-def" }
-
+hash-target = { path = "../hash-target" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-session = { path = "../hash-session" }
 

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -90,11 +90,17 @@ impl TryInto<CompilerSettings> for CompilerOptions {
     }
 }
 
+/// [SubCmd] specifies separate modes that the compiler can run in. These modes
+/// are used to terminate the compiler at a particular stage of the pipeline.
 #[derive(ClapParser, Clone)]
 pub(crate) enum SubCmd {
+    /// Parse the given program and terminate.
     AstGen(AstGenMode),
+    /// Only run the compiler up until the `de-sugaring` stage.
     DeSugar(DeSugarMode),
+    /// Typecheck the given module.
     Check(CheckMode),
+    /// Generate the IR for the given file.
     IrGen(IrGenMode),
 }
 

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -70,8 +70,9 @@ impl TryInto<CompilerSettings> for CompilerOptions {
             _ => CompilerStageKind::Full,
         };
 
-        let host = Target::from_string(std::env::consts::ARCH.to_string())
-            .ok_or_else(|| CompilerError::InvalidTarget(std::env::consts::ARCH.to_string()))?;
+        // We can use the default value of target since we are running
+        // on the current system...
+        let host = Target::default();
 
         let target = Target::from_string(self.target.clone())
             .ok_or_else(|| CompilerError::InvalidTarget(self.target))?;

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -1,7 +1,8 @@
 //! Hash Compiler arguments management.
 
 use clap::Parser as ClapParser;
-use hash_pipeline::settings::{CompilerSettings, CompilerStageKind};
+use hash_pipeline::settings::{CompilationTarget, CompilerSettings, CompilerStageKind};
+use hash_reporting::errors::CompilerError;
 
 /// CompilerOptions is a structural representation of what arguments the
 /// compiler can take when running. Compiler options are well documented on the
@@ -44,14 +45,22 @@ pub(crate) struct CompilerOptions {
     #[clap(short, long, default_value = Box::leak(num_cpus::get().to_string().into_boxed_str()))]
     pub(crate) worker_count: usize,
 
+    /// The target that the compiler will emit the executable for. This
+    /// will be used to determine the pointer size and other settings that
+    /// are **target specific**.
+    #[clap(long, default_value = std::env::consts::ARCH)]
+    pub(crate) target: String,
+
     /// Compiler mode
     #[clap(subcommand)]
     pub(crate) mode: Option<SubCmd>,
 }
 
-impl From<CompilerOptions> for CompilerSettings {
-    fn from(options: CompilerOptions) -> Self {
-        let stage = match options.mode {
+impl TryInto<CompilerSettings> for CompilerOptions {
+    type Error = CompilerError;
+
+    fn try_into(self) -> Result<CompilerSettings, Self::Error> {
+        let stage = match self.mode {
             Some(SubCmd::AstGen { .. }) => CompilerStageKind::Parse,
             Some(SubCmd::DeSugar { .. }) => CompilerStageKind::DeSugar,
 
@@ -60,15 +69,24 @@ impl From<CompilerOptions> for CompilerSettings {
             _ => CompilerStageKind::Full,
         };
 
-        Self {
-            output_stage_results: options.output_stage_results,
-            output_metrics: options.output_metrics,
-            worker_count: options.worker_count,
+        // Determine the target that the compiler should emit the executable for.
+        let target = match self.target.as_str() {
+            "x86" => CompilationTarget::X86,
+            "x86_64" => CompilationTarget::X86_64,
+            // @@Future: gracefully fail here rather than panicking
+            _ => return Err(CompilerError::InvalidTarget(self.target)),
+        };
+
+        Ok(CompilerSettings {
+            target,
+            output_stage_results: self.output_stage_results,
+            output_metrics: self.output_metrics,
+            worker_count: self.worker_count,
             skip_prelude: false,
             emit_errors: true,
-            dump_ast: options.dump_ast,
+            dump_ast: self.dump_ast,
             stage,
-        }
+        })
     }
 }
 

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -22,9 +22,9 @@ use crate::{
 
 pub static CONSOLE_LOGGER: CompilerLogger = CompilerLogger;
 
-fn execute(f: impl FnOnce() -> Result<(), CompilerError>) {
+fn execute<T>(f: impl FnOnce() -> Result<T, CompilerError>) -> T {
     match f() {
-        Ok(()) => (),
+        Ok(value) => value,
         Err(e) => e.report_and_exit(),
     }
 }
@@ -79,7 +79,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let compiler_settings: CompilerSettings = opts.into();
+    let compiler_settings: CompilerSettings = execute(|| opts.try_into());
 
     let workspace = Workspace::new();
     let session = CompilerSession::new(workspace, pool, compiler_settings);

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -82,11 +82,10 @@ fn main() {
         .build()
         .unwrap();
 
+    let workspace = Workspace::new();
     let compiler_settings: CompilerSettings = execute(|| opts.try_into());
 
-    let workspace = Workspace::new();
     let session = CompilerSession::new(workspace, pool, compiler_settings);
-
     let mut compiler = Compiler::new(make_stages());
     let compiler_state = compiler.bootstrap(session);
 

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -20,8 +20,11 @@ use crate::{
     crash_handler::panic_handler,
 };
 
-pub static CONSOLE_LOGGER: CompilerLogger = CompilerLogger;
+/// THe logger that is used by the compiler for `log!` statements.
+pub static COMPILER_LOGGER: CompilerLogger = CompilerLogger;
 
+/// Perform some task that might fail and if it does, report the error and exit,
+/// otherwise return the result of the task.
 fn execute<T>(f: impl FnOnce() -> Result<T, CompilerError>) -> T {
     match f() {
         Ok(value) => value,
@@ -32,7 +35,7 @@ fn execute<T>(f: impl FnOnce() -> Result<T, CompilerError>) -> T {
 fn main() {
     // Initial grunt work, panic handler and logger setup...
     panic::set_hook(Box::new(panic_handler));
-    log::set_logger(&CONSOLE_LOGGER).unwrap_or_else(|_| panic!("Couldn't initiate logger"));
+    log::set_logger(&COMPILER_LOGGER).unwrap_or_else(|_| panic!("Couldn't initiate logger"));
 
     // Starting the Tracy client is necessary before any invoking any of its APIs
     #[cfg(feature = "profile-with-tracy")]


### PR DESCRIPTION
This patch adds a new crate `hash-target` that contains all data structures that are needed for denoting which compilation target the compiler is emitting code for. There are two main data structures introduced:

- `Target` specifies the `point_width` in bytes and the name of the target (if applicable). It is likely that many more configurations/settings will be added to this struct.
- `TargetInfo` which specifies the `target` to which we are compiling, and `host` which is the host machine of the compiler represented as a `Target`. The `host` variant will be needed later for compile-time execution/VM operations.

Additionally, this patch integrates `pointer_width` based on the compilation target when computing the size, minimum and maximum values of `isize` and `usize` in `hash-source` and other places.