### PR TITLE
IR: implement a basic visitor for mutable context, and a modifying visitor

### DIFF
--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -10,7 +10,7 @@ use hash_source::{
     location::{SourceLocation, Span},
     SourceId,
 };
-use hash_types::{scope::ScopeId, terms::TermId};
+use hash_types::scope::ScopeId;
 use hash_utils::{
     new_sequence_store_key, new_store_key,
     store::{DefaultSequenceStore, DefaultStore, SequenceStore, Store},
@@ -24,6 +24,8 @@ use crate::{
     IrStorage,
 };
 
+/// A specified constant value within the Hash IR. These values and their
+/// shape is always known at compile-time.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Const {
     /// Nothing, it has zero size, and is associated with a particular type.
@@ -471,7 +473,7 @@ pub enum RValue {
     /// @@Future: maybe in the future this should be replaced by a compile-time
     /// API variant which will just run some kind of operation and return the
     /// constant.
-    ConstOp(ConstOp, TermId),
+    ConstOp(ConstOp, IrTyId),
 
     /// A unary expression with a unary operator.
     UnaryOp(UnaryOp, RValueId),
@@ -809,7 +811,8 @@ impl TerminatorKind {
 /// terminator. Initially, the `terminator` begins as [None], and will
 /// be set when the lowering process is completed.
 ///
-/// N.B. It is an invariant for a [BasicBlock] to not have a terminator.
+/// N.B. It is an invariant for a [BasicBlock] to not have a terminator
+/// once it has been built.
 #[derive(Debug, PartialEq, Eq)]
 pub struct BasicBlockData {
     /// The statements that the block has.

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -563,18 +563,26 @@ pub enum StatementKind {
 pub struct Statement {
     /// The kind of [Statement] that it is.
     pub kind: StatementKind,
+
     /// The [Span] of the statement, relative to the [Body]
-    /// `source-id`.
+    /// `source-id`. This is mostly used for error reporting or
+    /// generating debug information at later stages of lowering
+    /// beyond the IR.
     pub span: Span,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+/// The kind of assert terminator that it is.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AssertKind {
+    /// A Division by zero assertion.
     DivisionByZero,
+
     /// Occurs when an attempt to take the remainder of some operand with zero.
     RemainderByZero,
+
     /// Performing an arithmetic operation has caused the operation to overflow
     Overflow,
+
     /// Performing an arithmetic operation has caused the operation to overflow
     /// whilst subtracting or terms that are signed
     NegativeOverflow,
@@ -588,8 +596,11 @@ pub enum AssertKind {
 pub struct Terminator {
     /// The kind of [Terminator] that it is.
     pub kind: TerminatorKind,
+
     /// The [Span] of the statement, relative to the [Body]
-    /// `source-id`.
+    /// `source-id`. This is mostly used for error reporting or
+    /// generating debug information at later stages of lowering
+    /// beyond the IR.
     pub span: Span,
 }
 

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -1,24 +1,140 @@
-//! Hash Compiler Intermediate Representation (IR) crate.
-
-use std::process::Output;
+//! Hash IR visitor and walker trait definitions.
 
 use crate::{
-    ir::{BasicBlock, Body, RValue, Statement, Terminator},
-    IrStorage,
+    ir::{
+        AddressMode, AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, Body, ConstKind,
+        ConstOp, Local, Place, RValue, RValueId, Statement, SwitchTargets, Terminator,
+    },
+    ty::{IrTyId, Mutability, VariantIdx},
+    BodyDataStore,
 };
 
+/// A trait for visiting the IR with a mutable context. This trait should
+/// not be used for when modifications to the IR need to be made in place.
+/// This is because the IR values are mapped from the [RValueStore] and
+/// other stores in such a way that prevents in place modification. Any
+/// modifications should be made by modifying the [RValue]s after the process
+/// of visiting is complete or use the [ModifyingIrVisitor] trait families.
+pub trait IrVisitorMut<'ir> {
+    /// Return a reference to the [BodyDataStore].
+    fn storage(&self) -> &'ir BodyDataStore;
+
+    /// Return the [Body] of the current visitor.
+    fn body(&self) -> &'ir Body;
+
+    type BodyRet;
+    fn visit_body(&mut self, body: &'ir Body) -> Self::BodyRet;
+
+    type BlockRet;
+    fn visit_block(&mut self, block: &'ir BasicBlockData) -> Self::BlockRet;
+
+    type StatementRet;
+    fn visit_statement(&mut self, statement: &'ir Statement) -> Self::StatementRet;
+
+    fn visit_nop_statement(&mut self) -> Self::StatementRet;
+
+    fn visit_assign_statement(&mut self, place: &'ir Place, value: RValueId) -> Self::StatementRet;
+
+    fn visit_discriminator_statement(
+        &mut self,
+        place: &'ir Place,
+        variant: VariantIdx,
+    ) -> Self::StatementRet;
+
+    fn visit_alloc_statement(&mut self, local: Local) -> Self::StatementRet;
+
+    fn visit_alloc_raw_statement(&mut self, local: Local) -> Self::StatementRet;
+
+    type RValueRet;
+    fn visit_rvalue(&mut self, value: &'ir RValue) -> Self::RValueRet;
+
+    fn visit_const_rvalue(&mut self, value: &'ir ConstKind) -> Self::RValueRet;
+
+    fn visit_use_rvalue(&mut self, value: &'ir Place) -> Self::RValueRet;
+
+    fn visit_const_op_rvalue(&mut self, op: ConstOp, ty: IrTyId) -> Self::RValueRet;
+
+    fn visit_checked_binary_op_rvalue(
+        &mut self,
+        op: BinOp,
+        lhs: RValueId,
+        rhs: RValueId,
+    ) -> Self::RValueRet;
+
+    fn visit_len_rvalue(&mut self, value: &'ir Place) -> Self::RValueRet;
+
+    fn visit_ref_rvalue(
+        &mut self,
+        mutability: Mutability,
+        value: &'ir Place,
+        mode: AddressMode,
+    ) -> Self::RValueRet;
+
+    fn visit_aggregate_rvalue(
+        &mut self,
+        kind: AggregateKind,
+        values: &'ir [RValueId],
+    ) -> Self::RValueRet;
+
+    fn visit_discriminant(&mut self, value: &'ir Place) -> Self::RValueRet;
+
+    type TerminatorRet;
+    fn visit_terminator(&mut self, terminator: &'ir Terminator) -> Self::TerminatorRet;
+
+    fn visit_goto_terminator(&mut self, target: BasicBlock) -> Self::TerminatorRet;
+
+    fn visit_unreachable_terminator(&mut self) -> Self::TerminatorRet;
+
+    fn visit_return_terminator(&mut self) -> Self::TerminatorRet;
+
+    fn visit_call_terminator(
+        &mut self,
+        op: RValueId,
+        args: &'ir [RValueId],
+        destination: &'ir Place,
+        target: Option<BasicBlock>,
+    ) -> Self::TerminatorRet;
+
+    fn visit_switch_terminator(
+        &mut self,
+        value: RValueId,
+        targets: &'ir SwitchTargets,
+    ) -> Self::TerminatorRet;
+
+    fn visit_assert_terminator(
+        &mut self,
+        condition: &'ir Place,
+        expected: bool,
+        kind: AssertKind,
+        target: BasicBlock,
+    ) -> Self::TerminatorRet;
+
+    type PlaceRet;
+    fn visit_place(&mut self, place: &'ir Place) -> Self::PlaceRet;
+}
+
+// @@Todo: fill these in when the general structure of `IrVisitorMut` is
+// finalised.
 pub trait IrVisitor<'ir> {
-    type Output;
+    /// Return a reference to the [BodyDataStore].
+    fn storage(&self) -> &'ir BodyDataStore;
 
-    fn storage(&self) -> &'ir IrStorage;
+    /// Return the [Body] of the current visitor.
+    fn body(&self) -> &'ir Body;
+}
 
-    fn visit_body(&mut self, body: &'ir Body) -> Output;
+pub trait ModifyingIrVisitor<'ir> {
+    /// Return a reference to the [BodyDataStore].
+    fn storage(&self) -> &'ir BodyDataStore;
 
-    fn visit_block(&mut self, block: BasicBlock) -> Output;
+    /// Return the [Body] of the current visitor.
+    fn body(&self) -> &'ir Body;
+}
 
-    fn visit_statement(&mut self, statement: &'ir Statement) -> Output;
+pub trait ModifyingIrVisitorMut<'ir> {
+    /// Return a reference to the [BodyDataStore].
+    fn storage(&self) -> &'ir BodyDataStore;
 
-    fn visit_rvalue(&mut self, value: &'ir RValue) -> Output;
-
-    fn visit_terminator(&mut self, terminator: &'ir Terminator) -> Output;
+    /// Return the [Body] of the current visitor.
+    fn body(&self) -> &'ir Body;
 }

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -1,9 +1,22 @@
 //! Hash IR visitor and walker trait definitions.
-
+/// In an ideal world, this should be generated using a similar
+/// approach to as the AST. Most of the time, we don't want to
+/// write the visitor code by hand. Ideally, we want:
+///
+/// 1. A cartesian product of the IR Visitor traits, so that we
+///    can both visit with a mutable and immutable context, and an
+///    a visitor that can modify the IR in place and one that can't.
+///
+/// 2. The ability to generate walking methods for the IR that can accompany
+///    all variants fo the visiting traits.
+///
+/// 3. The ability to hide away the boilerplate of the visitor and walking
+///    code for nodes that don't need to be dealt with.
 use crate::{
     ir::{
         AddressMode, AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, Body, ConstKind,
-        ConstOp, Local, Place, RValue, RValueId, Statement, SwitchTargets, Terminator,
+        ConstOp, Local, Place, PlaceProjection, RValue, RValueId, Statement, SwitchTargets,
+        Terminator, UnaryOp,
     },
     ty::{IrTyId, Mutability, VariantIdx},
     BodyDataStore,
@@ -15,102 +28,456 @@ use crate::{
 /// other stores in such a way that prevents in place modification. Any
 /// modifications should be made by modifying the [RValue]s after the process
 /// of visiting is complete or use the [ModifyingIrVisitor] trait families.
-pub trait IrVisitorMut<'ir> {
+///
+/// @@Temporary: we don't support function returns yet, since we should do this
+/// when we can hide away implementation to simplify implementers.
+pub trait IrVisitorMut<'ir>: Sized {
     /// Return a reference to the [BodyDataStore].
-    fn storage(&self) -> &'ir BodyDataStore;
+    fn store(&self) -> &'ir BodyDataStore;
 
-    /// Return the [Body] of the current visitor.
-    fn body(&self) -> &'ir Body;
+    /// The entry point of the visitor. This is called when the visitor
+    /// is first initialised.
+    fn visit(&mut self, body: &Body) {
+        walk_mut::walk_body(self, body);
+    }
 
-    type BodyRet;
-    fn visit_body(&mut self, body: &'ir Body) -> Self::BodyRet;
+    fn visit_basic_block(&mut self, block: &BasicBlockData) {
+        walk_mut::walk_basic_block(self, block);
+    }
 
-    type BlockRet;
-    fn visit_block(&mut self, block: &'ir BasicBlockData) -> Self::BlockRet;
+    fn visit_statement(&mut self, statement: &Statement) {
+        walk_mut::walk_statement(self, statement);
+    }
 
-    type StatementRet;
-    fn visit_statement(&mut self, statement: &'ir Statement) -> Self::StatementRet;
+    fn visit_assign_statement(&mut self, place: &Place, value: &RValue) {
+        walk_mut::walk_assign_statement(self, place, value);
+    }
 
-    fn visit_nop_statement(&mut self) -> Self::StatementRet;
+    fn visit_discriminator_statement(&mut self, place: &Place, variant: VariantIdx) {
+        walk_mut::walk_discriminating_statement(self, place, variant);
+    }
 
-    fn visit_assign_statement(&mut self, place: &'ir Place, value: RValueId) -> Self::StatementRet;
+    fn visit_alloc_statement(&mut self, local: Local) {
+        walk_mut::walk_alloc_statement(self, local);
+    }
 
-    fn visit_discriminator_statement(
-        &mut self,
-        place: &'ir Place,
-        variant: VariantIdx,
-    ) -> Self::StatementRet;
+    fn visit_alloc_raw_statement(&mut self, local: Local) {
+        walk_mut::walk_alloc_raw_statement(self, local);
+    }
 
-    fn visit_alloc_statement(&mut self, local: Local) -> Self::StatementRet;
+    fn visit_rvalue(&mut self, value: &RValue) {
+        walk_mut::walk_rvalue(self, value);
+    }
 
-    fn visit_alloc_raw_statement(&mut self, local: Local) -> Self::StatementRet;
+    fn visit_const_rvalue(&mut self, _: &ConstKind) {}
 
-    type RValueRet;
-    fn visit_rvalue(&mut self, value: &'ir RValue) -> Self::RValueRet;
+    fn visit_use_rvalue(&mut self, value: &Place) {
+        walk_mut::walk_use_rvalue(self, value);
+    }
 
-    fn visit_const_rvalue(&mut self, value: &'ir ConstKind) -> Self::RValueRet;
+    fn visit_const_op_rvalue(&mut self, _: ConstOp, _: IrTyId) {}
 
-    fn visit_use_rvalue(&mut self, value: &'ir Place) -> Self::RValueRet;
+    fn visit_unary_op_rvalue(&mut self, op: UnaryOp, value: &RValue) {
+        walk_mut::walk_unary_op_rvalue(self, op, value);
+    }
 
-    fn visit_const_op_rvalue(&mut self, op: ConstOp, ty: IrTyId) -> Self::RValueRet;
+    fn visit_binary_op_rvalue(&mut self, op: BinOp, lhs: &RValue, rhs: &RValue) {
+        walk_mut::walk_binary_op_rvalue(self, op, lhs, rhs);
+    }
 
-    fn visit_checked_binary_op_rvalue(
-        &mut self,
-        op: BinOp,
-        lhs: RValueId,
-        rhs: RValueId,
-    ) -> Self::RValueRet;
+    fn visit_checked_binary_op_rvalue(&mut self, op: BinOp, lhs: &RValue, rhs: &RValue) {
+        walk_mut::walk_checked_binary_op_rvalue(self, op, lhs, rhs);
+    }
 
-    fn visit_len_rvalue(&mut self, value: &'ir Place) -> Self::RValueRet;
+    fn visit_len_rvalue(&mut self, value: &Place) {
+        walk_mut::walk_len_rvalue(self, value);
+    }
 
-    fn visit_ref_rvalue(
-        &mut self,
-        mutability: Mutability,
-        value: &'ir Place,
-        mode: AddressMode,
-    ) -> Self::RValueRet;
+    fn visit_ref_rvalue(&mut self, mutability: Mutability, value: &Place, mode: AddressMode) {
+        walk_mut::walk_ref_rvalue(self, mutability, value, mode);
+    }
 
-    fn visit_aggregate_rvalue(
-        &mut self,
-        kind: AggregateKind,
-        values: &'ir [RValueId],
-    ) -> Self::RValueRet;
+    fn visit_aggregate_rvalue(&mut self, kind: AggregateKind, values: &[&RValue]) {
+        walk_mut::walk_aggregate_rvalue(self, kind, values);
+    }
 
-    fn visit_discriminant(&mut self, value: &'ir Place) -> Self::RValueRet;
+    fn visit_discriminant_rvalue(&mut self, value: &Place) {
+        walk_mut::walk_discriminant_rvalue(self, value);
+    }
 
-    type TerminatorRet;
-    fn visit_terminator(&mut self, terminator: &'ir Terminator) -> Self::TerminatorRet;
+    fn visit_terminator(&mut self, terminator: &Terminator) {
+        walk_mut::walk_terminator(self, terminator);
+    }
 
-    fn visit_goto_terminator(&mut self, target: BasicBlock) -> Self::TerminatorRet;
+    fn visit_goto_terminator(&mut self, _: BasicBlock) {}
 
-    fn visit_unreachable_terminator(&mut self) -> Self::TerminatorRet;
+    fn visit_unreachable_terminator(&mut self) {}
 
-    fn visit_return_terminator(&mut self) -> Self::TerminatorRet;
+    fn visit_return_terminator(&mut self) {}
 
     fn visit_call_terminator(
         &mut self,
-        op: RValueId,
-        args: &'ir [RValueId],
-        destination: &'ir Place,
+        op: &RValue,
+        args: &[&RValue],
+        destination: &Place,
         target: Option<BasicBlock>,
-    ) -> Self::TerminatorRet;
+    ) {
+        walk_mut::walk_call_terminator(self, op, args, destination, target);
+    }
 
-    fn visit_switch_terminator(
-        &mut self,
-        value: RValueId,
-        targets: &'ir SwitchTargets,
-    ) -> Self::TerminatorRet;
+    fn visit_switch_terminator(&mut self, value: &RValue, targets: &SwitchTargets) {
+        walk_mut::walk_switch_terminator(self, value, targets);
+    }
 
     fn visit_assert_terminator(
         &mut self,
-        condition: &'ir Place,
+        condition: &Place,
         expected: bool,
         kind: AssertKind,
         target: BasicBlock,
-    ) -> Self::TerminatorRet;
+    ) {
+        walk_mut::walk_assert_terminator(self, condition, expected, kind, target);
+    }
 
-    type PlaceRet;
-    fn visit_place(&mut self, place: &'ir Place) -> Self::PlaceRet;
+    fn visit_place(&mut self, place: &Place) {
+        walk_mut::walk_place(self, place);
+    }
+
+    fn visit_local(&mut self, _: Local) {}
+
+    fn visit_projection(&mut self, projection: &PlaceProjection) {
+        walk_mut::walk_projection(self, projection);
+    }
+}
+
+/// Contains all of the walking methods for the [IrVisitorMut] trait.
+pub mod walk_mut {
+    use hash_utils::store::{SequenceStore, Store};
+
+    use super::{IrVisitorMut, *};
+    use crate::ir::{StatementKind, TerminatorKind};
+
+    /// Walk over all the [BasicBlock]s in the [Body] of the given
+    /// to the visitor.
+    pub fn walk_body<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, body: &Body) {
+        for block in body.blocks() {
+            visitor.visit_basic_block(block);
+        }
+    }
+
+    /// Walk over all the [Statement]s in the given [BasicBlock] to the
+    pub fn walk_basic_block<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, block: &BasicBlockData) {
+        for statement in block.statements.iter() {
+            visitor.visit_statement(statement);
+        }
+
+        if let Some(terminator) = &block.terminator {
+            visitor.visit_terminator(terminator);
+        }
+    }
+
+    pub fn walk_statement<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, statement: &Statement) {
+        let store = visitor.store().rvalues();
+
+        match &statement.kind {
+            StatementKind::Nop => {}
+            StatementKind::Assign(place, value) => {
+                store.map_fast(*value, |value| visitor.visit_assign_statement(place, value))
+            }
+
+            StatementKind::Discriminate(place, variant) => {
+                visitor.visit_discriminator_statement(place, *variant)
+            }
+            StatementKind::Alloc(local) => visitor.visit_alloc_statement(*local),
+            StatementKind::AllocRaw(local) => visitor.visit_alloc_raw_statement(*local),
+        }
+    }
+
+    // pub struct AssignStatementRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_assign_statement<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        place: &Place,
+        value: &RValue,
+    ) /* -> AssignStatementRet<'ir, V> */
+    {
+        // AssignStatementRet { place: visitor.visit_place(place), value:
+        // visitor.visit_rvalue(value) }
+        visitor.visit_place(place);
+        visitor.visit_rvalue(value);
+    }
+
+    // pub struct DiscriminatingStatementRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_discriminating_statement<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        place: &Place,
+        _: VariantIdx,
+    ) /* -> DiscriminatingStatementRet<'ir, V> */
+    {
+        // DiscriminatingStatementRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place);
+    }
+
+    pub fn walk_alloc_statement<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, local: Local) {
+        visitor.visit_local(local);
+    }
+
+    pub fn walk_alloc_raw_statement<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, local: Local) {
+        visitor.visit_local(local);
+    }
+
+    pub fn walk_rvalue<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, value: &RValue) /* -> V::RValueRet */
+    {
+        let store = visitor.store().rvalues();
+
+        match value {
+            RValue::Const(value) => visitor.visit_const_rvalue(value),
+            RValue::Use(place) => visitor.visit_use_rvalue(place),
+            RValue::ConstOp(op, ty) => visitor.visit_const_op_rvalue(*op, *ty),
+            RValue::UnaryOp(op, value) => {
+                store.map_fast(*value, |value| visitor.visit_unary_op_rvalue(*op, value))
+            }
+
+            RValue::BinaryOp(op, lhs, rhs) => store.map_many_fast([*lhs, *rhs], |values| {
+                let [lhs, rhs] = values else {
+                    unreachable!()
+                };
+
+                visitor.visit_binary_op_rvalue(*op, lhs, rhs)
+            }),
+            RValue::CheckedBinaryOp(op, lhs, rhs) => store.map_many_fast([*lhs, *rhs], |values| {
+                let [lhs, rhs] = values else {
+                    unreachable!()
+                };
+
+                visitor.visit_checked_binary_op_rvalue(*op, lhs, rhs)
+            }),
+            RValue::Len(place) => visitor.visit_len_rvalue(place),
+            RValue::Ref(mutability, place, mode) => {
+                visitor.visit_ref_rvalue(*mutability, place, *mode)
+            }
+            RValue::Aggregate(kind, values) => store.map_many_fast(values.clone(), |values| {
+                visitor.visit_aggregate_rvalue(*kind, values)
+            }),
+
+            RValue::Discriminant(place) => visitor.visit_discriminant_rvalue(place),
+        }
+    }
+
+    // pub struct UseRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_use_rvalue<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, place: &Place)
+    /* -> UseRValueRet<'ir, V> */
+    {
+        // UseRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct UnaryOpRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_unary_op_rvalue<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        _: UnaryOp,
+        value: &RValue,
+    ) /* -> UnaryOpRValueRet<'ir, V> */
+    {
+        // UnaryOpRValueRet { value: visitor.visit_rvalue(value) }
+        visitor.visit_rvalue(value)
+    }
+
+    // pub struct BinaryOpRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub lhs: V::RValueRet,
+    //     pub rhs: V::RValueRet,
+    // }
+
+    pub fn walk_binary_op_rvalue<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        _: BinOp,
+        lhs: &RValue,
+        rhs: &RValue,
+    ) /* -> BinaryOpRValueRet<'ir, V> */
+    {
+        // BinaryOpRValueRet { lhs: visitor.visit_rvalue(lhs), rhs:
+        // visitor.visit_rvalue(rhs) }
+        visitor.visit_rvalue(lhs);
+        visitor.visit_rvalue(rhs);
+    }
+
+    pub fn walk_checked_binary_op_rvalue<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        _: BinOp,
+        lhs: &RValue,
+        rhs: &RValue,
+    ) /* -> BinaryOpRValueRet<'ir, V> */
+    {
+        // BinaryOpRValueRet { lhs: visitor.visit_rvalue(lhs), rhs:
+        // visitor.visit_rvalue(rhs) }
+        visitor.visit_rvalue(lhs);
+        visitor.visit_rvalue(rhs);
+    }
+
+    // pub struct LenRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_len_rvalue<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, place: &Place)
+    /* -> LenRValueRet<'ir, V> */
+    {
+        // LenRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct RefRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_ref_rvalue<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        _: Mutability,
+        place: &Place,
+        _: AddressMode,
+    ) /* -> RefRValueRet<'ir, V> */
+    {
+        // RefRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct AggregateRValueRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub values: Vec<V::RValueRet>,
+    // }
+
+    pub fn walk_aggregate_rvalue<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        _: AggregateKind,
+        values: &[&RValue],
+    ) /* -> AggregateRValueRet<'ir, V> */
+    {
+        // AggregateRValueRet {
+        //     values: values.iter().map(|value| visitor.visit_rvalue(value)).collect(),
+        // }
+        values.iter().for_each(|value| visitor.visit_rvalue(value))
+    }
+
+    // pub struct DiscriminantRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_discriminant_rvalue<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, place: &Place)
+    /* -> DiscriminantRet<'ir, V> */
+    {
+        // DiscriminantRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    pub fn walk_terminator<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, terminator: &Terminator)
+    /* -> V::TerminatorRet */
+    {
+        let store = visitor.store().rvalues();
+
+        match &terminator.kind {
+            TerminatorKind::Goto(target) => visitor.visit_goto_terminator(*target),
+            TerminatorKind::Unreachable => visitor.visit_unreachable_terminator(),
+            TerminatorKind::Return => visitor.visit_return_terminator(),
+            TerminatorKind::Call { op, args, destination, target } => {
+                let store = visitor.store().rvalues();
+
+                store.map_fast(*op, |op| {
+                    store.map_many_fast(args.clone(), |args| {
+                        visitor.visit_call_terminator(op, args, destination, *target)
+                    })
+                })
+            }
+            TerminatorKind::Switch { value, targets } => {
+                store.map_fast(*value, |value| visitor.visit_switch_terminator(value, targets))
+            }
+            TerminatorKind::Assert { condition, expected, kind, target } => {
+                visitor.visit_assert_terminator(condition, *expected, *kind, *target)
+            }
+        }
+    }
+
+    // pub struct CallTerminatorRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub op: V::RValueRet,
+    //     pub args: Vec<V::RValueRet>,
+    //     pub destination: V::PlaceRet,
+    // }
+
+    pub fn walk_call_terminator<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        op: &RValue,
+        args: &[&RValue],
+        destination: &Place,
+        _: Option<BasicBlock>,
+    ) /* -> CallTerminatorRet<'ir, V> */
+    {
+        // CallTerminatorRet {
+        //     op: visitor.visit_rvalue(op),
+        //     args: args.iter().map(|arg| visitor.visit_rvalue(arg)).collect(),
+        //     destination: visitor.visit_place(destination),
+        // }
+        visitor.visit_rvalue(op);
+        args.iter().for_each(|arg| visitor.visit_rvalue(arg));
+        visitor.visit_place(destination);
+    }
+
+    // pub struct SwitchTerminatorRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_switch_terminator<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        value: &RValue,
+        _: &SwitchTargets,
+    ) /* -> SwitchTerminatorRet<'ir, V> */
+    {
+        // SwitchTerminatorRet { value: visitor.visit_rvalue(value) }
+        visitor.visit_rvalue(value)
+    }
+
+    // pub struct AssertTerminatorRet<'ir, V: IrVisitorMut<'ir>> {
+    //     pub condition: V::PlaceRet,
+    // }
+
+    pub fn walk_assert_terminator<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        condition: &Place,
+        _: bool,
+        _: AssertKind,
+        _: BasicBlock,
+    ) /* -> AssertTerminatorRet<'ir, V> */
+    {
+        // AssertTerminatorRet { condition: visitor.visit_place(condition) }
+        visitor.visit_place(condition)
+    }
+
+    pub fn walk_place<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, place: &Place) {
+        visitor.visit_local(place.local);
+
+        visitor.store().projections().map_fast(place.projections, |projection| {
+            for projection in projection.iter() {
+                visitor.visit_projection(projection)
+            }
+        })
+    }
+
+    pub fn walk_projection<'ir, V: IrVisitorMut<'ir>>(
+        visitor: &mut V,
+        projection: &PlaceProjection,
+    ) {
+        if let PlaceProjection::Index(local) = projection {
+            visitor.visit_local(*local)
+        }
+    }
 }
 
 // @@Todo: fill these in when the general structure of `IrVisitorMut` is
@@ -123,18 +490,464 @@ pub trait IrVisitor<'ir> {
     fn body(&self) -> &'ir Body;
 }
 
-pub trait ModifyingIrVisitor<'ir> {
+pub trait ModifyingIrVisitor<'ir>: Sized {
     /// Return a reference to the [BodyDataStore].
-    fn storage(&self) -> &'ir BodyDataStore;
+    fn store(&self) -> &'ir BodyDataStore;
 
-    /// Return the [Body] of the current visitor.
-    fn body(&self) -> &'ir Body;
+    /// The entry point of the visitor. This is called when the visitor
+    /// is first initialised.
+    fn visit(&self, body: &mut Body) {
+        walk_modifying::walk_body(self, body);
+    }
+
+    fn visit_basic_block(&self, block: &mut BasicBlockData) {
+        walk_modifying::walk_basic_block(self, block);
+    }
+
+    fn visit_statement(&self, statement: &mut Statement) {
+        walk_modifying::walk_statement(self, statement);
+    }
+
+    fn visit_assign_statement(&self, place: &mut Place, value: &mut RValue) {
+        walk_modifying::walk_assign_statement(self, place, value);
+    }
+
+    fn visit_discriminator_statement(&self, place: &mut Place, variant: &mut VariantIdx) {
+        walk_modifying::walk_discriminating_statement(self, place, variant);
+    }
+
+    fn visit_alloc_statement(&self, local: &mut Local) {
+        walk_modifying::walk_alloc_statement(self, local);
+    }
+
+    fn visit_alloc_raw_statement(&self, local: &mut Local) {
+        walk_modifying::walk_alloc_raw_statement(self, local);
+    }
+
+    fn visit_rvalue(&self, value: &mut RValue) {
+        walk_modifying::walk_rvalue(self, value);
+    }
+
+    fn visit_const_rvalue(&self, _: &mut ConstKind) {}
+
+    fn visit_use_rvalue(&self, value: &mut Place) {
+        walk_modifying::walk_use_rvalue(self, value);
+    }
+
+    fn visit_const_op_rvalue(&self, _: &mut ConstOp, _: &mut IrTyId) {}
+
+    fn visit_unary_op_rvalue(&self, op: &mut UnaryOp, value: &mut RValue) {
+        walk_modifying::walk_unary_op_rvalue(self, op, value);
+    }
+
+    fn visit_binary_op_rvalue(&self, op: &mut BinOp, lhs: &mut RValue, rhs: &mut RValue) {
+        walk_modifying::walk_binary_op_rvalue(self, op, lhs, rhs);
+    }
+
+    fn visit_checked_binary_op_rvalue(&self, op: &mut BinOp, lhs: &mut RValue, rhs: &mut RValue) {
+        walk_modifying::walk_checked_binary_op_rvalue(self, op, lhs, rhs);
+    }
+
+    fn visit_len_rvalue(&self, value: &mut Place) {
+        walk_modifying::walk_len_rvalue(self, value);
+    }
+
+    fn visit_ref_rvalue(
+        &self,
+        mutability: &mut Mutability,
+        value: &mut Place,
+        mode: &mut AddressMode,
+    ) {
+        walk_modifying::walk_ref_rvalue(self, mutability, value, mode);
+    }
+
+    fn visit_aggregate_rvalue(&self, kind: &mut AggregateKind, values: &mut [RValueId]) {
+        walk_modifying::walk_aggregate_rvalue(self, kind, values);
+    }
+
+    fn visit_discriminant_rvalue(&self, value: &mut Place) {
+        walk_modifying::walk_discriminant_rvalue(self, value);
+    }
+
+    fn visit_terminator(&self, terminator: &mut Terminator) {
+        walk_modifying::walk_terminator(self, terminator);
+    }
+
+    fn visit_goto_terminator(&self, _: BasicBlock) {}
+
+    fn visit_unreachable_terminator(&self) {}
+
+    fn visit_return_terminator(&self) {}
+
+    fn visit_call_terminator(
+        &self,
+        op: &mut RValue,
+        args: &[RValueId],
+        destination: &mut Place,
+        target: &mut Option<BasicBlock>,
+    ) {
+        walk_modifying::walk_call_terminator(self, op, args, destination, target);
+    }
+
+    fn visit_switch_terminator(&self, value: &mut RValue, targets: &mut SwitchTargets) {
+        walk_modifying::walk_switch_terminator(self, value, targets);
+    }
+
+    fn visit_assert_terminator(
+        &self,
+        condition: &mut Place,
+        expected: &mut bool,
+        kind: &mut AssertKind,
+        target: &mut BasicBlock,
+    ) {
+        walk_modifying::walk_assert_terminator(self, condition, expected, kind, target);
+    }
+
+    fn visit_place(&self, place: &mut Place) {
+        walk_modifying::walk_place(self, place);
+    }
+
+    fn visit_local(&self, _: &mut Local) {}
+
+    fn visit_projection(&self, projection: &mut PlaceProjection) {
+        walk_modifying::walk_projection(self, projection);
+    }
+}
+
+/// Contains all of the walking methods for the [IrVisitorMut] trait.
+pub mod walk_modifying {
+    use hash_utils::store::{CloneStore, SequenceStoreCopy};
+
+    use super::{ModifyingIrVisitor, *};
+    use crate::ir::{StatementKind, TerminatorKind};
+
+    /// Walk over all the [BasicBlock]s in the [Body] of the given
+    /// to the visitor.
+    pub fn walk_body<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, body: &mut Body) {
+        for block in body.basic_blocks.blocks_mut() {
+            visitor.visit_basic_block(block);
+        }
+    }
+
+    /// Walk over all the [Statement]s in the given [BasicBlock] to the
+    pub fn walk_basic_block<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        block: &mut BasicBlockData,
+    ) {
+        for statement in block.statements.iter_mut() {
+            visitor.visit_statement(statement);
+        }
+
+        if let Some(terminator) = &mut block.terminator {
+            visitor.visit_terminator(terminator);
+        }
+    }
+
+    pub fn walk_statement<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, statement: &mut Statement) {
+        let store = visitor.store().rvalues();
+
+        match &mut statement.kind {
+            StatementKind::Nop => {}
+            StatementKind::Assign(place, value) => {
+                store.modify(*value, |value| visitor.visit_assign_statement(place, value))
+            }
+
+            StatementKind::Discriminate(place, variant) => {
+                visitor.visit_discriminator_statement(place, variant)
+            }
+            StatementKind::Alloc(local) => visitor.visit_alloc_statement(local),
+            StatementKind::AllocRaw(local) => visitor.visit_alloc_raw_statement(local),
+        }
+    }
+
+    // pub struct AssignStatementRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_assign_statement<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        place: &mut Place,
+        value: &mut RValue,
+    ) /* -> AssignStatementRet<'ir, V> */
+    {
+        // AssignStatementRet { place: visitor.visit_place(place), value:
+        // visitor.visit_rvalue(value) }
+        visitor.visit_place(place);
+        visitor.visit_rvalue(value);
+    }
+
+    // pub struct DiscriminatingStatementRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_discriminating_statement<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        place: &mut Place,
+        _: &mut VariantIdx,
+    ) /* -> DiscriminatingStatementRet<'ir, V> */
+    {
+        // DiscriminatingStatementRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place);
+    }
+
+    pub fn walk_alloc_statement<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, local: &mut Local) {
+        visitor.visit_local(local);
+    }
+
+    pub fn walk_alloc_raw_statement<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        local: &mut Local,
+    ) {
+        visitor.visit_local(local);
+    }
+
+    pub fn walk_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, value: &mut RValue)
+    /* -> V::RValueRet */
+    {
+        let store = visitor.store().rvalues();
+
+        match value {
+            RValue::Const(value) => visitor.visit_const_rvalue(value),
+            RValue::Use(place) => visitor.visit_use_rvalue(place),
+            RValue::ConstOp(op, ty) => visitor.visit_const_op_rvalue(op, ty),
+            RValue::UnaryOp(op, value) => {
+                store.modify(*value, |value| visitor.visit_unary_op_rvalue(op, value))
+            }
+
+            RValue::BinaryOp(op, lhs, rhs) => store.modify(*lhs, |lhs| {
+                store.modify(*rhs, |rhs| visitor.visit_binary_op_rvalue(op, lhs, rhs))
+            }),
+            RValue::CheckedBinaryOp(op, lhs, rhs) => store.modify(*lhs, |lhs| {
+                store.modify(*rhs, |rhs| visitor.visit_checked_binary_op_rvalue(op, lhs, rhs))
+            }),
+            RValue::Len(place) => visitor.visit_len_rvalue(place),
+            RValue::Ref(mutability, place, mode) => {
+                visitor.visit_ref_rvalue(mutability, place, mode)
+            }
+            RValue::Aggregate(kind, values) => visitor.visit_aggregate_rvalue(kind, values),
+
+            RValue::Discriminant(place) => visitor.visit_discriminant_rvalue(place),
+        }
+    }
+
+    // pub struct UseRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_use_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, place: &mut Place)
+    /* -> UseRValueRet<'ir, V> */
+    {
+        // UseRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct UnaryOpRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_unary_op_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        _: &mut UnaryOp,
+        value: &mut RValue,
+    ) /* -> UnaryOpRValueRet<'ir, V> */
+    {
+        // UnaryOpRValueRet { value: visitor.visit_rvalue(value) }
+        visitor.visit_rvalue(value)
+    }
+
+    // pub struct BinaryOpRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub lhs: V::RValueRet,
+    //     pub rhs: V::RValueRet,
+    // }
+
+    pub fn walk_binary_op_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        _: &mut BinOp,
+        lhs: &mut RValue,
+        rhs: &mut RValue,
+    ) /* -> BinaryOpRValueRet<'ir, V> */
+    {
+        // BinaryOpRValueRet { lhs: visitor.visit_rvalue(lhs), rhs:
+        // visitor.visit_rvalue(rhs) }
+        visitor.visit_rvalue(lhs);
+        visitor.visit_rvalue(rhs);
+    }
+
+    pub fn walk_checked_binary_op_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        _: &mut BinOp,
+        lhs: &mut RValue,
+        rhs: &mut RValue,
+    ) /* -> BinaryOpRValueRet<'ir, V> */
+    {
+        // BinaryOpRValueRet { lhs: visitor.visit_rvalue(lhs), rhs:
+        // visitor.visit_rvalue(rhs) }
+        visitor.visit_rvalue(lhs);
+        visitor.visit_rvalue(rhs);
+    }
+
+    // pub struct LenRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_len_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, place: &mut Place)
+    /* -> LenRValueRet<'ir, V> */
+    {
+        // LenRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct RefRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_ref_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        _: &mut Mutability,
+        place: &mut Place,
+        _: &mut AddressMode,
+    ) /* -> RefRValueRet<'ir, V> */
+    {
+        // RefRValueRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    // pub struct AggregateRValueRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub values: Vec<V::RValueRet>,
+    // }
+
+    pub fn walk_aggregate_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        _: &mut AggregateKind,
+        values: &mut [RValueId],
+    ) /* -> AggregateRValueRet<'ir, V> */
+    {
+        // AggregateRValueRet {
+        //     values: values.iter().map(|value| visitor.visit_rvalue(value)).collect(),
+        // }
+        values.iter().for_each(|key| {
+            visitor.store().rvalues().modify(*key, |value| visitor.visit_rvalue(value))
+        })
+    }
+
+    // pub struct DiscriminantRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub place: V::PlaceRet,
+    // }
+
+    pub fn walk_discriminant_rvalue<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        place: &mut Place,
+    )
+    /* -> DiscriminantRet<'ir, V> */
+    {
+        // DiscriminantRet { place: visitor.visit_place(place) }
+        visitor.visit_place(place)
+    }
+
+    pub fn walk_terminator<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        terminator: &mut Terminator,
+    )
+    /* -> V::TerminatorRet */
+    {
+        let store = visitor.store().rvalues();
+
+        match &mut terminator.kind {
+            TerminatorKind::Goto(target) => visitor.visit_goto_terminator(*target),
+            TerminatorKind::Unreachable => visitor.visit_unreachable_terminator(),
+            TerminatorKind::Return => visitor.visit_return_terminator(),
+            TerminatorKind::Call { op, args, destination, target } => {
+                let store = visitor.store().rvalues();
+
+                store.modify(*op, |op| visitor.visit_call_terminator(op, args, destination, target))
+            }
+            TerminatorKind::Switch { value, targets } => {
+                store.modify(*value, |value| visitor.visit_switch_terminator(value, targets))
+            }
+            TerminatorKind::Assert { condition, expected, kind, target } => {
+                visitor.visit_assert_terminator(condition, expected, kind, target)
+            }
+        }
+    }
+
+    // pub struct CallTerminatorRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub op: V::RValueRet,
+    //     pub args: Vec<V::RValueRet>,
+    //     pub destination: V::PlaceRet,
+    // }
+
+    pub fn walk_call_terminator<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        op: &mut RValue,
+        args: &[RValueId],
+        destination: &mut Place,
+        _: &mut Option<BasicBlock>,
+    ) /* -> CallTerminatorRet<'ir, V> */
+    {
+        // CallTerminatorRet {
+        //     op: visitor.visit_rvalue(op),
+        //     args: args.iter().map(|arg| visitor.visit_rvalue(arg)).collect(),
+        //     destination: visitor.visit_place(destination),
+        // }
+        visitor.visit_rvalue(op);
+        args.iter().for_each(|arg| {
+            visitor.store().rvalues().modify(*arg, |value| visitor.visit_rvalue(value))
+        });
+        visitor.visit_place(destination);
+    }
+
+    // pub struct SwitchTerminatorRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub value: V::RValueRet,
+    // }
+
+    pub fn walk_switch_terminator<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        value: &mut RValue,
+        _: &mut SwitchTargets,
+    ) /* -> SwitchTerminatorRet<'ir, V> */
+    {
+        // SwitchTerminatorRet { value: visitor.visit_rvalue(value) }
+        visitor.visit_rvalue(value)
+    }
+
+    // pub struct AssertTerminatorRet<'ir, V: ModifyingIrVisitor<'ir>> {
+    //     pub condition: V::PlaceRet,
+    // }
+
+    pub fn walk_assert_terminator<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        condition: &mut Place,
+        _: &mut bool,
+        _: &mut AssertKind,
+        _: &mut BasicBlock,
+    ) /* -> AssertTerminatorRet<'ir, V> */
+    {
+        // AssertTerminatorRet { condition: visitor.visit_place(condition) }
+        visitor.visit_place(condition)
+    }
+
+    pub fn walk_place<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, place: &mut Place) {
+        visitor.visit_local(&mut place.local);
+
+        visitor.store().projections().modify_copied(place.projections, |projection| {
+            for projection in projection.iter_mut() {
+                visitor.visit_projection(projection)
+            }
+        })
+    }
+
+    pub fn walk_projection<'ir, V: ModifyingIrVisitor<'ir>>(
+        visitor: &V,
+        projection: &mut PlaceProjection,
+    ) {
+        if let PlaceProjection::Index(local) = projection {
+            visitor.visit_local(local)
+        }
+    }
 }
 
 pub trait ModifyingIrVisitorMut<'ir> {
     /// Return a reference to the [BodyDataStore].
     fn storage(&self) -> &'ir BodyDataStore;
-
-    /// Return the [Body] of the current visitor.
-    fn body(&self) -> &'ir Body;
 }

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -107,7 +107,7 @@ impl<'tcx> Builder<'tcx> {
                 let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));
                 let then_block = self.control_flow_graph.start_new_block();
 
-                let value = self.storage.push_rvalue(RValue::Use(place));
+                let value = self.storage.rvalues().create(RValue::Use(place));
                 let terminator =
                     TerminatorKind::make_if(value, then_block, else_block, self.storage);
                 self.control_flow_graph.terminate(block, span, terminator);
@@ -684,7 +684,7 @@ impl<'tcx> Builder<'tcx> {
             // @@Todo: we might have to do some special rules for the `by-ref` case
             //         when we start to think about reference rules more concretely.
             let rvalue = RValue::Ref(binding.mutability, binding.source, AddressMode::Raw);
-            let rvalue_id = self.storage.push_rvalue(rvalue);
+            let rvalue_id = self.storage.rvalues().create(rvalue);
             self.control_flow_graph.push_assign(block, value_place, rvalue_id, binding.span);
         }
     }
@@ -703,7 +703,7 @@ impl<'tcx> Builder<'tcx> {
                     RValue::Ref(binding.mutability, binding.source, AddressMode::Raw)
                 }
             };
-            let rvalue_id = self.storage.push_rvalue(rvalue);
+            let rvalue_id = self.storage.rvalues().create(rvalue);
 
             // Now resolve where the binding place from, and then push
             // an assign onto the binding source.

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -144,7 +144,7 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for IrOptimiser {
         let LoweringCtx { workspace, ir_storage, .. } = ctx.data();
         let source_map = &mut workspace.source_map;
 
-        let bodies = &mut ir_storage.generated_bodies;
+        let bodies = &mut ir_storage.bodies;
         let body_data = &ir_storage.body_data;
         // let optimiser = Optimiser::new(ir_storage, source_map, settings);
 
@@ -173,14 +173,9 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for IrOptimiser {
         // we need to check if any of the bodies have been marked for `dumping`
         // and emit the IR that they have generated.
         if settings.dump_mode == IrDumpMode::Graph {
-            graphviz::dump_ir_bodies(ir_storage, &ir_storage.generated_bodies, settings.dump_all);
+            graphviz::dump_ir_bodies(ir_storage, &ir_storage.bodies, settings.dump_all);
         } else {
-            pretty::dump_ir_bodies(
-                ir_storage,
-                source_map,
-                &ir_storage.generated_bodies,
-                settings.dump_all,
-            );
+            pretty::dump_ir_bodies(ir_storage, source_map, &ir_storage.bodies, settings.dump_all);
         }
     }
 }

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -8,8 +8,16 @@
 //!    assignments to those locals that may affect counts of other
 //!   [Local]s.
 
-use hash_ir::{ir::Body, BodyDataStore};
+use hash_ir::{
+    ir::{
+        Body, Local, LocalDecl, Place, PlaceProjection, RValue, Statement, StatementKind,
+        RETURN_PLACE,
+    },
+    visitor::{walk_mut, IrVisitorMut, ModifyingIrVisitor},
+    BodyDataStore,
+};
 use hash_pipeline::settings::{LoweringSettings, OptimisationLevel};
+use index_vec::{index_vec, IndexVec};
 
 use super::IrOptimisation;
 
@@ -27,11 +35,236 @@ impl IrOptimisation for CleanupLocalPass {
     /// Pass [CleanupLocalPass] is always enabled since it performs
     /// necessary cleanup of the initially generated IR.
     fn enabled(&self, settings: &LoweringSettings) -> bool {
-        settings.optimisation_level >= OptimisationLevel::Debug
+        settings.optimisation_level > OptimisationLevel::Debug
     }
 
-    fn optimise(&self, _body: &mut Body, _store: &BodyDataStore) {
-        // @@Todo: Need to implement an IR visitor in order to update
-        // all locals that were shifted when others were removed.
+    fn optimise(&self, body: &mut Body, store: &BodyDataStore) {
+        let mut local_map = LocalUseMap::new(body, store);
+        self.simplify_locals(body, &mut local_map);
+
+        // after the locals are simplified, we need to re-map all of the
+        // ones so that we can trim all of them from the body declaration.
+        let local_remaps = local_map.remap_locals(&mut body.declarations);
+
+        if local_remaps.iter().any(Option::is_none) {
+            // create an updater, and then we can remap all of the places.
+            let updater = LocalUpdater::new(local_remaps, store);
+            updater.visit(body);
+
+            body.declarations.shrink_to_fit();
+        }
+    }
+}
+
+impl CleanupLocalPass {
+    /// This is the main algorithm of this pass. We have already constructed a
+    /// [LocalUseMap] which denotes how many times each [Local] is used as an
+    /// [RValue] within the [Body]. We then iterate over all of the [Statement]s
+    /// and check whether the [Local] that they reference on the left-hand side
+    /// is not used. If it is not used, then we can remove the statement.
+    /// However, the removal of the statement may affect the counts of other
+    /// [Local]s, so we need to update the counts for each [Local] that we
+    /// see. This is done by re-visiting the statement that was removed, and
+    /// decrementing the count for each [Local] that we see in that
+    /// particular statement.
+    fn simplify_locals(&self, body: &mut Body, local_map: &mut LocalUseMap<'_>) {
+        let mut changed = true;
+
+        while changed {
+            changed = false;
+
+            // iterate all blocks and remove any dead local references
+            for block in body.basic_blocks.blocks_mut() {
+                block.statements.retain(|statement| {
+                    let (keep, is_nop) = match statement.kind {
+                        StatementKind::Nop => (false, true),
+                        StatementKind::Assign(place, _) | StatementKind::Discriminate(place, _)
+                            if !local_map.is_used(place.local) =>
+                        {
+                            (false, false)
+                        }
+                        _ => (true, false),
+                    };
+
+                    if !keep {
+                        // If we removed a `nop`, then we don't have to re-run the
+                        // whole graph since this does not affect the counts of any
+                        // other locals.
+                        if !is_nop {
+                            // we also need to perform an update to the local count
+                            // since we just removed the assignment to this local.
+                            local_map.statement_removed(statement);
+                        } else {
+                            changed = true;
+                        }
+                    }
+
+                    keep
+                });
+            }
+        }
+    }
+}
+
+/// A visitor that counts how many times each [Local] is used as an
+/// [RValue] within a particular [Body].
+pub struct LocalUseMap<'ir> {
+    /// All of the counts for each local in the specified body.
+    uses: Vec<usize>,
+
+    /// The number of arguments that the body contains. We need
+    /// to store this since we can't "eliminate" locals that represent
+    /// the return value or the arguments of the function.
+    arg_count: usize,
+
+    /// Whether the count for each local use should be incremented,
+    /// or whether it should be decremented. The count becomes decremented
+    /// when a statement is removed from the control flow graph due to
+    /// being dead code. This allows for the pass to avoid re-scanning
+    /// the entire CFG after each local removal, and only what is needed
+    /// for scanning.
+    increment: bool,
+
+    /// A reference to the [BodyDataStore] in order to access and
+    /// read values references by the [Body].
+    store: &'ir BodyDataStore,
+}
+
+impl<'ir> LocalUseMap<'ir> {
+    /// Create a new [LocalUseMap] for the specified [Body].
+    pub fn new(body: &Body, store: &'ir BodyDataStore) -> Self {
+        let mut counts = vec![0; body.declarations.len()];
+
+        // always set to `_0` to 1 since it is the return value and
+        // is always used
+        counts[RETURN_PLACE.index()] = 1;
+        let mut this = Self { uses: counts, store, arg_count: body.arg_count, increment: true };
+
+        // visit the body and record the counts for each local, then
+        // return the
+        this.visit(body);
+        this
+    }
+
+    /// Check if a [Local] is used within the [Body] that was visited.
+    pub fn is_used(&self, local: Local) -> bool {
+        local.index() <= self.arg_count || self.uses[local.index()] != 0
+    }
+
+    /// Update the count for a [Local] based on whether the count
+    /// should be incremented or decremented.
+    fn update_count_for(&mut self, local: Local) {
+        if self.increment {
+            self.uses[local.index()] += 1;
+        } else {
+            debug_assert_ne!(self.uses[local.index()], 0);
+            self.uses[local.index()] -= 1;
+        }
+    }
+
+    /// When a [Statement] is removed from the [Body], we need to
+    /// traverse the statement again, and update the counts for each
+    /// local as we see them. However, rather than incrementing the counts
+    /// for each local, we know decrement each item that we see.
+    pub fn statement_removed(&mut self, statement: &Statement) {
+        self.increment = false;
+
+        // re-visit this particular statement since we've just removed it.
+        self.visit_statement(statement);
+    }
+
+    /// Perform a remapping of the locals within the [Body] that was
+    /// visited. This function will generate a map to remap each local
+    /// to a possibly new local value. If the value is [None], then no
+    /// remapping is required.
+    pub fn remap_locals(
+        &self,
+        locals: &mut IndexVec<Local, LocalDecl>,
+    ) -> IndexVec<Local, Option<Local>> {
+        let mut remap = index_vec![None; self.uses.len()];
+        let mut used = Local::new(0);
+
+        // Iterate over each local, check if it is still alive, and it it isn't
+        // then we need to remap it to `used`
+        for alive_local in locals.indices() {
+            if !self.is_used(alive_local) {
+                continue;
+            }
+
+            // we swap the dead and alive indices, whilst also recording
+            // that we need to remap the actual IR to the new local.
+            remap[alive_local.index()] = Some(used);
+
+            if alive_local != used {
+                locals.swap(alive_local, used);
+            }
+            used += 1;
+        }
+
+        locals.truncate(used.index());
+        remap
+    }
+}
+
+// @@Todo: Simplify this implementation by hiding away un-used implementations.
+impl<'ir> IrVisitorMut<'ir> for LocalUseMap<'ir> {
+    fn store(&self) -> &'ir BodyDataStore {
+        self.store
+    }
+
+    /// Visit an assignment [Statement], we only visit the [RValue] part of the
+    /// assignment fully, and only check the projections of the [Place] in case
+    /// it is referenced within a [PlaceProjection::Index].
+    fn visit_assign_statement(&mut self, place: &Place, value: &RValue) {
+        self.store().map_place(*place, |_, projections| {
+            for projection in projections {
+                if let PlaceProjection::Index(index_local) = projection {
+                    self.update_count_for(*index_local);
+                }
+            }
+        });
+
+        // @@Safety: currently it is safe to remove all variants of an RValue, however
+        // if we add more rvalues (specifically casts), then we might need to be
+        // more careful about whether the rvalue is safe to remove or not.
+        walk_mut::walk_rvalue(self, value);
+    }
+
+    /// This function will update the count for the referenced local in this
+    /// place. We don't count places that "assign something" since this does
+    /// not inherently use the local.
+    fn visit_local(&mut self, local: Local) {
+        self.update_count_for(local);
+    }
+}
+
+pub struct LocalUpdater<'ir> {
+    /// The map of locals to remap to a new local. If the [Local] index is
+    /// [None], this means that the local is dead and was removed. If the
+    /// [Local] index is [Some], then the local was not removed and should
+    /// be remapped to the new [Local].
+    remap: IndexVec<Local, Option<Local>>,
+
+    /// Reference to body data store
+    store: &'ir BodyDataStore,
+}
+
+impl<'ir> LocalUpdater<'ir> {
+    /// Create a new [LocalUpdater].
+    pub fn new(remap: IndexVec<Local, Option<Local>>, store: &'ir BodyDataStore) -> Self {
+        Self { remap, store }
+    }
+}
+
+impl<'ir> ModifyingIrVisitor<'ir> for LocalUpdater<'ir> {
+    fn store(&self) -> &'ir BodyDataStore {
+        self.store
+    }
+
+    /// Perform a remapping of the [Local] within the [Place] to a new [Local].
+    fn visit_local(&self, local: &mut Local) {
+        if let Some(new_local) = self.remap[*local] {
+            *local = new_local;
+        }
     }
 }

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -155,6 +155,22 @@ pub trait Store<Key: StoreKey, Value> {
         f(value)
     }
 
+    /// Get many values by a collection of keys, and map them to another value.
+    ///
+    /// *Warning*: Do not call mutating store methods (`create` etc) in `f`
+    /// otherwise there will be a panic. If you want to do this, consider using
+    /// [`CloneStore::map_many()`] instead.
+    fn map_many_fast<T>(
+        &self,
+        keys: impl IntoIterator<Item = Key>,
+        f: impl FnOnce(&[&Value]) -> T,
+    ) -> T {
+        let data = self.internal_data().borrow();
+        let values =
+            keys.into_iter().map(|key| data.get(key.to_index()).unwrap()).collect::<Vec<_>>();
+        f(&values)
+    }
+
     /// Modify a value by a key, possibly returning another value.
     ///
     /// *Warning*: Do not call mutating store methods (`create` etc) in `f`

--- a/compiler/hash/src/args.rs
+++ b/compiler/hash/src/args.rs
@@ -1,6 +1,6 @@
 //! Hash Compiler arguments management.
 
-use clap::{self, command, Parser, Subcommand};
+use clap::{self, command, ArgAction, Parser, Subcommand};
 use hash_pipeline::settings::{
     CompilerSettings, CompilerStageKind, IrDumpMode, LoweringSettings, OptimisationLevel,
 };
@@ -136,7 +136,7 @@ pub(crate) struct IrGenMode {
     /// Whether the IR should use `checked` operations, if this flag
     /// is specified, this will insert `checked` operations regardless
     /// of the optimisation level.
-    #[arg(long, default_value_t = true)]
+    #[arg(long, default_value_t = true, action = ArgAction::Set)]
     pub(crate) checked_operations: bool,
 }
 


### PR DESCRIPTION
This patch adds new IR visitors that are able to traverse the generated IR with the following parameters:
- a visitor with a mutable context, but immutable read the IR
- a visitor with an immutable context, but mutably walk the IR

The current visitor implementation is written by hand (and it is quite ugly, especially the `modify`s), and I solemnly promise to create a macro for the visitor and walking code for the following attributes:
- a visitor with a mutable context, immutably walk the IR
- a visitor with an immutable context, immutably walk the IR
- a visitor with a mutable context, mutably walk the IR
- a visitor with an immutable context, mutably walk the IR

Furthermore, it would be nice to find a way to avoid constantly `modify`ing the IR (since it is a `clone()`) but attempts to use `fast_modify()` have led to runtime panics with borrowing errors. 

As a proof of concept for the visitors, the `eliminate_dead_locals` pass has been implemented. This pass removes all dead `Local`s that are never referenced within an `RValue`. The pass does multiple sweeps until it reaches a fixed point, where all `Local`s are alive.

fixes #632 
fixes #633 