### PR TITLE
ir+lowering improvements

### DIFF
--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1122,12 +1122,6 @@ new_store_key!(pub RValueId);
 /// [Rvalue]s are accessed by an ID, of type [RValueId].
 pub type RValueStore = DefaultStore<RValueId, RValue>;
 
-new_sequence_store_key!(pub AggregateId);
-
-/// Stores an associated collection of [RValue]s that are used to represent
-/// aggregate values.
-pub type AggregateValueStore = DefaultSequenceStore<AggregateId, RValueId>;
-
 new_sequence_store_key!(pub ProjectionId);
 
 /// Stores all collections of projections that can occur on a place.

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -458,7 +458,7 @@ impl AggregateKind {
 
 /// The representation of values that occur on the right-hand side of an
 /// assignment.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RValue {
     /// A constant value.
     Const(ConstKind),
@@ -497,7 +497,7 @@ pub enum RValue {
     Ref(Mutability, Place, AddressMode),
     /// Used for initialising structs, tuples and other aggregate
     /// data structures
-    Aggregate(AggregateKind, Vec<RValueId>),
+    Aggregate(AggregateKind, AggregateId),
     /// Compute the discriminant of a [Place], this is essentially checking
     /// which variant a union is. For types that don't have a discriminant
     /// (non-union types ) this will return the value as 0.
@@ -1044,6 +1044,12 @@ new_store_key!(pub RValueId);
 ///
 /// [Rvalue]s are accessed by an ID, of type [RValueId].
 pub type RValueStore = DefaultStore<RValueId, RValue>;
+
+new_sequence_store_key!(pub AggregateId);
+
+/// Stores an associated collection of [RValue]s that are used to represent
+/// aggregate values.
+pub type AggregateValueStore = DefaultSequenceStore<AggregateId, RValueId>;
 
 new_sequence_store_key!(pub ProjectionId);
 

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -16,8 +16,8 @@ use hash_source::{
 };
 use hash_types::scope::ScopeId;
 use hash_utils::{
-    new_sequence_store_key, new_store_key,
-    store::{DefaultSequenceStore, DefaultStore, SequenceStore, Store},
+    new_sequence_store_key,
+    store::{DefaultSequenceStore, SequenceStore, Store},
 };
 use index_vec::IndexVec;
 use smallvec::{smallvec, SmallVec};
@@ -591,7 +591,7 @@ pub enum StatementKind {
 
     /// An assignment expression, a right hand-side expression is assigned to a
     /// left hand-side pattern e.g. `x = 2`
-    Assign(Place, RValueId),
+    Assign(Place, RValue),
 
     /// Set the discriminant on a particular place, this is used to concretely
     /// specify what the discriminant of a particular enum/union type is.
@@ -1114,13 +1114,6 @@ impl BodyInfo {
         self.source
     }
 }
-
-new_store_key!(pub RValueId);
-
-/// Stores all the used [RValue]s.
-///
-/// [Rvalue]s are accessed by an ID, of type [RValueId].
-pub type RValueStore = DefaultStore<RValueId, RValue>;
 
 new_sequence_store_key!(pub ProjectionId);
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
 
 use hash_types::terms::TermId;
 use hash_utils::store::SequenceStore;
-use ir::{Body, Local, Place, PlaceProjection, ProjectionStore, RValueStore};
+use ir::{Body, Local, Place, PlaceProjection, ProjectionStore};
 use ty::{AdtStore, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the lowering stage. This stores all of the
@@ -53,11 +53,6 @@ impl IrStorage {
         self.body_data.adts()
     }
 
-    /// Get a reference to the [RValueStore]
-    pub fn rvalues(&self) -> &RValueStore {
-        self.body_data.rvalues()
-    }
-
     /// Get a reference to the [ProjectionStore]
     pub fn projections(&self) -> &ProjectionStore {
         self.body_data.projections()
@@ -81,9 +76,6 @@ impl IrStorage {
 
 #[derive(Default)]
 pub struct BodyDataStore {
-    /// The storage for all the [RValue]s.
-    rvalue_store: ir::RValueStore,
-
     /// This the storage for all projection collections.
     projection_store: ir::ProjectionStore,
 
@@ -107,7 +99,6 @@ impl BodyDataStore {
     /// Create a new [BodyDataStore].
     pub fn new() -> Self {
         Self {
-            rvalue_store: RValueStore::default(),
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::default(),
             ty_list_store: TyListStore::default(),
@@ -129,11 +120,6 @@ impl BodyDataStore {
     /// Get a reference to the [AdtStore]
     pub fn adts(&self) -> &AdtStore {
         &self.adt_store
-    }
-
-    /// Get a reference to the [RValueStore]
-    pub fn rvalues(&self) -> &RValueStore {
-        &self.rvalue_store
     }
 
     /// Get a reference to the [ProjectionStore]

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -15,7 +15,10 @@ use std::{
 
 use hash_types::terms::TermId;
 use hash_utils::store::{SequenceStore, Store};
-use ir::{Body, Local, Place, PlaceProjection, ProjectionStore, RValue, RValueId, RValueStore};
+use ir::{
+    AggregateValueStore, Body, Local, Place, PlaceProjection, ProjectionStore, RValue, RValueId,
+    RValueStore,
+};
 use ty::{AdtStore, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the lowering stage. This stores all of the
@@ -53,6 +56,11 @@ impl IrStorage {
         self.body_data.adts()
     }
 
+    /// Get a reference to the [AggregateValueStore]
+    pub fn aggregates(&self) -> &AggregateValueStore {
+        self.body_data.aggregates()
+    }
+
     /// Get a reference to the [RValueStore]
     pub fn rvalues(&self) -> &RValueStore {
         self.body_data.rvalues()
@@ -84,6 +92,10 @@ pub struct BodyDataStore {
     /// The storage for all the [RValue]s.
     rvalue_store: ir::RValueStore,
 
+    /// Store collections of [RValue]s which are grouped
+    /// together, such as [RValue::Aggregate]s.
+    aggregate_rvalue_store: ir::AggregateValueStore,
+
     /// This the storage for all projection collections.
     projection_store: ir::ProjectionStore,
 
@@ -108,6 +120,7 @@ impl BodyDataStore {
     pub fn new() -> Self {
         Self {
             rvalue_store: RValueStore::default(),
+            aggregate_rvalue_store: AggregateValueStore::default(),
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::default(),
             ty_list_store: TyListStore::default(),
@@ -134,6 +147,11 @@ impl BodyDataStore {
     /// Get a reference to the [RValueStore]
     pub fn rvalues(&self) -> &RValueStore {
         &self.rvalue_store
+    }
+
+    /// Get a reference to the [AggregateValueStore]
+    pub fn aggregates(&self) -> &AggregateValueStore {
+        &self.aggregate_rvalue_store
     }
 
     /// Get a reference to the [ProjectionStore]

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -14,11 +14,8 @@ use std::{
 };
 
 use hash_types::terms::TermId;
-use hash_utils::store::{SequenceStore, Store};
-use ir::{
-    AggregateValueStore, Body, Local, Place, PlaceProjection, ProjectionStore, RValue, RValueId,
-    RValueStore,
-};
+use hash_utils::store::SequenceStore;
+use ir::{Body, Local, Place, PlaceProjection, ProjectionStore, RValueStore};
 use ty::{AdtStore, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the lowering stage. This stores all of the
@@ -56,11 +53,6 @@ impl IrStorage {
         self.body_data.adts()
     }
 
-    /// Get a reference to the [AggregateValueStore]
-    pub fn aggregates(&self) -> &AggregateValueStore {
-        self.body_data.aggregates()
-    }
-
     /// Get a reference to the [RValueStore]
     pub fn rvalues(&self) -> &RValueStore {
         self.body_data.rvalues()
@@ -92,10 +84,6 @@ pub struct BodyDataStore {
     /// The storage for all the [RValue]s.
     rvalue_store: ir::RValueStore,
 
-    /// Store collections of [RValue]s which are grouped
-    /// together, such as [RValue::Aggregate]s.
-    aggregate_rvalue_store: ir::AggregateValueStore,
-
     /// This the storage for all projection collections.
     projection_store: ir::ProjectionStore,
 
@@ -120,7 +108,6 @@ impl BodyDataStore {
     pub fn new() -> Self {
         Self {
             rvalue_store: RValueStore::default(),
-            aggregate_rvalue_store: AggregateValueStore::default(),
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::default(),
             ty_list_store: TyListStore::default(),
@@ -149,11 +136,6 @@ impl BodyDataStore {
         &self.rvalue_store
     }
 
-    /// Get a reference to the [AggregateValueStore]
-    pub fn aggregates(&self) -> &AggregateValueStore {
-        &self.aggregate_rvalue_store
-    }
-
     /// Get a reference to the [ProjectionStore]
     pub fn projections(&self) -> &ProjectionStore {
         &self.projection_store
@@ -170,10 +152,5 @@ impl BodyDataStore {
         let Place { local, projections } = place;
 
         self.projections().map_fast(projections, |projections| map(local, projections))
-    }
-
-    /// Push an [RValue] on the storage.
-    pub fn push_rvalue(&self, rvalue: RValue) -> RValueId {
-        self.rvalue_store.create(rvalue)
     }
 }

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -158,7 +158,7 @@ pub trait IrVisitorMut<'ir>: Sized {
 
 /// Contains all of the walking methods for the [IrVisitorMut] trait.
 pub mod walk_mut {
-    use hash_utils::store::{SequenceStore, Store};
+    use hash_utils::store::SequenceStore;
 
     use super::{IrVisitorMut, *};
     use crate::ir::{StatementKind, TerminatorKind};
@@ -183,13 +183,9 @@ pub mod walk_mut {
     }
 
     pub fn walk_statement<'ir, V: IrVisitorMut<'ir>>(visitor: &mut V, statement: &Statement) {
-        let store = visitor.store().rvalues();
-
         match &statement.kind {
             StatementKind::Nop => {}
-            StatementKind::Assign(place, value) => {
-                store.map_fast(*value, |value| visitor.visit_assign_statement(place, value))
-            }
+            StatementKind::Assign(place, value) => visitor.visit_assign_statement(place, value),
 
             StatementKind::Discriminate(place, variant) => {
                 visitor.visit_discriminator_statement(place, *variant)
@@ -608,7 +604,7 @@ pub trait ModifyingIrVisitor<'ir>: Sized {
 
 /// Contains all of the walking methods for the [IrVisitorMut] trait.
 pub mod walk_modifying {
-    use hash_utils::store::{CloneStore, SequenceStoreCopy};
+    use hash_utils::store::SequenceStoreCopy;
 
     use super::{ModifyingIrVisitor, *};
     use crate::ir::{StatementKind, TerminatorKind};
@@ -636,13 +632,9 @@ pub mod walk_modifying {
     }
 
     pub fn walk_statement<'ir, V: ModifyingIrVisitor<'ir>>(visitor: &V, statement: &mut Statement) {
-        let store = visitor.store().rvalues();
-
         match &mut statement.kind {
             StatementKind::Nop => {}
-            StatementKind::Assign(place, value) => {
-                store.modify(*value, |value| visitor.visit_assign_statement(place, value))
-            }
+            StatementKind::Assign(place, value) => visitor.visit_assign_statement(place, value),
 
             StatementKind::Discriminate(place, variant) => {
                 visitor.visit_discriminator_statement(place, variant)

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -104,20 +104,34 @@ impl fmt::Display for ForFormatting<'_, Place> {
     }
 }
 
+impl WriteIr for Operand {}
+
+impl fmt::Display for ForFormatting<'_, Operand> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.item {
+            Operand::Place(place) => write!(f, "{}", place.for_fmt(self.storage)),
+            Operand::Const(ConstKind::Value(Const::Zero(ty))) => {
+                write!(f, "{}", ty.for_fmt(self.storage))
+            }
+            Operand::Const(const_value) => write!(f, "const {const_value}"),
+        }
+    }
+}
+
 impl WriteIr for RValueId {}
 
 impl fmt::Display for ForFormatting<'_, RValueId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.storage.rvalues().map_fast(self.item, |rvalue| match rvalue {
-            RValue::Use(place) => write!(f, "{}", place.for_fmt(self.storage)),
-            RValue::Const(ConstKind::Value(Const::Zero(ty))) => {
-                write!(f, "{}", ty.for_fmt(self.storage))
-            }
-            RValue::Const(const_value) => write!(f, "const {const_value}"),
-            RValue::BinaryOp(op, lhs, rhs) => {
+            RValue::Use(operand) => write!(f, "{}", operand.for_fmt(self.storage)),
+            RValue::BinaryOp(op, operands) => {
+                let (lhs, rhs) = operands.as_ref();
+
                 write!(f, "{op:?}({}, {})", lhs.for_fmt(self.storage), rhs.for_fmt(self.storage))
             }
-            RValue::CheckedBinaryOp(op, lhs, rhs) => {
+            RValue::CheckedBinaryOp(op, operands) => {
+                let (lhs, rhs) = operands.as_ref();
+
                 write!(
                     f,
                     "Checked{op:?}({}, {})",
@@ -140,16 +154,12 @@ impl fmt::Display for ForFormatting<'_, RValueId> {
                 let fmt_operands = |f: &mut fmt::Formatter, start: char, end: char| {
                     write!(f, "{start}")?;
 
-                    self.storage.aggregates().map_fast(*operands, |operands| {
-                        for (i, operand) in operands.iter().enumerate() {
-                            if i != 0 {
-                                write!(f, ", ")?;
-                            }
-                            write!(f, "{}", operand.for_fmt(self.storage))?;
+                    for (i, operand) in operands.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
                         }
-
-                        Ok(())
-                    })?;
+                        write!(f, "{}", operand.for_fmt(self.storage))?;
+                    }
 
                     write!(f, "{end}")
                 };

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -118,11 +118,11 @@ impl fmt::Display for ForFormatting<'_, Operand> {
     }
 }
 
-impl WriteIr for RValueId {}
+impl WriteIr for &RValue {}
 
-impl fmt::Display for ForFormatting<'_, RValueId> {
+impl fmt::Display for ForFormatting<'_, &RValue> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.storage.rvalues().map_fast(self.item, |rvalue| match rvalue {
+        match self.item {
             RValue::Use(operand) => write!(f, "{}", operand.for_fmt(self.storage)),
             RValue::BinaryOp(op, operands) => {
                 let (lhs, rhs) = operands.as_ref();
@@ -182,7 +182,7 @@ impl fmt::Display for ForFormatting<'_, RValueId> {
                     }
                 }
             }
-        })
+        }
     }
 }
 
@@ -193,7 +193,7 @@ impl fmt::Display for ForFormatting<'_, &Statement> {
         match &self.item.kind {
             StatementKind::Nop => write!(f, "nop"),
             StatementKind::Assign(place, value) => {
-                write!(f, "{} = {}", place.for_fmt(self.storage), (*value).for_fmt(self.storage))
+                write!(f, "{} = {}", place.for_fmt(self.storage), value.for_fmt(self.storage))
             }
             StatementKind::Discriminate(place, index) => {
                 write!(f, "discriminant({}) = {index}", place.for_fmt(self.storage))

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -139,12 +139,17 @@ impl fmt::Display for ForFormatting<'_, RValueId> {
             RValue::Aggregate(aggregate_kind, operands) => {
                 let fmt_operands = |f: &mut fmt::Formatter, start: char, end: char| {
                     write!(f, "{start}")?;
-                    for (i, operand) in operands.iter().enumerate() {
-                        if i != 0 {
-                            write!(f, ", ")?;
+
+                    self.storage.aggregates().map_fast(*operands, |operands| {
+                        for (i, operand) in operands.iter().enumerate() {
+                            if i != 0 {
+                                write!(f, ", ")?;
+                            }
+                            write!(f, "{}", operand.for_fmt(self.storage))?;
                         }
-                        write!(f, "{}", operand.for_fmt(self.storage))?;
-                    }
+
+                        Ok(())
+                    })?;
 
                     write!(f, "{end}")
                 };

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -90,6 +90,10 @@ impl<'tcx> Builder<'tcx> {
             }
         }
 
+        // we finally reset the reached terminator flag so that we can
+        // continue to lower the rest of the program
+        self.reached_terminator = false;
+
         // If this block has an expression, we need to deal with it since
         // it might change the destination of this block.
         if let Some(expr) = body.expr.as_ref() && !self.reached_terminator {

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -20,7 +20,7 @@ use hash_ir::{
 use hash_reporting::macros::panic_on_span;
 use hash_source::{identifier::Identifier, location::Span};
 use hash_types::scope::ScopeKind;
-use hash_utils::store::{SequenceStoreKey, Store};
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 
 use super::{unpack, BlockAnd, BlockAndExtend, Builder, LoopBlockInfo};
 
@@ -583,7 +583,8 @@ impl<'tcx> Builder<'tcx> {
             }
         }
 
-        let fields = fields.into_values().into_iter().collect();
+        let fields =
+            self.storage.aggregates().create_from_iter_fast(fields.into_values().into_iter());
         let aggregate = RValue::Aggregate(aggregate_kind, fields);
         let value = self.storage.rvalues().create(aggregate);
 

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -107,9 +107,8 @@ impl<'tcx> Builder<'tcx> {
                 let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));
                 let then_block = self.control_flow_graph.start_new_block();
 
-                let value = self.storage.rvalues().create(RValue::Use(place));
                 let terminator =
-                    TerminatorKind::make_if(value, then_block, else_block, self.storage);
+                    TerminatorKind::make_if(place.into(), then_block, else_block, self.storage);
                 self.control_flow_graph.terminate(block, span, terminator);
 
                 then_block.unit()
@@ -698,7 +697,7 @@ impl<'tcx> Builder<'tcx> {
     {
         for binding in bindings {
             let rvalue = match binding.mode {
-                candidate::BindingMode::ByValue => RValue::Use(binding.source),
+                candidate::BindingMode::ByValue => binding.source.into(),
                 candidate::BindingMode::ByRef => {
                     RValue::Ref(binding.mutability, binding.source, AddressMode::Raw)
                 }

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -683,8 +683,7 @@ impl<'tcx> Builder<'tcx> {
             // @@Todo: we might have to do some special rules for the `by-ref` case
             //         when we start to think about reference rules more concretely.
             let rvalue = RValue::Ref(binding.mutability, binding.source, AddressMode::Raw);
-            let rvalue_id = self.storage.rvalues().create(rvalue);
-            self.control_flow_graph.push_assign(block, value_place, rvalue_id, binding.span);
+            self.control_flow_graph.push_assign(block, value_place, rvalue, binding.span);
         }
     }
 
@@ -702,14 +701,13 @@ impl<'tcx> Builder<'tcx> {
                     RValue::Ref(binding.mutability, binding.source, AddressMode::Raw)
                 }
             };
-            let rvalue_id = self.storage.rvalues().create(rvalue);
 
             // Now resolve where the binding place from, and then push
             // an assign onto the binding source.
             let value_place =
                 Place::from_local(self.lookup_local(binding.name).unwrap(), self.storage);
 
-            self.control_flow_graph.push_assign(block, value_place, rvalue_id, binding.span);
+            self.control_flow_graph.push_assign(block, value_place, rvalue, binding.span);
         }
     }
 }

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -582,7 +582,7 @@ impl<'tcx> Builder<'tcx> {
                 // can compare the discriminant to the specified value within the
                 // switch statement.
                 let discriminant_tmp = self.temp_place(discriminant_ty);
-                let value = self.storage.rvalues().create(RValue::Discriminant(place));
+                let value = RValue::Discriminant(place);
                 self.control_flow_graph.push_assign(block, discriminant_tmp, value, subject_span);
 
                 // then terminate this block with the `switch` terminator
@@ -713,7 +713,7 @@ impl<'tcx> Builder<'tcx> {
                 let actual = self.temp_place(usize_ty);
 
                 // Assign `actual = length(place)`
-                let value = self.storage.rvalues().create(RValue::Len(place));
+                let value = RValue::Len(place);
                 self.control_flow_graph.push_assign(block, actual, value, span);
 
                 // @@Todo: can we not just use the `value` directly, there should be no
@@ -737,7 +737,7 @@ impl<'tcx> Builder<'tcx> {
     }
 
     /// Generate IR for a comparison operation with a specified comparison
-    /// [BinOp]. This will take in the two [RValueId] operands, push a
+    /// [BinOp]. This will take in the two [Operand]s, push a
     /// [RValue::BinaryOp], and then insert a [TerminatorKind::Switch] which
     /// determines where the control flow goes based on the result of the
     /// comparison.
@@ -759,7 +759,7 @@ impl<'tcx> Builder<'tcx> {
         // Push an assignment with the result of the comparison, i.e. `result = op(lhs,
         // rhs)`
         let operands = Box::new((lhs, rhs));
-        let value = self.storage.rvalues().create(RValue::BinaryOp(op, operands));
+        let value = RValue::BinaryOp(op, operands);
         self.control_flow_graph.push_assign(block, result, value, span);
 
         // Then insert the switch statement, which determines where the cfg goes based

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -8,7 +8,7 @@ use fixedbitset::FixedBitSet;
 use hash_ast::ast::RangeEnd;
 use hash_ir::{
     ir::{
-        BasicBlock, BinOp, Const, PlaceProjection, RValue, RValueId, SwitchTargets, TerminatorKind,
+        BasicBlock, BinOp, Const, Operand, PlaceProjection, RValue, SwitchTargets, TerminatorKind,
     },
     ty::{AdtId, IrTy, IrTyId, VariantIdx},
     IrStorage,
@@ -159,7 +159,7 @@ impl<'tcx> Builder<'tcx> {
         };
 
         // Perform the algorithm on these or-pats, and then attempt
-        // to simplify anthing trivial, and assume the starting block
+        // to simplify anything trivial, and assume the starting block
         // is the pre-binding block of the overall candidate.
         self.match_candidates(
             or_span,
@@ -488,7 +488,7 @@ impl<'tcx> Builder<'tcx> {
 
     /// Perform a downcast on the given candidate, and adjust the candidate
     /// sub-patterns if they exist on the variant. In principle, this means that
-    /// each sub-pattern now references the downcasted place of the enum.
+    /// each sub-pattern now references the downcast place of the enum.
     fn candidate_after_variant_switch(
         &mut self,
         pair_index: usize,
@@ -499,7 +499,7 @@ impl<'tcx> Builder<'tcx> {
     ) {
         let pair = candidate.pairs.remove(pair_index);
 
-        // we need to compute the subsequent match pairs after the downcastr
+        // we need to compute the subsequent match pairs after the downcast
         // and add them to the candidate.
         let downcast_place = pair.place.downcast(variant_index);
 
@@ -585,13 +585,11 @@ impl<'tcx> Builder<'tcx> {
                 let value = self.storage.rvalues().create(RValue::Discriminant(place));
                 self.control_flow_graph.push_assign(block, discriminant_tmp, value, subject_span);
 
-                let switch_value = self.storage.rvalues().create(RValue::Use(discriminant_tmp));
-
                 // then terminate this block with the `switch` terminator
                 self.control_flow_graph.terminate(
                     block,
                     span,
-                    TerminatorKind::Switch { value: switch_value, targets },
+                    TerminatorKind::Switch { value: discriminant_tmp.into(), targets },
                 );
             }
             TestKind::SwitchInt { ty, ref options } => {
@@ -610,8 +608,7 @@ impl<'tcx> Builder<'tcx> {
                         _ => panic!("expected boolean switch to have only two options"),
                     };
 
-                    let value = self.storage.rvalues().create(RValue::Use(place));
-                    TerminatorKind::make_if(value, true_block, false_block, self.storage)
+                    TerminatorKind::make_if(place.into(), true_block, false_block, self.storage)
                 } else {
                     debug_assert_eq!(options.len() + 1, target_blocks.len());
                     let otherwise_block = target_blocks.last().copied();
@@ -622,8 +619,7 @@ impl<'tcx> Builder<'tcx> {
                         otherwise_block,
                     );
 
-                    let value = self.storage.rvalues().create(RValue::Use(place));
-                    TerminatorKind::Switch { value, targets }
+                    TerminatorKind::Switch { value: place.into(), targets }
                 };
 
                 self.control_flow_graph.terminate(block, span, terminator_kind);
@@ -646,10 +642,10 @@ impl<'tcx> Builder<'tcx> {
                             panic!("expected two target blocks for `Eq` test");
                         };
 
-                    let expected = self.storage.rvalues().create(value.into());
-                    let value = self.storage.rvalues().create(RValue::Use(place));
+                    let expected = Operand::Const(value.into());
+                    let actual = place.into();
 
-                    self.compare(block, success, fail, BinOp::Eq, expected, value, span);
+                    self.compare(block, success, fail, BinOp::Eq, expected, actual, span);
                 } else {
                     // @@Todo: here we essentially have to make a call to some alternative
                     //         equality mechanism since the [BinOp::EqEq] cannot handle
@@ -661,16 +657,16 @@ impl<'tcx> Builder<'tcx> {
                 let lb_success = self.control_flow_graph.start_new_block();
                 let target_blocks = make_target_blocks(self);
 
-                let lo = self.storage.rvalues().create(lo.into());
-                let hi = self.storage.rvalues().create(hi.into());
-                let val = self.storage.rvalues().create(RValue::Use(place));
+                let lo = Operand::Const(lo.into());
+                let hi = Operand::Const(hi.into());
+                let val = place.into();
 
                 let [success, fail] = *target_blocks else {
                     panic!("expected two target blocks for `Range` test");
                 };
 
                 // So here, we generate the control flow checks for the range comparison.
-                // Firslty, we generate the check to see if the `value` is less
+                // Firstly, we generate the check to see if the `value` is less
                 // than or equal to the `lo` value. If so, the cfg progresses to
                 // `lb_success` which means that is has passed the first check.
                 // If not, then the cfg progresses to `fail` which means that the
@@ -723,19 +719,19 @@ impl<'tcx> Builder<'tcx> {
                 // @@Todo: can we not just use the `value` directly, there should be no
                 // dependency on it in other places, and it will always be a
                 // `usize`.
-                let actual_operand = self.storage.rvalues().create(RValue::Use(actual));
+                let actual = actual.into();
 
                 // Now, we generate a temporary for the expected length, and then
                 // compare the two.
                 let const_len =
                     Const::Int(CONSTANT_MAP.create_int_constant(IntConstant::from(len)));
-                let expected = self.storage.rvalues().create(const_len.into());
+                let expected = Operand::Const(const_len.into());
 
                 let [success, fail] = *target_blocks else {
                     panic!("expected two target blocks for `Len` test");
                 };
 
-                self.compare(block, success, fail, op, actual_operand, expected, span);
+                self.compare(block, success, fail, op, actual, expected, span);
             }
         }
     }
@@ -751,8 +747,8 @@ impl<'tcx> Builder<'tcx> {
         success: BasicBlock,
         fail: BasicBlock,
         op: BinOp,
-        lhs: RValueId,
-        rhs: RValueId,
+        lhs: Operand,
+        rhs: Operand,
         span: Span,
     ) {
         debug_assert!(op.is_comparator());
@@ -762,17 +758,16 @@ impl<'tcx> Builder<'tcx> {
 
         // Push an assignment with the result of the comparison, i.e. `result = op(lhs,
         // rhs)`
-        let value = self.storage.rvalues().create(RValue::BinaryOp(op, lhs, rhs));
+        let operands = Box::new((lhs, rhs));
+        let value = self.storage.rvalues().create(RValue::BinaryOp(op, operands));
         self.control_flow_graph.push_assign(block, result, value, span);
 
         // Then insert the switch statement, which determines where the cfg goes based
         // on if the comparison was true or false.
-        let result = self.storage.rvalues().create(RValue::Use(result));
         self.control_flow_graph.terminate(
             block,
             span,
-            // @@Todo: make `Place` copy!
-            TerminatorKind::make_if(result, success, fail, self.storage),
+            TerminatorKind::make_if(result.into(), success, fail, self.storage),
         );
     }
 
@@ -785,7 +780,7 @@ impl<'tcx> Builder<'tcx> {
         variants: &mut FixedBitSet,
     ) -> bool {
         // Find the common matching place between the candidate and this
-        // value, if there is none then we cannot merge these togegher.
+        // value, if there is none then we cannot merge these together.
         let Some(match_pair) = candidate.pairs.iter().find(|pair| pair.place == *test_place) else {
             return false;
         };

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -4,8 +4,7 @@
 use std::fmt;
 
 use hash_ir::ir::{
-    BasicBlock, BasicBlockData, Place, RValueId, Statement, StatementKind, Terminator,
-    TerminatorKind,
+    BasicBlock, BasicBlockData, Place, RValue, Statement, StatementKind, Terminator, TerminatorKind,
 };
 use hash_source::location::Span;
 use index_vec::IndexVec;
@@ -89,7 +88,7 @@ impl ControlFlowGraph {
         &mut self,
         block: BasicBlock,
         place: Place,
-        value: RValueId,
+        value: RValue,
         span: Span,
     ) {
         self.push(block, Statement { kind: StatementKind::Assign(place, value), span });

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -35,7 +35,7 @@ impl IrOptimisation for CleanupLocalPass {
     /// Pass [CleanupLocalPass] is always enabled since it performs
     /// necessary cleanup of the initially generated IR.
     fn enabled(&self, settings: &LoweringSettings) -> bool {
-        settings.optimisation_level > OptimisationLevel::Debug
+        settings.optimisation_level >= OptimisationLevel::Debug
     }
 
     fn optimise(&self, body: &mut Body, store: &BodyDataStore) {

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -78,9 +78,7 @@ fn compute_predecessor_counts(body: &Body) -> IndexVec<BasicBlock, u32> {
     // it might not ever have any predecessors, but it is still reachable.
     counts[START_BLOCK] = 1;
 
-    let traverser = traversal::PreOrder::new_from_start(body);
-
-    for (_, data) in traverser {
+    for (_, data) in traversal::PreOrder::new_from_start(body) {
         if let Some(ref term) = data.terminator {
             for target in term.successors() {
                 counts[target] += 1;
@@ -99,7 +97,7 @@ impl IrOptimisation for SimplifyGraph {
     }
 
     fn enabled(&self, settings: &LoweringSettings) -> bool {
-        settings.optimisation_level > OptimisationLevel::Debug
+        settings.optimisation_level >= OptimisationLevel::Debug
     }
 
     fn optimise(&self, body: &mut Body, _: &BodyDataStore) {

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -12,10 +12,12 @@
 //!   have been updated, the current block is removed from the body.
 
 use hash_ir::{
-    ir::{BasicBlock, Body, TerminatorKind},
+    ir::{BasicBlock, BasicBlockData, Body, Terminator, TerminatorKind, START_BLOCK},
     BodyDataStore,
 };
 use hash_pipeline::settings::{LoweringSettings, OptimisationLevel};
+use index_vec::{index_vec, Idx, IndexVec};
+use smallvec::{smallvec, SmallVec};
 
 use super::IrOptimisation;
 use crate::traversal;
@@ -56,10 +58,37 @@ pub fn remove_dead_blocks(body: &mut Body) {
     // of the block terminators with the terminators that are
     // specified within the replacement map.
     for block in basic_blocks {
-        for target in block.terminator_mut().successors() {
-            block.terminator_mut().replace_edge(target, replacement_map[target.index()])
+        for target in block.terminator_mut().successors_mut() {
+            *target = replacement_map[target.index()];
         }
     }
+}
+
+fn copy_index_vec<S, T: Clone, I: Idx>(value: T, previous: &IndexVec<I, S>) -> IndexVec<I, T> {
+    index_vec![value; previous.len()]
+}
+
+/// This function is used to compute a predecessor count for each block, and
+/// returns a vector of the counts. This is used to determine if a block has
+/// a single predecessor, and therefore can be removed.
+fn compute_predecessor_counts(body: &Body) -> IndexVec<BasicBlock, u32> {
+    let mut counts = copy_index_vec(0, &body.basic_blocks.blocks);
+
+    // We have to always set the count of the basic block as `1` since
+    // it might not ever have any predecessors, but it is still reachable.
+    counts[START_BLOCK] = 1;
+
+    let traverser = traversal::PreOrder::new_from_start(body);
+
+    for (_, data) in traverser {
+        if let Some(ref term) = data.terminator {
+            for target in term.successors() {
+                counts[target] += 1;
+            }
+        }
+    }
+
+    counts
 }
 
 pub struct SimplifyGraph;
@@ -74,13 +103,30 @@ impl IrOptimisation for SimplifyGraph {
     }
 
     fn optimise(&self, body: &mut Body, _: &BodyDataStore) {
-        // Firstly, lets check if there are any predecessors for each block. If the
-        // block has no predecessors then we remove the block from the body entirely.
-        // This is because the block is unreachable.
-        //
-        // It's safe not to invalidate the cache here since we are removing dead blocks.
-        remove_dead_blocks(body);
+        GraphSimplifier::new(body).simplify();
 
+        // Now we can remove the blocks that we no longer need.
+        remove_dead_blocks(body);
+    }
+}
+
+pub struct GraphSimplifier<'ir> {
+    /// A reference to all of the basic blocks in the graph
+    basic_blocks: &'ir mut IndexVec<BasicBlock, BasicBlockData>,
+
+    /// A reference to the predecessor count for each block
+    predecessor_count: IndexVec<BasicBlock, u32>,
+}
+
+impl<'ir> GraphSimplifier<'ir> {
+    /// Create a new [`GraphSimplifier`] from the given body
+    pub fn new(body: &'ir mut Body) -> Self {
+        let predecessor_count = compute_predecessor_counts(body);
+
+        GraphSimplifier { basic_blocks: body.basic_blocks.blocks_mut(), predecessor_count }
+    }
+
+    pub fn simplify(mut self) {
         // Now we try to simplify the graph by removing blocks that only perform
         // a goto to another block. We perform this optimisation until we reached
         // a fixed point since it maybe be that we can remove multiple blocks in
@@ -88,48 +134,96 @@ impl IrOptimisation for SimplifyGraph {
         loop {
             let mut changed = false;
 
-            // stores the index of the block that can be removed, and the block
-            // that it should be substituted with.
-            let mut changes: Vec<(BasicBlock, BasicBlock)> = Vec::new();
-
-            for (index, block) in body.blocks().iter_enumerated() {
-                // If there are any statements in the block, or if the block is the
-                // starting block, we cannot remove it since the entry point is
-                // always the starting block.
-                if !block.statements.is_empty()
-                    || body.basic_blocks.predecessors_of(index).is_empty()
-                {
+            for index in self.basic_blocks.indices() {
+                // if this block has no predecessors, then we can just skip it
+                if self.predecessor_count[index] == 0 {
                     continue;
                 }
 
-                if let TerminatorKind::Goto(substitution) = block.terminator.as_ref().unwrap().kind
-                {
-                    // we want to get all of the predecessors of this block, and substitute any
-                    // references to the current block with the destination block.
-                    changes.push((index, substitution));
-                    changed = true;
+                let mut terminator = self.basic_blocks[index].terminator.take().unwrap();
+
+                // attempt to simplify the goto chain
+                for successor in terminator.successors_mut() {
+                    self.fold_goto_chain(successor, &mut changed);
                 }
+
+                // @@Future: we could try to perform some optimisations with
+                // merging blocks, and some branch simplification.
+
+                // Reset the terminator of the block
+                self.basic_blocks[index].terminator = Some(terminator);
             }
 
             // Short-circuit if we didn't make any changes.
             if !changed {
                 break;
             }
+        }
+    }
 
-            // Now we can perform the changes to the body.
-            for (index, substitution) in changes {
-                let predecessors = body.basic_blocks.predecessors_of(index);
+    /// Traverse along a line of of goto chains and replace them with a single
+    /// jump. These jump chains can occur in common with complex `match`
+    /// expressions or `loop` control flow.
+    fn fold_goto_chain(&mut self, block: &mut BasicBlock, changed: &mut bool) {
+        // @@Note: usually the go-to chain will be of length 1, so we use a
+        // smallvec here.
+        let mut terminators: SmallVec<[_; 1]> = smallvec![];
 
-                for predecessor in predecessors {
-                    if let Some(block) = body.basic_blocks.blocks_mut().get_mut(predecessor) {
-                        let terminator = block.terminator.as_mut().unwrap();
-                        terminator.replace_edge(index, substitution);
-                    }
-                }
+        // Begin by traversing up the successor chain until we reach a
+        // block that does not have a terminator which is a goto.
+        let mut current = *block;
+
+        while let Some(terminator) = self.take_terminator_on_goto(current) {
+            let Terminator { kind: TerminatorKind::Goto(target), .. } = terminator else {
+                unreachable!()
+            };
+
+            terminators.push((current, terminator));
+            current = target;
+        }
+
+        let last = current;
+        *block = last;
+
+        // Now we iterate over all of the blocks that we have found to
+        // be in the chain and update our `predecessor_count` to reflect
+        // their removal.
+        while let Some((current, mut terminator)) = terminators.pop() {
+            let Terminator { kind: TerminatorKind::Goto (ref mut target), .. } = terminator else {
+                unreachable!();
+            };
+
+            // update changed, and update the target
+            *changed |= *target != last;
+            *target = last;
+
+            // If this is the last predecessor, then we don;t need to update
+            // the count of the `target` since it will be removed.
+            if self.predecessor_count[current] == 1 {
+                self.predecessor_count[current] = 0;
+            } else {
+                self.predecessor_count[*target] += 1;
+                self.predecessor_count[current] -= 1;
             }
 
-            // Now we can remove the blocks that we no longer need.
-            remove_dead_blocks(body);
+            // finally, update the terminator of the current block
+            self.basic_blocks[current].terminator = Some(terminator);
+        }
+    }
+
+    /// Take the terminator from the given block, if it is a
+    /// [TerminatorKind::Goto]. Additionally, the block must not have any
+    /// statements since this may is not trivially collapsable.
+    ///
+    /// This is used continue traversing a goto chain.
+    fn take_terminator_on_goto(&mut self, block: BasicBlock) -> Option<Terminator> {
+        match self.basic_blocks[block] {
+            BasicBlockData {
+                ref statements,
+                terminator:
+                    ref mut terminator @ Some(Terminator { kind: TerminatorKind::Goto(_), .. }),
+            } if statements.is_empty() => terminator.take(),
+            _ => None,
         }
     }
 }

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -1,5 +1,5 @@
 //! Contains the `simplification` pass which simplifies the control
-//! flow graph by consiering the predecessors of each block and
+//! flow graph by considering the predecessors of each block and
 //! whether:
 //!
 //! - If the block has no predecessors, it is unreachable, and therefore we can
@@ -70,7 +70,7 @@ impl IrOptimisation for SimplifyGraph {
     }
 
     fn enabled(&self, settings: &LoweringSettings) -> bool {
-        settings.optimisation_level >= OptimisationLevel::Debug
+        settings.optimisation_level > OptimisationLevel::Debug
     }
 
     fn optimise(&self, body: &mut Body, _: &BodyDataStore) {

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -175,4 +175,16 @@ impl<Ctx: TypecheckingCtx> CompilerStage<Ctx> for Typechecker {
 
         Ok(())
     }
+
+    /// We use the cleanup function to report on cache metrics for the
+    /// typechecker.
+    fn cleanup(&mut self, _entry_point: SourceId, _stage_data: &mut Ctx) {
+        log::debug!(
+            "tc cache metrics:\n{: <8}: {}\n{: <8}: {}\n",
+            "validate",
+            self.cache.validation_store.metrics(),
+            "infer",
+            self.cache.inference_store.metrics()
+        );
+    }
 }

--- a/compiler/hash-typecheck/src/ops/cache.rs
+++ b/compiler/hash-typecheck/src/ops/cache.rs
@@ -1,6 +1,6 @@
 //! Typechecking cache manager
 
-use hash_types::terms::{Sub, TermId};
+use hash_types::terms::TermId;
 use hash_utils::store::PartialStore;
 
 use super::validate::TermValidation;
@@ -29,22 +29,10 @@ impl<'tc> CacheManager<'tc> {
         Self { storage }
     }
 
-    /// Check whether `simplification` has been performed on the
-    /// given [TermId].
-    pub(crate) fn has_been_simplified(&self, term: TermId) -> Option<TermId> {
-        self.cache().simplification_store.get(term)
-    }
-
     /// Check whether a `validation` has been performed on the given
     /// [TermId].
     pub(crate) fn has_been_validated(&self, term: TermId) -> Option<TermValidation> {
         self.cache().validation_store.get(term)
-    }
-
-    /// Check whether a `unification` has been performed on the given
-    /// [TermId].
-    pub(crate) fn has_been_unified(&self, pair: (TermId, TermId)) -> Option<Sub> {
-        self.cache().unification_store.get(pair)
     }
 
     /// Check whether a `validation` has been performed on the given
@@ -53,19 +41,9 @@ impl<'tc> CacheManager<'tc> {
         self.cache().inference_store.get(term)
     }
 
-    /// Record an entry for a `simplification` operation.
-    pub(crate) fn add_simplification_entry(&self, key: TermId, value: TermId) {
-        self.cache().simplification_store.insert(key, value);
-    }
-
     /// Record an entry for a `validation` operation.
     pub(crate) fn add_validation_entry(&self, key: TermId, value: TermValidation) {
         self.cache().validation_store.insert(key, value);
-    }
-
-    /// Record an entry for a `unification` operation.
-    pub(crate) fn add_unification_entry(&self, key: (TermId, TermId), value: &Sub) {
-        self.cache().unification_store.insert(key, value.clone());
     }
 
     /// Record an entry for a `inference` operation.

--- a/compiler/hash-typecheck/src/ops/simplify.rs
+++ b/compiler/hash-typecheck/src/ops/simplify.rs
@@ -1291,12 +1291,6 @@ impl<'tc> Simplifier<'tc> {
     /// This does not perform all validity checks, some are performed by
     /// [super::Typer], and all are by [super::Validator].
     pub(crate) fn simplify_term(&self, term_id: TermId) -> TcResult<Option<TermId>> {
-        // Check if we have already performed a simplification on this term, if so
-        // return the result.
-        if let Some(term) = self.cacher().has_been_simplified(term_id) {
-            return Ok(Some(term));
-        }
-
         let value = self.reader().get_term(term_id);
         let new_term = match value {
             Term::Merge(inner) => Ok(self
@@ -1482,9 +1476,6 @@ impl<'tc> Simplifier<'tc> {
         // Copy over the location if a new term was created
         if let Some(new_term) = new_term {
             self.location_store().copy_location(term_id, new_term);
-
-            // We want to add an entry for the operation within the cache...
-            self.cacher().add_simplification_entry(term_id, new_term);
         }
 
         Ok(new_term)

--- a/compiler/hash-typecheck/src/ops/unify.rs
+++ b/compiler/hash-typecheck/src/ops/unify.rs
@@ -353,10 +353,6 @@ impl<'tc> Unifier<'tc> {
             return Ok(Sub::empty());
         }
 
-        if let Some(sub) = self.cacher().has_been_unified((src_id, target_id)) {
-            return Ok(sub);
-        }
-
         // First we want to simplify the terms:
         let simplified_src_id = self.simplifier().potentially_simplify_term(src_id)?;
         let simplified_target_id = self.simplifier().potentially_simplify_term(target_id)?;
@@ -812,8 +808,6 @@ impl<'tc> Unifier<'tc> {
             (Term::Root, Term::Root) => Ok(Sub::empty()),
             (_, Term::Root) | (Term::Root, _) => cannot_unify(),
         }?;
-
-        self.cacher().add_unification_entry((src_id, target_id), &sub);
 
         Ok(sub)
     }

--- a/compiler/hash-typecheck/src/storage/cache.rs
+++ b/compiler/hash-typecheck/src/storage/cache.rs
@@ -8,7 +8,7 @@ use std::{
     hash::Hash,
 };
 
-use hash_types::terms::{Sub, TermId};
+use hash_types::terms::TermId;
 use hash_utils::store::{DefaultPartialStore, PartialStore};
 use log::log_enabled;
 
@@ -100,11 +100,7 @@ impl<K: Copy + Hash + Eq, V: Clone> CacheStore<K, V> {
 #[derive(Debug, Default)]
 pub struct Cache {
     /// Inner store for the results from term simplifications
-    pub(crate) simplification_store: CacheStore<TermId, TermId>,
-    /// Inner store for the results from term simplifications
     pub(crate) validation_store: CacheStore<TermId, TermValidation>,
-    /// Inner store for the results from term unifications
-    pub(crate) unification_store: CacheStore<(TermId, TermId), Sub>,
     /// Inner store for the results from term inference operations
     pub(crate) inference_store: CacheStore<TermId, TermId>,
 }

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -105,18 +105,6 @@ impl<'tc> TcVisitor<'tc> {
         // dependencies. Need to find a way to prevent this.
         self.checked_sources().mark_checked(source_id, result);
 
-        log::debug!(
-            "tc cache metrics:\n{: <8}: {}\n{: <8}: {}\n{: <8}: {}\n{: <8}: {}\n",
-            "simplify",
-            self.cache().simplification_store.metrics(),
-            "validate",
-            self.cache().validation_store.metrics(),
-            "unify",
-            self.cache().unification_store.metrics(),
-            "infer",
-            self.cache().inference_store.metrics()
-        );
-
         Ok(result)
     }
 

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -775,7 +775,7 @@ impl<K: Copy + Eq + Hash, V: Clone> PartialStore<K, V> for DefaultPartialStore<K
 /// [`RefCell<Vec<_>>`], so that there isn't additional overhead when
 /// reading/writing elements; you can take references out of it. The trade-off
 /// is that the value needs to implement [`Copy`].
-pub trait CellStore<Key: StoreKey, Value: Copy> {
+pub trait AppendOnlyStore<Key: StoreKey, Value: Copy> {
     /// Get a reference to the internal data of the store.
     ///
     /// This should only be used to implement new store methods, not to access
@@ -804,32 +804,27 @@ pub trait CellStore<Key: StoreKey, Value: Copy> {
         let data = self.internal_data();
         &data[key.to_index()]
     }
-
-    // fn set(&self, key: Key, value: Value) {
-    //     let data = self.internal_data();
-    //     data[key.to_index()] = value;
-    // }
 }
 
-/// A default implementation of [`PartialStore`].
-pub struct DefaultCellStore<K, V> {
+/// A default implementation of [`DefaultAppendOnlyStore`].
+pub struct DefaultAppendOnlyStore<K, V> {
     data: AppendOnlyVec<V>,
     _phantom: PhantomData<K>,
 }
 
-impl<K, V> Default for DefaultCellStore<K, V> {
+impl<K, V> Default for DefaultAppendOnlyStore<K, V> {
     fn default() -> Self {
         Self { data: AppendOnlyVec::new(), _phantom: PhantomData }
     }
 }
 
-impl<K, V> DefaultCellStore<K, V> {
+impl<K, V> DefaultAppendOnlyStore<K, V> {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<K: StoreKey, V: Copy> CellStore<K, V> for DefaultCellStore<K, V> {
+impl<K: StoreKey, V: Copy> AppendOnlyStore<K, V> for DefaultAppendOnlyStore<K, V> {
     fn internal_data(&self) -> &AppendOnlyVec<V> {
         &self.data
     }


### PR DESCRIPTION
### Changes to IR
This patch makes the `RValue` tree simpler by introducing the notion of an `Operand`, which is essentially the leaf of an `RValue` tree. Introducing this item will do the following:
- reduce the number of `RValue`s created overall.
- simplify and improve the performance of traversals that may modify the IR as they go.

### Additionally:

- This patch also greatly improves the performance of the `simplify_graph` pass making it run in about `<1ms`, where as previously it was taking `~550ms` for a particular test case. This optimisation was achieved by keeping an in-place up-to-date record of graph block predecessors when eliminating `goto` chains.

- fix bug where `reached_terminator` wasn't being reset in `Builder` causing all future blocks to not be lowered.

### Some future work and questions:
- Is the whole `Operand::Const(ConstKind::Value(Const::<...>)))` naming sensible or should we rethink this?
- ~~I still think it might be worth giving a try to see if the `RValue` store can be completely eliminated so that we 
  just operate on pointers rather than being behind a store (this should be easier to do now that the tree is relatively flat).~~ (done)
- can we go back to the original `SwitchTargets` representation of `table` which groups value and target pairs, unlike it is now?
- Are there any other dead easy optimisations we should spend time implementing for the IR before moving onto codegen?
- Should we move optimisation passes on IR into its own crate?