### PR TITLE
Add unsupported error message for merge declarations

### DIFF
--- a/compiler/hash-typecheck/src/new/diagnostics/error.rs
+++ b/compiler/hash-typecheck/src/new/diagnostics/error.rs
@@ -16,6 +16,8 @@ pub enum TcError {
     NeedMoreTypeAnnotationsToInfer { term: TermId },
     /// Traits are not yet supported.
     TraitsNotSupported { trait_location: SourceLocation },
+    /// Merge declarations are not yet supported.
+    MergeDeclarationsNotSupported { merge_location: SourceLocation },
 }
 
 pub type TcResult<T> = Result<T, TcError>;
@@ -53,7 +55,14 @@ impl<'tc> WithTcEnv<'tc, &TcError> {
                     .code(HashErrorCode::UnsupportedTraits)
                     .title("traits are work-in-progress and currently not supported".to_string());
 
-                error.add_span(*trait_location).add_help("traits are not yet supported");
+                error.add_span(*trait_location).add_help("cannot use traits yet");
+            }
+            TcError::MergeDeclarationsNotSupported { merge_location } => {
+                error
+                    .code(HashErrorCode::UnsupportedTraits)
+                    .title("merge declarations are currently not supported".to_string());
+
+                error.add_span(*merge_location).add_help("cannot use merge declarations yet");
             }
         }
     }

--- a/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
+++ b/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
@@ -532,6 +532,7 @@ impl<'tc> ast::AstVisitor for ScopeDiscoveryPass<'tc> {
         FnDef,
         TyFnDef,
         BodyBlock,
+        MergeDeclaration
     );
 
     type DeclarationRet = ();
@@ -674,17 +675,6 @@ impl<'tc> ast::AstVisitor for ScopeDiscoveryPass<'tc> {
         Ok(())
     }
 
-    type TraitDefRet = ();
-    fn visit_trait_def(
-        &self,
-        node: ast::AstNodeRef<ast::TraitDef>,
-    ) -> Result<Self::TraitDefRet, Self::Error> {
-        // Traits are not yet supported
-        self.diagnostics()
-            .add_error(TcError::TraitsNotSupported { trait_location: self.node_location(node) });
-        Ok(())
-    }
-
     type FnDefRet = ();
     fn visit_fn_def(&self, node: AstNodeRef<ast::FnDef>) -> Result<Self::FnDefRet, Self::Error> {
         // Get the function name from the name hint.
@@ -758,5 +748,27 @@ impl<'tc> ast::AstVisitor for ScopeDiscoveryPass<'tc> {
                 Ok(())
             }
         }
+    }
+
+    type TraitDefRet = ();
+    fn visit_trait_def(
+        &self,
+        node: ast::AstNodeRef<ast::TraitDef>,
+    ) -> Result<Self::TraitDefRet, Self::Error> {
+        // Traits are not yet supported
+        self.diagnostics()
+            .add_error(TcError::TraitsNotSupported { trait_location: self.node_location(node) });
+        Ok(())
+    }
+
+    type MergeDeclarationRet = ();
+    fn visit_merge_declaration(
+        &self,
+        node: AstNodeRef<ast::MergeDeclaration>,
+    ) -> Result<Self::MergeDeclarationRet, Self::Error> {
+        // Merge declarations are not yet supported
+        self.diagnostics()
+            .add_error(TcError::TraitsNotSupported { trait_location: self.node_location(node) });
+        Ok(())
     }
 }


### PR DESCRIPTION
Since the new typechecker does not currently support traits, it doesn't make sense for it to support merge declarations, so this PR adds an error message when a merge declaration is encountered.


#626 should be merged first.
Closes #627 
