### PR TITLE
lowering: introduce a optimisation pass manager for the IR

### DIFF
--- a/compiler/hash-ir/src/basic_blocks.rs
+++ b/compiler/hash-ir/src/basic_blocks.rs
@@ -1,0 +1,87 @@
+//! Module that contains a manager for basic blocks of a particular
+//! IR [Body]. The manager stores all of the basic blocks and provides
+//! functionality for computing the predecessors and successors of
+//! each basic block, and stores a cache on various traversal orders
+//! of the stored basic blocks.
+
+use std::cell::OnceCell;
+
+use index_vec::IndexVec;
+use smallvec::SmallVec;
+
+use crate::ir::{BasicBlock, BasicBlockData};
+
+/// [BasicBlocks] is a manager for basic blocks of a particular
+/// IR [Body]. The manager stores all of the basic blocks and provides
+/// functionality for computing the predecessors and successors of
+/// each basic block, and stores a cache on various traversal orders
+/// of the stored basic blocks.
+pub struct BasicBlocks {
+    /// The blocks that the function is represented with
+    pub blocks: IndexVec<BasicBlock, BasicBlockData>,
+
+    /// A cache that stores all of the predecessors of a block.
+    predecessor_cache: PredecessorCache,
+}
+
+impl BasicBlocks {
+    /// Creates a new instance of [BasicBlocks].
+    pub fn new(blocks: IndexVec<BasicBlock, BasicBlockData>) -> Self {
+        Self { blocks, predecessor_cache: PredecessorCache::new() }
+    }
+
+    /// Get a mutable reference to the stored basic blocks. This does not
+    /// invalidate any of the caches. Given that none of the caches are
+    /// invalided, the following is assumed:
+    ///
+    ///  1) The number of basic blocks remains unchanged.
+    ///  2) The set of successors of each terminator remains unchanged.
+    ///
+    /// If any of these conditions are violated, then the caller should
+    /// invalidate all blocks that have been changed in order to either
+    /// purge the cache of an entry or to update the entry if it is still
+    /// required.
+    #[inline]
+    pub fn blocks_mut(&mut self) -> &mut IndexVec<BasicBlock, BasicBlockData> {
+        &mut self.blocks
+    }
+
+    /// Compute the predecessors of a basic block, or return the cached
+    /// value if it has already been computed.
+    pub fn predecessors_of(&self, block: BasicBlock) -> &[BasicBlock] {
+        self.predecessor_cache.compute(&self.blocks)[block].as_slice()
+    }
+}
+
+/// Represents the map of basic blocks to their predecessors.
+///
+/// Typically 95%+ of basic blocks have 4 or fewer predecessors.
+pub type Predecessors = IndexVec<BasicBlock, SmallVec<[BasicBlock; 4]>>;
+
+/// A wrapper around storing the predecessors of a basic block.
+struct PredecessorCache {
+    /// A cache that stores all of the predecessors of a block.
+    pub cache: OnceCell<Predecessors>,
+}
+
+impl PredecessorCache {
+    fn new() -> Self {
+        Self { cache: OnceCell::new() }
+    }
+
+    /// Compute the predecessors of a basic block, or return the cached
+    /// value if it has already been computed.
+    pub fn compute(&self, blocks: &IndexVec<BasicBlock, BasicBlockData>) -> &Predecessors {
+        self.cache.get_or_init(|| {
+            let mut predecessors = Predecessors::with_capacity(blocks.len());
+
+            for (bb, data) in blocks.iter_enumerated() {
+                for successor in data.successors() {
+                    predecessors[successor].push(bb);
+                }
+            }
+
+            predecessors
+        })
+    }
+}

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -52,7 +52,7 @@ pub enum Const {
 impl Const {
     /// Create a [Const::Zero] with a unit type, the total zero.
     pub fn zero(storage: &IrStorage) -> Self {
-        let unit = storage.ty_store().create(IrTy::unit(storage));
+        let unit = storage.tys().create(IrTy::unit(storage));
         Self::Zero(unit)
     }
 
@@ -64,7 +64,7 @@ impl Const {
     /// Create a new [Const] from a scalar value, with the appropriate
     /// type.
     pub fn from_scalar(value: u128, ty: IrTyId, storage: &IrStorage) -> Self {
-        storage.ty_store().map_fast(ty, |ty| match ty {
+        storage.tys().map_fast(ty, |ty| match ty {
             IrTy::Int(int_ty) => {
                 let interned_value = IntConstant::from_uint(value, (*int_ty).into());
                 Self::Int(CONSTANT_MAP.create_int_constant(interned_value))
@@ -397,21 +397,21 @@ pub struct Place {
 impl Place {
     /// Create a [Place] that points to the return `place` of a lowered  body.
     pub fn return_place(storage: &IrStorage) -> Self {
-        Self { local: RETURN_PLACE, projections: storage.projection_store.create_empty() }
+        Self { local: RETURN_PLACE, projections: storage.projections().create_empty() }
     }
 
     pub fn from_local(local: Local, storage: &IrStorage) -> Self {
-        Self { local, projections: storage.projection_store.create_empty() }
+        Self { local, projections: storage.projections().create_empty() }
     }
 
     /// Create a new [Place] from an existing place whilst also
     /// applying a a [PlaceProjection::Field] on the old one.
     pub fn field(&self, field: usize, storage: &IrStorage) -> Self {
-        let projections = storage.projection_store.get_vec(self.projections);
+        let projections = storage.projections().get_vec(self.projections);
 
         Self {
             local: self.local,
-            projections: storage.projection_store.create_from_iter_fast(
+            projections: storage.projections().create_from_iter_fast(
                 projections.iter().copied().chain(once(PlaceProjection::Field(field))),
             ),
         }
@@ -793,7 +793,7 @@ impl TerminatorKind {
     ) -> Self {
         let targets = SwitchTargets::new(
             std::iter::once((false.into(), false_block)),
-            storage.ty_store().make_bool(),
+            storage.tys().make_bool(),
             Some(true_block),
         );
 
@@ -1045,7 +1045,7 @@ mod tests {
 
         let place = Place {
             local: Local::new(0),
-            projections: storage.projection_store.create_from_slice(&[
+            projections: storage.projections().create_from_slice(&[
                 PlaceProjection::Deref,
                 PlaceProjection::Field(0),
                 PlaceProjection::Index(Local::new(1)),
@@ -1057,7 +1057,7 @@ mod tests {
 
         let place = Place {
             local: Local::new(0),
-            projections: storage.projection_store.create_from_slice(&[
+            projections: storage.projections().create_from_slice(&[
                 PlaceProjection::Deref,
                 PlaceProjection::Deref,
                 PlaceProjection::Deref,

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -1,7 +1,8 @@
 //! Hash Compiler Intermediate Representation (IR) crate.
 #![allow(clippy::too_many_arguments)]
-#![feature(let_chains)]
+#![feature(let_chains, once_cell)]
 
+pub mod basic_blocks;
 pub mod ir;
 pub mod ty;
 pub mod visitor;

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -19,10 +19,67 @@ use ir::{Body, ProjectionStore, RValue, RValueId, RValueStore};
 use ty::{AdtStore, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the IR builder.
+#[derive(Default)]
 pub struct IrStorage {
     /// The type storage for the IR.
     pub generated_bodies: Vec<Body>,
 
+    pub body_data: BodyDataStore,
+}
+
+impl IrStorage {
+    pub fn new() -> Self {
+        Self { generated_bodies: Vec::new(), body_data: BodyDataStore::default() }
+    }
+
+    /// Get a reference to the [TyStore]
+    pub fn tys(&self) -> &TyStore {
+        &self.body_data.ty_store
+    }
+
+    /// Get a reference to the [TyListStore]
+    pub fn tls(&self) -> &TyListStore {
+        &self.body_data.ty_list_store
+    }
+
+    /// Get a reference to the [AdtStore]
+    pub fn adts(&self) -> &AdtStore {
+        &self.body_data.adt_store
+    }
+
+    /// Get a reference to the [RValueStore]
+    pub fn rvalues(&self) -> &RValueStore {
+        &self.body_data.rvalue_store
+    }
+
+    /// Get a reference to the [ProjectionStore]
+    pub fn projections(&self) -> &ProjectionStore {
+        &self.body_data.projection_store
+    }
+
+    /// Get a reference to the type cache.
+    pub fn ty_cache(&self) -> Ref<HashMap<TermId, IrTyId>> {
+        self.body_data.ty_cache.borrow()
+    }
+
+    /// Add an entry to the type cache.
+    pub fn add_ty_cache_entry(&self, term_id: TermId, ty_id: IrTyId) {
+        self.body_data.ty_cache.borrow_mut().insert(term_id, ty_id);
+    }
+
+    /// Push an [RValue] on the storage.
+    pub fn push_rvalue(&self, rvalue: RValue) -> RValueId {
+        self.body_data.rvalue_store.create(rvalue)
+    }
+
+    /// Extend the IR storage with the given bodies.
+    pub fn add_bodies(&mut self, bodies: impl IntoIterator<Item = Body>) {
+        self.generated_bodies.extend(bodies)
+    }
+}
+
+#[derive(Default)]
+pub struct BodyDataStore {
     /// The storage for all the [RValue]s.
     rvalue_store: ir::RValueStore,
 
@@ -45,10 +102,9 @@ pub struct IrStorage {
     ty_cache: RefCell<HashMap<TermId, IrTyId>>,
 }
 
-impl IrStorage {
+impl BodyDataStore {
     pub fn new() -> Self {
         Self {
-            generated_bodies: Vec::new(),
             rvalue_store: RValueStore::default(),
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::default(),
@@ -56,56 +112,5 @@ impl IrStorage {
             adt_store: AdtStore::default(),
             ty_cache: RefCell::new(HashMap::new()),
         }
-    }
-
-    /// Get a reference to the [TyStore]
-    pub fn ty_store(&self) -> &TyStore {
-        &self.ty_store
-    }
-
-    /// Get a reference to the [TyListStore]
-    pub fn ty_list_store(&self) -> &TyListStore {
-        &self.ty_list_store
-    }
-
-    /// Get a reference to the [AdtStore]
-    pub fn adt_store(&self) -> &AdtStore {
-        &self.adt_store
-    }
-
-    /// Get a reference to the [RValueStore]
-    pub fn rvalue_store(&self) -> &RValueStore {
-        &self.rvalue_store
-    }
-
-    /// Get a reference to the [ProjectionStore]
-    pub fn projection_store(&self) -> &ProjectionStore {
-        &self.projection_store
-    }
-
-    /// Get a reference to the type cache.
-    pub fn ty_cache(&self) -> Ref<HashMap<TermId, IrTyId>> {
-        self.ty_cache.borrow()
-    }
-
-    /// Add an entry to the type cache.
-    pub fn add_ty_cache_entry(&self, term_id: TermId, ty_id: IrTyId) {
-        self.ty_cache.borrow_mut().insert(term_id, ty_id);
-    }
-
-    /// Push an [RValue] on the storage.
-    pub fn push_rvalue(&self, rvalue: RValue) -> RValueId {
-        self.rvalue_store.create(rvalue)
-    }
-
-    /// Extend the IR storage with the given bodies.
-    pub fn add_bodies(&mut self, bodies: impl IntoIterator<Item = Body>) {
-        self.generated_bodies.extend(bodies)
-    }
-}
-
-impl Default for IrStorage {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -135,7 +135,7 @@ impl IrTy {
     pub fn unit(ir_storage: &IrStorage) -> Self {
         let variants = index_vec![AdtVariant { name: 0usize.into(), fields: vec![] }];
         let adt = AdtData::new_with_flags("unit".into(), variants, AdtFlags::TUPLE);
-        let adt_id = ir_storage.adt_store().create(adt);
+        let adt_id = ir_storage.adts().create(adt);
 
         Self::Adt(adt_id)
     }
@@ -152,7 +152,7 @@ impl IrTy {
                 .collect(),
         }];
         let adt = AdtData::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
-        let adt_id = ir_storage.adt_store().create(adt);
+        let adt_id = ir_storage.adts().create(adt);
 
         Self::Adt(adt_id)
     }
@@ -382,7 +382,7 @@ pub type AdtStore = DefaultStore<AdtId, AdtData>;
 
 impl fmt::Display for ForFormatting<'_, AdtId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.storage.adt_store.map_fast(self.item, |adt| {
+        self.storage.adts().map_fast(self.item, |adt| {
             match adt.flags {
                 AdtFlags::TUPLE => {
                     assert!(adt.variants.len() == 1);
@@ -451,7 +451,7 @@ impl Store<IrTyId, IrTy> for TyStore {
 
 impl fmt::Display for ForFormatting<'_, IrTyId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ty = self.storage.ty_store().get(self.item);
+        let ty = self.storage.tys().get(self.item);
 
         match ty {
             IrTy::Int(variant) => write!(f, "{variant}"),
@@ -507,7 +507,7 @@ pub type TyListStore = DefaultSequenceStore<IrTyListId, IrTyId>;
 
 impl fmt::Display for ForFormatting<'_, IrTyListId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let items = self.storage.ty_list_store().get_vec(self.item);
+        let items = self.storage.tls().get_vec(self.item);
         let mut tys = items.iter();
 
         if let Some(first) = tys.next() {

--- a/compiler/hash-ir/src/write/graphviz.rs
+++ b/compiler/hash-ir/src/write/graphviz.rs
@@ -110,12 +110,12 @@ impl<'ir> IrGraphWriter<'ir> {
         writeln!(w, ">;")?;
 
         // Now we write all of the blocks
-        for (id, block) in self.body.blocks.iter_enumerated() {
+        for (id, block) in self.body.blocks().iter_enumerated() {
             self.write_block(w, id, block)?;
         }
 
         // Now we need to write all of the edges of the control flow graph
-        for (id, block) in self.body.blocks.iter_enumerated() {
+        for (id, block) in self.body.blocks().iter_enumerated() {
             if let Some(terminator) = &block.terminator {
                 let prefix = if let Some(index) = self.options.use_subgraph {
                     format!("c{index}_")

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -57,7 +57,7 @@ impl WriteIr for Place {}
 
 impl fmt::Display for ForFormatting<'_, Place> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.storage.projection_store.map_fast(self.item.projections, |projections| {
+        self.storage.projections().map_fast(self.item.projections, |projections| {
             // First we, need to deal with the `deref` projections, since
             // they need to be printed in reverse
             for projection in projections.iter().rev() {
@@ -108,7 +108,7 @@ impl WriteIr for RValueId {}
 
 impl fmt::Display for ForFormatting<'_, RValueId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.storage.rvalue_store().map_fast(self.item, |rvalue| match rvalue {
+        self.storage.rvalues().map_fast(self.item, |rvalue| match rvalue {
             RValue::Use(place) => write!(f, "{}", place.for_fmt(self.storage)),
             RValue::Const(ConstKind::Value(Const::Zero(ty))) => {
                 write!(f, "{}", ty.for_fmt(self.storage))
@@ -153,7 +153,7 @@ impl fmt::Display for ForFormatting<'_, RValueId> {
                     AggregateKind::Tuple => fmt_operands(f, '(', ')'),
                     AggregateKind::Array(_) => fmt_operands(f, '[', ']'),
                     AggregateKind::Enum(adt, index) => {
-                        self.storage.adt_store().map_fast(*adt, |def| {
+                        self.storage.adts().map_fast(*adt, |def| {
                             let name = def.variants.get(*index).unwrap().name;
 
                             write!(f, "{}::{name}", adt.for_fmt(self.storage))

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -96,7 +96,7 @@ impl<'ir> IrBodyWriter<'ir> {
         }
 
         // Print all of the basic blocks
-        for (bb, _) in self.body.blocks.iter_enumerated() {
+        for (bb, _) in self.body.basic_blocks.blocks.iter_enumerated() {
             writeln!(f)?;
             self.write_block(bb, f)?;
         }
@@ -107,7 +107,7 @@ impl<'ir> IrBodyWriter<'ir> {
     fn write_block(&self, block: BasicBlock, f: &mut fmt::Formatter) -> fmt::Result {
         // Print the label for the block
         writeln!(f, "{: <1$}{block:?} {{", "", 4)?;
-        let block_data = &self.body.blocks[block];
+        let block_data = &self.body.blocks()[block];
 
         // Write all of the statements within the block
         for statement in &block_data.statements {

--- a/compiler/hash-lexer/src/utils.rs
+++ b/compiler/hash-lexer/src/utils.rs
@@ -1,13 +1,15 @@
 //! Hash Compiler lexer utilities for identifiers and other character sequences.
 
 /// True if `c` is valid as a first character of an identifier.
-// @@Future: Support unicode within idents?
+///
+/// @@Future: Support unicode within idents?
 pub(crate) fn is_id_start(c: char) -> bool {
-    ('a'..='z').contains(&c) || ('A'..='Z').contains(&c) || c == '_'
+    c.is_ascii_alphabetic() || c == '_'
 }
 
 /// True if `c` is valid as a non-first character of an identifier.
-// @@Future: Support unicode within idents?
+///
+/// @@Future: Support unicode within idents?
 pub(crate) fn is_id_continue(c: char) -> bool {
-    ('a'..='z').contains(&c) || ('A'..='Z').contains(&c) || ('0'..='9').contains(&c) || c == '_'
+    c.is_ascii_alphanumeric() || c == '_'
 }

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -121,7 +121,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Create an RValue for this reference
                 let addr_of = RValue::Ref(mutability, place, kind);
-                let rvalue = self.storage.rvalue_store().create(addr_of);
+                let rvalue = self.storage.rvalues().create(addr_of);
 
                 self.control_flow_graph.push_assign(block, destination, rvalue, span);
                 block.unit()

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -333,7 +333,7 @@ impl<'tcx> Builder<'tcx> {
                     // get the type of the tuple so that we can read all of the
                     // fields
                     let ty = self.ty_of_pat(pair.pat);
-                    let adt = self.storage.ty_store().map_fast(ty, IrTy::as_adt);
+                    let adt = self.storage.tys().map_fast(ty, IrTy::as_adt);
 
                     candidate.pairs.extend(self.match_pat_fields(*pat_args, adt, pair.place));
                     Ok(())
@@ -434,7 +434,7 @@ impl<'tcx> Builder<'tcx> {
         ty: AdtId,
         place: PlaceBuilder,
     ) -> Vec<MatchPair> {
-        self.storage.adt_store().map_fast(ty, |adt| {
+        self.storage.adts().map_fast(ty, |adt| {
             debug_assert!(adt.flags.is_struct() || adt.flags.is_tuple());
 
             let variant = adt.variants.first().unwrap();

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -196,7 +196,14 @@ impl<'tcx> Builder<'tcx> {
                 .map(|stmt| stmt.span)
                 .unwrap_or(subject_span);
 
-            self.control_flow_graph.goto(unpack!(arm_edge), end_block, span);
+            let arm_block_edge = unpack!(arm_edge);
+
+            // In the event that this block has already been terminated
+            // due to a `break` or `continue` or `return` control flow
+            // statement, then we don't terminate this block again.
+            if !self.control_flow_graph.is_terminated(arm_block_edge) {
+                self.control_flow_graph.goto(arm_block_edge, end_block, span);
+            }
         }
 
         end_block.unit()

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -367,7 +367,7 @@ impl<'tcx> Builder<'tcx> {
         // If it is a function type, then we use the return type of the
         // funciton as the `return_ty`, otherwise we assume the type provided
         // is the `return_ty`
-        let (return_ty, params) = self.storage.ty_store().map_fast(ty, |item_ty| match item_ty {
+        let (return_ty, params) = self.storage.tys().map_fast(ty, |item_ty| match item_ty {
             IrTy::Fn { return_ty, params, .. } => (*return_ty, Some(*params)),
             _ => (ty, None),
         });
@@ -403,7 +403,7 @@ impl<'tcx> Builder<'tcx> {
         // Add each parameter as a declaration to the body.
         let scope = self.current_scope();
         for (index, param) in fn_params.iter().enumerate() {
-            let ir_ty = self.storage.ty_list_store().get_at_index(param_tys, index);
+            let ir_ty = self.storage.tls().get_at_index(param_tys, index);
             let param_name = param.name.unwrap();
 
             // @@Future: deal with parameter attributes that are mutable?

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -68,9 +68,7 @@ impl PlaceBuilder {
     pub(crate) fn into_place(self, storage: &IrStorage) -> Place {
         Place {
             local: self.base,
-            projections: storage
-                .projection_store()
-                .create_from_iter_fast(self.projections.into_iter()),
+            projections: storage.projections().create_from_iter_fast(self.projections.into_iter()),
         }
     }
 }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -88,7 +88,7 @@ impl<'tcx> Builder<'tcx> {
 
                     let variants = index_vec![AdtVariant { name: 0usize.into(), fields }];
                     let adt = AdtData::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
-                    let adt_id = self.storage.adt_store().create(adt);
+                    let adt_id = self.storage.adts().create(adt);
                     IrTy::Adt(adt_id)
                 }
                 Level0Term::Lit(lit_term) => match lit_term {
@@ -127,7 +127,7 @@ impl<'tcx> Builder<'tcx> {
 
                     let variants = index_vec![AdtVariant { name: 0usize.into(), fields }];
                     let adt = AdtData::new_with_flags("tuple".into(), variants, AdtFlags::TUPLE);
-                    let adt_id = self.storage.adt_store().create(adt);
+                    let adt_id = self.storage.adts().create(adt);
                     IrTy::Adt(adt_id)
                 }
                 Level1Term::Fn(FnTy { name, params, return_ty }) => {
@@ -140,7 +140,7 @@ impl<'tcx> Builder<'tcx> {
                         .into_iter()
                         .map(|param| self.convert_term_into_ir_ty(param.ty));
 
-                    let params = self.storage.ty_list_store().create_from_iter(params);
+                    let params = self.storage.tls().create_from_iter(params);
                     IrTy::Fn { name, params, return_ty }
                 }
                 Level1Term::ModDef(_) => unreachable!(),
@@ -187,7 +187,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // @@Future: figure out what name to use when printing the name of the union.
                 let adt = AdtData::new_with_flags("union{...}".into(), variants, AdtFlags::UNION);
-                let adt_id = self.storage.adt_store().create(adt);
+                let adt_id = self.storage.adts().create(adt);
 
                 IrTy::Adt(adt_id)
             }
@@ -195,7 +195,7 @@ impl<'tcx> Builder<'tcx> {
             // @@FixMe: we assume that a merge term is going to be either a
             // list or some other collection type.
             Term::TyFnCall(_) | Term::Merge(_) => {
-                IrTy::Slice(self.storage.ty_store().create(IrTy::Int(SIntTy::I32)))
+                IrTy::Slice(self.storage.tys().create(IrTy::Int(SIntTy::I32)))
             }
             Term::Var(_)
             | Term::Access(_)
@@ -271,7 +271,7 @@ impl<'tcx> Builder<'tcx> {
                                 let variants = index_vec![AdtVariant { name, fields }];
 
                                 let adt = AdtData::new_with_flags(name, variants, AdtFlags::STRUCT);
-                                let adt_id = self.storage.adt_store().create(adt);
+                                let adt_id = self.storage.adts().create(adt);
 
                                 IrTy::Adt(adt_id)
                             } else {
@@ -316,7 +316,7 @@ impl<'tcx> Builder<'tcx> {
                             .collect();
 
                         let adt = AdtData::new_with_flags(name, variants, AdtFlags::ENUM);
-                        let adt_id = self.storage.adt_store().create(adt);
+                        let adt_id = self.storage.adts().create(adt);
 
                         IrTy::Adt(adt_id)
                     }
@@ -352,7 +352,7 @@ impl<'tcx> Builder<'tcx> {
         }
 
         let ir_ty = self.lower_term(term);
-        let ir_ty_id = self.storage.ty_store().create(ir_ty);
+        let ir_ty_id = self.storage.tys().create(ir_ty);
 
         // Add an entry into the cache for this term
         self.storage.add_ty_cache_entry(term, ir_ty_id);

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -66,9 +66,9 @@ impl<'tcx> Builder<'tcx> {
 
     /// Apply a function on a [IrTy::Adt].
     pub(crate) fn map_on_adt<T>(&self, ty: IrTyId, f: impl FnOnce(&AdtData, AdtId) -> T) -> T {
-        self.storage.ty_store().map_fast(ty, |ty| {
-            self.storage.adt_store().map_fast(ty.as_adt(), |adt| f(adt, ty.as_adt()))
-        })
+        self.storage
+            .tys()
+            .map_fast(ty, |ty| self.storage.adts().map_fast(ty.as_adt(), |adt| f(adt, ty.as_adt())))
     }
 
     /// Function to create a new [Place] that is used to ignore
@@ -78,7 +78,7 @@ impl<'tcx> Builder<'tcx> {
             Some(tmp) => *tmp,
             None => {
                 let ty = IrTy::unit(self.storage);
-                let ty_id = self.storage.ty_store().create(ty);
+                let ty_id = self.storage.tys().create(ty);
 
                 let local = LocalDecl::new_auxiliary(ty_id, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
@@ -136,6 +136,6 @@ impl<'tcx> Builder<'tcx> {
     ///      new [IrTy]s, whislt this is checking, this is only meant as a
     /// read-only      context over the whole type storage.
     pub(crate) fn map_ty<T>(&mut self, ty: IrTyId, f: impl FnOnce(&IrTy) -> T) -> T {
-        self.storage.ty_store().map_fast(ty, f)
+        self.storage.tys().map_fast(ty, f)
     }
 }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -8,6 +8,8 @@
 mod build;
 mod cfg;
 mod discover;
+mod optimise;
+mod traversal;
 
 use discover::LoweringVisitor;
 use hash_ast::ast::{AstVisitorMutSelf, OwnsAstNode};
@@ -22,6 +24,7 @@ use hash_pipeline::{
 };
 use hash_source::SourceId;
 use hash_types::storage::TyStorage;
+use optimise::Optimiser;
 
 /// The Hash IR builder compiler stage. This will walk the AST, and
 /// lower all items within a particular module.
@@ -40,7 +43,7 @@ impl Default for AstLowerer {
 }
 
 pub trait IrLoweringCtx: CompilerInterface {
-    fn data(&mut self) -> (&mut Workspace, &TyStorage, &mut IrStorage);
+    fn data(&mut self) -> (&mut Workspace, &TyStorage, &mut IrStorage, &rayon::ThreadPool);
 }
 
 impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
@@ -58,7 +61,7 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
     fn run_stage(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
         let settings = ctx.settings().lowering_settings;
 
-        let (workspace, ty_storage, ir_storage) = ctx.data();
+        let (workspace, ty_storage, ir_storage, _) = ctx.data();
         let source_map = &mut workspace.source_map;
         let source_stage_info = &mut workspace.source_stage_info;
 
@@ -89,20 +92,74 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
             lowered_bodies.extend(discoverer.into_bodies());
         }
 
-        // we need to check if any of the bodies have been marked for `dumping`
-        // and emit the IR that they have generated.
-
-        if settings.dump_mode == IrDumpMode::Graph {
-            graphviz::dump_ir_bodies(ir_storage, &lowered_bodies, settings.dump_all);
-        } else {
-            pretty::dump_ir_bodies(ir_storage, source_map, &lowered_bodies, settings.dump_all);
-        }
-
         // Mark all modules now as lowered, and all generated
         // bodies to the store.
         source_stage_info.set_all(SourceStageInfo::LOWERED);
         ir_storage.add_bodies(lowered_bodies);
 
         Ok(())
+    }
+}
+
+/// Compiler stage that is responsible for performing optimisations on the
+/// Hash IR. This will iterate over all of the bodies that have been generated
+/// and perform optimisations on them based on if they are applicable and the
+/// current configuration settings of the compiler.
+#[derive(Default)]
+pub struct IrOptimiser;
+
+impl IrOptimiser {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for IrOptimiser {
+    /// Return that this is [CompilerStageKind::IrGen].
+    fn stage_kind(&self) -> CompilerStageKind {
+        CompilerStageKind::IrGen
+    }
+
+    fn run_stage(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
+        let settings = ctx.settings().lowering_settings;
+
+        let (workspace, _, ir_storage, _) = ctx.data();
+        let source_map = &mut workspace.source_map;
+
+        let optimiser = Optimiser::new(source_map, settings);
+
+        // @@Todo: think about making optimisation passes in parallel...
+        // pool.scope(|scope| {
+        //     for body in &mut ir_storage.generated_bodies {
+        //         scope.spawn(|_| {
+        //             optimiser.optimise(body);
+        //         });
+        //     }
+        // });
+
+        for body in ir_storage.generated_bodies.iter_mut() {
+            optimiser.optimise(body);
+        }
+
+        Ok(())
+    }
+
+    fn cleanup(&mut self, _entry_point: SourceId, ctx: &mut Ctx) {
+        let settings = ctx.settings().lowering_settings;
+        let (workspace, _, ir_storage, _) = ctx.data();
+        let source_map = &mut workspace.source_map;
+
+        // we need to check if any of the bodies have been marked for `dumping`
+        // and emit the IR that they have generated.
+        if settings.dump_mode == IrDumpMode::Graph {
+            graphviz::dump_ir_bodies(ir_storage, &ir_storage.generated_bodies, settings.dump_all);
+        } else {
+            pretty::dump_ir_bodies(
+                ir_storage,
+                source_map,
+                &ir_storage.generated_bodies,
+                settings.dump_all,
+            );
+        }
     }
 }

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -1,0 +1,37 @@
+//! IR Optimisation pass that aims at removing un-used [Local]s
+//! within a particular graph. This involves checking the following
+//! properties:
+//!
+//! 1. Count how many times the [Local] is used as an [RValue].
+//!
+//! 2. For any [Local]s that are to be removed, we also remove all
+//!    assignments to those locals that may affect counts of other
+//!   [Local]s.
+
+use hash_ir::{ir::Body, BodyDataStore};
+use hash_pipeline::settings::{LoweringSettings, OptimisationLevel};
+
+use super::IrOptimisation;
+
+/// The [CleanupLocalPass] is responsible for removing un-used [Local]s
+/// from a given [Body]. This removes any assignments to dead locals, and
+/// re-orders all of the used locals to have valid indices after that
+/// pass is completed.
+pub struct CleanupLocalPass;
+
+impl IrOptimisation for CleanupLocalPass {
+    fn name(&self) -> &'static str {
+        "cleanup_locals"
+    }
+
+    /// Pass [CleanupLocalPass] is always enabled since it performs
+    /// necessary cleanup of the initially generated IR.
+    fn enabled(&self, settings: &LoweringSettings) -> bool {
+        settings.optimisation_level >= OptimisationLevel::Debug
+    }
+
+    fn optimise(&self, _body: &mut Body, _store: &BodyDataStore) {
+        // @@Todo: Need to implement an IR visitor in order to update
+        // all locals that were shifted when others were removed.
+    }
+}

--- a/compiler/hash-lower/src/optimise/mod.rs
+++ b/compiler/hash-lower/src/optimise/mod.rs
@@ -1,0 +1,53 @@
+//! Module contains all of the logic that involves optimising the
+//! generated IR bodies of various items from the source. Each optimisation
+//! pass is implemented as a function that takes a mutable reference to a
+//! `Body` and may modify the body by removing, or adding instructions and
+//! or basic blocks.
+
+use hash_ir::ir::Body;
+use hash_pipeline::settings::LoweringSettings;
+use hash_source::SourceMap;
+
+// Various passes that are used to optimise the generated IR bodies.
+mod simplify;
+
+pub trait IrOptimisation {
+    /// Check if this optimisation pas is enabled with accordance to
+    /// the current [LoweringSettings].
+    fn enabled(&self, settings: &LoweringSettings) -> bool;
+
+    /// Perform the optimisation pass on the body.
+    fn optimise(&self, body: &mut Body);
+}
+
+/// The optimiser is responsible for running all of the optimisation passes.
+/// Since all bodies are already lowered, and they have no interdependencies,
+/// we can run all of the optimisation passes on each body in parallel.
+pub struct Optimiser<'ir> {
+    /// The compiler source map.
+    _source_map: &'ir SourceMap,
+
+    /// Stores all of the lowering settings that are used to
+    /// determine which passes are enabled.
+    settings: LoweringSettings,
+
+    /// The various passes that have been added to the optimisation
+    /// pipeline.
+    passes: Vec<Box<dyn IrOptimisation + Send>>,
+}
+
+impl<'ir> Optimiser<'ir> {
+    pub fn new(source_map: &'ir SourceMap, settings: LoweringSettings) -> Self {
+        Self { _source_map: source_map, settings, passes: vec![Box::new(simplify::SimplifyGraph)] }
+    }
+
+    /// Optimise a specific body. This will run all of the optimisation passes
+    /// on the body.
+    pub fn optimise(&self, body: &mut Body) {
+        for pass in self.passes.iter() {
+            if pass.enabled(&self.settings) {
+                pass.optimise(body);
+            }
+        }
+    }
+}

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -11,7 +11,10 @@
 //!   pointing to the current block and updated. Once all of the predecessors
 //!   have been updated, the current block is removed from the body.
 
-use hash_ir::ir::{BasicBlock, Body, TerminatorKind};
+use hash_ir::{
+    ir::{BasicBlock, Body, TerminatorKind},
+    BodyDataStore,
+};
 use hash_pipeline::settings::{LoweringSettings, OptimisationLevel};
 
 use super::IrOptimisation;
@@ -62,11 +65,15 @@ pub fn remove_dead_blocks(body: &mut Body) {
 pub struct SimplifyGraph;
 
 impl IrOptimisation for SimplifyGraph {
-    fn enabled(&self, settings: &LoweringSettings) -> bool {
-        settings.optimisation_level >= OptimisationLevel::Release
+    fn name(&self) -> &'static str {
+        "simplify-graph"
     }
 
-    fn optimise(&self, body: &mut Body) {
+    fn enabled(&self, settings: &LoweringSettings) -> bool {
+        settings.optimisation_level >= OptimisationLevel::Debug
+    }
+
+    fn optimise(&self, body: &mut Body, _: &BodyDataStore) {
         // Firstly, lets check if there are any predecessors for each block. If the
         // block has no predecessors then we remove the block from the body entirely.
         // This is because the block is unreachable.

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -1,0 +1,128 @@
+//! Contains the `simplification` pass which simplifies the control
+//! flow graph by consiering the predecessors of each block and
+//! whether:
+//!
+//! - If the block has no predecessors, it is unreachable, and therefore we can
+//!   remove the block from the body, and potentially check if any of the
+//!   successors of the block also become unreachable.
+//!
+//! - If a block has a single unconditional successor and no instructions, the
+//!   destination of the block is propagated to all of the predecessor blocks
+//!   pointing to the current block and updated. Once all of the predecessors
+//!   have been updated, the current block is removed from the body.
+
+use hash_ir::ir::{BasicBlock, Body, TerminatorKind};
+use hash_pipeline::settings::{LoweringSettings, OptimisationLevel};
+
+use super::IrOptimisation;
+use crate::traversal;
+
+/// Function that will iterate over all of the blocks and remove them
+/// from the body source.
+pub fn remove_dead_blocks(body: &mut Body) {
+    let reachable_blocks = traversal::reachable_block_indices(body);
+    let block_count = body.basic_blocks.len();
+
+    // If all blocks are reachable, then we don't need to
+    // anything.
+    if reachable_blocks.ones().count() == block_count {
+        return;
+    }
+
+    let basic_blocks = body.basic_blocks.blocks_mut();
+    let mut replacement_map: Vec<_> = (0..block_count).map(BasicBlock::new).collect();
+    let mut used_blocks = 0;
+
+    for alive_index in reachable_blocks.ones() {
+        replacement_map[alive_index] = BasicBlock::new(used_blocks);
+
+        // We essentially fill in the next available block slot (dead block)
+        // with the current alive block. This is okay to do since `alive_index`
+        // will always be increasing.
+        if alive_index != used_blocks {
+            basic_blocks.raw.swap(alive_index, used_blocks);
+        }
+
+        used_blocks += 1;
+    }
+
+    // cleanup any remnants
+    basic_blocks.raw.truncate(used_blocks);
+
+    // now we need to go through and update all of the indices
+    // of the block terminators with the terminators that are
+    // specified within the replacement map.
+    for block in basic_blocks {
+        for target in block.terminator_mut().successors() {
+            block.terminator_mut().replace_edge(target, replacement_map[target.index()])
+        }
+    }
+}
+
+pub struct SimplifyGraph;
+
+impl IrOptimisation for SimplifyGraph {
+    fn enabled(&self, settings: &LoweringSettings) -> bool {
+        settings.optimisation_level >= OptimisationLevel::Release
+    }
+
+    fn optimise(&self, body: &mut Body) {
+        // Firstly, lets check if there are any predecessors for each block. If the
+        // block has no predecessors then we remove the block from the body entirely.
+        // This is because the block is unreachable.
+        //
+        // It's safe not to invalidate the cache here since we are removing dead blocks.
+        remove_dead_blocks(body);
+
+        // Now we try to simplify the graph by removing blocks that only perform
+        // a goto to another block. We perform this optimisation until we reached
+        // a fixed point since it maybe be that we can remove multiple blocks in
+        // a multiple iterations.
+        loop {
+            let mut changed = false;
+
+            // stores the index of the block that can be removed, and the block
+            // that it should be substituted with.
+            let mut changes: Vec<(BasicBlock, BasicBlock)> = Vec::new();
+
+            for (index, block) in body.blocks().iter_enumerated() {
+                // If there are any statements in the block, or if the block is the
+                // starting block, we cannot remove it since the entry point is
+                // always the starting block.
+                if !block.statements.is_empty()
+                    || body.basic_blocks.predecessors_of(index).is_empty()
+                {
+                    continue;
+                }
+
+                if let TerminatorKind::Goto(substitution) = block.terminator.as_ref().unwrap().kind
+                {
+                    // we want to get all of the predecessors of this block, and substitute any
+                    // references to the current block with the destination block.
+                    changes.push((index, substitution));
+                    changed = true;
+                }
+            }
+
+            // Short-circuit if we didn't make any changes.
+            if !changed {
+                break;
+            }
+
+            // Now we can perform the changes to the body.
+            for (index, substitution) in changes {
+                let predecessors = body.basic_blocks.predecessors_of(index);
+
+                for predecessor in predecessors {
+                    if let Some(block) = body.basic_blocks.blocks_mut().get_mut(predecessor) {
+                        let terminator = block.terminator.as_mut().unwrap();
+                        terminator.replace_edge(index, substitution);
+                    }
+                }
+            }
+
+            // Now we can remove the blocks that we no longer need.
+            remove_dead_blocks(body);
+        }
+    }
+}

--- a/compiler/hash-lower/src/traversal.rs
+++ b/compiler/hash-lower/src/traversal.rs
@@ -1,0 +1,98 @@
+//! Contains useful utilities for traversing a CFG of
+//! a particular body.
+
+use fixedbitset::FixedBitSet;
+use hash_ir::ir::{BasicBlock, BasicBlockData, Body, START_BLOCK};
+
+/// A [PreOrder] struct contains the relevant information
+/// about a pre-order traversal of a [Body]. This implements
+/// the [Iterator] trait and will yield the next basic block
+/// in the pre-order traversal.
+pub struct PreOrder<'ir> {
+    /// The body that we are traversing.
+    body: &'ir Body,
+
+    /// The visited blocks of the body.
+    visited: FixedBitSet,
+
+    /// The current worklist of the nodes that
+    /// need to visited
+    work_list: Vec<BasicBlock>,
+
+    /// If the traversal orders starts at the beginning
+    /// [START_BLOCK] of the body.
+    root_is_start_block: bool,
+}
+
+impl<'ir> PreOrder<'ir> {
+    /// Creates a new instance of [PreOrder] that will
+    /// traverse the body in pre-order.
+    pub fn new(body: &'ir Body, root: BasicBlock) -> Self {
+        Self {
+            body,
+            visited: FixedBitSet::with_capacity(body.blocks().len()),
+            work_list: vec![root],
+            root_is_start_block: root == START_BLOCK,
+        }
+    }
+
+    /// Create a new instance of [PreOrder] that will
+    /// traverse the body in pre-order starting at the
+    /// beginning [START_BLOCK] of the body.
+    pub fn new_from_start(body: &'ir Body) -> Self {
+        Self::new(body, START_BLOCK)
+    }
+}
+
+impl<'ir> Iterator for PreOrder<'ir> {
+    type Item = (BasicBlock, &'ir BasicBlockData);
+
+    /// Implements the [Iterator] trait for [PreOrder]. Essentially
+    /// traverses the body [BasicBlock]s in pre-order.
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(next) = self.work_list.pop() {
+            // Check if we have already visited this block, if not
+            // then add it to the `visited` list and return this as
+            // the next element of the graph traversal.
+            if self.visited.contains(next.index()) {
+                continue;
+            } else {
+                self.visited.insert(next.index());
+            }
+
+            let data = &self.body.blocks()[next];
+
+            // Add all of the successors to the worklist so we
+            // can visit them on the next iteration.
+            if let Some(ref term) = data.terminator {
+                self.work_list.extend(term.successors());
+            }
+
+            return Some((next, data));
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // All the blocks, minus the number of blocks we've visited.
+        let upper = self.body.basic_blocks.len() - self.visited.ones().count();
+
+        // If we start at the root, then we will visit all of the remaining
+        // blocks in the body, otherwise we only visit the remaining blocks
+        // in the `work_list`.
+        let lower = if self.root_is_start_block { upper } else { self.work_list.len() };
+
+        (lower, Some(upper))
+    }
+}
+
+/// Compute reachable blocks from the [START_BLOCK] of the body.
+pub(crate) fn reachable_block_indices(body: &Body) -> FixedBitSet {
+    let mut pre_order_traversal = PreOrder::new_from_start(body);
+
+    // now we perform the iteration, and only keep the visited blocks.
+    (&mut pre_order_traversal).for_each(drop);
+
+    pre_order_traversal.visited
+}

--- a/compiler/hash-lower/src/traversal.rs
+++ b/compiler/hash-lower/src/traversal.rs
@@ -15,7 +15,7 @@ pub struct PreOrder<'ir> {
     /// The visited blocks of the body.
     visited: FixedBitSet,
 
-    /// The current worklist of the nodes that
+    /// The current work_list of the nodes that
     /// need to visited
     work_list: Vec<BasicBlock>,
 

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -94,7 +94,7 @@ impl Default for CompilerSettings {
 }
 
 /// What optimisation level the compiler should run at.
-#[derive(ValueEnum, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OptimisationLevel {
     /// Run the compiler using the debug optimisation level. This will
     /// disable most optimisations that the compiler would otherwise do.
@@ -117,6 +117,9 @@ impl Default for OptimisationLevel {
 /// whether the IR should use `checked` operations, etc.
 #[derive(Debug, Clone, Copy)]
 pub struct LoweringSettings {
+    /// The optimisation level that is to be performed.
+    pub optimisation_level: OptimisationLevel,
+
     /// Whether the IR should dump all lowered bodies, rather than
     /// relying on user directives to select specific bodies.
     pub dump_all: bool,
@@ -131,7 +134,12 @@ pub struct LoweringSettings {
 
 impl Default for LoweringSettings {
     fn default() -> Self {
-        Self { dump_mode: IrDumpMode::Pretty, checked_operations: true, dump_all: false }
+        Self {
+            dump_mode: IrDumpMode::Pretty,
+            checked_operations: true,
+            dump_all: false,
+            optimisation_level: OptimisationLevel::Debug,
+        }
     }
 }
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -12,7 +12,7 @@ use hash_ast::node_map::NodeMap;
 use hash_ast_desugaring::{AstDesugaringCtx, AstDesugaringPass};
 use hash_ast_expand::{AstExpansionCtx, AstExpansionPass};
 use hash_ir::IrStorage;
-use hash_lower::{AstLowerer, IrLoweringCtx};
+use hash_lower::{AstLowerer, IrLoweringCtx, IrOptimiser};
 use hash_parser::{Parser, ParserCtx};
 use hash_pipeline::{
     interface::{CompilerInterface, CompilerStage},
@@ -35,6 +35,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
         Box::new(SemanticAnalysis),
         Box::new(Typechecker::new()),
         Box::new(AstLowerer::new()),
+        Box::new(IrOptimiser::new()),
         Box::new(Interpreter::new()),
     ]
 }
@@ -147,8 +148,8 @@ impl TypecheckingCtx for CompilerSession {
 }
 
 impl IrLoweringCtx for CompilerSession {
-    fn data(&mut self) -> (&mut Workspace, &TyStorage, &mut IrStorage) {
-        (&mut self.workspace, &self.ty_storage, &mut self.ir_storage)
+    fn data(&mut self) -> (&mut Workspace, &TyStorage, &mut IrStorage, &rayon::ThreadPool) {
+        (&mut self.workspace, &self.ty_storage, &mut self.ir_storage, &self.pool)
     }
 }
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -148,8 +148,13 @@ impl TypecheckingCtx for CompilerSession {
 }
 
 impl IrLoweringCtx for CompilerSession {
-    fn data(&mut self) -> (&mut Workspace, &TyStorage, &mut IrStorage, &rayon::ThreadPool) {
-        (&mut self.workspace, &self.ty_storage, &mut self.ir_storage, &self.pool)
+    fn data(&mut self) -> hash_lower::LoweringCtx {
+        hash_lower::LoweringCtx::new(
+            &mut self.workspace,
+            &self.ty_storage,
+            &mut self.ir_storage,
+            &self.pool,
+        )
     }
 }
 

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -140,16 +140,6 @@ pub(crate) struct IrGenMode {
     pub(crate) checked_operations: bool,
 }
 
-impl From<IrGenMode> for LoweringSettings {
-    fn from(options: IrGenMode) -> Self {
-        Self {
-            dump_mode: options.dump_mode,
-            dump_all: options.dump,
-            checked_operations: options.checked_operations,
-        }
-    }
-}
-
 impl TryInto<CompilerSettings> for CompilerOptions {
     type Error = CompilerError;
 
@@ -162,7 +152,13 @@ impl TryInto<CompilerSettings> for CompilerOptions {
 
             Some(SubCmd::Check { .. }) => CompilerStageKind::Typecheck,
             Some(SubCmd::IrGen(opts)) => {
-                lowering_settings = opts.into();
+                lowering_settings = LoweringSettings {
+                    dump_mode: opts.dump_mode,
+                    dump_all: opts.dump,
+                    checked_operations: opts.checked_operations,
+                    optimisation_level: self.optimisation_level,
+                };
+
                 CompilerStageKind::IrGen
             }
             _ => CompilerStageKind::Full,


### PR DESCRIPTION
This patch introduces a new stage to the lowering pipeline responsible for orchestrating optimisations on the IR. The first implementation is not currently sophisticated and cannot be parallelised, however, it is a good starting point for the future when considering this problem.

The first pass implemented is a simplification pass which trims dead blocks from the graph and removes redundant jump chains. There are many other possible and more sophisticated optimisations that can be performed on the IR before code generation, however, this commit is a good starting point for future work.

The next step to adding more optimisations is creating an IR visitor that can walk the IR mutably for simplifying and re-writing the IR, and immutably (for later stages of code generation).

closes #588