### PR TITLE
lower: implement `{binary+unary}` operators, function calls, indexing, field access 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "hash-types",
  "hash-utils",
  "index_vec",
+ "num-traits",
  "rayon",
 ]
 

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -686,8 +686,7 @@ define_tree! {
         /// This function is used to determine if the current literal tree only
         /// contains constants. Constants are other literals that are not subject
         /// to change, e.g. a number like `5` or a string `hello`. This function
-        /// implements short circuiting behaviour and thus should check if the
-        /// literal is constant in the minimal time possible.
+        /// implements short circuiting behaviour.
         pub fn is_constant(&self) -> bool {
             let is_expr_lit_and_const = |expr: &AstNode<Expr>| -> bool {
                 match expr.body() {

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -712,6 +712,18 @@ define_tree! {
                 _ => true,
             }
         }
+
+        /// Check whether the given literal is a primitive literal. Primitive
+        /// literals consist of the following:
+        ///
+        /// - `StrLit`
+        /// - `CharLit`
+        /// - `IntLit`
+        /// - `FloatLit`
+        /// - `BoolLit`
+        pub fn is_primitive(&self) -> bool {
+            matches!(self, Lit::Str(_) | Lit::Char(_) | Lit::Int(_) | Lit::Float(_) | Lit::Bool(_))
+        }
     }
 
     /// An alternative pattern, e.g. `Red | Blue`.
@@ -1002,7 +1014,7 @@ define_tree! {
     }
 
     /// Unary operators that are defined within the core of the language.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Copy)]
     #[node]
     pub enum UnOp {
         // Bitwise logical inversion

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -2,6 +2,7 @@
 //! under construction and is subject to change.
 use std::fmt;
 
+use hash_ast::ast;
 use hash_source::{
     constant::{InternedFloat, InternedInt, InternedStr},
     identifier::Identifier,
@@ -70,6 +71,17 @@ pub enum UnaryOp {
     Not,
     /// The operator '-' for negation
     Neg,
+}
+
+impl From<ast::UnOp> for UnaryOp {
+    fn from(value: ast::UnOp) -> Self {
+        match value {
+            ast::UnOp::BitNot => Self::BitNot,
+            ast::UnOp::Not => Self::Not,
+            ast::UnOp::Neg => Self::Neg,
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Binary operations on [RValue]s that are typed as primitive, or have

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -326,7 +326,7 @@ pub enum RValue {
 
     /// An expression which is taking the address of another expression with an
     /// mutability modifier e.g. `&mut x`.
-    Ref(Mutability, Statement, AddressMode),
+    Ref(Mutability, Place, AddressMode),
     /// Used for initialising structs, tuples and other aggregate
     /// data structures
     Aggregate(AggregateKind, Vec<Place>),

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -7,6 +7,7 @@
 use std::{cell::Cell, fmt};
 
 use bitflags::bitflags;
+use hash_ast::ast;
 use hash_source::{
     constant::{FloatTy, IntTy, SIntTy, UIntTy},
     identifier::Identifier,
@@ -47,6 +48,15 @@ impl Mutability {
         match self {
             Mutability::Mutable => "mut ",
             Mutability::Immutable => "",
+        }
+    }
+}
+
+impl From<ast::Mutability> for Mutability {
+    fn from(value: ast::Mutability) -> Self {
+        match value {
+            ast::Mutability::Mutable => Mutability::Mutable,
+            ast::Mutability::Immutable => Mutability::Immutable,
         }
     }
 }
@@ -212,6 +222,28 @@ bitflags! {
 
         /// The underlying ADT is a tuple.
         const TUPLE  = 0b00001000;
+    }
+}
+
+impl AdtFlags {
+    /// Check if the underlying ADT is a union.
+    pub fn is_union(&self) -> bool {
+        self.contains(Self::UNION)
+    }
+
+    /// Check if the underlying ADT is a struct.
+    pub fn is_struct(&self) -> bool {
+        self.contains(Self::STRUCT)
+    }
+
+    /// Check if the underlying ADT is a enum.
+    pub fn is_enum(&self) -> bool {
+        self.contains(Self::ENUM)
+    }
+
+    /// Check if the underlying ADT is a tuple.
+    pub fn is_tuple(&self) -> bool {
+        self.contains(Self::TUPLE)
     }
 }
 

--- a/compiler/hash-ir/src/write.rs
+++ b/compiler/hash-ir/src/write.rs
@@ -171,6 +171,13 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
                 self.write_rvalue(rhs, f)?;
                 write!(f, ")")
             }
+            RValue::CheckedBinaryOp(op, lhs, rhs) => {
+                write!(f, "Checked{op:?}(")?;
+                self.write_rvalue(lhs, f)?;
+                write!(f, ", ")?;
+                self.write_rvalue(rhs, f)?;
+                write!(f, ")")
+            }
             RValue::UnaryOp(op, operand) => {
                 write!(f, "{op:?}(")?;
                 self.write_rvalue(operand, f)?;
@@ -224,7 +231,7 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
                 writeln!(f, "otherwise -> {otherwise:?}];")
             }
             TerminatorKind::Assert { condition, expected, kind, target } => {
-                writeln!(f, "assert({condition:?}, {expected:?}, {kind:?}) -> {target:?};")
+                writeln!(f, "assert({condition}, {expected:?}, {kind:?}) -> {target:?};")
             }
         }
     }

--- a/compiler/hash-ir/src/write.rs
+++ b/compiler/hash-ir/src/write.rs
@@ -164,8 +164,18 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
         match rvalue {
             RValue::Use(place) => write!(f, "{place}"),
             RValue::Const(operand) => write!(f, "const {operand}"),
-            RValue::BinaryOp(op, lhs, rhs) => write!(f, "{lhs:?} {op:?} {rhs:?}"),
-            RValue::UnaryOp(op, operand) => write!(f, "{op:?}({operand:?})"),
+            RValue::BinaryOp(op, lhs, rhs) => {
+                write!(f, "{op:?}(")?;
+                self.write_rvalue(lhs, f)?;
+                write!(f, ", ")?;
+                self.write_rvalue(rhs, f)?;
+                write!(f, ")")
+            }
+            RValue::UnaryOp(op, operand) => {
+                write!(f, "{op:?}(")?;
+                self.write_rvalue(operand, f)?;
+                write!(f, ")")
+            }
             RValue::ConstOp(op, operand) => write!(f, "{op:?}({operand:?})"),
             RValue::Discriminant(place) => write!(f, "discriminant({place:?})"),
             RValue::Ref(region, borrow_kind, place) => {

--- a/compiler/hash-ir/src/write.rs
+++ b/compiler/hash-ir/src/write.rs
@@ -17,13 +17,23 @@ use crate::{
 
 /// Struct that is used to write [IrTy]s.
 pub struct ForFormatting<'ir, T> {
-    pub t: T,
+    /// The item that is being printed.
+    pub item: T,
+
+    /// Whether the formatting should be verbose or not.
+    pub verbose: bool,
+
+    /// The storage used to print various IR constructs.
     pub storage: &'ir IrStorage,
 }
 
 pub trait WriteTyIr: Sized {
     fn for_fmt(self, storage: &IrStorage) -> ForFormatting<Self> {
-        ForFormatting { t: self, storage }
+        ForFormatting { item: self, storage, verbose: false }
+    }
+
+    fn verbose_fmt(self, storage: &IrStorage) -> ForFormatting<Self> {
+        ForFormatting { item: self, storage, verbose: true }
     }
 }
 
@@ -163,7 +173,8 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
 
         match rvalue {
             RValue::Use(place) => write!(f, "{place}"),
-            RValue::Const(operand) => write!(f, "const {operand}"),
+            RValue::Const(Const::Zero(ty)) => write!(f, "{}", ty.for_fmt(self.ctx)),
+            RValue::Const(const_value) => write!(f, "const {const_value}"),
             RValue::BinaryOp(op, lhs, rhs) => {
                 write!(f, "{op:?}(")?;
                 self.write_rvalue(lhs, f)?;
@@ -201,8 +212,10 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
         match &terminator.kind {
             TerminatorKind::Goto(place) => writeln!(f, "goto -> {place:?};"),
             TerminatorKind::Return => writeln!(f, "return;"),
-            TerminatorKind::Call { op, args, target } => {
-                write!(f, "{op:?}(")?;
+            TerminatorKind::Call { op, args, target, destination } => {
+                write!(f, "{destination} = ")?;
+                self.write_rvalue(*op, f)?;
+                write!(f, "(")?;
 
                 // write all of the arguments
                 for (i, arg) in args.iter().enumerate() {
@@ -210,11 +223,14 @@ impl<'ir> WriteIr<'ir> for IrWriter<'ir> {
                         write!(f, ", ")?;
                     }
 
-                    // @@Todo: should we write the type of the operand here?
-                    write!(f, "{arg:?}")?;
+                    self.write_rvalue(*arg, f)?;
                 }
 
-                writeln!(f, ") -> {target:?};")
+                if let Some(target) = target {
+                    writeln!(f, ") -> {target:?};")
+                } else {
+                    writeln!(f, ");")
+                }
             }
             TerminatorKind::Unreachable => write!(f, "unreachable;"),
             TerminatorKind::Switch(value, branches, otherwise) => {

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -411,7 +411,7 @@ impl<'a> Lexer<'a> {
         let parsed = BigInt::from_str_radix(chars, radix).unwrap();
 
         // We need to create a interned constant here...
-        let interned_const = CONSTANT_MAP.create_int_constant(parsed, ascription);
+        let interned_const = CONSTANT_MAP.create_int_constant_from_value(parsed, ascription);
         TokenKind::IntLit(interned_const)
     }
 

--- a/compiler/hash-lower/Cargo.toml
+++ b/compiler/hash-lower/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 index_vec = "0.1.3"
 rayon = "1.5.0"
+num-traits = "0.2.15"
 
 hash-ast = { path = "../hash-ast" }
 hash-tree-def = { path = "../hash-tree-def" }

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -28,7 +28,7 @@ impl<'tcx> Builder<'tcx> {
             }
 
             // Send this off into the `match` lowering logic
-            Block::Match(..) => todo!(),
+            Block::Match(..) => unimplemented!(),
 
             Block::Loop(LoopBlock { contents }) => {
                 // Begin the loop block by connecting the previous block

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -5,7 +5,10 @@
 use std::mem;
 
 use hash_ast::ast::{AstNodeRef, Block, BodyBlock, Expr, LoopBlock};
-use hash_ir::ir::{BasicBlock, Place};
+use hash_ir::{
+    ir::{BasicBlock, Place},
+    ty::Mutability,
+};
 
 use super::{BlockAnd, BlockAndExtend, Builder, LoopBlockInfo};
 use crate::build::unpack;
@@ -83,7 +86,9 @@ impl<'tcx> Builder<'tcx> {
                 unpack!(block = self.handle_expr_declaration(block, decl));
             } else {
                 // @@Investigate: do we need to deal with the temporary here?
-                unpack!(block = self.expr_into_temp(block, statement.ast_ref()));
+                unpack!(
+                    block = self.expr_into_temp(block, statement.ast_ref(), Mutability::Immutable)
+                );
             }
         }
 

--- a/compiler/hash-lower/src/build/category.rs
+++ b/compiler/hash-lower/src/build/category.rs
@@ -19,7 +19,7 @@ pub(crate) enum Category {
 
     // Something that generates a new value at runtime, like `x + y`
     // or `foo()`.
-    Rvalue,
+    RValue,
 }
 
 /// Determines the category for a given expression. Note that scope
@@ -38,7 +38,7 @@ impl Category {
             | Expr::Variable(..) => Self::Place,
 
             // Everything else is considered as an RValue of some kind.
-            _ => Self::Rvalue,
+            _ => Self::RValue,
         }
     }
 }

--- a/compiler/hash-lower/src/build/category.rs
+++ b/compiler/hash-lower/src/build/category.rs
@@ -1,0 +1,44 @@
+//! Defines a category of AST expressions which can be used to determine how to
+//! lower them throughout the lowering stage.
+
+use hash_ast::ast::{AstNodeRef, Expr, LitExpr};
+
+/// A [Category] represents what category [Expr]s belong to
+/// when they are being lowered. Depending on the category, we
+/// might emit different code when dealing with temporaries, etc.
+#[derive(Debug, PartialEq)]
+pub(crate) enum Category {
+    // An assignable memory location like `x`, `x.f`, `foo()[3]`, that
+    // sort of thing. Something that could appear on the LHS of an `=`
+    // sign.
+    Place,
+
+    // A literal like `23` or `"foo"`. Does not include constant
+    // expressions like `3 + 5`.
+    Constant,
+
+    // Something that generates a new value at runtime, like `x + y`
+    // or `foo()`.
+    Rvalue,
+}
+
+/// Determines the category for a given expression. Note that scope
+/// and paren expressions have no category.
+impl Category {
+    pub(crate) fn of(expr: AstNodeRef<'_, Expr>) -> Self {
+        match expr.body() {
+            // Constants that are not primitive are dealt with as
+            // RValues.
+            Expr::Lit(LitExpr { data }) if data.is_primitive() => Self::Constant,
+
+            Expr::Access(..)
+            | Expr::Index(..)
+            | Expr::Ref(..)
+            | Expr::Deref(..)
+            | Expr::Variable(..) => Self::Place,
+
+            // Everything else is considered as an RValue of some kind.
+            _ => Self::Rvalue,
+        }
+    }
+}

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -1,6 +1,16 @@
+//! Utilities and operations that involve [Const]s when lowering expressions.
+//! This module also includes logic that can perform constant folding on
+//! various constants.
+
+use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
+
 use hash_ast::ast::{AstNodeRef, Lit};
-use hash_ir::ir;
+use hash_ir::ir::{self, BinOp, Const};
 use hash_reporting::macros::panic_on_span;
+use hash_source::{
+    constant::{FloatConstant, FloatConstantValue, IntConstant, CONSTANT_MAP},
+    identifier::IDENTS,
+};
 
 use super::Builder;
 
@@ -23,4 +33,146 @@ impl<'tcx> Builder<'tcx> {
             }
         }
     }
+
+    /// Function that attempts to fold a constant operation. The function
+    /// expects that the provided [Const]s are of integral kind i.e.
+    /// `float`, `int`, or `char` and then tries to perform the operation on
+    /// them. If the operation is not possible, then the function will
+    /// return [None].
+    pub(crate) fn try_fold_const_op(&mut self, op: BinOp, lhs: Const, rhs: Const) -> Option<Const> {
+        // @@Todo: for now we only handle `small` values of integer types, in the
+        // future we should also be able to perform folds on `ibig` and `ubig` values.
+        if let Const::Int(interned_lhs) = lhs && let Const::Int(interned_rhs) = rhs &&
+            CONSTANT_MAP.map_int_constant(interned_lhs, |v| v.is_small()) &&
+            CONSTANT_MAP.map_int_constant(interned_rhs, |v| v.is_small())
+        {
+            let lhs_const = CONSTANT_MAP.lookup_int_constant(interned_lhs);
+            let rhs_const = CONSTANT_MAP.lookup_int_constant(interned_rhs);
+
+            // First we need to coerce the types into the same primitive integer type, we do this 
+            // by checking the `suffix` and then coercing both ints into that value
+            return match lhs_const.suffix.unwrap_or(IDENTS.i32) {
+                i if i == IDENTS.i8 => fold_int_const(op, TryInto::<i8>::try_into(lhs_const).unwrap(), TryInto::<i8>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.i16 => fold_int_const(op, TryInto::<i16>::try_into(lhs_const).unwrap(), TryInto::<i16>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.i32 => fold_int_const(op, TryInto::<i32>::try_into(lhs_const).unwrap(), TryInto::<i32>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.i64 => fold_int_const(op, TryInto::<i64>::try_into(lhs_const).unwrap(), TryInto::<i64>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.isize => fold_int_const(op, TryInto::<isize>::try_into(lhs_const).unwrap(), TryInto::<isize>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.u8 => fold_int_const(op, TryInto::<u8>::try_into(lhs_const).unwrap(), TryInto::<u8>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.u16 => fold_int_const(op, TryInto::<u16>::try_into(lhs_const).unwrap(), TryInto::<u16>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.u32 => fold_int_const(op, TryInto::<u32>::try_into(lhs_const).unwrap(), TryInto::<u32>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.u64 => fold_int_const(op, TryInto::<u64>::try_into(lhs_const).unwrap(), TryInto::<u64>::try_into(rhs_const).unwrap()),
+                i if i == IDENTS.usize => fold_int_const(op, TryInto::<usize>::try_into(lhs_const).unwrap(), TryInto::<usize>::try_into(rhs_const).unwrap()),
+                _ => unreachable!(),
+            }
+        }
+
+        // Check if these two operands are floating point numbers
+        if let Const::Float(interned_lhs) = lhs && let Const::Float(interned_rhs) = rhs {
+            let lhs_const = CONSTANT_MAP.lookup_float_constant(interned_lhs);
+            let rhs_const = CONSTANT_MAP.lookup_float_constant(interned_rhs);
+
+            return match (lhs_const.value, rhs_const.value) {
+                (FloatConstantValue::F32(lhs), FloatConstantValue::F32(rhs)) => fold_float_const(op, lhs, rhs),
+                (FloatConstantValue::F64(lhs), FloatConstantValue::F64(rhs)) => fold_float_const(op, lhs, rhs),
+                _ => unreachable!(),
+            }
+        }
+
+        None
+    }
+}
+
+/// Function that will take two operands and perform a binary operation on them
+/// whilst yielding a [Const] value. If the operation is not possible, then the
+/// function will return [None].
+fn fold_int_const<T>(op: BinOp, lhs: T, rhs: T) -> Option<Const>
+where
+    T: Add<Output = T>
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Rem<Output = T>
+        + BitAnd<Output = T>
+        + BitOr<Output = T>
+        + BitXor<Output = T>
+        + Shl<Output = T>
+        + Shr<Output = T>
+        + PartialEq
+        + PartialOrd
+        + Into<IntConstant>,
+{
+    let value: Option<T> = match op {
+        BinOp::Gt => return Some(Const::Byte((lhs > rhs).into())),
+        BinOp::GtEq => return Some(Const::Byte((lhs >= rhs).into())),
+        BinOp::Lt => return Some(Const::Byte((lhs < rhs).into())),
+        BinOp::LtEq => return Some(Const::Byte((lhs <= rhs).into())),
+        BinOp::EqEq => return Some(Const::Byte((lhs == rhs).into())),
+        BinOp::NotEq => return Some(Const::Byte((lhs != rhs).into())),
+        BinOp::Add => Some(lhs + rhs),
+        BinOp::Sub => Some(lhs - rhs),
+        BinOp::Mul => Some(lhs * rhs),
+        BinOp::Div => Some(lhs / rhs),
+        BinOp::Mod => Some(lhs % rhs),
+
+        BinOp::BitAnd => Some(lhs & rhs),
+        BinOp::BitOr => Some(lhs | rhs),
+        BinOp::BitXor => Some(lhs ^ rhs),
+        BinOp::Shl => Some(lhs << rhs),
+        BinOp::Shr => Some(lhs >> rhs),
+
+        // Don't do anything for exponents, since not all integral kinds support this.
+        BinOp::Exp => None,
+
+        // We don't deal with logical operations here since these are
+        // not integral operations
+        BinOp::Or | BinOp::And => None,
+    };
+
+    value.map(|val| {
+        // Create the new constant value and return it as a `const`
+        let value: IntConstant = val.into();
+        let id = CONSTANT_MAP.create_int_constant(value);
+        Const::Int(id)
+    })
+}
+
+/// Function that will take two operands of a [FloatConstant] kind and perform a
+/// binary operation on them whilst yielding a [Const] value. If the operation
+/// is not possible, then the function will return [None].
+fn fold_float_const<T>(op: BinOp, lhs: T, rhs: T) -> Option<Const>
+where
+    T: Add<Output = T>
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Rem<Output = T>
+        + num_traits::float::Float
+        + PartialEq
+        + PartialOrd
+        + Into<FloatConstant>,
+{
+    let value = match op {
+        BinOp::Gt => return Some(Const::Byte((lhs > rhs).into())),
+        BinOp::GtEq => return Some(Const::Byte((lhs >= rhs).into())),
+        BinOp::Lt => return Some(Const::Byte((lhs < rhs).into())),
+        BinOp::LtEq => return Some(Const::Byte((lhs <= rhs).into())),
+        BinOp::EqEq => return Some(Const::Byte((lhs == rhs).into())),
+        BinOp::NotEq => return Some(Const::Byte((lhs != rhs).into())),
+        BinOp::Add => Some(lhs + rhs),
+        BinOp::Sub => Some(lhs - rhs),
+        BinOp::Mul => Some(lhs * rhs),
+        BinOp::Div => Some(lhs / rhs),
+        BinOp::Mod => Some(lhs % rhs),
+        BinOp::Exp => Some(lhs.powf(rhs)),
+
+        // No other operations can be performed on floats
+        _ => None,
+    };
+
+    value.map(|val| {
+        // Create the new constant value and return it as a `const`
+        let value: FloatConstant = val.into();
+        let id = CONSTANT_MAP.create_float_constant(value);
+        Const::Float(id)
+    })
 }

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -18,7 +18,7 @@ impl<'tcx> Builder<'tcx> {
                 panic_on_span!(
                     lit.span().into_location(self.source_id),
                     self.source_map,
-                    "cannot lower compound literal into constant"
+                    "cannot lower non-primitive literal into constant"
                 )
             }
         }

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -91,7 +91,7 @@ impl<'tcx> Builder<'tcx> {
 
             // Traverse the lhs of the cast, and then apply the cast
             // to the result... although this should be a no-op?
-            Expr::Cast(..) => todo!(),
+            Expr::Cast(..) => unimplemented!(),
 
             // This includes `loop { ... } `, `{ ... }`, `match { ... }`
             Expr::Block(BlockExpr { data }) => {
@@ -311,6 +311,6 @@ impl<'tcx> Builder<'tcx> {
         _subject: AstNodeRef<'tcx, Expr>,
         _args: &'tcx AstNodes<ConstructorCallArg>,
     ) -> BlockAnd<()> {
-        todo!()
+        unimplemented!()
     }
 }

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -17,7 +17,10 @@ use std::collections::{HashMap, HashSet};
 
 use hash_ast::ast::{AstNodeId, AstNodeRef, Expr, FnDef};
 use hash_ir::{
-    ir::{BasicBlock, Body, BodySource, Local, LocalDecl, Place, TerminatorKind, START_BLOCK},
+    ir::{
+        AssertKind, BasicBlock, Body, BodySource, Local, LocalDecl, Place, TerminatorKind,
+        START_BLOCK,
+    },
     ty::{IrTy, IrTyId, Mutability},
     IrStorage,
 };
@@ -311,6 +314,26 @@ impl<'tcx> Builder<'tcx> {
                 place
             }
         }
+    }
+
+    /// Create an assertion on a particular block
+    pub(crate) fn assert(
+        &mut self,
+        block: BasicBlock,
+        condition: Place,
+        expected: bool,
+        kind: AssertKind,
+        span: Span,
+    ) -> BasicBlock {
+        let success_block = self.control_flow_graph.start_new_block();
+
+        self.control_flow_graph.terminate(
+            block,
+            span,
+            TerminatorKind::Assert { condition, expected, kind, target: success_block },
+        );
+
+        success_block
     }
 
     /// Run a lowering operation whilst entering a new scope which is derived

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod block;
+mod category;
 mod constant;
 mod expr;
 mod matches;

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -414,14 +414,14 @@ impl<'tcx> Builder<'tcx> {
         let fn_params =
             self.tcx.params_store.get_owned_param_list(fn_term.params).into_positional();
 
-        let IrTy::Fn(params, ret_ty) = lower_term(term_id, self.tcx, self.storage) else {
+        let IrTy::Fn {params, return_ty, .. } = lower_term(term_id, self.tcx, self.storage) else {
             panic!("Expected a function type");
         };
 
         // The first local declaration is used as the return type. The return local
         // declaration is always mutable because it will be set at some point in
         // the end, not the beginning.
-        let ret_local = LocalDecl::new_auxiliary(ret_ty, Mutability::Mutable);
+        let ret_local = LocalDecl::new_auxiliary(return_ty, Mutability::Mutable);
         self.declarations.push(ret_local);
 
         // Deal with all the function parameters that are given to the function.

--- a/compiler/hash-lower/src/build/pat.rs
+++ b/compiler/hash-lower/src/build/pat.rs
@@ -30,7 +30,6 @@ impl<'tcx> Builder<'tcx> {
                 let ty = self.get_ty_id_of_node(node_id);
                 self.declare_binding(name, ty, mutability)
             }
-            ast::Pat::Constructor(_) => todo!(),
             ast::Pat::Tuple(ast::TuplePat { fields }) => {
                 // @@Todo: deal with associating a projection here.
 
@@ -39,9 +38,10 @@ impl<'tcx> Builder<'tcx> {
                     self.visit_bindings(pat.ast_ref());
                 }
             }
-            ast::Pat::List(_) => todo!(),
-            ast::Pat::Or(_) => todo!(),
-            ast::Pat::If(_) => todo!(),
+            ast::Pat::Constructor(_) => unimplemented!(),
+            ast::Pat::List(_) => unimplemented!(),
+            ast::Pat::Or(_) => unimplemented!(),
+            ast::Pat::If(_) => unimplemented!(),
             ast::Pat::Lit(_)
             | ast::Pat::Module(_)
             | ast::Pat::Access(_)
@@ -75,12 +75,12 @@ impl<'tcx> Builder<'tcx> {
                 unpack!(block = self.expr_into_dest(place, block, rvalue));
                 block.unit()
             }
-            ast::Pat::Wild(_) => todo!(),
-            ast::Pat::Constructor(_) => todo!(),
-            ast::Pat::Tuple(_) => todo!(),
-            ast::Pat::List(_) => todo!(),
-            ast::Pat::Lit(_) => todo!(),
-            ast::Pat::Or(_) => todo!(),
+            ast::Pat::Wild(_) => unimplemented!(),
+            ast::Pat::Constructor(_) => unimplemented!(),
+            ast::Pat::Tuple(_) => unimplemented!(),
+            ast::Pat::List(_) => unimplemented!(),
+            ast::Pat::Lit(_) => unimplemented!(),
+            ast::Pat::Or(_) => unimplemented!(),
             pat => {
                 panic!("reached irrefutable pattern: {pat:?} in `expr_into_pat`");
             }

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -1,11 +1,12 @@
 //! Utilities for dealing with [Place]s when building up Hash IR.
 #![allow(unused)]
 
-use hash_ast::ast::{AstNodeRef, Expr};
+use hash_ast::ast::{AccessExpr, AccessKind, AstNodeRef, DerefExpr, Expr, IndexExpr, PropertyKind};
 use hash_ir::{
     ir::{BasicBlock, Local, Place, PlaceProjection},
-    ty::Mutability,
+    ty::{IrTy, IrTyId, Mutability},
 };
+use hash_utils::store::CloneStore;
 
 use super::{unpack, BlockAnd, BlockAndExtend, Builder};
 
@@ -90,10 +91,42 @@ impl<'tcx> Builder<'tcx> {
                 let local = self.lookup_local(name).unwrap();
                 block.and(PlaceBuilder::from(local))
             }
-            Expr::Ref(_) => todo!(),
-            Expr::Access(_) => todo!(),
-            Expr::Deref(_) => todo!(),
-            Expr::Index(_) => todo!(),
+            Expr::Access(AccessExpr { subject, property, kind: AccessKind::Property }) => {
+                let place_builder =
+                    unpack!(block = self.as_place_builder(block, subject.ast_ref(), mutability));
+
+                let subject_ty = self.get_ty_id_of_node(subject.id());
+
+                let index = self.lookup_field_index(subject_ty, *property.body());
+                block.and(place_builder.field(index))
+            }
+            Expr::Access(AccessExpr { subject, .. }) => {
+                // @@Todo: we need to check here if the type of the subject is
+                // an enum, and if so then we perform a *downcast* to the correct
+                // variant of the enum.
+
+                // Otherwise, if this is a namespace access, we only need to look at the subject
+                // of the access
+                self.as_place_builder(block, subject.ast_ref(), mutability)
+            }
+            Expr::Deref(DerefExpr { data }) => {
+                let place_builder =
+                    unpack!(block = self.as_place_builder(block, data.ast_ref(), mutability));
+                block.and(place_builder.deref())
+            }
+            Expr::Index(IndexExpr { subject, index_expr }) => {
+                let base_place =
+                    unpack!(block = self.as_place_builder(block, subject.ast_ref(), mutability));
+
+                // Create a temporary for the index expression.
+                let index =
+                    unpack!(block = self.expr_into_temp(block, index_expr.ast_ref(), mutability));
+
+                // @@Todo: depending on the configuration, we may need to insert a bounds check
+                // here.
+
+                block.and(base_place.index(index))
+            }
 
             Expr::Import(_)
             | Expr::StructDef(_)
@@ -110,7 +143,8 @@ impl<'tcx> Builder<'tcx> {
                 unreachable!()
             }
 
-            Expr::ConstructorCall(_)
+            Expr::Ref(_)
+            | Expr::ConstructorCall(_)
             | Expr::Declaration(_)
             | Expr::Unsafe(_)
             | Expr::Lit(_)
@@ -129,6 +163,39 @@ impl<'tcx> Builder<'tcx> {
                 let temp = unpack!(block = self.expr_into_temp(block, expr, mutability));
                 block.and(PlaceBuilder::from(temp))
             }
+        }
+    }
+
+    /// Function to lookup the index of a particular field within a [IrTy] using
+    /// a [PropertyKind]. This function assumes that the underlying type is
+    /// a [IrTy::Adt].
+    fn lookup_field_index(&mut self, ty: IrTyId, field: PropertyKind) -> usize {
+        let ty = self.storage.ty_store().get(ty);
+
+        // This must be an adt...
+        let IrTy::Adt(adt_id) = ty else {
+            unreachable!()
+        };
+
+        let adt = self.storage.adt_store().get(adt_id);
+
+        // @@Todo: deal with unions here.
+        if adt.flags.is_struct() || adt.flags.is_tuple() {
+            // So we get the first variant of the ADT since structs, tuples always
+            // have a single variant
+            let variant = adt.variants.first().unwrap();
+
+            match field {
+                PropertyKind::NamedField(name) => {
+                    // @@Optimisation: we could use a lookup table for `AdtField` to
+                    // immediately lookup the field rather than looping through the
+                    // whole vector trying to find the field with the same name.
+                    variant.fields.iter().position(|field| field.name == name).unwrap()
+                }
+                PropertyKind::NumericField(index) => index,
+            }
+        } else {
+            unreachable!("attempt to access a field of a non-struct or tuple type")
         }
     }
 }

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -122,8 +122,7 @@ impl<'tcx> Builder<'tcx> {
         if op.is_checkable() && ty.is_integral() {
             // Create a new tuple that contains the result of the operation
             let expr_ty = self.storage.ty_store().create(ty);
-            let ret_ty = [expr_ty, self.storage.ty_store().make_bool()];
-            let ty = IrTy::tuple(self.storage, &ret_ty);
+            let ty = IrTy::tuple(self.storage, &[expr_ty, self.storage.ty_store().make_bool()]);
             let ty_id = self.storage.ty_store().create(ty);
 
             let temp = self.temp_place(ty_id);

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -1,14 +1,14 @@
-use hash_ast::ast::{AstNodeRef, Expr};
-use hash_ir::ir::{BasicBlock, RValueId};
+use hash_ast::ast::{self, AstNodeRef, Expr, UnaryExpr};
+use hash_ir::ir::{BasicBlock, RValue, RValueId};
 use hash_utils::store::Store;
 
-use super::{BlockAnd, BlockAndExtend, Builder};
+use super::{category::Category, unpack, BlockAnd, BlockAndExtend, Builder};
 
 impl<'tcx> Builder<'tcx> {
     /// Construct an [RValue] from the given [Expr] and return the [RValueId].
     pub(crate) fn as_rvalue(
         &mut self,
-        block: BasicBlock,
+        mut block: BasicBlock,
         expr: AstNodeRef<'tcx, Expr>,
     ) -> BlockAnd<RValueId> {
         // @@Todo: use a notion of `categories` to determine if we should
@@ -16,10 +16,52 @@ impl<'tcx> Builder<'tcx> {
         // the expression itself,
         let rvalue = match expr.body {
             Expr::Lit(lit) => self.as_constant(lit.data.ast_ref()).into(),
+            Expr::UnaryExpr(UnaryExpr { operator, expr }) => {
+                // If the unary operator is a typeof, we should have already dealt with
+                // this...
+                if matches!(operator.body(), ast::UnOp::TypeOf) {
+                    panic!("`typeof` should have been handled already");
+                }
+
+                let arg = unpack!(block = self.as_operand(block, expr.ast_ref()));
+
+                // @@Todo: depending on what mode we're running in (which should be derived from
+                // the compiler session, we         should emit a check here
+                // determining if the operation might cause an overflow, or an underflow).
+                RValue::UnaryOp((*(operator.body())).into(), arg)
+            }
+            Expr::BinaryExpr(..) => todo!(),
+            Expr::Index(..) => todo!(),
             _ => unimplemented!(),
         };
 
         let rvalue_id = self.storage.rvalue_store().create(rvalue);
         block.and(rvalue_id)
+    }
+
+    /// Convert the given expression into an [RValue] operand which means that
+    /// this is either a constant or a local variable. In the case of a
+    /// constant, this means that the value is [RValue::Const], and in the
+    /// case of a local variable, this means that the value is
+    /// [RValue::Use].
+    pub(crate) fn as_operand(
+        &mut self,
+        mut block: BasicBlock,
+        expr: AstNodeRef<'tcx, Expr>,
+    ) -> BlockAnd<RValueId> {
+        let category = Category::of(expr);
+
+        match category {
+            // Just directly recurse and create the constant.
+            Category::Constant => self.as_rvalue(block, expr),
+            Category::Place | Category::Rvalue => {
+                let place = unpack!(block = self.as_place(block, expr));
+
+                let rvalue = RValue::Use(place);
+                let rvalue_id = self.storage.rvalue_store().create(rvalue);
+
+                block.and(rvalue_id)
+            }
+        }
     }
 }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -162,7 +162,7 @@ pub(super) fn lower_term(term: TermId, tcx: &GlobalStorage, ir_ctx: &IrStorage) 
                 let adt_id = ir_ctx.adt_store().create(adt);
                 IrTy::Adt(adt_id)
             }
-            Level1Term::Fn(FnTy { params, return_ty }) => {
+            Level1Term::Fn(FnTy { name, params, return_ty }) => {
                 let return_ty = convert_term_into_ir_ty(return_ty, tcx, ir_ctx);
                 let params = tcx
                     .params_store
@@ -171,8 +171,8 @@ pub(super) fn lower_term(term: TermId, tcx: &GlobalStorage, ir_ctx: &IrStorage) 
                     .into_iter()
                     .map(|param| convert_term_into_ir_ty(param.ty, tcx, ir_ctx));
 
-                let params_id = ir_ctx.ty_list_store().create_from_iter(params);
-                IrTy::Fn(params_id, return_ty)
+                let params = ir_ctx.ty_list_store().create_from_iter(params);
+                IrTy::Fn { name, params, return_ty }
             }
             Level1Term::ModDef(_) => unreachable!(),
         },

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -16,7 +16,7 @@ use hash_source::{
 use hash_types::{
     nominals::{NominalDef, StructFields},
     storage::GlobalStorage,
-    terms::{FnLit, FnTy, Level0Term, Level1Term, Term, TermId, TupleLit, TupleTy},
+    terms::{FnLit, FnTy, Level0Term, Level1Term, LitTerm, Term, TermId, TupleLit, TupleTy},
 };
 use hash_utils::store::{CloneStore, SequenceStore, Store};
 use index_vec::index_vec;
@@ -59,8 +59,12 @@ pub(super) fn lower_term(term: TermId, tcx: &GlobalStorage, ir_ctx: &IrStorage) 
                 let adt_id = ir_ctx.adt_store().create(adt);
                 IrTy::Adt(adt_id)
             }
+            Level0Term::Lit(lit_term) => match lit_term {
+                LitTerm::Str(_) => IrTy::Str,
+                LitTerm::Int { kind, .. } => kind.into(),
+                LitTerm::Char(_) => IrTy::Char,
+            },
             Level0Term::Unit(_)
-            | Level0Term::Lit(_)
             | Level0Term::FnCall(_)
             | Level0Term::EnumVariant(_)
             | Level0Term::Constructed(_) => panic!("unexpected level 0 term: {lvl_0_term:?}"),

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -73,6 +73,25 @@ impl FloatConstant {
     }
 }
 
+/// Provide implementations for converting primitive floating point types into
+/// [FloatConstant]s.
+macro_rules! float_const_impl_into {
+    ($($ty:ident, $kind: ident);*) => {
+        $(
+            impl From<$ty> for FloatConstant {
+                fn from(value: $ty) -> Self {
+                    Self {
+                        value: FloatConstantValue::$kind(value),
+                        suffix: Some(IDENTS.$ty),
+                    }
+                }
+            }
+        )*
+    };
+}
+
+float_const_impl_into!(f32, F32; f64, F64);
+
 counter! {
     name: InternedFloat,
     counter_name: INTERNED_FLOAT_COUNTER,
@@ -384,7 +403,7 @@ impl IntConstant {
     /// Check if the [IntConstant] is `signed` by checking if the specified
     /// suffix matches one of the available signed integer suffixes. If no
     /// suffix is specified, the assumed type of the integer constant is `i32`
-    /// and therefore this follows the same assumption.
+    /// and therefore this follows the same assu¬mption.
     pub fn is_signed(&self) -> bool {
         match self.suffix {
             Some(suffix) => match suffix {
@@ -401,6 +420,20 @@ impl IntConstant {
         }
     }
 
+    /// Check if the [IntConstant] is represented as the
+    /// [IntConstantValue::Small], as in this is an integer type that is not
+    /// represented using a `ibig` or `ubig` type.
+    pub fn is_small(&self) -> bool {
+        matches!(self.value, IntConstantValue::Small(_))
+    }
+
+    fn get_bytes(&self) -> [u8; 8] {
+        match &self.value {
+            IntConstantValue::Small(value) => *value,
+            _ => unreachable!(),
+        }
+    }
+
     /// Negate the [IntConstant] provided that the constant is signed. If
     /// the constant is not signed, then no negation operation is applied.
     pub fn negate(self) -> Self {
@@ -411,6 +444,8 @@ impl IntConstant {
 
         let value = match self.value {
             IntConstantValue::Small(inner) => {
+                // @@Todo: don't always assume that this is a 64 biy integer.
+
                 // Flip the sign, and the convert back to `be` bytes
                 let value = -i64::from_be_bytes(inner);
                 IntConstantValue::Small(value.to_be_bytes())
@@ -419,6 +454,69 @@ impl IntConstant {
         };
 
         Self { value, suffix: self.suffix }
+    }
+}
+
+/// Provide implementations for converting primitive integer types into
+/// [IntConstant]s.
+macro_rules! int_const_impl_from {
+    ($($ty:ident),*; $into: ty) => {
+        $(
+            impl From<$ty> for IntConstant {
+                fn from(value: $ty) -> Self {
+                    Self {
+                        value: IntConstantValue::Small((value as $into).to_be_bytes()),
+                        suffix: Some(IDENTS.$ty),
+                    }
+                }
+            }
+        )*
+    };
+    () => {
+    };
+}
+
+int_const_impl_from!(i8, i16, i32, i64, isize; i64);
+int_const_impl_from!(u8, u16, u32, u64, usize; u64);
+
+macro_rules! int_const_impl_into {
+    ($($ty:ident),*) => {
+        $(
+            impl TryFrom<IntConstant> for $ty {
+                type Error = ();
+
+                fn try_from(value: IntConstant) -> Result<Self, Self::Error> {
+                    if value.suffix == Some(IDENTS.$ty) {
+                        let value = value.to_bytes_be();
+                        Ok(<$ty>::from_be_bytes(value.try_into().unwrap()))
+                    } else {
+                        Err(())
+                    }
+                }
+            }
+        )*
+    };
+    () => {
+    };
+}
+
+int_const_impl_into!(i8, i16, i64, isize);
+int_const_impl_into!(u8, u16, u32, u64, usize);
+
+// We need to have a special implementation for `i32` as it is the default
+// integer type when no suffix is provided.
+//
+// @@Todo: potentially make `suffix` field on `IntConstant` non-optional
+impl TryFrom<IntConstant> for i32 {
+    type Error = ();
+
+    fn try_from(value: IntConstant) -> Result<Self, Self::Error> {
+        if value.suffix == Some(IDENTS.i32) || value.suffix.is_none() {
+            debug_assert!(value.is_small());
+            Ok(<i64>::from_be_bytes(value.get_bytes()) as i32)
+        } else {
+            Err(())
+        }
     }
 }
 
@@ -550,11 +648,8 @@ impl ConstantMap {
         value: f64,
         suffix: Option<Identifier>,
     ) -> InternedFloat {
-        let ident = InternedFloat::new();
         let constant = FloatConstant { value: FloatConstantValue::F64(value), suffix };
-
-        self.float_table.insert(ident, constant);
-        ident
+        self.create_float_constant(constant)
     }
 
     /// Create a `f32` [FloatConstant] within the [ConstantMap]
@@ -563,10 +658,15 @@ impl ConstantMap {
         value: f32,
         suffix: Option<Identifier>,
     ) -> InternedFloat {
-        let ident = InternedFloat::new();
         let constant = FloatConstant { value: FloatConstantValue::F32(value), suffix };
+        self.create_float_constant(constant)
+    }
 
+    /// Create a [FloatConstant] within the [ConstantMap]
+    pub fn create_float_constant(&self, constant: FloatConstant) -> InternedFloat {
+        let ident = InternedFloat::new();
         self.float_table.insert(ident, constant);
+
         ident
     }
 
@@ -580,16 +680,24 @@ impl ConstantMap {
         self.float_table.alter(&id, |_, value| value.negate());
     }
 
-    /// Create a [IntConstant] within the [ConstantMap].
-    pub fn create_int_constant(&self, value: BigInt, suffix: Option<Identifier>) -> InternedInt {
+    /// Create a [IntConstant] from the a provided value and suffix, and then
+    /// insert it into the [ConstantMap] returning the [InternedInt].
+    pub fn create_int_constant_from_value(
+        &self,
+        value: BigInt,
+        suffix: Option<Identifier>,
+    ) -> InternedInt {
         let value = IntConstantValue::from(value);
-
-        let ident = InternedInt::new();
         let constant = IntConstant { value, suffix };
+        self.create_int_constant(constant)
+    }
+
+    /// Create a [IntConstant] within the [ConstantMap].
+    pub fn create_int_constant(&self, constant: IntConstant) -> InternedInt {
+        let ident = InternedInt::new();
 
         // Insert the entries into the map and the reverse-lookup map
         self.int_table.insert(ident, constant);
-
         ident
     }
 
@@ -604,6 +712,13 @@ impl ConstantMap {
         };
 
         IntConstant { value, suffix: *suffix }
+    }
+
+    /// Perform a transformation on the [IntConstant] behind the [InternedInt]
+    /// without making a copy of the original value.
+    pub fn map_int_constant<T>(&self, id: InternedInt, f: impl FnOnce(&IntConstant) -> T) -> T {
+        let lookup_value = self.int_table.get(&id).unwrap();
+        f(lookup_value.value())
     }
 
     /// Perform a negation operation on an [InternedInt].

--- a/compiler/hash-typecheck/src/ops/discover.rs
+++ b/compiler/hash-typecheck/src/ops/discover.rs
@@ -959,7 +959,7 @@ impl<'tc> Discoverer<'tc> {
                 if !applied_once {
                     Ok(None)
                 } else {
-                    Ok(Some(self.builder().create_fn_ty_term(params, return_ty)))
+                    Ok(Some(self.builder().create_fn_ty_term(fn_ty.name, params, return_ty)))
                 }
             }
             Term::Level0(term) => match term {

--- a/compiler/hash-typecheck/src/ops/substitute.rs
+++ b/compiler/hash-typecheck/src/ops/substitute.rs
@@ -67,7 +67,7 @@ impl<'tc> Substituter<'tc> {
         // Apply to parameters and return type
         let subbed_params = self.apply_sub_to_params(sub, fn_ty.params);
         let subbed_return_ty = self.apply_sub_to_term(sub, fn_ty.return_ty);
-        FnTy { params: subbed_params, return_ty: subbed_return_ty }
+        FnTy { name: fn_ty.name, params: subbed_params, return_ty: subbed_return_ty }
     }
 
     /// Apply the given substitution to the given [ConstructedTerm], producing a

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -220,7 +220,11 @@ impl<'tc> Typer<'tc> {
                         let enum_ty =
                             self.builder().create_nominal_def_term(enum_variant.enum_def_id);
                         match variant.fields {
-                            Some(fields) => Ok(self.builder().create_fn_ty_term(fields, enum_ty)),
+                            Some(fields) => Ok(self.builder().create_fn_ty_term(
+                                Some(variant.name),
+                                fields,
+                                enum_ty,
+                            )),
                             None => Ok(enum_ty),
                         }
                     }

--- a/compiler/hash-typecheck/src/traverse/operators.rs
+++ b/compiler/hash-typecheck/src/traverse/operators.rs
@@ -52,11 +52,13 @@ impl<'tc> TcVisitor<'tc> {
         let builder = self.builder();
 
         // () => lhs
-        let fn_ty = builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), lhs_ty);
+        let fn_ty =
+            builder.create_fn_ty_term(None, builder.create_params([], ParamOrigin::Fn), lhs_ty);
         let lhs = builder.create_fn_lit_term(None, fn_ty, lhs);
 
         // () => rhs
-        let fn_ty = builder.create_fn_ty_term(builder.create_params([], ParamOrigin::Fn), rhs_ty);
+        let fn_ty =
+            builder.create_fn_ty_term(None, builder.create_params([], ParamOrigin::Fn), rhs_ty);
         let rhs = builder.create_fn_lit_term(None, fn_ty, rhs);
 
         // (() => lhs).trait_name()

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -841,7 +841,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         self.copy_location_from_nodes_to_targets(node.params.ast_ref_iter(), params);
 
         // Create the function type term:
-        let fn_ty_term = self.builder().create_fn_ty_term(params, return_ty);
+        let fn_ty_term = self.builder().create_fn_ty_term(None, params, return_ty);
 
         self.validate_and_register_simplified_term(node, fn_ty_term)
     }
@@ -1096,7 +1096,7 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
 
         let fn_ty_term = builder.create_fn_lit_term(
             name,
-            builder.create_fn_ty_term(params, return_ty),
+            builder.create_fn_ty_term(name, params, return_ty),
             return_value,
         );
 

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -1701,7 +1701,9 @@ impl<'tc> visitor::AstVisitor for TcVisitor<'tc> {
         // @@Hack: currently, trait resolution logic is broken, so we introduce
         // a workaround for primitives to support all unary operators on primitive
         // types.
-        if self.oracle().term_is_primitive(expr) {
+        let expr_ty = self.typer().infer_ty_of_term(expr)?;
+
+        if self.oracle().term_is_primitive(expr_ty) {
             let term = self.term_store().get(expr);
             let term = self.builder().create_term(term);
 

--- a/compiler/hash-types/src/bootstrap.rs
+++ b/compiler/hash-types/src/bootstrap.rs
@@ -130,6 +130,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
                     IDENTS.hash,
                     Visibility::Public,
                     builder.create_fn_ty_term(
+                        Some(IDENTS.hash),
                         builder.create_params(
                             [builder.create_param(
                                 IDENTS.value,
@@ -153,6 +154,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
                     IDENTS.eq,
                     Visibility::Public,
                     builder.create_fn_ty_term(
+                        Some(IDENTS.eq),
                         builder.create_params(
                             [
                                 builder
@@ -182,6 +184,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
                     IDENTS.index,
                     Visibility::Public,
                     builder.create_fn_ty_term(
+                        Some(IDENTS.index),
                         builder.create_params(
                             [
                                 builder.create_param(
@@ -239,6 +242,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
                     IDENTS.index,
                     Visibility::Public,
                     builder.create_fn_ty_term(
+                        Some(IDENTS.index),
                         builder.create_params(
                             [
                                 builder.create_param(
@@ -257,6 +261,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
                     builder.create_fn_lit_term(
                         Some(IDENTS.index),
                         builder.create_fn_ty_term(
+                            Some(IDENTS.index),
                             builder.create_params(
                                 [
                                     builder.create_param(

--- a/compiler/hash-types/src/builder.rs
+++ b/compiler/hash-types/src/builder.rs
@@ -428,8 +428,13 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a [Level1Term::Fn] term with the given parameters and return
     /// type.
-    pub fn create_fn_ty_term(&self, params: ParamsId, return_ty: TermId) -> TermId {
-        self.create_term(Term::Level1(Level1Term::Fn(FnTy { params, return_ty })))
+    pub fn create_fn_ty_term(
+        &self,
+        name: Option<Identifier>,
+        params: ParamsId,
+        return_ty: TermId,
+    ) -> TermId {
+        self.create_term(Term::Level1(Level1Term::Fn(FnTy { name, params, return_ty })))
     }
 
     /// Create a [Level1Term::NominalDef] from the given [NominalDefId].

--- a/compiler/hash-types/src/terms.rs
+++ b/compiler/hash-types/src/terms.rs
@@ -39,7 +39,13 @@ pub struct TupleTy {
 /// All the parameter types and return type must be level 0
 #[derive(Debug, Clone, Copy)]
 pub struct FnTy {
+    /// The name of the function.
+    pub name: Option<Identifier>,
+
+    /// All of the parameters that the function accepts.
     pub params: ParamsId,
+
+    /// The return type of the function
     pub return_ty: TermId,
 }
 


### PR DESCRIPTION
This patch implements lowering for the following items:
- binary operators (with addition of `CheckedOp`)
- basic constant folding
- unary operators
- function calls
- index expressions and assignments
- field expressions and assignments

closes #580 
closes #574 
closes #582
