### PR TITLE
Traverse functions and blocks in scope discovery

### DIFF
--- a/compiler/hash-typecheck/src/new/ops/fns.rs
+++ b/compiler/hash-typecheck/src/new/ops/fns.rs
@@ -1,0 +1,28 @@
+// @@Docs
+use derive_more::Constructor;
+use hash_types::new::{
+    environment::env::AccessToEnv,
+    fns::{FnDef, FnDefData, FnDefId},
+};
+use hash_utils::store::Store;
+
+use crate::{impl_access_to_tc_env, new::environment::tc_env::TcEnv};
+
+#[derive(Constructor)]
+pub struct FnOps<'tc> {
+    tc_env: &'tc TcEnv<'tc>,
+}
+
+impl_access_to_tc_env!(FnOps<'tc>);
+
+impl<'tc> FnOps<'tc> {
+    /// Create a function definition.
+    pub fn create_fn_def(&self, data: FnDefData) -> FnDefId {
+        self.stores().fn_def().create_with(|id| FnDef {
+            id,
+            name: data.name,
+            ty: data.ty,
+            body: data.body,
+        })
+    }
+}

--- a/compiler/hash-typecheck/src/new/ops/mod.rs
+++ b/compiler/hash-typecheck/src/new/ops/mod.rs
@@ -1,12 +1,17 @@
 // @@Docs
-use self::{data::DataOps, defs::CommonDefOps, infer::InferOps, mods::ModOps, stack::StackOps};
+use self::{
+    data::DataOps, defs::CommonDefOps, fns::FnOps, infer::InferOps, mods::ModOps, params::ParamOps,
+    stack::StackOps,
+};
 
 pub mod common;
 pub mod data;
 pub mod defs;
+pub mod fns;
 pub mod infer;
 pub mod mods;
 pub mod oracle;
+pub mod params;
 pub mod stack;
 pub mod tuple;
 
@@ -30,4 +35,6 @@ ops! {
   stack_ops: StackOps,
   infer_ops: InferOps,
   common_def_ops: CommonDefOps,
+  fn_ops: FnOps,
+  param_ops: ParamOps,
 }

--- a/compiler/hash-typecheck/src/new/ops/mods.rs
+++ b/compiler/hash-typecheck/src/new/ops/mods.rs
@@ -1,10 +1,8 @@
 // @@Docs
 use derive_more::Constructor;
 use hash_types::new::{
-    defs::DefParamsId,
     environment::env::AccessToEnv,
-    mods::{ModDef, ModDefId, ModKind, ModMember, ModMemberData, ModMembersId},
-    symbols::Symbol,
+    mods::{ModDef, ModDefData, ModDefId, ModMember, ModMemberData, ModMembersId},
 };
 use hash_utils::store::{SequenceStore, Store};
 
@@ -20,20 +18,14 @@ impl_access_to_tc_env!(ModOps<'tc>);
 
 impl<'tc> ModOps<'tc> {
     /// Create an empty module definition.
-    pub fn create_mod_def(
-        &self,
-        name: Symbol,
-        params: DefParamsId,
-        kind: ModKind,
-        self_ty_name: Option<Symbol>,
-    ) -> ModDefId {
+    pub fn create_mod_def(&self, data: ModDefData) -> ModDefId {
         self.stores().mod_def().create_with(|id| ModDef {
             id,
-            name,
-            params,
-            kind,
-            members: self.stores().mod_members().create_from_slice(&[]),
-            self_ty_name,
+            name: data.name,
+            params: data.params,
+            kind: data.kind,
+            members: data.members,
+            self_ty_name: data.self_ty_name,
         })
     }
 
@@ -43,6 +35,11 @@ impl<'tc> ModOps<'tc> {
             mod_def.members = members;
         });
         members
+    }
+
+    /// Create an empty set of module members.
+    pub fn create_empty_mod_members(&self) -> ModMembersId {
+        self.stores().mod_members().create_from_slice(&[])
     }
 
     /// Create module members from the given set of members as an iterator.

--- a/compiler/hash-typecheck/src/new/ops/params.rs
+++ b/compiler/hash-typecheck/src/new/ops/params.rs
@@ -1,0 +1,44 @@
+use derive_more::Constructor;
+use hash_types::new::{
+    defs::{DefParamGroup, DefParamGroupData, DefParamsId},
+    environment::env::AccessToEnv,
+    params::{Param, ParamsId},
+    symbols::Symbol,
+};
+use hash_utils::store::SequenceStore;
+
+use super::common::CommonOps;
+use crate::{impl_access_to_tc_env, new::environment::tc_env::TcEnv};
+
+#[derive(Constructor)]
+pub struct ParamOps<'tc> {
+    tc_env: &'tc TcEnv<'tc>,
+}
+
+impl_access_to_tc_env!(ParamOps<'tc>);
+
+impl<'tc> ParamOps<'tc> {
+    /// Create a new parameter list with the given names, and holes for all
+    /// types.
+    pub fn create_hole_params(
+        &self,
+        param_names: impl Iterator<Item = Symbol> + ExactSizeIterator,
+    ) -> ParamsId {
+        self.stores().params().create_from_iter_with(
+            param_names.map(|name| {
+                move |id| Param { id, name, ty: self.new_ty_hole(), default_value: None }
+            }),
+        )
+    }
+
+    /// Create definition parameters from the given iterator of parameter group
+    /// data.
+    pub fn create_def_params(
+        &self,
+        param_groups: impl Iterator<Item = DefParamGroupData> + ExactSizeIterator,
+    ) -> DefParamsId {
+        self.stores().def_params().create_from_iter_with(param_groups.map(|data| {
+            move |id| DefParamGroup { id, params: data.params, implicit: data.implicit }
+        }))
+    }
+}

--- a/compiler/hash-types/src/new/mods.rs
+++ b/compiler/hash-types/src/new/mods.rs
@@ -133,7 +133,7 @@ impl Display for WithEnv<'_, &ModDef> {
                     "mod [name={}, type=file, src=\"{source_name}\"] {} {{\n{}}}",
                     self.env().with(self.value.name),
                     self.env().with(self.value.params),
-                    indent(&members, "    ")
+                    indent(&members, "  ")
                 )
             }
         }


### PR DESCRIPTION
This PR adds code to traverse function definitions during scope discovery and add them to the storage. At this stage, all types and terms are left as holes, and will be resolved further down the line when all the declarations have been discovered.

Closes #601 