### PR TITLE
Implement scope discovery for structs and enums

### DIFF
--- a/compiler/hash-typecheck/src/new/ops/data.rs
+++ b/compiler/hash-typecheck/src/new/ops/data.rs
@@ -1,5 +1,5 @@
 // @@Docs
-use std::iter::once;
+use std::iter::{empty, once};
 
 use derive_more::Constructor;
 use hash_types::new::{
@@ -14,7 +14,7 @@ use hash_types::new::{
     symbols::Symbol,
     terms::Term,
 };
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 use itertools::Itertools;
 
 use super::{common::CommonOps, AccessToOps};
@@ -199,11 +199,14 @@ impl<'tc> DataOps<'tc> {
                     let fields_params =
                         self.param_ops().create_params(variant_fields.iter().copied());
                     // The field parameters correspond to a single parameter group
-                    let fields_def_params =
+                    let fields_def_params = if !fields_params.is_empty() {
                         self.param_ops().create_def_params(once(DefParamGroupData {
                             implicit: false,
                             params: fields_params,
-                        }));
+                        }))
+                    } else {
+                        self.param_ops().create_def_params(empty())
+                    };
 
                     // Create a constructor for each variant
                     move |ctor_id| CtorDef {

--- a/compiler/hash-typecheck/src/new/ops/params.rs
+++ b/compiler/hash-typecheck/src/new/ops/params.rs
@@ -1,8 +1,11 @@
 use derive_more::Constructor;
 use hash_types::new::{
-    defs::{DefParamGroup, DefParamGroupData, DefParamsId},
+    args::{Arg, ArgData, ArgsId},
+    defs::{
+        DefArgGroup, DefArgGroupData, DefArgsId, DefParamGroup, DefParamGroupData, DefParamsId,
+    },
     environment::env::AccessToEnv,
-    params::{Param, ParamsId},
+    params::{Param, ParamData, ParamsId},
     symbols::Symbol,
 };
 use hash_utils::store::SequenceStore;
@@ -40,5 +43,33 @@ impl<'tc> ParamOps<'tc> {
         self.stores().def_params().create_from_iter_with(param_groups.map(|data| {
             move |id| DefParamGroup { id, params: data.params, implicit: data.implicit }
         }))
+    }
+
+    /// Create definition arguments from the given iterator of argument group
+    /// data.
+    pub fn create_def_args(
+        &self,
+        arg_groups: impl Iterator<Item = DefArgGroupData> + ExactSizeIterator,
+    ) -> DefArgsId {
+        self.stores().def_args().create_from_iter_with(arg_groups.map(|data| {
+            move |id| DefArgGroup { id, args: data.args, param_group: data.param_group }
+        }))
+    }
+
+    /// Create parameters from the given iterator of parameter data.
+    pub fn create_params(
+        &self,
+        params: impl Iterator<Item = ParamData> + ExactSizeIterator,
+    ) -> ParamsId {
+        self.stores().params().create_from_iter_with(params.map(|data| {
+            move |id| Param { id, name: data.name, ty: data.ty, default_value: data.default_value }
+        }))
+    }
+
+    /// Create arguments from the given iterator of argument data.
+    pub fn create_args(&self, args: impl Iterator<Item = ArgData> + ExactSizeIterator) -> ArgsId {
+        self.stores().args().create_from_iter_with(
+            args.map(|data| move |id| Arg { id, target: data.target, value: data.value }),
+        )
     }
 }


### PR DESCRIPTION
This PR adds discovery for struct and enum definitions. These are converted into data definitions.
The following snippet:
```
Lin := mod {
  Fing := struct <A, B, C> (foo: i32, bar: str, baz: char)
  Zing := enum <X, Y, Z> (Red(u8), Blue, Green(a: str, b: i32))
}
```

now produces the definitions:

```
 Lin := mod [name=Lin, type=block]  {
    Fing := datatype [name=Fing] <A: Hole8, B: Hole9, C: Hole10> {
      Fing: (foo: Hole11, bar: Hole12, baz: Hole13) -> Fing<A, B, C>
    }
    Zing := datatype [name=Zing] <X: Hole14, Y: Hole15, Z: Hole16> {
      Red: (s25: Hole17) -> Zing<X, Y, Z>
      Blue: Zing<X, Y, Z>
      Green: (a: Hole18, b: Hole19) -> Zing<X, Y, Z>
    }
}
```

Closes #604 