### PR TITLE
lower: correctly handle logical operator short-circuiting

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1167,6 +1167,14 @@ define_tree! {
             )
         }
 
+        /// Check whether an operator is a comparator operator, i.e. `==`, `!=`, etc.
+        pub fn is_comparator(&self) -> bool {
+            matches!(
+                self,
+                BinOp::EqEq | BinOp::NotEq | BinOp::Gt | BinOp::GtEq | BinOp::Lt | BinOp::LtEq
+            )
+        }
+
         /// Checks whether this operator is a ordering comparison operator, i.e. `<`
         /// `<=`, `>`, etc.
         pub fn is_ordering_comparator(&self) -> bool {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -154,12 +154,8 @@ pub enum BinOp {
     Neq,
     /// '|'
     BitOr,
-    /// '||'
-    Or,
     /// '&'
     BitAnd,
-    /// '&&'
-    And,
     /// '^'
     BitXor,
     /// '^^'
@@ -206,9 +202,7 @@ impl From<ast::BinOp> for BinOp {
             ast::BinOp::EqEq => Self::Eq,
             ast::BinOp::NotEq => Self::Neq,
             ast::BinOp::BitOr => Self::BitOr,
-            ast::BinOp::Or => Self::Or,
             ast::BinOp::BitAnd => Self::BitAnd,
-            ast::BinOp::And => Self::And,
             ast::BinOp::BitXor => Self::BitXor,
             ast::BinOp::Exp => Self::Exp,
             ast::BinOp::Gt => Self::Gt,
@@ -706,21 +700,22 @@ pub enum TerminatorKind {
 }
 
 impl TerminatorKind {
+    /// Utility to createa a [TerminatorKind::Switch] which emulates the
+    /// behaviour of an `if` branch where the `true` branch is the
+    /// `true_block` and the `false` branch is the `false_block`.
     pub fn make_if(
-        place: Place,
+        operand: RValueId,
         true_block: BasicBlock,
         false_block: BasicBlock,
         storage: &IrStorage,
     ) -> Self {
-        let value = storage.push_rvalue(RValue::Use(place));
-
         let targets = SwitchTargets::new(
             std::iter::once((false.into(), false_block)),
             storage.ty_store().make_bool(),
             Some(true_block),
         );
 
-        TerminatorKind::Switch { value, targets }
+        TerminatorKind::Switch { value: operand, targets }
     }
 }
 

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -28,8 +28,8 @@ impl<'tcx> Builder<'tcx> {
             }
 
             // Send this off into the `match` lowering logic
-            Block::Match(MatchBlock { subject, cases, .. }) => {
-                self.match_expr(place, block, span, subject.ast_ref(), cases)
+            Block::Match(MatchBlock { subject, cases, origin }) => {
+                self.match_expr(place, block, span, subject.ast_ref(), cases, *origin)
             }
 
             Block::Loop(LoopBlock { contents }) => {

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -121,10 +121,6 @@ where
 
         // Don't do anything for exponents, since not all integral kinds support this.
         BinOp::Exp => None,
-
-        // We don't deal with logical operations here since these are
-        // not integral operations
-        BinOp::Or | BinOp::And => None,
     };
 
     value.map(|val| {

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -322,7 +322,7 @@ impl<'tcx> Builder<'tcx> {
                 );
 
                 let lhs =
-                    unpack!(block = self.as_operand(block, lhs.ast_ref(), Mutability::Immutable));
+                    unpack!(block = self.as_operand(block, lhs.ast_ref(), Mutability::Mutable));
 
                 let blocks = match *operator.body() {
                     BinOp::And => (else_block, shortcircuiting_block),
@@ -352,7 +352,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Now deal with the non-short-circuiting block
                 let rhs = unpack!(
-                    else_block = self.as_operand(else_block, rhs.ast_ref(), Mutability::Immutable)
+                    else_block = self.as_operand(else_block, rhs.ast_ref(), Mutability::Mutable)
                 );
                 self.control_flow_graph.push_assign(else_block, destination, rhs, span);
                 self.control_flow_graph.goto(else_block, join_block, span);

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -96,11 +96,11 @@ impl<'tcx> Builder<'tcx> {
             }
             _ => {
                 let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));
-
                 let then_block = self.control_flow_graph.start_new_block();
 
+                let value = self.storage.push_rvalue(RValue::Use(place));
                 let terminator =
-                    TerminatorKind::make_if(place, then_block, else_block, self.storage);
+                    TerminatorKind::make_if(value, then_block, else_block, self.storage);
                 self.control_flow_graph.terminate(block, span, terminator);
 
                 then_block.unit()

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -610,7 +610,8 @@ impl<'tcx> Builder<'tcx> {
                         _ => panic!("expected boolean switch to have only two options"),
                     };
 
-                    TerminatorKind::make_if(place, true_block, false_block, self.storage)
+                    let value = self.storage.push_rvalue(RValue::Use(place));
+                    TerminatorKind::make_if(value, true_block, false_block, self.storage)
                 } else {
                     debug_assert_eq!(options.len() + 1, target_blocks.len());
                     let otherwise_block = target_blocks.last().copied();
@@ -766,6 +767,7 @@ impl<'tcx> Builder<'tcx> {
 
         // Then insert the switch statement, which determines where the cfg goes based
         // on if the comparison was true or false.
+        let result = self.storage.push_rvalue(RValue::Use(result));
         self.control_flow_graph.terminate(
             block,
             span,

--- a/compiler/hash-token/src/lib.rs
+++ b/compiler/hash-token/src/lib.rs
@@ -187,6 +187,12 @@ pub enum TokenKind {
     /// Tree - The index is set as a `u32` since it isn't going
     /// to be the case that the index will or should ever really
     /// reach `2^32` since the index is per module and not per project.
+    ///
+    /// @@Todo: rather than using an index into the token trees, we should
+    /// use it as a index into the token stream to denote where the
+    /// token tree ends. This means that we can have a flat token
+    /// stream which removes the need for storing token trees
+    /// separately.
     Tree(Delimiter, u32),
 
     /// Keyword

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -1477,8 +1477,15 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
                 return Err(TcError::CannotUnify { src: rhs_term, target: lhs_term });
             }
 
-            let lhs_term = self.term_store().get(lhs);
-            let term = self.builder().create_term(lhs_term);
+            // If the operator is a logical operator, or comparator, then the result of the
+            // expression will be a boolean term, so we return the type of the expression as
+            // yielding a boolean term.
+            let term = if node.operator.is_lazy() || node.operator.is_comparator() {
+                self.builder().create_rt_term(self.core_defs().bool_ty())
+            } else {
+                let lhs_term = self.term_store().get(lhs);
+                self.builder().create_term(lhs_term)
+            };
 
             return self.validate_and_register_simplified_term(node, term);
         }

--- a/tests/cases/parser/literals/overeager_tuple_lit_entry.hash
+++ b/tests/cases/parser/literals/overeager_tuple_lit_entry.hash
@@ -1,0 +1,13 @@
+// run=pass, stage=parse
+
+
+main := (y: bool, x: i32) => {
+    // This should be parsed as a parenthesised binary expression, not a tuple 
+    // that tries to assign a named member `x`, but then proceeds to fail due to 
+    // the `==`. 
+    if (x == 3) {
+        4
+    } else {
+        2
+    }
+}


### PR DESCRIPTION
This patch introduces proper handling of a logical operator (`&&` and `||`) short-circuiting properties during IR generation.

Additionally,
- fix parser bug with over-eager tuple parsing, when expressions like `(x == ...)` are encountered.
- don't lower the subject of a `match` block that originates from an `if` expression.
- typechecker: properly type binary expressions that yield a boolean result.

closes #617 