### PR TITLE
Add `Reporter` to `reporting` crate to create `Vec<Report>` easily

### DIFF
--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -14,13 +14,13 @@ use std::{collections::HashMap, env, time::Duration};
 
 use fs::{read_in_path, resolve_path, PRELUDE};
 use hash_ast::node_map::ModuleEntry;
-use hash_reporting::{report::Report, writer::ReportWriter};
+use hash_reporting::{builder::Reports, writer::ReportWriter};
 use hash_source::{constant::CONSTANT_MAP, ModuleKind, SourceId};
 use hash_utils::timing::timed;
 use interface::{CompilerInterface, CompilerStage};
 use settings::CompilerStageKind;
 
-pub type CompilerResult<T> = Result<T, Vec<Report>>;
+pub type CompilerResult<T> = Result<T, Reports>;
 
 /// The Hash Compiler interface. This interface allows a caller to create a
 /// [Compiler] with the specified components. This allows external tinkerers

--- a/compiler/hash-reporting/src/builder.rs
+++ b/compiler/hash-reporting/src/builder.rs
@@ -3,6 +3,31 @@ use hash_error_codes::error_codes::HashErrorCode;
 
 use crate::report::{Report, ReportElement, ReportKind};
 
+pub type Reports = Vec<Report>;
+
+/// Facilitates the creation of lists of [Report]s in a declarative way.
+#[derive(Debug, Default)]
+pub struct Reporter {
+    report_builders: Vec<ReportBuilder>,
+}
+
+impl Reporter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a report to the builder.
+    pub fn add_report(&mut self) -> &mut ReportBuilder {
+        self.report_builders.push(ReportBuilder::new());
+        self.report_builders.last_mut().unwrap()
+    }
+
+    /// Build the report list.
+    pub fn build(self) -> Reports {
+        self.report_builders.into_iter().map(|mut builder| builder.build()).collect()
+    }
+}
+
 /// A utility struct that allows for a [Report] to be built incrementally
 /// adding annotations and other metadata to the report.
 #[derive(Debug, Default)]

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -143,12 +143,12 @@ impl<Ctx: TypecheckingCtx> CompilerStage<Ctx> for Typechecker {
             let tc_visitor = new::passes::TcVisitor::new(&storage._new);
             tc_visitor.visit_source();
             if tc_visitor.tc_env().diagnostics().has_errors() {
-                return Err(vec![tc_visitor
+                return Err(tc_visitor
                     .tc_env()
                     .with(&crate::new::diagnostics::error::TcError::Compound {
                         errors: tc_visitor.diagnostics().errors_owned(),
                     })
-                    .into()]);
+                    .into());
             }
         } else {
             let tc_visitor = TcVisitor::new_in_source(storage.storages(), &workspace.node_map);


### PR DESCRIPTION
This commit adds the `Reporter` struct to the `reporting` crate. This struct is used to create a `Vec<Report>` from `ReportBuilder`s which are created using `add_report()`.