### PR TITLE
source: re-work constants and start lowering `match`es

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,13 +456,11 @@ dependencies = [
 name = "hash-lexer"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "hash-reporting",
  "hash-source",
  "hash-token",
  "num-bigint",
  "num-traits",
- "thiserror",
 ]
 
 [[package]]
@@ -474,12 +472,14 @@ dependencies = [
  "hash-pipeline",
  "hash-reporting",
  "hash-source",
+ "hash-target",
  "hash-tree-def",
  "hash-types",
  "hash-utils",
  "index_vec",
  "num-traits",
  "rayon",
+ "smallvec",
 ]
 
 [[package]]
@@ -564,6 +564,7 @@ dependencies = [
  "derive_more",
  "fnv",
  "hash-alloc",
+ "hash-target",
  "hash-utils",
  "lazy_static",
  "num-bigint",

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use hash_source::{
-    constant::{FloatTy, IntTy, InternedFloat, InternedInt, InternedStr},
+    constant::{FloatTy, IntTy, InternedFloat, InternedInt, InternedStr, SIntTy},
     identifier::Identifier,
     location::Span,
 };
@@ -602,6 +602,16 @@ define_tree! {
         Suffixed(IntTy),
         /// No provided suffix type, so defaults to `i32`
         Unsuffixed,
+    }
+
+    impl IntLitKind {
+        /// Get the type of the integer literal
+        pub fn ty(&self) -> IntTy {
+            match self {
+                IntLitKind::Suffixed(ty) => *ty,
+                IntLitKind::Unsuffixed => IntTy::Int(SIntTy::I32),
+            }
+        }
     }
 
     impl Display for IntLitKind {
@@ -1290,6 +1300,13 @@ define_tree! {
         ///
         /// Will be executed if the pattern succeeds.
         pub expr: Child!(Expr),
+    }
+
+    impl MatchCase {
+        /// Check if the pattern of the case is an `if-pattern`
+        pub fn has_if_pat(&self) -> bool {
+            matches!(self.pat.body(), Pat::If(_))
+        }
     }
 
     /// The origin of a match block when the AST is

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -7,7 +7,6 @@
 use std::{cell::Cell, fmt};
 
 use bitflags::bitflags;
-use hash_ast::ast;
 use hash_source::{
     constant::{FloatTy, IntTy, SIntTy, UIntTy},
     identifier::Identifier,
@@ -52,11 +51,24 @@ impl Mutability {
     }
 }
 
-impl From<ast::Mutability> for Mutability {
-    fn from(value: ast::Mutability) -> Self {
+impl From<hash_ast::ast::Mutability> for Mutability {
+    fn from(value: hash_ast::ast::Mutability) -> Self {
+        use hash_ast::ast::Mutability::*;
+
         match value {
-            ast::Mutability::Mutable => Mutability::Mutable,
-            ast::Mutability::Immutable => Mutability::Immutable,
+            Mutable => Mutability::Mutable,
+            Immutable => Mutability::Immutable,
+        }
+    }
+}
+
+impl From<hash_types::scope::Mutability> for Mutability {
+    fn from(value: hash_types::scope::Mutability) -> Self {
+        use hash_types::scope::Mutability::*;
+
+        match value {
+            Mutable => Mutability::Mutable,
+            Immutable => Mutability::Immutable,
         }
     }
 }

--- a/compiler/hash-lexer/Cargo.toml
+++ b/compiler/hash-lexer/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0"
-derive_more = "0.99"
 num-bigint = "0.4"
 num-traits = "0.2.15"
 

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -582,6 +582,15 @@ impl<'a> Lexer<'a> {
                         let float_const = if let Some(suffix_ident) = suffix && suffix_ident == IDENTS.f32 {
                             CONSTANT_MAP.create_f32_float_constant(value as f32, suffix)
                         } else {
+                            // Check that the suffix is correct for the literal
+                            if let Some(suffix_ident) = suffix && suffix_ident != IDENTS.f64 {
+                                self.emit_error(
+                                    None,
+                                    LexerErrorKind::InvalidLitSuffix(NumericLitKind::Float, suffix_ident),
+                                    Span::new(start, self.offset.get()),
+                                );
+                            }
+
                             CONSTANT_MAP.create_f64_float_constant(value, suffix)
                         };
 
@@ -637,7 +646,7 @@ impl<'a> Lexer<'a> {
     /// Consume only decimal digits up to encountering a non-decimal digit
     /// whilst taking into account that the language supports '_' as digit
     /// separators which should just be skipped over...
-    fn eat_decimal_digits(&'a self, radix: u32) -> &'a str {
+    fn eat_decimal_digits(&self, radix: u32) -> &str {
         self.eat_while_and_slice(move |c| c.is_digit(radix) || c == '_')
     }
 

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -3,10 +3,10 @@
 
 use std::{cell::Cell, iter};
 
-use error::{LexerDiagnostics, LexerError, LexerErrorKind, LexerResult};
+use error::{LexerDiagnostics, LexerError, LexerErrorKind, LexerResult, NumericLitKind};
 use hash_reporting::diagnostic::Diagnostics;
 use hash_source::{
-    constant::CONSTANT_MAP,
+    constant::{IntTy, SIntTy, CONSTANT_MAP},
     identifier::{Identifier, IDENTS},
     location::{SourceLocation, Span},
     SourceId,
@@ -96,7 +96,11 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: Span,
     ) -> TokenKind {
-        self.add_error(LexerError::new(message, kind, SourceLocation { span, id: self.source_id }));
+        self.add_error(LexerError {
+            message,
+            kind,
+            location: SourceLocation { span, id: self.source_id },
+        });
 
         TokenKind::Err
     }
@@ -110,7 +114,7 @@ impl<'a> Lexer<'a> {
         kind: LexerErrorKind,
         span: Span,
     ) -> Result<T, LexerError> {
-        Err(LexerError::new(message, kind, SourceLocation { span, id: self.source_id }))
+        Err(LexerError { message, kind, location: SourceLocation { span, id: self.source_id } })
     }
 
     /// Returns a reference to the stored token trees for the current job
@@ -399,10 +403,10 @@ impl<'a> Lexer<'a> {
     /// Function to create an integer constant from characters and
     /// a specific radix.
     fn create_int_const(
-        &self,
+        &mut self,
         chars: &str,
         radix: u32,
-        ascription: Option<Identifier>,
+        suffix: Option<Identifier>,
     ) -> TokenKind {
         // ##Safety: this can't fail since the radix is validated by the parsing, and
         //   we will always have at least one character in `chars`...
@@ -411,7 +415,19 @@ impl<'a> Lexer<'a> {
         let parsed = BigInt::from_str_radix(chars, radix).unwrap();
 
         // We need to create a interned constant here...
-        let interned_const = CONSTANT_MAP.create_int_constant_from_value(parsed, ascription);
+        let ty: IntTy = match (suffix.unwrap_or(IDENTS.i32)).try_into() {
+            Ok(ty) => ty,
+            Err(_) => {
+                self.emit_error(
+                    None,
+                    LexerErrorKind::InvalidLitSuffix(NumericLitKind::Integer, suffix.unwrap()),
+                    Span::new(self.offset.get(), self.offset.get()),
+                );
+                IntTy::Int(SIntTy::I32)
+            }
+        };
+
+        let interned_const = CONSTANT_MAP.create_int_constant_from_value(parsed, ty, suffix);
         TokenKind::IntLit(interned_const)
     }
 
@@ -453,7 +469,7 @@ impl<'a> Lexer<'a> {
             // if this does have a radix then we need to handle the radix
             if let Some(radix) = maybe_radix {
                 self.skip(); // accounting for the radix
-                let chars = self.eat_decimal_digits(radix);
+                let chars = self.eat_decimal_digits(radix).to_string();
 
                 // If we didn't get any characters, this means that
                 if chars.is_empty() {
@@ -480,7 +496,7 @@ impl<'a> Lexer<'a> {
                         Span::new(start, self.offset.get()),
                     );
                 } else {
-                    return self.create_int_const(chars, radix, suffix);
+                    return self.create_int_const(chars.as_str(), radix, suffix);
                 }
             }
         }
@@ -621,7 +637,7 @@ impl<'a> Lexer<'a> {
     /// Consume only decimal digits up to encountering a non-decimal digit
     /// whilst taking into account that the language supports '_' as digit
     /// separators which should just be skipped over...
-    fn eat_decimal_digits(&self, radix: u32) -> &str {
+    fn eat_decimal_digits(&'a self, radix: u32) -> &'a str {
         self.eat_while_and_slice(move |c| c.is_digit(radix) || c == '_')
     }
 

--- a/compiler/hash-lower/Cargo.toml
+++ b/compiler/hash-lower/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 index_vec = "0.1.3"
 rayon = "1.5.0"
+smallvec = "1.9.0"
 num-traits = "0.2.15"
 
 hash-ast = { path = "../hash-ast" }
@@ -16,4 +17,5 @@ hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }
 hash-types = { path = "../hash-types" }
+hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -7,9 +7,8 @@ use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 use hash_ast::ast::{AstNodeRef, Lit};
 use hash_ir::ir::{self, BinOp, Const};
 use hash_reporting::macros::panic_on_span;
-use hash_source::{
-    constant::{FloatConstant, FloatConstantValue, IntConstant, CONSTANT_MAP},
-    identifier::IDENTS,
+use hash_source::constant::{
+    FloatConstant, FloatConstantValue, IntConstant, IntTy, SIntTy, UIntTy, CONSTANT_MAP,
 };
 
 use super::Builder;
@@ -51,17 +50,17 @@ impl<'tcx> Builder<'tcx> {
 
             // First we need to coerce the types into the same primitive integer type, we do this 
             // by checking the `suffix` and then coercing both ints into that value
-            return match lhs_const.suffix.unwrap_or(IDENTS.i32) {
-                i if i == IDENTS.i8 => fold_int_const(op, TryInto::<i8>::try_into(lhs_const).unwrap(), TryInto::<i8>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.i16 => fold_int_const(op, TryInto::<i16>::try_into(lhs_const).unwrap(), TryInto::<i16>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.i32 => fold_int_const(op, TryInto::<i32>::try_into(lhs_const).unwrap(), TryInto::<i32>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.i64 => fold_int_const(op, TryInto::<i64>::try_into(lhs_const).unwrap(), TryInto::<i64>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.isize => fold_int_const(op, TryInto::<isize>::try_into(lhs_const).unwrap(), TryInto::<isize>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.u8 => fold_int_const(op, TryInto::<u8>::try_into(lhs_const).unwrap(), TryInto::<u8>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.u16 => fold_int_const(op, TryInto::<u16>::try_into(lhs_const).unwrap(), TryInto::<u16>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.u32 => fold_int_const(op, TryInto::<u32>::try_into(lhs_const).unwrap(), TryInto::<u32>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.u64 => fold_int_const(op, TryInto::<u64>::try_into(lhs_const).unwrap(), TryInto::<u64>::try_into(rhs_const).unwrap()),
-                i if i == IDENTS.usize => fold_int_const(op, TryInto::<usize>::try_into(lhs_const).unwrap(), TryInto::<usize>::try_into(rhs_const).unwrap()),
+            return match lhs_const.ty {
+                IntTy::Int(SIntTy::I8) => fold_int_const(op, TryInto::<i8>::try_into(lhs_const).unwrap(), TryInto::<i8>::try_into(rhs_const).unwrap()),
+                IntTy::Int(SIntTy::I16) => fold_int_const(op, TryInto::<i16>::try_into(lhs_const).unwrap(), TryInto::<i16>::try_into(rhs_const).unwrap()),
+                IntTy::Int(SIntTy::I32) => fold_int_const(op, TryInto::<i32>::try_into(lhs_const).unwrap(), TryInto::<i32>::try_into(rhs_const).unwrap()),
+                IntTy::Int(SIntTy::I64) => fold_int_const(op, TryInto::<i64>::try_into(lhs_const).unwrap(), TryInto::<i64>::try_into(rhs_const).unwrap()),
+                IntTy::Int(SIntTy::ISize) => fold_int_const(op, TryInto::<isize>::try_into(lhs_const).unwrap(), TryInto::<isize>::try_into(rhs_const).unwrap()),
+                IntTy::UInt(UIntTy::U8) => fold_int_const(op, TryInto::<u8>::try_into(lhs_const).unwrap(), TryInto::<u8>::try_into(rhs_const).unwrap()),
+                IntTy::UInt(UIntTy::U16) => fold_int_const(op, TryInto::<u16>::try_into(lhs_const).unwrap(), TryInto::<u16>::try_into(rhs_const).unwrap()),
+                IntTy::UInt(UIntTy::U32) => fold_int_const(op, TryInto::<u32>::try_into(lhs_const).unwrap(), TryInto::<u32>::try_into(rhs_const).unwrap()),
+                IntTy::UInt(UIntTy::U64) => fold_int_const(op, TryInto::<u64>::try_into(lhs_const).unwrap(), TryInto::<u64>::try_into(rhs_const).unwrap()),
+                IntTy::UInt(UIntTy::U128) => fold_int_const(op, TryInto::<usize>::try_into(lhs_const).unwrap(), TryInto::<usize>::try_into(rhs_const).unwrap()),
                 _ => unreachable!(),
             }
         }

--- a/compiler/hash-lower/src/build/matches.rs
+++ b/compiler/hash-lower/src/build/matches.rs
@@ -1,3 +1,461 @@
-use super::Builder;
+//! Module that contains all of the logic with dealing with `match` blocks.
+//! Lowering `match` blocks is probably the most complex part of lowering, since
+//! we have to create essentially a *jump* table each case that is specified in
+//! the `match` arms, which might also have `if` guards, `or` patterns, etc.
+#![allow(unused, dead_code)]
 
-impl<'tcx> Builder<'tcx> {}
+use std::{borrow::Borrow, mem};
+
+use hash_ast::ast::{AstNodeRef, Expr, MatchCase};
+use hash_ir::{
+    ir::{BasicBlock, Place, TerminatorKind},
+    ty::{IrTy, Mutability},
+};
+use hash_source::{constant::CONSTANT_MAP, location::Span};
+use hash_target::size::Size;
+use hash_types::{
+    pats::{BindingPat, IfPat, Pat, PatId, RangePat, SpreadPat},
+    terms::{Level0Term, LitTerm, Term, TermId},
+};
+use hash_utils::{stack::ensure_sufficient_stack, store::Store};
+use smallvec::{smallvec, SmallVec};
+
+use super::{place::PlaceBuilder, ty::lower_term, unpack, BlockAnd, BlockAndExtend, Builder};
+
+pub struct Candidate {
+    /// The span of the `match` arm, for-error reporting
+    /// functionality.
+    pub span: Span,
+
+    /// Whether or not the candidate arm hsa an associated guard,
+    pub has_guard: bool,
+
+    /// All the bindings that are created in the candidate arm.
+    pub bindings: Vec<Binding>,
+
+    /// The match pair that is associated with the binding.
+    pub pats: SmallVec<[PatId; 1]>,
+
+    ///
+    pub otherwise_block: Option<BasicBlock>,
+    ///
+    pub pre_binding_block: Option<BasicBlock>,
+    ///
+    pub next_candidate_pre_bind_block: Option<BasicBlock>,
+
+    /// Any sub-candidates that are associated with this candidate.
+    pub sub_candidates: Vec<Candidate>,
+}
+
+impl Candidate {
+    /// Create a new [Candidate].
+    pub fn new(span: Span, pat: PatId, has_guard: bool) -> Self {
+        Self {
+            span,
+            has_guard,
+            otherwise_block: None,
+            pre_binding_block: None,
+            next_candidate_pre_bind_block: None,
+            // @@Todo: do we need to store an associated place with this pattern?
+            pats: smallvec![pat],
+            bindings: Vec::new(),
+            sub_candidates: Vec::new(),
+        }
+    }
+
+    /// Visit all of the leaves of a candidate and apply some operation on
+    /// each one that is contained in the current candidate.
+    pub fn visit_leaves<'a>(&'a mut self, mut visit_leaf: impl FnMut(&'a mut Candidate)) {
+        traverse_candidate(
+            self,
+            &mut (),
+            &mut move |c, _| visit_leaf(c),
+            move |c, _| c.sub_candidates.iter_mut(),
+            |_| {},
+        );
+    }
+}
+
+/// A depth-first traversal of the [Candidate] and all of its recursive
+/// sub candidates.
+fn traverse_candidate<C, T, I>(
+    candidate: C,
+    context: &mut T,
+    visit_leaf: &mut impl FnMut(C, &mut T),
+    get_children: impl Copy + Fn(C, &mut T) -> I,
+    complete_children: impl Copy + Fn(&mut T),
+) where
+    C: Borrow<Candidate>,
+    I: Iterator<Item = C>,
+{
+    if candidate.borrow().sub_candidates.is_empty() {
+        visit_leaf(candidate, context);
+    } else {
+        for child in get_children(candidate, context) {
+            traverse_candidate(child, context, visit_leaf, get_children, complete_children);
+        }
+
+        complete_children(context);
+    }
+}
+
+/// All the bindings that occur in a `match` arm.
+#[derive(Debug, Clone)]
+pub struct Binding {
+    /// The span of the binding.
+    pub span: Span,
+
+    // @@Todo: do we need to store an associated place with the pattern?
+    //
+    // The source of the binding, where the value is coming from.
+    // pub place: Place,
+    /// The mutability of the binding
+    pub mutability: Mutability,
+
+    /// The mode of the bind, whether it is by reference or by the value.
+    pub mode: BindingMode,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BindingMode {
+    ByValue,
+    ByRef,
+}
+
+type Candidates<'tcx> = (AstNodeRef<'tcx, MatchCase>, Candidate);
+
+impl<'tcx> Builder<'tcx> {
+    /// This is the entry point of matching an expression. Firstly, we deal with
+    /// the subject of the match, and then we build a decision tree of all
+    /// of the arms that have been specified, then we create all of the
+    /// blocks that are required to represent the decision tree. After the
+    /// decision tree has been built, we then build the blocks
+    /// that are required to represent the actual match arms.
+    pub(crate) fn match_expr(
+        &mut self,
+        destination: Place,
+        mut block: BasicBlock,
+        subject: AstNodeRef<'tcx, Expr>,
+        arms: Vec<AstNodeRef<'tcx, MatchCase>>,
+    ) -> BlockAnd<()> {
+        let subject_place =
+            unpack!(block = self.as_place_builder(block, subject, Mutability::Immutable));
+
+        // Make the decision tree here...
+        let mut arm_candidates = self.create_match_candidates(&arms);
+
+        let mut candidates =
+            arm_candidates.iter_mut().map(|(_, candidate)| candidate).collect::<Vec<_>>();
+
+        // Using the decision tree, now build up the blocks for each arm, and then
+        // join them at the end to the next block after the match, i.e. the `ending
+        // block`.
+        let ending_block = self.lower_match_arms(
+            block,
+            destination,
+            subject_place,
+            subject.span(),
+            &mut candidates,
+        );
+
+        ending_block.unit()
+    }
+
+    fn create_match_candidates(
+        &mut self,
+        arms: &[AstNodeRef<'tcx, MatchCase>],
+    ) -> Vec<Candidates<'tcx>> {
+        arms.iter()
+            .copied()
+            .map(|arm| {
+                let pat_id = self.get_pat_id_of_node(arm.pat.id());
+                let candidate = Candidate::new(arm.span, pat_id, arm.has_if_pat());
+                (arm, candidate)
+            })
+            .collect()
+    }
+
+    fn lower_match_arms(
+        &mut self,
+        block: BasicBlock,
+        destination: Place,
+        subject_place: PlaceBuilder,
+        subject_span: Span,
+        arm_candidates: &mut [&mut Candidate],
+    ) -> BasicBlock {
+        // This is the basic block that is derived for using when the
+        // matching fails on the pattern, and that it should jump to
+        // in the `otherwise` situation.
+        let mut otherwise = None;
+
+        self.match_candidates(block, &mut otherwise, arm_candidates);
+
+        // We need to terminate the otherwise block with an `unreachable` since
+        // this branch should never be reached since the `match` is exhaustive.
+        if let Some(otherwise_block) = otherwise {
+            self.control_flow_graph.terminate(
+                otherwise_block,
+                subject_span,
+                TerminatorKind::Unreachable,
+            );
+        }
+
+        todo!()
+    }
+
+    /// This is the main **entry point** of the match-lowering algorithm.
+    fn match_candidates(
+        &mut self,
+        block: BasicBlock,
+        otherwise: &mut Option<BasicBlock>,
+        candidates: &mut [&mut Candidate],
+    ) {
+        // Start by simplifying the candidates, i.e. splitting them into sub-candidates
+        // so that they can be dealt with in a much easier way. If any of the
+        // candidates we're split in the simplification process, we need to
+        // later re-add them to the `candidates` list so that when they are
+        // actually generated, they can be generated for only simple candidates,
+        // and that all of them are dealt with.
+        let mut split_or_candidate = false;
+
+        for candidate in &mut *candidates {
+            split_or_candidate |= self.simplify_candidate(candidate);
+        }
+
+        ensure_sufficient_stack(|| {
+            if split_or_candidate {
+                let mut new_candidates = Vec::new();
+
+                // Iterate over all of the candidates and essentially flatten the
+                // candidate list...
+                for candidate in candidates {
+                    candidate.visit_leaves(|leaf| new_candidates.push(leaf));
+                }
+
+                self.match_simplified_candidates(block, otherwise, &mut new_candidates)
+            } else {
+                self.match_simplified_candidates(block, otherwise, candidates)
+            }
+        });
+    }
+
+    fn match_simplified_candidates(
+        &mut self,
+        block: BasicBlock,
+        otherwise: &mut Option<BasicBlock>,
+        candidates: &mut [&mut Candidate],
+    ) {
+        todo!()
+    }
+
+    /// This function attempts to simplify a [Candidate] so that all match pairs
+    /// can be tested. This method will also split the candidate in which
+    /// the only match pair is a `or` pattern, in order for matches like:
+    /// ```ignore
+    /// match x {
+    ///    1 | 2 => {}
+    ///    4 | 6 => {}
+    /// }
+    /// ```
+    /// Will generate a single switch table.
+    ///
+    /// The function returns a boolean denoting whether it has performed any
+    /// splits on the given candidate.
+    fn simplify_candidate(&mut self, candidate: &mut Candidate) -> bool {
+        // keep a record of the existing bindings and all of the bindings that
+        // are to be added when exploring the pattern.
+        let mut existing_bindings = mem::take(&mut candidate.bindings);
+        let mut new_bindings = Vec::new();
+
+        loop {
+            let match_pairs = mem::take(&mut candidate.pats);
+
+            // Check if the bindings has a single or-pattern
+            if let [pat] = *match_pairs {
+                if self.tcx.pat_store.map_fast(pat, Pat::is_or) {
+                    // append all the new bindings, and then swap the two vecs around
+                    existing_bindings.extend_from_slice(&new_bindings);
+                    mem::swap(&mut candidate.bindings, &mut existing_bindings);
+
+                    // Now we need to create sub-candidates for each of the or-patterns
+                    return self.tcx.pat_store.map_fast(pat, |pat| {
+                        let Pat::Or(sub_pats) = pat else {
+                            unreachable!()
+                        };
+
+                        candidate.sub_candidates = self.create_sub_candidates(candidate, sub_pats);
+
+                        true
+                    });
+                }
+            }
+
+            // There are multiple patterns to check here, so we need to iterate
+            // over each one and perform a simplification...
+            let mut changed = false;
+
+            for pat in match_pairs {
+                match self.simplify_pat(pat, candidate) {
+                    Ok(_) => {
+                        changed = true;
+                    }
+                    // We need to re-evaluate one of the patterns later on
+                    Err(pat_id) => candidate.pats.push(pat_id),
+                }
+            }
+
+            // Combine the `new` bindings with the ones in the candidate, then swap
+            // the vectors, and delete the old candidate bindings.
+            candidate.bindings.extend_from_slice(&new_bindings);
+            mem::swap(&mut candidate.bindings, &mut new_bindings);
+            candidate.bindings.clear();
+
+            if !changed {
+                // append all the new bindings, and then swap the two vecs around
+                existing_bindings.extend_from_slice(&new_bindings);
+                mem::swap(&mut candidate.bindings, &mut existing_bindings);
+
+                // sort all of the pats in the candidate by `or-pat` last
+                candidate.pats.sort_by_key(|pat| self.tcx.pat_store.map_fast(*pat, Pat::is_or));
+
+                // We weren't able to perform any further simplifications, so return false
+                return false;
+            }
+        }
+    }
+
+    fn simplify_pat(&mut self, pat_id: PatId, candidate: &mut Candidate) -> Result<(), PatId> {
+        self.tcx.pat_store.map_fast(pat_id, |pat| {
+            // Get the span of this partciular pattern...
+            let span = self.tcx.location_store.get_span(pat_id).unwrap();
+
+            match pat {
+                Pat::Binding(BindingPat { mutability, .. }) => {
+                    candidate.bindings.push(Binding {
+                        span,
+                        mutability: (*mutability).into(),
+                        // @@Todo: introduce a way of specifying what the binding
+                        // mode of a particular binding is, but for now we assume that
+                        // it is always by value.
+                        mode: BindingMode::ByValue,
+                    });
+
+                    // @@SubPatterns: we don't currently support sub-patterns in bindings, i.e.
+                    // when a pattern binds a sub-pattern: `x @ (y, z)` where `(y, z)` is the
+                    // sub patterns. When this is added, we need to push all of the
+                    // sub-patterns into the `pats` of the candidate so that they can be dealt with.
+
+                    Ok(())
+                }
+                Pat::Range(RangePat { lo, hi, end }) => {
+                    // get the range and bias of this range pattern from
+                    // the `lo`
+                    let lo_ty = lower_term(*lo, self.tcx, self.storage);
+                    // let lo_ty_id = self.storage.ty_store().create(lo_ty);
+
+                    // The range is the minimum value, maximum value, and the size of
+                    // the item that is being compared.
+                    //
+                    // @@Todo: deal with big-ints
+                    let (range, bias) = match lo_ty {
+                        IrTy::Char => (
+                            Some(('\u{0000}' as u128, '\u{10FFFF}' as u128, Size::from_bytes(4))),
+                            0,
+                        ),
+                        IrTy::Int(int_ty) => {
+                            let size = int_ty.size(self.tcx.target_pointer_width).unwrap();
+                            let max = size.truncate(u128::MAX);
+                            let bias = 1u128 << (size.bits() - 1);
+                            (Some((0, max, size)), bias)
+                        }
+                        IrTy::UInt(uint_ty) => {
+                            let size = uint_ty.size(self.tcx.target_pointer_width).unwrap();
+                            let max = size.truncate(u128::MAX);
+                            (Some((0, max, size)), 0)
+                        }
+                        _ => (None, 0),
+                    };
+
+                    // We want to compare ranges numerically, but the order of the bitwise
+                    // representation of signed integers does not match their numeric order. Thus,
+                    // to correct the ordering, we need to shift the range of signed integers to
+                    // correct the comparison. This is achieved by XORing with a bias.
+                    if let Some((min, max, size)) = range {
+                        let term_to_val = |term: TermId| -> u128 {
+                            self.tcx.term_store.map_fast(*lo, |term| match term {
+                                Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => {
+                                    CONSTANT_MAP.map_int_constant(*value, |val| {
+                                        u128::from_be_bytes(val.get_bytes())
+                                    })
+                                }
+                                _ => unreachable!(),
+                            })
+                        };
+
+                        // we have to convert the `lo` term into the actual value, by getting
+                        // the literal term from this term, and then converting the stored value
+                        // into a u128...
+                        let lo_val = term_to_val(*lo);
+
+                        // let lo = lo.try_to_bits(sz).unwrap() ^ bias;
+                    }
+
+                    Err(pat_id)
+                }
+                Pat::Tuple(_) => todo!(),
+                Pat::Access(_) | Pat::Const(_) | Pat::Constructor(_) => todo!(),
+                Pat::List(_) => todo!(),
+
+                // We essentially create a new bind for the tuple here
+                // that captures all of the members. We create a new bind
+                // with the type of this `spread` type which is derived
+                // during typechecking...
+                Pat::Spread(SpreadPat { name }) if name.is_some() => {
+                    candidate.bindings.push(Binding {
+                        span,
+                        // @@FixMe: allow for spread patterns to be declared as `mut`
+                        mutability: Mutability::Immutable,
+
+                        // @@FixMe: is this correct? Since it shouldn't always be passed by
+                        // reference into the proceeding block
+                        mode: BindingMode::ByRef,
+                    });
+
+                    Ok(())
+                }
+
+                // We don't need to do anything with this pattern here.
+                Pat::Spread(_) | Pat::Mod(_) | Pat::Wild => Ok(()),
+
+                // Look at the pattern located within the if-pat
+                Pat::If(IfPat { pat, .. }) => self.simplify_pat(*pat, candidate),
+
+                // We have to deal with these outside of this function
+                Pat::Lit(_) => Err(pat_id),
+                Pat::Or(_) => Err(pat_id),
+            }
+        })
+    }
+
+    /// Iterate over a set of sub candidates and create a new candidate for each
+    /// of them. This function also propagates if any of the above patterns have
+    /// an `if` guard around the pattern, in the event that they have to
+    /// jump to an `otherwise` case later on during the lowering process.
+    fn create_sub_candidates(
+        &mut self,
+        candidate: &mut Candidate,
+        sub_pats: &[PatId],
+    ) -> Vec<Candidate> {
+        sub_pats
+            .iter()
+            .copied()
+            .map(|pat_id| {
+                let pat_has_guard = self.tcx.pat_store.map_fast(pat_id, Pat::is_or);
+                let mut sub_candidate =
+                    Candidate::new(candidate.span, pat_id, candidate.has_guard || pat_has_guard);
+                self.simplify_candidate(candidate);
+                sub_candidate
+            })
+            .collect()
+    }
+}

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -26,8 +26,8 @@ use hash_ir::{
 };
 use hash_pipeline::settings::LoweringSettings;
 use hash_source::{identifier::Identifier, location::Span, SourceId, SourceMap};
-use hash_types::{pats::Pat, scope::ScopeId, storage::GlobalStorage};
-use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
+use hash_types::{pats::PatId, scope::ScopeId, storage::GlobalStorage};
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 use index_vec::IndexVec;
 
 use self::ty::{convert_term_into_ir_ty, get_fn_ty_from_term, lower_term};
@@ -307,10 +307,8 @@ impl<'tcx> Builder<'tcx> {
     /// Function to get the associated [PatId] with the
     /// provided [AstNodeId].
     #[inline]
-    fn get_pat_id_of_node(&self, id: AstNodeId) -> Pat {
-        let pat_id = self.tcx.node_info_store.node_info(id).map(|f| f.pat_id()).unwrap();
-
-        self.tcx.pat_store.get(pat_id)
+    fn get_pat_id_of_node(&self, id: AstNodeId) -> PatId {
+        self.tcx.node_info_store.node_info(id).map(|f| f.pat_id()).unwrap()
     }
 
     /// Function to create a new [Place] that is used to ignore

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -13,6 +13,7 @@ use super::{unpack, BlockAnd, BlockAndExtend, Builder};
 /// A builder interface for building a [Place] with a base [Local]
 /// and a collection of projections that are applied as the
 /// [Place] is constructed.
+#[derive(Debug, Clone)]
 pub struct PlaceBuilder {
     /// The place that we are building.
     base: Local,

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -10,7 +10,7 @@ use hash_ir::{
     IrStorage,
 };
 use hash_source::{
-    constant::{FloatTy, SIntTy, UIntTy},
+    constant::{FloatTy, SIntTy, UIntTy, CONSTANT_MAP},
     identifier::IDENTS,
 };
 use hash_types::{
@@ -61,7 +61,7 @@ pub(super) fn lower_term(term: TermId, tcx: &GlobalStorage, ir_ctx: &IrStorage) 
             }
             Level0Term::Lit(lit_term) => match lit_term {
                 LitTerm::Str(_) => IrTy::Str,
-                LitTerm::Int { kind, .. } => kind.into(),
+                LitTerm::Int { value } => CONSTANT_MAP.map_int_constant(value, |val| val.ty).into(),
                 LitTerm::Char(_) => IrTy::Char,
             },
             Level0Term::Unit(_)

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -788,12 +788,12 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 // Now read the value and verify that it has no numeric prefix
                 let interned_lit = CONSTANT_MAP.lookup_int_constant(value);
 
-                if let Some(suffix )= interned_lit.suffix {
+                if let Some(suffix) = interned_lit.suffix {
                     return self.err_with_location(ParseErrorKind::DisallowedSuffix(suffix), None, None, token.span)?;
                 }
 
                 self.skip_token();
-                let value = usize::try_from(interned_lit.to_big_int()).map_err(|_| {
+                let value = usize::try_from(interned_lit).map_err(|_| {
                     self.make_err(ParseErrorKind::InvalidPropertyAccess, None, None, Some(token.span))
                 })?;
 

--- a/compiler/hash-source/Cargo.toml
+++ b/compiler/hash-source/Cargo.toml
@@ -15,3 +15,4 @@ derive_more = "0.99"
 
 hash-utils = { path = "../hash-utils" } 
 hash-alloc = { path = "../hash-alloc" }
+hash-target = { path = "../hash-target" }

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -1,5 +1,7 @@
 //! Definitions to describe the target of Hash compilation.
 
+pub mod size;
+
 use std::{
     env::consts::ARCH,
     fmt::{Display, Formatter},

--- a/compiler/hash-target/src/size.rs
+++ b/compiler/hash-target/src/size.rs
@@ -1,0 +1,57 @@
+//! Represents all of the logic related to type sizes, and various
+//! utilities surrounding type sizes.
+
+/// Represents the size of some constant in bytes. [Size] is a
+/// utility type that allows one to perform various conversions
+/// on the size (bits and bytes), and to derive .
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Size {
+    value: u64,
+}
+
+impl Size {
+    /// The [Size::ZERO] is often used for type of size 0.
+    pub const ZERO: Size = Size { value: 0 };
+
+    /// Create a [Size] from the number of bytes.
+    pub fn from_bytes(value: impl TryInto<u64>) -> Self {
+        Self { value: value.try_into().ok().unwrap() }
+    }
+
+    /// Create a [Size] from the number of bits. This function will
+    /// rounds `value` up to the next-higher byte boundary, if `bits` is
+    /// not a multiple of 8.
+    pub fn from_bits(value: impl TryInto<u64>) -> Self {
+        let bits = value.try_into().ok().unwrap();
+
+        // Avoid potential overflow from `bits + 7`.
+        Size { value: bits / 8 + ((bits % 8) + 7) / 8 }
+    }
+
+    /// Return the [Size] in bytes.
+    #[inline]
+    pub fn bytes(self) -> u64 {
+        self.value
+    }
+
+    /// Convert the [Size] into the number of bits.
+    #[inline]
+    pub fn bits(self) -> u64 {
+        self.value * 8
+    }
+
+    /// Truncates `value` to `self` bits.
+    #[inline]
+    pub fn truncate(self, value: u128) -> u128 {
+        let size = self.bits();
+        if size == 0 {
+            // Truncated until nothing is left.
+            return 0;
+        }
+
+        let shift = 128 - size;
+        // Truncate (shift left to drop out leftover values, shift right to fill with
+        // zeroes).
+        (value << shift) >> shift
+    }
+}

--- a/compiler/hash-typecheck/src/exhaustiveness/constant.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/constant.rs
@@ -2,9 +2,8 @@
 //! to represent literals, and convert them into a `ConstantValue` which is
 //! used within the exhaustiveness sub-system to represent these values within
 //! a single data type.
-use hash_source::constant::IntTy;
+use hash_source::constant::{InternedInt, CONSTANT_MAP};
 use hash_types::terms::TermId;
-use num_bigint::BigInt;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Constant {
@@ -26,31 +25,24 @@ impl Constant {
         Constant { data: num, ty }
     }
 
-    /// Function to convert a [BigInt] into a [Constant]. The only
+    /// Function to convert a [InternedInt] into a [Constant]. The only
     /// constraint is that it can fit into a [u128], otherwise the
     /// function will currently panic.
-    pub fn from_int(int: BigInt, kind: IntTy, ty: TermId, ptr_width: usize) -> Self {
-        let size = kind.size(ptr_width).map(|size| size * 8).unwrap_or_else(|| int.bits());
-        assert!(size < 128);
+    pub fn from_int(value: InternedInt, ty: TermId, ptr_width: usize) -> Self {
+        let kind = CONSTANT_MAP.map_int_constant(value, |value| value.ty);
+        let bytes = kind.size(ptr_width).unwrap().bytes() as usize;
 
-        // @@Hack: this should be done in some better way or tidied up!
-        // This is here because `BigInt::to_be_bytes()` returns the minimum
-        // number of bytes rather than providing functions that could coerce the
-        // type into another. Since we work with only `u128` we need to
-        // perform this ugly bit shifts in order for this to work...
+        // Get the associated bytes with the interned-int so we can convert
+        // into a constant.
+        let mut data = CONSTANT_MAP.lookup_int_constant(value).get_bytes();
+
+        // memset the upper 16-kind.size() bytes to zero since they aren't
+        // necessary.
         if kind.is_signed() {
-            // Cast the `bigint` into a i128 and then convert to big-endian bytes
-            let mut data = (<BigInt as TryInto<i128>>::try_into(int).unwrap()).to_be_bytes();
-
-            // memset the upper 16-kind.size() bytes to zero since they aren't
-            // necessary.
-            data[0..(16 - kind.size(ptr_width).unwrap() as usize)].fill(0);
-
-            Constant { data: u128::from_be_bytes(data), ty }
-        } else {
-            let (_, data) = int.into_parts();
-            Constant { data: data.try_into().unwrap(), ty }
+            data[0..(16 - bytes)].fill(0);
         }
+
+        Constant { data: u128::from_be_bytes(data), ty }
     }
 
     /// Get the data stored within the [Constant].

--- a/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-typecheck/src/exhaustiveness/wildcard.rs
@@ -93,9 +93,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                 kind if kind.is_signed() => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
                     let ptr_width = self.global_storage().target_pointer_width;
-                    let size = kind.size(ptr_width).unwrap();
-                    let bits = (size * 8) as u128;
-
+                    let bits = kind.size(ptr_width).unwrap().bits() as u128;
                     let min = 1u128 << (bits - 1);
                     let max = min - 1;
 
@@ -106,13 +104,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
                     let ptr_width = self.global_storage().target_pointer_width;
                     let size = kind.size(ptr_width).unwrap();
-                    let bits = size * 8;
-
-                    let shift = 128 - bits;
-
-                    // Truncate (shift left to drop out leftover values, shift right to
-                    // fill with zeroes).
-                    let max = (u128::MAX << shift) >> shift;
+                    let max = size.truncate(u128::MAX);
 
                     smallvec![make_range(0, max)]
                 }

--- a/compiler/hash-typecheck/src/ops/typing.rs
+++ b/compiler/hash-typecheck/src/ops/typing.rs
@@ -1,5 +1,6 @@
 //! Contains operations to get the type of a term.
 use hash_ast::ast::ParamOrigin;
+use hash_source::{constant::CONSTANT_MAP, identifier::Identifier};
 use hash_types::{
     args::{Arg, ArgsId},
     mods::ModDefOrigin,
@@ -242,8 +243,10 @@ impl<'tc> Typer<'tc> {
                         let term = match lit_term {
                             LitTerm::Str(_) => self.core_defs().str_ty(),
                             // @@Todo: do some more sophisticated inferring here
-                            LitTerm::Int { kind, .. } => {
-                                self.core_defs().resolve_core_def(kind.to_name().into())
+                            LitTerm::Int { value } => {
+                                let kind: Identifier =
+                                    CONSTANT_MAP.map_int_constant(value, |int| int.ty).into();
+                                self.core_defs().resolve_core_def(kind)
                             }
                             LitTerm::Char(_) => self.core_defs().char_ty(),
                         };

--- a/compiler/hash-typecheck/src/ops/validate.rs
+++ b/compiler/hash-typecheck/src/ops/validate.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 
 use hash_ast::ast::{ParamOrigin, RangeEnd};
 use hash_reporting::diagnostic::Diagnostics;
+use hash_source::constant::CONSTANT_MAP;
 use hash_types::{
     args::ArgsId,
     mods::{ModDefId, ModDefOrigin},
@@ -1213,10 +1214,12 @@ impl<'tc> Validator<'tc> {
                 _ => Ok(()),
             },
             (
-                Term::Level0(Level0Term::Lit(LitTerm::Int { value: lhs, kind: lhs_kind })),
-                Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs, kind: rhs_kind })),
+                Term::Level0(Level0Term::Lit(LitTerm::Int { value: lhs })),
+                Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs })),
             ) => {
                 let ptr_width = self.global_storage().target_pointer_width;
+                let lhs_kind = CONSTANT_MAP.map_int_constant(lhs, |val| val.ty);
+                let rhs_kind = CONSTANT_MAP.map_int_constant(rhs, |val| val.ty);
 
                 // Check that the integer type is sized, if it is not then we currently
                 // say that this is not supported...

--- a/compiler/hash-types/src/pats.rs
+++ b/compiler/hash-types/src/pats.rs
@@ -159,6 +159,11 @@ impl Pat {
         matches!(self, Pat::Spread(_))
     }
 
+    /// Check if this pattern is a or-pattern
+    pub fn is_or(&self) -> bool {
+        matches!(self, Pat::Or(_))
+    }
+
     /// Check if the pattern is of the [Pat::Spread] variant.
     pub fn is_bind(&self) -> bool {
         matches!(self, Pat::Binding(_))

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -126,11 +126,11 @@ pub(crate) struct IrGenMode {
 
     /// If the IR should be printed to stdout or not, and in which
     /// format, options are `pretty` or `graph`.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, default_value_t = IrDumpMode::Pretty)]
     pub(crate) dump_mode: IrDumpMode,
 
     /// Whether to print the IR to stdout or not.
-    #[arg(long)]
+    #[arg(long, default_value_t = false)]
     pub(crate) dump: bool,
 
     /// Whether the IR should use `checked` operations, this flag is


### PR DESCRIPTION
This patch re-works `IntConstant` to store the `IntTy` on each constant so that it can be accessed across all users of the value. This has simplified some code and has changed some responsibilities (from the parser to the lexer). More specifically, when literals have suffixes, it is now the lexer's job to verify that they are valid suffixes instead of letting this be dealt with later at the parsing stage.

Furthermore, this adds some of the beginnings of the lowering process for `match` expressions. The procedure is as follows:
- firstly, we convert all the match arms into `Candidate`s which store information about the binds that occur in each arm, whether they have an `if_guard` etc, and the blocks they will jump. (done)
- next, all the `Candidate`s are flattened since patterns may have sub-patterns (like `or` patterns) which need to become their own `Candidate`s. (partially done)
- we compute `Test`s which are essentially various ways of representing what arms test what values, and therefore deriving where they need to **jump** if the value is correct, or otherwise. (todo)
- next, all the `start_block`s, `otherwise_block`s  are derived. (todo)