### PR TITLE
lowering: support lowering `enum`, `struct`, `(a, b)` and `[a, b, c]` as `RValue`s

### DIFF
--- a/compiler/hash-error-codes/src/error_codes.rs
+++ b/compiler/hash-error-codes/src/error_codes.rs
@@ -31,6 +31,7 @@ error_codes! {
     UnsupportedTyFnApplication = 26,
     TypeIsNotTrait = 27,
     InvalidUnionElement = 28,
+    InvalidIndexSubject = 29,
 
     // Errors in regard to parameter lists
     ParameterLengthMismatch = 35,

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -398,9 +398,9 @@ impl Place {
 /// structure be it a tuple, array, struct, etc.
 ///
 /// @@Todo: decide whether to keep this, or to stick with just immediately
-///         lowering items as setting values for each field within the aggregate
-///         data structure (as it). If we stick with initially generating
-/// aggregates,         then we will have to de-aggregate them before lowering
+/// lowering items as setting values for each field within the aggregate
+/// data structure (as it). If we stick with initially generating
+/// aggregates, then we will have to de-aggregate them before lowering
 /// to bytecode/llvm.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AggregateKind {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -412,11 +412,18 @@ pub enum AggregateKind {
 
     /// Enum aggregate kind, this is used to represent an initialisation
     /// of an enum variant with the specified variant index.
-    Enum(AdtId, usize),
+    Enum(AdtId, VariantIdx),
 
     /// Struct aggregate kind, this is used to represent a struct
     /// initialisation.
     Struct(AdtId),
+}
+
+impl AggregateKind {
+    /// Check if the [AggregateKind] represents an ADT.
+    pub fn is_adt(&self) -> bool {
+        !matches!(self, AggregateKind::Array(_))
+    }
 }
 
 /// The representation of values that occur on the right-hand side of an
@@ -460,7 +467,7 @@ pub enum RValue {
     Ref(Mutability, Place, AddressMode),
     /// Used for initialising structs, tuples and other aggregate
     /// data structures
-    Aggregate(AggregateKind, Vec<Place>),
+    Aggregate(AggregateKind, Vec<RValueId>),
     /// Compute the discriminant of a [Place], this is essentially checking
     /// which variant a union is. For types that don't have a discriminant
     /// (non-union types ) this will return the value as 0.

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1,7 +1,7 @@
 //! Hash Compiler Intermediate Representation (IR) crate. This module is still
 //! under construction and is subject to change.
 use core::slice;
-use std::{cmp::Ordering, fmt};
+use std::{cmp::Ordering, fmt, iter::once};
 
 use hash_ast::ast;
 use hash_source::{
@@ -12,14 +12,14 @@ use hash_source::{
 };
 use hash_types::terms::TermId;
 use hash_utils::{
-    new_store_key,
-    store::{DefaultStore, Store},
+    new_sequence_store_key, new_store_key,
+    store::{DefaultSequenceStore, DefaultStore, SequenceStore, Store},
 };
 use index_vec::IndexVec;
 use smallvec::SmallVec;
 
 use crate::{
-    ty::{IrTy, IrTyId, Mutability, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, Mutability, VariantIdx},
     IrStorage,
 };
 
@@ -360,84 +360,37 @@ pub enum PlaceProjection {
     Deref,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Place {
     /// The original place of where this is referring to.
     pub local: Local,
+
     /// Any projections that are applied onto the `local` in
     /// order to specify an exact location within the local.
-    ///
-    /// @@Todo: maybe make this a slice rather than a vec, we
-    /// could create a `projection` store..., in order to make
-    /// this copyable.
-    pub projections: Vec<PlaceProjection>,
+    pub projections: ProjectionId,
 }
 
 impl Place {
     /// Create a [Place] that points to the return `place` of a lowered  body.
-    pub fn return_place() -> Self {
-        Self { local: RETURN_PLACE, projections: Vec::new() }
+    pub fn return_place(storage: &IrStorage) -> Self {
+        Self { local: RETURN_PLACE, projections: storage.projection_store.create_empty() }
+    }
+
+    pub fn from_local(local: Local, storage: &IrStorage) -> Self {
+        Self { local, projections: storage.projection_store.create_empty() }
     }
 
     /// Create a new [Place] from an existing place whilst also
     /// applying a a [PlaceProjection::Field] on the old one.
-    pub fn field(&self, field: usize) -> Self {
-        let mut projections = self.projections.clone();
-        projections.push(PlaceProjection::Field(field));
-        Self { local: self.local, projections }
-    }
-}
+    pub fn field(&self, field: usize, storage: &IrStorage) -> Self {
+        let projections = storage.projection_store.get_vec(self.projections);
 
-impl From<Local> for Place {
-    fn from(value: Local) -> Self {
-        Self { local: value, projections: Vec::new() }
-    }
-}
-
-impl fmt::Display for Place {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // First we, need to deal with the `deref` projections, since
-        // they need to be printed in reverse
-        for projection in self.projections.iter().rev() {
-            match projection {
-                PlaceProjection::Downcast(_) | PlaceProjection::Field(_) => write!(f, "(")?,
-                PlaceProjection::Deref => write!(f, "(*")?,
-                PlaceProjection::Subslice { .. }
-                | PlaceProjection::ConstantIndex { .. }
-                | PlaceProjection::Index(_) => {}
-            }
+        Self {
+            local: self.local,
+            projections: storage.projection_store.create_from_iter_fast(
+                projections.iter().copied().chain(once(PlaceProjection::Field(field))),
+            ),
         }
-
-        write!(f, "{:?}", self.local)?;
-
-        for projection in &self.projections {
-            match projection {
-                PlaceProjection::Downcast(index) => write!(f, " as variant#{index})")?,
-                PlaceProjection::Index(local) => write!(f, "[{local:?}]")?,
-                PlaceProjection::ConstantIndex { offset, min_length, from_end: true } => {
-                    write!(f, "[-{offset:?} of {min_length:?}]")?;
-                }
-                PlaceProjection::ConstantIndex { offset, min_length, from_end: false } => {
-                    write!(f, "[{offset:?} of {min_length:?}]")?;
-                }
-                PlaceProjection::Subslice { from, to, from_end: true } if *to == 0 => {
-                    write!(f, "[{from}:]")?;
-                }
-                PlaceProjection::Subslice { from, to, from_end: false } if *from == 0 => {
-                    write!(f, "[:-{to:?}]")?;
-                }
-                PlaceProjection::Subslice { from, to, from_end: true } => {
-                    write!(f, "[{from}:-{to:?}]")?;
-                }
-                PlaceProjection::Subslice { from, to, from_end: false } => {
-                    write!(f, "[{from:?}:{to:?}]")?;
-                }
-                PlaceProjection::Field(index) => write!(f, ".{index})")?,
-                PlaceProjection::Deref => write!(f, ")")?,
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -459,11 +412,11 @@ pub enum AggregateKind {
 
     /// Enum aggregate kind, this is used to represent an initialisation
     /// of an enum variant with the specified variant index.
-    Enum(IrTyId, usize),
+    Enum(AdtId, usize),
 
     /// Struct aggregate kind, this is used to represent a struct
     /// initialisation.
-    Struct(IrTyId),
+    Struct(AdtId),
 }
 
 /// The representation of values that occur on the right-hand side of an
@@ -960,33 +913,43 @@ new_store_key!(pub RValueId);
 /// [Rvalue]s are accessed by an ID, of type [RValueId].
 pub type RValueStore = DefaultStore<RValueId, RValue>;
 
+new_sequence_store_key!(pub ProjectionId);
+
+/// Stores all collections of projections that can occur on a place.
+///
+/// This is used to efficiently represent [Place]s that might have many
+/// projections, and to easily copy them when duplicating places.
+pub type ProjectionStore = DefaultSequenceStore<ProjectionId, PlaceProjection>;
+
 #[cfg(test)]
 mod tests {
-    use crate::ir::*;
+    use crate::{ir::*, write::WriteIr};
 
     #[test]
     fn test_place_display() {
+        let storage = IrStorage::new();
+
         let place = Place {
             local: Local::new(0),
-            projections: vec![
+            projections: storage.projection_store.create_from_slice(&[
                 PlaceProjection::Deref,
                 PlaceProjection::Field(0),
                 PlaceProjection::Index(Local::new(1)),
                 PlaceProjection::Downcast(VariantIdx::from_usize(0)),
-            ],
+            ]),
         };
 
-        assert_eq!(format!("{place}"), "(((*_0).0)[_1] as variant#0)");
+        assert_eq!(format!("{}", place.for_fmt(&storage)), "(((*_0).0)[_1] as variant#0)");
 
         let place = Place {
             local: Local::new(0),
-            projections: vec![
+            projections: storage.projection_store.create_from_slice(&[
                 PlaceProjection::Deref,
                 PlaceProjection::Deref,
                 PlaceProjection::Deref,
-            ],
+            ]),
         };
 
-        assert_eq!(format!("{place}"), "(*(*(*_0)))");
+        assert_eq!(format!("{}", place.for_fmt(&storage)), "(*(*(*_0)))");
     }
 }

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 
 use hash_types::terms::TermId;
 use hash_utils::store::Store;
-use ir::{Body, RValue, RValueId, RValueStore};
+use ir::{Body, ProjectionStore, RValue, RValueId, RValueStore};
 use ty::{AdtStore, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the IR builder.
@@ -24,6 +24,9 @@ pub struct IrStorage {
 
     /// The storage for all the [RValue]s.
     rvalue_store: ir::RValueStore,
+
+    /// This the storage for all projection collections.
+    projection_store: ir::ProjectionStore,
 
     /// The storage for all of the used types that are within the IR.
     ty_store: ty::TyStore,
@@ -46,6 +49,7 @@ impl IrStorage {
         Self {
             generated_bodies: Vec::new(),
             rvalue_store: RValueStore::default(),
+            projection_store: ProjectionStore::default(),
             ty_store: TyStore::default(),
             ty_list_store: TyListStore::default(),
             adt_store: AdtStore::default(),
@@ -71,6 +75,11 @@ impl IrStorage {
     /// Get a reference to the [RValueStore]
     pub fn rvalue_store(&self) -> &RValueStore {
         &self.rvalue_store
+    }
+
+    /// Get a reference to the [ProjectionStore]
+    pub fn projection_store(&self) -> &ProjectionStore {
+        &self.projection_store
     }
 
     /// Get a reference to the type cache.

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -210,6 +210,8 @@ index_vec::define_index_type! {
     DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
 
     DEBUG_FORMAT = "variant#{}";
+
+    DISPLAY_FORMAT="{}";
 }
 
 /// This is the underlying data of an ADT which is stored behind an [AdtId].
@@ -255,8 +257,8 @@ impl AdtData {
     }
 
     /// Lookup the index of a variant by its name.
-    pub fn variant_idx(&self, name: &Identifier) -> Option<usize> {
-        self.variants.iter().position(|variant| &variant.name == name)
+    pub fn variant_idx(&self, name: &Identifier) -> Option<VariantIdx> {
+        self.variants.position(|variant| &variant.name == name)
     }
 
     /// Compute the discriminant type of this ADT, assuming that this

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -10,7 +10,7 @@ pub mod pretty;
 
 use std::fmt;
 
-use hash_utils::store::Store;
+use hash_utils::store::{SequenceStore, Store};
 
 use super::ir::*;
 use crate::{
@@ -53,12 +53,63 @@ impl WriteIr for IrTyId {}
 impl WriteIr for IrTyListId {}
 impl WriteIr for AdtId {}
 
+impl WriteIr for Place {}
+
+impl fmt::Display for ForFormatting<'_, Place> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.storage.projection_store.map_fast(self.item.projections, |projections| {
+            // First we, need to deal with the `deref` projections, since
+            // they need to be printed in reverse
+            for projection in projections.iter().rev() {
+                match projection {
+                    PlaceProjection::Downcast(_) | PlaceProjection::Field(_) => write!(f, "(")?,
+                    PlaceProjection::Deref => write!(f, "(*")?,
+                    PlaceProjection::Subslice { .. }
+                    | PlaceProjection::ConstantIndex { .. }
+                    | PlaceProjection::Index(_) => {}
+                }
+            }
+
+            write!(f, "{:?}", self.item.local)?;
+
+            for projection in projections.iter() {
+                match projection {
+                    PlaceProjection::Downcast(index) => write!(f, " as variant#{index})")?,
+                    PlaceProjection::Index(local) => write!(f, "[{local:?}]")?,
+                    PlaceProjection::ConstantIndex { offset, min_length, from_end: true } => {
+                        write!(f, "[-{offset:?} of {min_length:?}]")?;
+                    }
+                    PlaceProjection::ConstantIndex { offset, min_length, from_end: false } => {
+                        write!(f, "[{offset:?} of {min_length:?}]")?;
+                    }
+                    PlaceProjection::Subslice { from, to, from_end: true } if *to == 0 => {
+                        write!(f, "[{from}:]")?;
+                    }
+                    PlaceProjection::Subslice { from, to, from_end: false } if *from == 0 => {
+                        write!(f, "[:-{to:?}]")?;
+                    }
+                    PlaceProjection::Subslice { from, to, from_end: true } => {
+                        write!(f, "[{from}:-{to:?}]")?;
+                    }
+                    PlaceProjection::Subslice { from, to, from_end: false } => {
+                        write!(f, "[{from:?}:{to:?}]")?;
+                    }
+                    PlaceProjection::Field(index) => write!(f, ".{index})")?,
+                    PlaceProjection::Deref => write!(f, ")")?,
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
 impl WriteIr for RValueId {}
 
 impl fmt::Display for ForFormatting<'_, RValueId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.storage.rvalue_store().map_fast(self.item, |rvalue| match rvalue {
-            RValue::Use(place) => write!(f, "{place}"),
+            RValue::Use(place) => write!(f, "{}", place.for_fmt(self.storage)),
             RValue::Const(Const::Zero(ty)) => write!(f, "{}", ty.for_fmt(self.storage)),
             RValue::Const(const_value) => write!(f, "const {const_value}"),
             RValue::BinaryOp(op, lhs, rhs) => {
@@ -72,12 +123,14 @@ impl fmt::Display for ForFormatting<'_, RValueId> {
                     rhs.for_fmt(self.storage)
                 )
             }
-            RValue::Len(place) => write!(f, "len({place})"),
+            RValue::Len(place) => write!(f, "len({})", place.for_fmt(self.storage)),
             RValue::UnaryOp(op, operand) => {
                 write!(f, "{op:?}({})", operand.for_fmt(self.storage))
             }
             RValue::ConstOp(op, operand) => write!(f, "{op:?}({operand:?})"),
-            RValue::Discriminant(place) => write!(f, "discriminant({place})"),
+            RValue::Discriminant(place) => {
+                write!(f, "discriminant({})", place.for_fmt(self.storage))
+            }
             RValue::Ref(region, borrow_kind, place) => {
                 write!(f, "&{region:?} {borrow_kind:?} {place:?}")
             }
@@ -95,10 +148,10 @@ impl fmt::Display for ForFormatting<'_, &Statement> {
         match &self.item.kind {
             StatementKind::Nop => write!(f, "nop"),
             StatementKind::Assign(place, value) => {
-                write!(f, "{place} = {}", (*value).for_fmt(self.storage))
+                write!(f, "{} = {}", place.for_fmt(self.storage), (*value).for_fmt(self.storage))
             }
             StatementKind::Discriminate(place, index) => {
-                write!(f, "discriminant({place}) = {index}")
+                write!(f, "discriminant({}) = {index}", place.for_fmt(self.storage))
             }
             // @@Todo: figure out format for printing out the allocations that
             // are made.
@@ -117,7 +170,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
             TerminatorKind::Goto(_) => write!(f, "goto"),
             TerminatorKind::Return => write!(f, "return"),
             TerminatorKind::Call { op, args, target, destination } => {
-                write!(f, "{destination} = {}(", op.for_fmt(self.storage))?;
+                write!(f, "{} = {}(", destination.for_fmt(self.storage), op.for_fmt(self.storage))?;
 
                 // write all of the arguments
                 for (i, arg) in args.iter().enumerate() {
@@ -167,7 +220,7 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
                 Ok(())
             }
             TerminatorKind::Assert { condition, expected, kind, target } => {
-                write!(f, "assert({condition}, {expected:?}, {kind:?})")?;
+                write!(f, "assert({}, {expected:?}, {kind:?})", condition.for_fmt(self.storage))?;
 
                 if self.with_edges {
                     write!(f, "-> {target:?}")?;

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -97,6 +97,9 @@ impl fmt::Display for ForFormatting<'_, &Statement> {
             StatementKind::Assign(place, value) => {
                 write!(f, "{place} = {}", (*value).for_fmt(self.storage))
             }
+            StatementKind::Discriminate(place, index) => {
+                write!(f, "discriminant({place}) = {index}")
+            }
             // @@Todo: figure out format for printing out the allocations that
             // are made.
             StatementKind::Alloc(_) => todo!(),

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -159,7 +159,7 @@ impl<'tcx> Builder<'tcx> {
                 if let Some(return_expr) = &expr {
                     unpack!(
                         block = self.expr_into_dest(
-                            Place::return_place(),
+                            Place::return_place(self.storage),
                             block,
                             return_expr.ast_ref()
                         )
@@ -170,7 +170,12 @@ impl<'tcx> Builder<'tcx> {
                     let const_value = ir::Const::zero(self.storage);
 
                     let unit = self.storage.push_rvalue(RValue::Const(const_value));
-                    self.control_flow_graph.push_assign(block, Place::return_place(), unit, span);
+                    self.control_flow_graph.push_assign(
+                        block,
+                        Place::return_place(self.storage),
+                        unit,
+                        span,
+                    );
                 }
 
                 // Create a new block for the `return` statement and make this block

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -3,17 +3,22 @@
 //! `strategies` can be found in [crate::build::rvalue] and
 //! [crate::build::temp].
 
+use std::collections::HashMap;
+
 use hash_ast::ast::{
     AccessExpr, AccessKind, AssignExpr, AssignOpExpr, AstNodeRef, AstNodes, BlockExpr,
-    ConstructorCallArg, ConstructorCallExpr, Declaration, Expr, PropertyKind, RefExpr, RefKind,
-    ReturnStatement, UnsafeExpr,
+    ConstructorCallArg, ConstructorCallExpr, Declaration, Expr, ListLit, Lit, PropertyKind,
+    RefExpr, RefKind, ReturnStatement, TupleLit, UnsafeExpr,
 };
 use hash_ir::{
-    ir::{self, AddressMode, BasicBlock, Place, RValue, Statement, StatementKind, TerminatorKind},
-    ty::{IrTy, Mutability, VariantIdx},
+    ir::{
+        self, AddressMode, AggregateKind, BasicBlock, Place, RValue, Statement, StatementKind,
+        TerminatorKind,
+    },
+    ty::{IrTy, IrTyId, Mutability, VariantIdx},
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::location::Span;
+use hash_source::{identifier::Identifier, location::Span};
 use hash_utils::store::{SequenceStoreKey, Store};
 
 use super::{unpack, BlockAnd, BlockAndExtend, Builder, LoopBlockInfo};
@@ -41,7 +46,7 @@ impl<'tcx> Builder<'tcx> {
                     self.fn_call_into_dest(destination, block, subject.ast_ref(), args, span)
                 } else {
                     // This is a constructor call, so we need to handle it as such.
-                    self.constructor_into_dest(destination, block, subject.ast_ref(), args)
+                    self.constructor_into_dest(destination, block, subject.ast_ref(), args, span)
                 }
             }
             Expr::Directive(expr) => {
@@ -51,7 +56,6 @@ impl<'tcx> Builder<'tcx> {
             | Expr::Deref(..)
             | Expr::Access(AccessExpr { kind: AccessKind::Property, .. })
             | Expr::Variable(..) => {
-                let _term = self.ty_of_node(expr.id());
                 let place = unpack!(block = self.as_place(block, expr, Mutability::Immutable));
 
                 let rvalue = self.storage.push_rvalue(RValue::Use(place));
@@ -188,7 +192,6 @@ impl<'tcx> Builder<'tcx> {
                 self.control_flow_graph.start_new_block().unit()
             }
 
-            // These should be unreachable in this context
             Expr::Continue { .. } | Expr::Break { .. } => {
                 // Specify that we have reached the terminator of this block...
                 self.reached_terminator = true;
@@ -197,7 +200,11 @@ impl<'tcx> Builder<'tcx> {
                 // start of the loop block, and when this is a break, we need to
                 // **jump** to the proceeding block of the loop block
                 let Some(LoopBlockInfo { loop_body, next_block }) = self.loop_block_info else {
-                    panic!("`continue` or `break` outside of loop");
+                    panic_on_span!(
+                        span.into_location(self.source_id),
+                        self.source_map,
+                        "`continue` or `break` outside of loop"
+                    );
                 };
 
                 // Add terminators to this block to specify where this block will jump...
@@ -214,13 +221,67 @@ impl<'tcx> Builder<'tcx> {
                 block.unit()
             }
 
-            // Lower this as an Rvalue
             Expr::Lit(literal) => {
-                let constant = self.as_constant(literal.data.ast_ref());
-                let rvalue = self.storage.push_rvalue(constant.into());
-                self.control_flow_graph.push_assign(block, destination, rvalue, span);
+                // We lower primitive (integrals, strings, etc) literals as constants, and
+                // other literals like `sets`, `maps`, `lists`, and `tuples` as aggregates.
+                match literal.data.body() {
+                    Lit::Map(_) | Lit::Set(_) => unimplemented!(),
+                    Lit::List(ListLit { elements }) => {
+                        let ty = self.ty_id_of_node(expr.id());
+                        let el_ty = self.map_ty(ty, |ty| match ty {
+                            IrTy::Slice(ty) | IrTy::Array { ty, .. } => *ty,
+                            _ => unreachable!(),
+                        });
 
-                block.unit()
+                        let aggregate_kind = AggregateKind::Array(el_ty);
+                        let args = elements
+                            .iter()
+                            .enumerate()
+                            .map(|(index, element)| (index.into(), element.ast_ref()))
+                            .collect::<Vec<_>>();
+
+                        self.aggregate_into_dest(
+                            destination,
+                            block,
+                            ty,
+                            aggregate_kind,
+                            &args,
+                            span,
+                        )
+                    }
+                    Lit::Tuple(TupleLit { elements }) => {
+                        let ty = self.ty_id_of_node(expr.id());
+                        let aggregate_kind = AggregateKind::Tuple;
+                        let args = elements
+                            .iter()
+                            .enumerate()
+                            .map(|(index, element)| {
+                                let name = match &element.body().name {
+                                    Some(name) => name.ident,
+                                    None => index.into(),
+                                };
+
+                                (name, element.body().value.ast_ref())
+                            })
+                            .collect::<Vec<_>>();
+
+                        self.aggregate_into_dest(
+                            destination,
+                            block,
+                            ty,
+                            aggregate_kind,
+                            &args,
+                            span,
+                        )
+                    }
+                    Lit::Str(_) | Lit::Char(_) | Lit::Int(_) | Lit::Float(_) | Lit::Bool(_) => {
+                        let constant = self.as_constant(literal.data.ast_ref());
+                        let rvalue = self.storage.push_rvalue(constant.into());
+                        self.control_flow_graph.push_assign(block, destination, rvalue, span);
+
+                        block.unit()
+                    }
+                }
             }
 
             Expr::BinaryExpr(..) | Expr::UnaryExpr(..) => {
@@ -243,7 +304,7 @@ impl<'tcx> Builder<'tcx> {
     /// have dead ends...
     pub(crate) fn handle_expr_declaration(
         &mut self,
-        block: BasicBlock,
+        mut block: BasicBlock,
         decl: &'tcx Declaration,
     ) -> BlockAnd<()> {
         if self.dead_ends.contains(&decl.pat.id()) {
@@ -255,7 +316,7 @@ impl<'tcx> Builder<'tcx> {
         self.visit_bindings(decl.pat.ast_ref());
 
         if let Some(rvalue) = &decl.value {
-            self.expr_into_pat(block, decl.pat.ast_ref(), rvalue.ast_ref());
+            unpack!(block = self.expr_into_pat(block, decl.pat.ast_ref(), rvalue.ast_ref()));
         } else {
             panic_on_span!(
                 decl.pat.span().into_location(self.source_id),
@@ -349,13 +410,121 @@ impl<'tcx> Builder<'tcx> {
         success.unit()
     }
 
+    /// Function that deals with lowering a constructor call which might involve
+    /// either a `struct` or an `enum` constructor. This function constructs an
+    /// [RValue::Aggregate] and assigns it to the specified destination.
+    ///
+    /// However, due to the fact that we haven't decided whether it is easier to
+    /// deal with aggregate values or direct fields assignments, we might have
+    /// to end up de-aggregating the aggregate values into a series of
+    /// assignments as they are specified within their declaration order.
     pub fn constructor_into_dest(
         &mut self,
-        _destination: Place,
-        mut _block: BasicBlock,
-        _subject: AstNodeRef<'tcx, Expr>,
-        _args: &'tcx AstNodes<ConstructorCallArg>,
+        destination: Place,
+        mut block: BasicBlock,
+        subject: AstNodeRef<'tcx, Expr>,
+        args: &'tcx AstNodes<ConstructorCallArg>,
+        span: Span,
     ) -> BlockAnd<()> {
-        unimplemented!()
+        let subject_ty = self.ty_id_of_node(subject.id());
+        let aggregate_kind = self.map_on_adt(subject_ty, |adt, id| {
+            if adt.flags.is_enum() || adt.flags.is_union() {
+                // here, we have to work out which variant is being used, so we look at the
+                // subject type as an `enum variant` value, and extract the index
+                let index =
+                    if let Expr::Access(AccessExpr {
+                        property, kind: AccessKind::Namespace, ..
+                    }) = &subject.body
+                    {
+                        match property.body() {
+                            PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
+                            PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
+                        }
+                    } else {
+                        panic!("expected an enum variant")
+                    };
+
+                AggregateKind::Enum(id, index)
+            } else {
+                debug_assert!(adt.flags.is_struct());
+                AggregateKind::Struct(id)
+            }
+        });
+
+        // deal with the subject first, since it might involve creating a
+        // discriminant on the destination.
+        if matches!(aggregate_kind, AggregateKind::Enum(..)) {
+            unpack!(block = self.expr_into_dest(destination, block, subject));
+        }
+
+        let args = args
+            .iter()
+            .enumerate()
+            .map(|(index, arg)| {
+                let name = match &arg.name {
+                    Some(name) => name.ident,
+                    None => index.into(),
+                };
+
+                (name, arg.value.ast_ref())
+            })
+            .collect::<Vec<_>>();
+
+        self.aggregate_into_dest(destination, block, subject_ty, aggregate_kind, &args, span)
+    }
+
+    /// Place any aggregate value into the specified destination. This does not
+    /// currently deal with default arguments to a specified ADT, so it will
+    /// panic if the number of arguments provided is not equal to the number of
+    /// fields in the ADT.
+    fn aggregate_into_dest(
+        &mut self,
+        destination: Place,
+        mut block: BasicBlock,
+        ty: IrTyId,
+        aggregate_kind: AggregateKind,
+        args: &[(Identifier, AstNodeRef<'tcx, Expr>)],
+        span: Span,
+    ) -> BlockAnd<()> {
+        // @@Todo: deal with the situation where we need to fill in default
+        //  values for various parameters. For now, we ensure that all
+        //  values are specified for the particular definition, and ensure
+        // that the provided fields are equal. When we do add support for
+        // default field values, it should be that the type checker
+        // emits information about what fields need to be added to this
+        // aggregate value.
+        let fields: HashMap<_, _> = args
+            .iter()
+            .map(|(name, arg)| (name, unpack!(block = self.as_rvalue(block, *arg))))
+            .collect();
+
+        // We don't need to perform this check for arrays since they don't need
+        // to have a specific amount of arguments to the constructor.
+        if aggregate_kind.is_adt() {
+            let field_count = self.map_on_adt(ty, |adt, _| {
+                if let AggregateKind::Enum(_, index) = aggregate_kind {
+                    adt.variants[index].fields.len()
+                } else {
+                    adt.variants[0].fields.len()
+                }
+            });
+
+            // Ensure we have the exact amount of arguments as the definition expects.
+            if args.len() != field_count {
+                panic_on_span!(
+                    span.into_location(self.source_id),
+                    self.source_map,
+                    "default arguments on constructors are not currently supported",
+                );
+            }
+        }
+
+        let fields = fields.into_values().into_iter().collect();
+        let aggregate = RValue::Aggregate(aggregate_kind, fields);
+        let value = self.storage.push_rvalue(aggregate);
+
+        self.control_flow_graph.push_assign(block, destination, value, span);
+
+        block.unit()
     }
 }

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -95,7 +95,6 @@ impl Candidate {
             otherwise_block: None,
             pre_binding_block: None,
             next_candidate_pre_bind_block: None,
-            // @@Todo: do we need to store an associated place with this pattern?
             pairs: smallvec![MatchPair { pat, place: place.clone() }],
             bindings: Vec::new(),
             sub_candidates: Vec::new(),
@@ -262,7 +261,7 @@ impl<'tcx> Builder<'tcx> {
                     candidate.bindings.push(Binding {
                         span,
                         mutability: (*mutability).into(),
-                        source: pair.place.into_place(),
+                        source: pair.place.into_place(self.storage),
                         name: *name,
 
                         // @@Todo: introduce a way of specifying what the binding
@@ -401,7 +400,7 @@ impl<'tcx> Builder<'tcx> {
                         //           specific pattern, which means that we can more precisely
                         // determine           the place that we are
                         // referencing.
-                        source: pair.place.into_place(),
+                        source: pair.place.into_place(self.storage),
                         mode: BindingMode::ByRef,
                     });
 

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -10,7 +10,7 @@ use hash_ir::{
     ir::{
         BasicBlock, BinOp, Const, PlaceProjection, RValue, RValueId, SwitchTargets, TerminatorKind,
     },
-    ty::{AdtId, IrTy, IrTyId},
+    ty::{AdtId, IrTy, IrTyId, VariantIdx},
     IrStorage,
 };
 use hash_reporting::macros::panic_on_span;
@@ -289,7 +289,7 @@ impl<'tcx> Builder<'tcx> {
                     candidate,
                 );
 
-                Some(variant_index)
+                Some(variant_index.index())
             }
             // @@Todo: remove this branch since this is just for handling enumerations.
             (TestKind::Switch { adt, .. }, Pat::Access(..) | Pat::Const(..)) => {
@@ -316,7 +316,7 @@ impl<'tcx> Builder<'tcx> {
                     candidate,
                 );
 
-                Some(variant_index)
+                Some(variant_index.index())
             }
 
             (TestKind::Switch { .. }, _) => None,
@@ -493,7 +493,7 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         pair_index: usize,
         adt: AdtId,
-        variant_index: usize,
+        variant_index: VariantIdx,
         sub_patterns: Option<PatArgsId>,
         candidate: &mut Candidate,
     ) {
@@ -807,7 +807,7 @@ impl<'tcx> Builder<'tcx> {
 
                     self.map_on_adt(ty, |adt, _| {
                         let variant_index = adt.variant_idx(property).unwrap();
-                        variants.insert(variant_index);
+                        variants.insert(variant_index.index());
                         true
                     })
                 }

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -541,7 +541,7 @@ impl<'tcx> Builder<'tcx> {
         make_target_blocks: impl FnOnce(&mut Self) -> Vec<BasicBlock>,
     ) {
         // Build the place from the provided place builder
-        let place = place_builder.clone().into_place();
+        let place = place_builder.clone().into_place(self.storage);
         let span = test.span;
 
         match test.kind {
@@ -583,12 +583,7 @@ impl<'tcx> Builder<'tcx> {
                 // switch statement.
                 let discriminant_tmp = self.temp_place(discriminant_ty);
                 let value = self.storage.push_rvalue(RValue::Discriminant(place));
-                self.control_flow_graph.push_assign(
-                    block,
-                    discriminant_tmp.clone(),
-                    value,
-                    subject_span,
-                );
+                self.control_flow_graph.push_assign(block, discriminant_tmp, value, subject_span);
 
                 let switch_value = self.storage.push_rvalue(RValue::Use(discriminant_tmp));
 
@@ -722,7 +717,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Assign `actual = length(place)`
                 let value = self.storage.push_rvalue(RValue::Len(place));
-                self.control_flow_graph.push_assign(block, actual.clone(), value, span);
+                self.control_flow_graph.push_assign(block, actual, value, span);
 
                 // @@Todo: can we not just use the `value` directly, there should be no
                 // dependency on it in other places, and it will always be a
@@ -767,7 +762,7 @@ impl<'tcx> Builder<'tcx> {
         // Push an assignment with the result of the comparison, i.e. `result = op(lhs,
         // rhs)`
         let value = self.storage.push_rvalue(RValue::BinaryOp(op, lhs, rhs));
-        self.control_flow_graph.push_assign(block, result.clone(), value, span);
+        self.control_flow_graph.push_assign(block, result, value, span);
 
         // Then insert the switch statement, which determines where the cfg goes based
         // on if the comparison was true or false.

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -364,8 +364,11 @@ impl<'tcx> Builder<'tcx> {
         let ret_span = node.span(); // @@Fixme: this should be the span of the ending part of the function body
                                     // span!
 
-        let return_block =
-            unpack!(self.expr_into_dest(Place::return_place(), start, node.body.fn_body.ast_ref()));
+        let return_block = unpack!(self.expr_into_dest(
+            Place::return_place(self.storage),
+            start,
+            node.body.fn_body.ast_ref()
+        ));
 
         self.control_flow_graph.terminate(return_block, ret_span, TerminatorKind::Return)
     }

--- a/compiler/hash-lower/src/build/pat.rs
+++ b/compiler/hash-lower/src/build/pat.rs
@@ -72,7 +72,7 @@ impl<'tcx> Builder<'tcx> {
             // The simple case of a just writing into the binding, we can
             // directly assign into the binding that is provided.
             ast::Pat::Binding(ast::BindingPat { name, .. }) => {
-                let place = Place::from(self.lookup_local(name.ident).unwrap());
+                let place = Place::from_local(self.lookup_local(name.ident).unwrap(), self.storage);
                 unpack!(block = self.expr_into_dest(place, block, rvalue));
                 block.unit()
             }

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -3,7 +3,7 @@
 use hash_ast::ast::{AccessExpr, AccessKind, AstNodeRef, DerefExpr, Expr, IndexExpr, PropertyKind};
 use hash_ir::{
     ir::{BasicBlock, Local, Place, PlaceProjection},
-    ty::{IrTyId, Mutability},
+    ty::{IrTyId, Mutability, VariantIdx},
 };
 
 use super::{unpack, BlockAnd, BlockAndExtend, Builder};
@@ -41,7 +41,7 @@ impl PlaceBuilder {
     }
 
     /// Apply a [PlaceProjection::Downcast] to the [PlaceBuilder].
-    pub(crate) fn downcast(self, index: usize) -> Self {
+    pub(crate) fn downcast(self, index: VariantIdx) -> Self {
         self.project(PlaceProjection::Downcast(index))
     }
 

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -166,8 +166,8 @@ impl<'tcx> Builder<'tcx> {
             let rvalue_id =
                 self.storage.rvalue_store().create(RValue::CheckedBinaryOp(op, lhs, rhs));
 
-            let result = temp.field(0);
-            let overflow = temp.field(1);
+            let result = temp.field(0, self.storage);
+            let overflow = temp.field(1, self.storage);
 
             // Push an assignment to the tuple on the operation
             self.control_flow_graph.push_assign(block, temp, rvalue_id, span);

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -28,7 +28,7 @@ impl<'tcx> Builder<'tcx> {
 
             self.push_local(local, scope)
         };
-        let temp_place = Place::from(temp);
+        let temp_place = Place::from_local(temp, self.storage);
 
         unpack!(block = self.expr_into_dest(temp_place, block, expr));
         block.and(temp)
@@ -39,7 +39,6 @@ impl<'tcx> Builder<'tcx> {
         let local = LocalDecl::new_auxiliary(ty, Mutability::Immutable);
         let scope = self.current_scope();
 
-        let local = self.push_local(local, scope);
-        Place::from(local)
+        Place::from_local(self.push_local(local, scope), self.storage)
     }
 }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -7,7 +7,7 @@
 
 use hash_ir::{
     ir::Const,
-    ty::{AdtData, AdtField, AdtFlags, AdtVariant, IrTy, IrTyId},
+    ty::{AdtData, AdtField, AdtFlags, AdtVariant, IrTy, IrTyId, VariantIdx},
 };
 use hash_source::{
     constant::{FloatTy, SIntTy, UIntTy, CONSTANT_MAP},
@@ -314,7 +314,7 @@ impl<'tcx> Builder<'tcx> {
     /// variant of a [AdtData]. This function assumed that the specified term is
     /// a [Term::Level0] enum variant which belongs to the specified adt,
     /// otherwise the function will panic.
-    pub(crate) fn lower_enum_variant_ty(&self, adt: &AdtData, term: TermId) -> usize {
+    pub(crate) fn lower_enum_variant_ty(&self, adt: &AdtData, term: TermId) -> VariantIdx {
         self.tcx.term_store.map_fast(term, |term| match term {
             Term::Level0(level0_term) => match level0_term {
                 Level0Term::EnumVariant(EnumVariantValue { name: variant_name, .. }) => {

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -78,7 +78,7 @@ impl<'tcx> Builder<'tcx> {
     /// the results of expressions, i.e. blocks.
     pub(crate) fn make_tmp_unit(&mut self) -> Place {
         match &self.tmp_place {
-            Some(tmp) => tmp.clone(),
+            Some(tmp) => *tmp,
             None => {
                 let ty = IrTy::unit(self.storage);
                 let ty_id = self.storage.ty_store().create(ty);
@@ -86,9 +86,8 @@ impl<'tcx> Builder<'tcx> {
                 let local = LocalDecl::new_auxiliary(ty_id, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
 
-                let place = Place::from(local_id);
-                self.tmp_place = Some(place.clone());
-
+                let place = Place::from_local(local_id, self.storage);
+                self.tmp_place = Some(place);
                 place
             }
         }

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -66,9 +66,9 @@ impl ControlFlowGraph {
     pub(crate) fn terminate(&mut self, block: BasicBlock, span: Span, kind: TerminatorKind) {
         debug_assert!(
             self.block_data(block).terminator.is_none(),
-            "terminate: block {:?}={:?} already has a terminator set",
+            "terminate: block `{:?}` already has a terminator `{:?}` set",
             block,
-            self.block_data(block)
+            self.block_data(block).terminator.as_ref().unwrap()
         );
 
         self.block_data_mut(block).terminator = Some(Terminator { span, kind });

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -111,7 +111,7 @@ impl Display for FloatConstant {
         write!(f, "{}", self.value)?;
 
         if let Some(suffix) = self.suffix {
-            write!(f, "{suffix}")?;
+            write!(f, "_{suffix}")?;
         }
 
         Ok(())
@@ -717,7 +717,7 @@ impl Display for IntConstant {
             IntConstantValue::Big(value) => write!(f, "{value}")?,
         }
 
-        write!(f, "{}", self.ty)
+        write!(f, "_{}", self.ty)
     }
 }
 

--- a/compiler/hash-typecheck/src/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/diagnostics/error.rs
@@ -37,7 +37,10 @@ pub type TcResult<T> = Result<T, TcError>;
 #[derive(Debug, Clone)]
 pub enum TcError {
     /// Cannot unify the two terms.
-    CannotUnify { src: TermId, target: TermId },
+    CannotUnify {
+        src: TermId,
+        target: TermId,
+    },
     // @@Refactor: It would be nice to not have separate variants for `CannotUnifyArgs` and
     // `CannotUnifyParams`.
     /// Cannot unify the two argument lists. This can occur if the names
@@ -61,9 +64,13 @@ pub enum TcError {
         reason: ParamUnificationErrorReason,
     },
     /// The given term should be a type function but it isn't.
-    NotATyFn { term: TermId },
+    NotATyFn {
+        term: TermId,
+    },
     /// The given value cannot be used as a type.
-    CannotUseValueAsTy { value: TermId },
+    CannotUseValueAsTy {
+        value: TermId,
+    },
     /// The given arguments do not match the length of the target parameters.
     MismatchingArgParamLength {
         args_kind: ParamListKind,
@@ -73,12 +80,22 @@ pub enum TcError {
     },
     /// The parameter with the given name is not found in the given parameter
     /// list.
-    ParamNotFound { args_kind: ParamListKind, params_subject: LocationTarget, name: Identifier },
+    ParamNotFound {
+        args_kind: ParamListKind,
+        params_subject: LocationTarget,
+        name: Identifier,
+    },
     /// There is a argument or parameter (at the index) which is
     /// specified twice in the given argument list.
-    ParamGivenTwice { param_kind: ParamListKind, index: usize },
+    ParamGivenTwice {
+        param_kind: ParamListKind,
+        index: usize,
+    },
     /// It is invalid to use a positional argument after a named argument.
-    AmbiguousArgumentOrdering { param_kind: ParamListKind, index: usize },
+    AmbiguousArgumentOrdering {
+        param_kind: ParamListKind,
+        index: usize,
+    },
     /// The given name cannot be resolved in the given value.
     UnresolvedNameInValue {
         // @@ErrorReporting: add more info about the term. Maybe we need a general way of
@@ -88,14 +105,26 @@ pub enum TcError {
         value: TermId,
     },
     /// The given variable cannot be resolved in the current context.
-    UnresolvedVariable { name: Identifier, value: TermId },
+    UnresolvedVariable {
+        name: Identifier,
+        value: TermId,
+    },
     /// The given value does not support accessing (of the given name).
-    UnsupportedAccess { name: Identifier, value: TermId },
+    UnsupportedAccess {
+        name: Identifier,
+        value: TermId,
+    },
     /// The given value does not support namespace accessing (of the given
     /// name).
-    UnsupportedNamespaceAccess { name: Field, value: TermId },
+    UnsupportedNamespaceAccess {
+        name: Field,
+        value: TermId,
+    },
     /// The given value does not support property accessing (of the given name).
-    UnsupportedPropertyAccess { name: Field, value: TermId },
+    UnsupportedPropertyAccess {
+        name: Field,
+        value: TermId,
+    },
     /// The given type function cannot be applied to the given arguments, due to
     /// the given errors.
     InvalidTyFnApplication {
@@ -105,15 +134,25 @@ pub enum TcError {
         unification_errors: Vec<TcError>,
     },
     /// The given term cannot be used in a merge operation.
-    InvalidMergeElement { term: TermId },
+    InvalidMergeElement {
+        term: TermId,
+    },
     /// The given term cannot be used in a union operation.
-    InvalidUnionElement { term: TermId },
+    InvalidUnionElement {
+        term: TermId,
+    },
     /// The given term cannot be used as a type function parameter type.
-    InvalidTyFnParamTy { param_ty: TermId },
+    InvalidTyFnParamTy {
+        param_ty: TermId,
+    },
     /// The given term cannot be used as a type function return type.
-    InvalidTyFnReturnTy { return_ty: TermId },
+    InvalidTyFnReturnTy {
+        return_ty: TermId,
+    },
     /// The given term cannot be used as a type function return value.
-    InvalidTyFnReturnValue { return_value: TermId },
+    InvalidTyFnReturnValue {
+        return_value: TermId,
+    },
     /// The given merge term should only contain zero or one nominal elements,
     /// but it contains more.
     MergeShouldOnlyContainOneNominal {
@@ -124,27 +163,51 @@ pub enum TcError {
         offending_term: TermId,
     },
     /// The given merge term should contain only level 1 terms.
-    MergeShouldBeLevel1 { merge_term: TermId, offending_term: TermId },
+    MergeShouldBeLevel1 {
+        merge_term: TermId,
+        offending_term: TermId,
+    },
     /// The given merge term should contain only level 2 terms.
-    MergeShouldBeLevel2 { merge_term: TermId, offending_term: TermId },
+    MergeShouldBeLevel2 {
+        merge_term: TermId,
+        offending_term: TermId,
+    },
     /// More type annotations are needed to resolve the given term.
-    NeedMoreTypeAnnotationsToResolve { term: TermId },
+    NeedMoreTypeAnnotationsToResolve {
+        term: TermId,
+    },
     /// The given term cannot be instantiated at runtime.
-    TermIsNotRuntimeInstantiable { term: TermId },
+    TermIsNotRuntimeInstantiable {
+        term: TermId,
+    },
     /// The given term cannot be used as the subject of a type function
     /// application.
-    UnsupportedTyFnApplication { subject_id: TermId },
+    UnsupportedTyFnApplication {
+        subject_id: TermId,
+    },
     /// The given access operation results in more than one result.
-    AmbiguousAccess { access: AccessTerm, results: Vec<TermId> },
+    AmbiguousAccess {
+        access: AccessTerm,
+        results: Vec<TermId>,
+    },
     /// Cannot use this as a function call or struct subject.
-    InvalidCallSubject { term: TermId },
+    InvalidCallSubject {
+        term: TermId,
+    },
     /// The given access operation does not resolve to a method.
-    InvalidPropertyAccessOfNonMethod { subject: TermId, property: Field },
+    InvalidPropertyAccessOfNonMethod {
+        subject: TermId,
+        property: Field,
+    },
     /// The given member requires an initialisation in the current scope.
     /// @@ErrorReporting: add span of member.
-    UninitialisedMemberNotAllowed { member: LocationTarget },
+    UninitialisedMemberNotAllowed {
+        member: LocationTarget,
+    },
     /// Cannot implement something that isn't a trait.
-    CannotImplementNonTrait { term: TermId },
+    CannotImplementNonTrait {
+        term: TermId,
+    },
     /// The trait implementation `trt_impl_term_id` is missing the member
     /// `trt_def_missing_member_id` from the trait `trt_def_term_id`.
     TraitImplMissingMember {
@@ -158,25 +221,48 @@ pub enum TcError {
     },
     /// When a member of an `impl` block that implements a trait is not present
     /// within the trait definition, in other words a non-member.
-    MethodNotAMemberOfTrait { trt_def_term_id: TermId, member: LocationTarget, name: Identifier },
+    MethodNotAMemberOfTrait {
+        trt_def_term_id: TermId,
+        member: LocationTarget,
+        name: Identifier,
+    },
     /// Cannot use pattern matching in a declaration without an assignment
-    CannotPatMatchWithoutAssignment { pat: PatId },
+    CannotPatMatchWithoutAssignment {
+        pat: PatId,
+    },
     /// Cannot use a non-name as an assign subject.
-    InvalidAssignSubject { location: LocationTarget },
+    InvalidAssignSubject {
+        location: LocationTarget,
+    },
+
+    InvalidIndexSubject {
+        subject: TermId,
+        site: LocationTarget,
+    },
 
     /// Cannot find a constructor for the given type
-    NoConstructorOnType { subject: TermId },
+    NoConstructorOnType {
+        subject: TermId,
+    },
 
     /// The subject does not have a callable constructor (i.e. it is constant).
-    NoCallableConstructorOnType { subject: TermId },
+    NoCallableConstructorOnType {
+        subject: TermId,
+    },
 
     /// When a bind within a pattern is declared more than one
-    IdentifierBoundMultipleTimes { name: Identifier, pat: PatId },
+    IdentifierBoundMultipleTimes {
+        name: Identifier,
+        pat: PatId,
+    },
 
     /// Within an `or` pattern, where there is a discrepancy between the
     /// declared bounds within two patterns. For example, if one pattern
     /// binds `k`, but the other doesn't.
-    MissingPatternBounds { pat: PatId, bounds: Vec<Identifier> },
+    MissingPatternBounds {
+        pat: PatId,
+        bounds: Vec<Identifier>,
+    },
 
     /// When a pattern is expected to be irrefutable but was found to be
     /// refutable with provided `witnesses` or possible patterns that are
@@ -209,7 +295,9 @@ pub enum TcError {
     /// When an unsized integer literal is specified in the range. This
     /// is currently not supported because the exhaustiveness checking
     /// cannot currently deal with this kind of range.
-    UnsupportedRangePatTy { term: TermId },
+    UnsupportedRangePatTy {
+        term: TermId,
+    },
 
     /// When a particular scope member is declared as `immutable` but an
     /// attempt was made to perform a mutable operation on this item.
@@ -1452,6 +1540,19 @@ impl<'tc> From<TcErrorWithStorage<'tc>> for Reports {
                         location,
                         "this member cannot be declared as mutable: remove `mut`",
                     )));
+                }
+            }
+            TcError::InvalidIndexSubject { subject, site } => {
+                builder.code(HashErrorCode::InvalidIndexSubject).title(format!(
+                    "cannot index into `{}`",
+                    subject.for_formatting(ctx.global_storage())
+                ));
+
+                if let Some(location) = ctx.location_store().get_location(site) {
+                    builder.add_labelled_span(
+                        location,
+                        "cannot index into this type, type must be of shape `[T]`",
+                    );
                 }
             }
         };

--- a/compiler/hash-typecheck/src/ops/oracle.rs
+++ b/compiler/hash-typecheck/src/ops/oracle.rs
@@ -126,6 +126,7 @@ impl<'tc> Oracle<'tc> {
     pub fn term_as_list_ty(&self, term: TermId) -> Option<TermId> {
         let list_inner_ty = self.builder().create_unresolved_term();
         let builder = self.builder();
+
         let list_ty = builder.create_app_ty_fn_term(
             self.core_defs().list_ty_fn(),
             builder.create_args(


### PR DESCRIPTION
This patch allows for constructors, tuples, and arrays as `RValue`s. Additionally, this patch makes `Place` store projections in a `projection_store` to make `Place` copyable and smaller when being passed around during the lowering stage.

closes #578 
closes #612 
closes #579 
closes #618 