### PR TITLE
source: Shrink `SourceId` from 12 bytes to 4 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
  "hash-alloc",
  "hash-target",
  "hash-utils",
+ "index_vec",
  "lazy_static",
  "num-bigint",
- "slotmap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,6 @@ dependencies = [
  "hash-alloc",
  "hash-target",
  "hash-utils",
- "index_vec",
  "lazy_static",
  "num-bigint",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "hash-source",
  "hash-tree-def",
  "hash-utils",
+ "index_vec",
  "num-bigint",
  "replace_with",
 ]
@@ -635,6 +636,7 @@ dependencies = [
  "hash-alloc",
  "hash-target",
  "hash-utils",
+ "index_vec",
  "lazy_static",
  "num-bigint",
 ]

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -61,7 +61,7 @@ impl<Ctx: AstDesugaringCtx> CompilerStage<Ctx> for AstDesugaringPass {
         pool.scope(|scope| {
             // De-sugar the target if it isn't already de-sugared
             if !source_stage_info.get(entry_point).is_desugared() && entry_point.is_interactive() {
-                let source = node_map.get_interactive_block_mut(entry_point);
+                let source = node_map.get_interactive_block_mut(entry_point.into());
                 let mut desugarer = AstDesugaring::new(source_map, entry_point);
 
                 desugarer.visit_body_block(source.node_ref_mut()).unwrap();

--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -60,19 +60,17 @@ impl<Ctx: AstDesugaringCtx> CompilerStage<Ctx> for AstDesugaringPass {
 
         pool.scope(|scope| {
             // De-sugar the target if it isn't already de-sugared
-            if !source_stage_info.get(entry_point).is_desugared() {
-                if let SourceId::Interactive(id) = entry_point {
-                    let source = node_map.get_interactive_block_mut(id);
-                    let mut desugarer = AstDesugaring::new(source_map, entry_point);
+            if !source_stage_info.get(entry_point).is_desugared() && entry_point.is_interactive() {
+                let source = node_map.get_interactive_block_mut(entry_point);
+                let mut desugarer = AstDesugaring::new(source_map, entry_point);
 
-                    desugarer.visit_body_block(source.node_ref_mut()).unwrap();
-                }
+                desugarer.visit_body_block(source.node_ref_mut()).unwrap();
             }
 
             // Iterate over all of the modules and add the expressions
             // to the queue so it can be distributed over the threads
-            for (id, module) in node_map.iter_mut_modules() {
-                let source_id = SourceId::Module(*id);
+            for (id, module) in node_map.iter_mut_modules().enumerate() {
+                let source_id = SourceId::new_module(id as u32);
                 let stage_info = source_stage_info.get(source_id);
 
                 // Skip any modules that have already been de-sugared
@@ -89,8 +87,8 @@ impl<Ctx: AstDesugaringCtx> CompilerStage<Ctx> for AstDesugaringPass {
                 // process of adding these items to the queue. However, it might be worth
                 // investigating this in the future.
                 for expr in module.node_mut().contents.iter_mut() {
-                    scope.spawn(|_| {
-                        let mut desugarer = AstDesugaring::new(source_map, SourceId::Module(*id));
+                    scope.spawn(move |_| {
+                        let mut desugarer = AstDesugaring::new(source_map, source_id);
                         desugarer.visit_expr(expr.ast_ref_mut()).unwrap()
                     })
                 }

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -40,7 +40,7 @@ impl<Ctx: AstExpansionCtx> CompilerStage<Ctx> for AstExpansionPass {
         // De-sugar the target if it isn't already de-sugared
         if source_info.is_expanded() && entry_point.is_interactive() {
             let expander = AstExpander::new(source_map, entry_point);
-            let source = node_map.get_interactive_block(entry_point);
+            let source = node_map.get_interactive_block(entry_point.into());
 
             expander.visit_body_block(source.node_ref()).unwrap();
         }

--- a/compiler/hash-ast-expand/src/lib.rs
+++ b/compiler/hash-ast-expand/src/lib.rs
@@ -38,25 +38,23 @@ impl<Ctx: AstExpansionCtx> CompilerStage<Ctx> for AstExpansionPass {
         let source_info = source_stage_info.get(entry_point);
 
         // De-sugar the target if it isn't already de-sugared
-        if source_info.is_expanded() {
-            if let SourceId::Interactive(id) = entry_point {
-                let expander = AstExpander::new(source_map, entry_point);
-                let source = node_map.get_interactive_block(id);
+        if source_info.is_expanded() && entry_point.is_interactive() {
+            let expander = AstExpander::new(source_map, entry_point);
+            let source = node_map.get_interactive_block(entry_point);
 
-                expander.visit_body_block(source.node_ref()).unwrap();
-            }
+            expander.visit_body_block(source.node_ref()).unwrap();
         }
 
-        for (id, module) in node_map.iter_modules() {
-            let module_id = SourceId::Module(*id);
-            let stage_info = source_stage_info.get(module_id);
+        for (id, module) in node_map.iter_modules().enumerate() {
+            let source_id = SourceId::new_module(id as u32);
+            let stage_info = source_stage_info.get(source_id);
 
             // Skip any modules that have already been de-sugared
             if stage_info.is_expanded() {
                 continue;
             }
 
-            let expander = AstExpander::new(source_map, module_id);
+            let expander = AstExpander::new(source_map, source_id);
             expander.visit_module(module.node_ref()).unwrap();
         }
 

--- a/compiler/hash-ast/Cargo.toml
+++ b/compiler/hash-ast/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 num-bigint = "0.4"
 replace_with = "0.1.7"
+index_vec = "0.1.3"
 
 hash-source = { path = "../hash-source" }
 hash-tree-def = { path = "../hash-tree-def" }

--- a/compiler/hash-ast/src/node_map.rs
+++ b/compiler/hash-ast/src/node_map.rs
@@ -2,14 +2,11 @@
 //! This is used to ensure that the same node is not parsed and to retrieve
 //! nodes in later compilation stages.
 use std::{
-    collections::{
-        hash_map::{Iter, IterMut},
-        HashMap,
-    },
     path::{Path, PathBuf},
+    slice::{Iter, IterMut},
 };
 
-use hash_source::{InteractiveId, ModuleId, SourceId};
+use hash_source::SourceId;
 use hash_utils::path::adjust_canonicalisation;
 
 use crate::ast::{AstNode, BodyBlock, Module, OwnsAstNode};
@@ -125,71 +122,71 @@ pub enum SourceRef<'i> {
 #[derive(Debug, Default)]
 pub struct NodeMap {
     /// All [Module] nodes that have been parsed.
-    modules: HashMap<ModuleId, ModuleEntry>,
+    modules: Vec<ModuleEntry>,
     /// All [InteractiveBlock] nodes that have been parsed.
-    interactive_blocks: HashMap<InteractiveId, InteractiveBlock>,
+    interactive_blocks: Vec<InteractiveBlock>,
 }
 
 impl NodeMap {
     /// Create a new [NodeMap]
     pub fn new() -> Self {
-        Self { modules: HashMap::new(), interactive_blocks: HashMap::new() }
+        Self { modules: vec![], interactive_blocks: vec![] }
     }
 
     /// Add a [InteractiveBlock] to the [NodeMap]
-    pub fn add_interactive_block(&mut self, id: InteractiveId, block: InteractiveBlock) {
-        self.interactive_blocks.insert(id, block);
+    pub fn add_interactive_block(&mut self, block: InteractiveBlock) {
+        self.interactive_blocks.push(block);
     }
 
     /// Add a [Module] to the [NodeMap]
-    pub fn add_module(&mut self, id: ModuleId, module: ModuleEntry) {
-        self.modules.insert(id, module);
+    pub fn add_module(&mut self, module: ModuleEntry) {
+        self.modules.push(module);
     }
 
     /// Get a [SourceRef] by [SourceId].
     pub fn get_source(&self, source_id: SourceId) -> SourceRef<'_> {
-        match source_id {
-            SourceId::Interactive(interactive_id) => {
-                SourceRef::Interactive(self.get_interactive_block(interactive_id))
-            }
-            SourceId::Module(module_id) => SourceRef::Module(self.get_module(module_id)),
+        if source_id.is_interactive() {
+            SourceRef::Interactive(self.get_interactive_block(source_id))
+        } else {
+            SourceRef::Module(self.get_module(source_id))
         }
     }
 
     /// Get a reference to an [InteractiveBlock], panics if the [InteractiveId]
     /// has no backing [InteractiveBlock].
-    pub fn get_interactive_block(&self, interactive_id: InteractiveId) -> &InteractiveBlock {
-        self.interactive_blocks.get(&interactive_id).unwrap()
+    pub fn get_interactive_block(&self, id: SourceId) -> &InteractiveBlock {
+        debug_assert!(id.is_interactive());
+        self.interactive_blocks.get(id.value_usize()).unwrap()
     }
 
     /// Get a mutable reference to an [InteractiveBlock], panics if the
     /// [InteractiveId] has no backing [InteractiveBlock].
-    pub fn get_interactive_block_mut(
-        &mut self,
-        interactive_id: InteractiveId,
-    ) -> &mut InteractiveBlock {
-        self.interactive_blocks.get_mut(&interactive_id).unwrap()
+    pub fn get_interactive_block_mut(&mut self, id: SourceId) -> &mut InteractiveBlock {
+        debug_assert!(id.is_interactive());
+        self.interactive_blocks.get_mut(id.value_usize()).unwrap()
     }
 
-    /// Get a mutable reference to an [Module], panics if the [ModuleId]
+    /// Get a mutable reference to an [Module], panics if the [SourceId]
     /// has no backing [Module].
-    pub fn get_module(&self, module_id: ModuleId) -> &ModuleEntry {
-        self.modules.get(&module_id).unwrap()
+    pub fn get_module(&self, id: SourceId) -> &ModuleEntry {
+        debug_assert!(id.is_module());
+        self.modules.get(id.value_usize()).unwrap()
     }
 
-    /// Get a reference to an [Module], panics if the [ModuleId]
+    /// Get a reference to an [Module], panics if the [SourceId]
     /// has no backing [Module].
-    pub fn get_module_mut(&mut self, module_id: ModuleId) -> &mut ModuleEntry {
-        self.modules.get_mut(&module_id).unwrap()
+    pub fn get_module_mut(&mut self, id: SourceId) -> &mut ModuleEntry {
+        debug_assert!(id.is_module());
+        self.modules.get_mut(id.value_usize()).unwrap()
     }
 
     /// /// Create an [Iter] over the currently stores modules within [NodeMap]
-    pub fn iter_modules(&self) -> Iter<'_, ModuleId, ModuleEntry> {
+    pub fn iter_modules(&self) -> Iter<ModuleEntry> {
         self.modules.iter()
     }
 
     /// Create an [IterMut] over the currently stores modules within [NodeMap].
-    pub fn iter_mut_modules(&mut self) -> IterMut<'_, ModuleId, ModuleEntry> {
+    pub fn iter_mut_modules(&mut self) -> IterMut<ModuleEntry> {
         self.modules.iter_mut()
     }
 }

--- a/compiler/hash-interactive/src/lib.rs
+++ b/compiler/hash-interactive/src/lib.rs
@@ -8,7 +8,6 @@ use command::InteractiveCommand;
 use hash_ast::node_map::InteractiveBlock;
 use hash_pipeline::{interface::CompilerInterface, settings::CompilerStageKind, Compiler};
 use hash_reporting::errors::{CompilerError, InteractiveCommandError};
-use hash_source::SourceId;
 use rustyline::{error::ReadlineError, Editor};
 
 type CompilerResult<T> = Result<T, CompilerError>;
@@ -117,7 +116,7 @@ fn execute<I: CompilerInterface>(input: &str, compiler: &mut Compiler<I>, mut ct
             // We don't want the old diagnostics
             // @@Refactor: we don't want to leak the diagnostics here..
             ctx.diagnostics_mut().clear();
-            let new_state = compiler.run(SourceId::Interactive(interactive_id), ctx);
+            let new_state = compiler.run(interactive_id, ctx);
             return new_state;
         }
         Err(e) => CompilerError::from(e).report(),

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -87,8 +87,8 @@ impl<Ctx: IrLoweringCtx> CompilerStage<Ctx> for AstLowerer {
 
         // We need to visit all of the modules in the workspace and discover
         // what needs to be lowered.
-        for (module_id, module) in workspace.node_map.iter_modules() {
-            let source_id = SourceId::Module(*module_id);
+        for (id, module) in workspace.node_map.iter_modules().enumerate() {
+            let source_id = SourceId::new_module(id as u32);
             let stage_info = source_stage_info.get(source_id);
 
             // Skip any modules that have already been checked

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -206,7 +206,6 @@ impl<'ir> LocalUseMap<'ir> {
     }
 }
 
-// @@Todo: Simplify this implementation by hiding away un-used implementations.
 impl<'ir> IrVisitorMut<'ir> for LocalUseMap<'ir> {
     fn store(&self) -> &'ir BodyDataStore {
         self.store

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -21,7 +21,7 @@ use hash_pipeline::{
     workspace::Workspace,
 };
 use hash_reporting::{diagnostic::Diagnostics, report::Report};
-use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId};
+use hash_source::{ModuleKind, SourceId};
 use import_resolver::ImportResolver;
 use parser::AstGen;
 use source::ParseSource;
@@ -37,8 +37,8 @@ pub enum ParserAction {
     /// A worker has completed processing an interactive block and now provides
     /// the generated AST.
     SetInteractiveNode {
-        /// The corresponding id of the parsed interactive block.
-        interactive_id: InteractiveId,
+        /// The corresponding [SourceId] of the parsed interactive block.
+        id: SourceId,
         /// The resultant parsed interactive body block.
         node: ast::AstNode<ast::BodyBlock>,
         /// The parser may still produce diagnostics for this module, and so we
@@ -48,8 +48,8 @@ pub enum ParserAction {
     /// A worker has completed processing an module and now provides the
     /// generated AST.
     SetModuleNode {
-        /// The corresponding id of the parsed module.
-        module_id: ModuleId,
+        /// The corresponding [SourceId] of the parsed module.
+        id: SourceId,
         /// The resultant parsed module.
         node: ast::AstNode<ast::Module>,
         /// The parser may still produce diagnostics for this module, and so we
@@ -60,7 +60,7 @@ pub enum ParserAction {
 
 /// Parse a specific source specified by [ParseSource].
 fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
-    let source_id = source.source_id();
+    let source_id = source.id();
     let contents = source.contents();
 
     // Lex the contents of the module or interactive block
@@ -84,20 +84,15 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
 
     // Perform the parsing operation now... and send the result through the
     // message queue, regardless of it being an error or not.
-    let action = match &source.source_id() {
-        SourceId::Module(id) => {
+    let id = source.id();
+    let action = match id.is_interactive() {
+        false => {
             let node = gen.parse_module();
-
-            ParserAction::SetModuleNode { module_id: *id, node, diagnostics: gen.into_reports() }
+            ParserAction::SetModuleNode { id, node, diagnostics: gen.into_reports() }
         }
-        SourceId::Interactive(id) => {
+        true => {
             let node = gen.parse_expr_from_interactive();
-
-            ParserAction::SetInteractiveNode {
-                interactive_id: *id,
-                node,
-                diagnostics: gen.into_reports(),
-            }
+            ParserAction::SetInteractiveNode { id, node, diagnostics: gen.into_reports() }
         }
     };
 
@@ -144,12 +139,12 @@ impl Parser {
         pool.scope(|scope| {
             while let Ok(message) = receiver.recv() {
                 match message {
-                    ParserAction::SetInteractiveNode { interactive_id, node, diagnostics } => {
+                    ParserAction::SetInteractiveNode { id: interactive_id, node, diagnostics } => {
                         collected_diagnostics.extend(diagnostics);
 
                         node_map.get_interactive_block_mut(interactive_id).set_node(node);
                     }
-                    ParserAction::SetModuleNode { module_id, node, diagnostics } => {
+                    ParserAction::SetModuleNode { id: module_id, node, diagnostics } => {
                         collected_diagnostics.extend(diagnostics);
 
                         node_map.get_module_mut(module_id).set_node(node);
@@ -166,7 +161,7 @@ impl Parser {
                         );
 
                         let module = ModuleEntry::new(resolved_path);
-                        node_map.add_module(module_id, module);
+                        node_map.add_module(module);
 
                         let source = ParseSource::from_module(module_id, node_map, source_map);
                         scope.spawn(move |_| parse_source(source, sender));

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -4,7 +4,7 @@
 use std::{borrow::Cow, path::PathBuf};
 
 use hash_ast::node_map::NodeMap;
-use hash_source::{InteractiveId, ModuleId, SourceId, SourceMap};
+use hash_source::{SourceId, SourceMap};
 
 /// A [ParseSource] represents the pre-processed information before a module
 /// or an interactive block gets lexed and parsed. Logic related to
@@ -21,40 +21,31 @@ pub struct ParseSource {
 }
 
 impl ParseSource {
-    /// Create a new [ParseSource] from a [ModuleId].
-    pub fn from_module(module_id: ModuleId, node_map: &NodeMap, source_map: &SourceMap) -> Self {
-        let module = node_map.get_module(module_id);
-        let contents = source_map.contents_by_id(SourceId::Module(module_id)).to_owned();
+    /// Create a new [ParseSource] from a [SourceId].
+    pub(crate) fn from_module(id: SourceId, node_map: &NodeMap, source_map: &SourceMap) -> Self {
+        let module = node_map.get_module(id);
+        let contents = source_map.contents_by_id(id).to_owned();
 
-        Self {
-            id: SourceId::Module(module_id),
-            contents,
-            path: module.path().parent().unwrap().to_owned(),
-        }
+        Self { id, contents, path: module.path().parent().unwrap().to_owned() }
     }
     /// Create a new [ParseSource] from a [InteractiveId].
-    pub fn from_interactive(
-        interactive_id: InteractiveId,
-        source_map: &SourceMap,
-        current_dir: PathBuf,
-    ) -> Self {
-        let contents = source_map.contents_by_id(SourceId::Interactive(interactive_id)).to_owned();
+    fn from_interactive(id: SourceId, source_map: &SourceMap, current_dir: PathBuf) -> Self {
+        let contents = source_map.contents_by_id(id).to_owned();
 
-        Self { id: SourceId::Interactive(interactive_id), contents, path: current_dir }
+        Self { id, contents, path: current_dir }
     }
 
     /// Create a [ParseSource] from a general [SourceId]
     pub fn from_source(
-        source_id: SourceId,
+        id: SourceId,
         node_map: &NodeMap,
         source_map: &SourceMap,
         current_dir: PathBuf,
     ) -> Self {
-        match source_id {
-            SourceId::Interactive(interactive_id) => {
-                Self::from_interactive(interactive_id, source_map, current_dir)
-            }
-            SourceId::Module(module_id) => Self::from_module(module_id, node_map, source_map),
+        if id.is_interactive() {
+            Self::from_interactive(id, source_map, current_dir)
+        } else {
+            Self::from_module(id, node_map, source_map)
         }
     }
 
@@ -64,7 +55,7 @@ impl ParseSource {
     }
 
     /// Get the associated [SourceId] from the [ParseSource]
-    pub fn source_id(&self) -> SourceId {
+    pub fn id(&self) -> SourceId {
         self.id
     }
 

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -23,7 +23,7 @@ pub struct ParseSource {
 impl ParseSource {
     /// Create a new [ParseSource] from a [SourceId].
     pub(crate) fn from_module(id: SourceId, node_map: &NodeMap, source_map: &SourceMap) -> Self {
-        let module = node_map.get_module(id);
+        let module = node_map.get_module(id.into());
         let contents = source_map.contents_by_id(id).to_owned();
 
         Self { id, contents, path: module.path().parent().unwrap().to_owned() }

--- a/compiler/hash-pipeline/src/interface.rs
+++ b/compiler/hash-pipeline/src/interface.rs
@@ -4,7 +4,7 @@
 
 use hash_ast::node_map::{InteractiveBlock, ModuleEntry, NodeMap};
 use hash_reporting::report::Report;
-use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId, SourceMap};
+use hash_source::{ModuleKind, SourceId, SourceMap};
 
 use crate::{
     settings::{CompilerSettings, CompilerStageKind},
@@ -77,12 +77,12 @@ pub trait CompilerInterface {
     fn source_map(&self) -> &SourceMap;
 
     /// Add a [ModuleEntry] via the [Workspace].
-    fn add_module(&mut self, contents: String, module: ModuleEntry, kind: ModuleKind) -> ModuleId {
+    fn add_module(&mut self, contents: String, module: ModuleEntry, kind: ModuleKind) -> SourceId {
         self.workspace_mut().add_module(contents, module, kind)
     }
 
     /// Add a [InteractiveBlock] via the [Workspace].
-    fn add_interactive_block(&mut self, input: String, block: InteractiveBlock) -> InteractiveId {
+    fn add_interactive_block(&mut self, input: String, block: InteractiveBlock) -> SourceId {
         self.workspace_mut().add_interactive_block(input, block)
     }
 }

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -265,6 +265,6 @@ impl<I: CompilerInterface> Compiler<I> {
         let entry_point =
             ctx.workspace_mut().add_module(contents.unwrap(), ModuleEntry::new(filename), kind);
 
-        self.run(SourceId::Module(entry_point), ctx)
+        self.run(entry_point, ctx)
     }
 }

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -16,7 +16,7 @@ use hash_ast::{
     node_map::{InteractiveBlock, ModuleEntry, NodeMap},
     tree::AstTreeGenerator,
 };
-use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId, SourceMap};
+use hash_source::{ModuleKind, SourceId, SourceMap};
 use hash_utils::tree_writing::TreeWriter;
 
 bitflags! {
@@ -145,7 +145,7 @@ impl Default for StageInfo {
 #[derive(Debug)]
 pub struct Workspace {
     /// Dependency map between sources and modules.
-    dependencies: HashMap<SourceId, HashSet<ModuleId>>,
+    dependencies: HashMap<SourceId, HashSet<SourceId>>,
     /// Stores all of the raw file contents of the interactive blocks and
     /// modules.
     pub source_map: SourceMap,
@@ -177,73 +177,67 @@ impl Workspace {
     /// Add a interactive block to the [Workspace] by providing the contents and
     /// the [InteractiveBlock]. Returns the created [InteractiveId] from
     /// adding it to the source map.
-    pub fn add_interactive_block(
-        &mut self,
-        input: String,
-        block: InteractiveBlock,
-    ) -> InteractiveId {
+    pub fn add_interactive_block(&mut self, input: String, block: InteractiveBlock) -> SourceId {
         let id = self.source_map.add_interactive_block(input);
 
         // Add this source to the node map, and to the stage info
-        self.node_map.add_interactive_block(id, block);
-        self.source_stage_info.add(SourceId::Interactive(id), SourceStageInfo::empty());
+        self.node_map.add_interactive_block(block);
+        self.source_stage_info.add(id, SourceStageInfo::empty());
 
         id
     }
 
     /// Add a module to the [Workspace] by providing the contents and the
-    /// [Module]. Returns the created [ModuleId] from adding it to the
+    /// [ModuleEntry]. Returns the created [SourceId] from adding it to the
     /// source map.
     pub fn add_module(
         &mut self,
         contents: String,
         module: ModuleEntry,
         kind: ModuleKind,
-    ) -> ModuleId {
+    ) -> SourceId {
         let id = self.source_map.add_module(module.path.to_owned(), contents, kind);
 
         // Add this source to the node map, and to the stage info
-        self.node_map.add_module(id, module);
-        self.source_stage_info.add(SourceId::Module(id), SourceStageInfo::empty());
+        self.node_map.add_module(module);
+        self.source_stage_info.add(id, SourceStageInfo::empty());
 
         id
     }
 
-    /// Get the [ModuleId] of the module by the specified [Path].
-    pub fn get_module_id_by_path(&self, path: &Path) -> Option<ModuleId> {
+    /// Get the [SourceId] of the module by the specified [Path].
+    pub fn get_module_id_by_path(&self, path: &Path) -> Option<SourceId> {
         self.source_map.get_module_id_by_path(path)
     }
 
-    /// Add a module dependency specified by a [ModuleId] to a specific source
+    /// Add a module dependency specified by a [SourceId] to a specific source
     /// specified by a [SourceId].
-    pub fn add_dependency(&mut self, source_id: SourceId, dependency: ModuleId) {
+    pub fn add_dependency(&mut self, source_id: SourceId, dependency: SourceId) {
+        debug_assert!(dependency.is_module());
         self.dependencies.entry(source_id).or_insert_with(HashSet::new).insert(dependency);
     }
 
     /// Utility function used by AST-like stages in order to print the
     /// current [NodeMap].
     pub fn print_sources(&self, entry_point: SourceId) {
-        match entry_point {
-            SourceId::Interactive(id) => {
-                // If this is an interactive statement, we want to print the statement that was
-                // just parsed.
-                let source = self.node_map.get_interactive_block(id);
-                let tree = AstTreeGenerator.visit_body_block(source.node_ref()).unwrap();
+        if entry_point.is_interactive() {
+            // If this is an interactive statement, we want to print the statement that was
+            // just parsed.
+            let source = self.node_map.get_interactive_block(entry_point);
+            let tree = AstTreeGenerator.visit_body_block(source.node_ref()).unwrap();
 
-                println!("{}", TreeWriter::new(&tree));
-            }
-            SourceId::Module(_) => {
-                // If this is a module, we want to print all of the generated modules from the
-                // parsing stage
-                for (_, generated_module) in self.node_map.iter_modules() {
-                    let tree = AstTreeGenerator.visit_module(generated_module.node_ref()).unwrap();
+            println!("{}", TreeWriter::new(&tree));
+        } else {
+            // If this is a module, we want to print all of the generated modules from the
+            // parsing stage
+            for generated_module in self.node_map.iter_modules() {
+                let tree = AstTreeGenerator.visit_module(generated_module.node_ref()).unwrap();
 
-                    println!(
-                        "AST for `{}`:\n{}",
-                        generated_module.canonicalised_path(),
-                        TreeWriter::new(&tree)
-                    );
-                }
+                println!(
+                    "AST for `{}`:\n{}",
+                    generated_module.canonicalised_path(),
+                    TreeWriter::new(&tree)
+                );
             }
         }
     }

--- a/compiler/hash-source/Cargo.toml
+++ b/compiler/hash-source/Cargo.toml
@@ -11,7 +11,6 @@ derive_more = "0.99"
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 num-bigint = "0.4"
-index_vec = "0.1.3"
 
 hash-alloc = { path = "../hash-alloc" }
 hash-target = { path = "../hash-target" }

--- a/compiler/hash-source/Cargo.toml
+++ b/compiler/hash-source/Cargo.toml
@@ -11,7 +11,7 @@ derive_more = "0.99"
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 num-bigint = "0.4"
-slotmap = "1.0"
+index_vec = "0.1.3"
 
 hash-alloc = { path = "../hash-alloc" }
 hash-target = { path = "../hash-target" }

--- a/compiler/hash-source/Cargo.toml
+++ b/compiler/hash-source/Cargo.toml
@@ -11,6 +11,7 @@ derive_more = "0.99"
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 num-bigint = "0.4"
+index_vec = "0.1.3"
 
 hash-alloc = { path = "../hash-alloc" }
 hash-target = { path = "../hash-target" }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -2,65 +2,92 @@
 #![feature(path_file_prefix, let_chains)]
 
 use std::{
-    collections::HashMap,
+    fmt,
     path::{Path, PathBuf},
 };
 
 use bimap::BiMap;
 use hash_utils::path::adjust_canonicalisation;
-use index_vec::{define_index_type, index_vec, IndexVec};
 use location::{compute_row_col_from_offset, RowColSpan, SourceLocation};
 
 pub mod constant;
 pub mod identifier;
 pub mod location;
 
-define_index_type! {
-    pub struct ModuleId = u32;
+/// Used to check what kind of [SourceId] is being
+/// stored, i.e. the most significant bit denotes whether
+/// it is a module or an interactive block.
+const SOURCE_KIND_MASK: u32 = 0x8000_0000;
 
-    MAX_INDEX = i32::max_value() as usize;
-    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
-
-    DEBUG_FORMAT = "module#{}";
-
-    DISPLAY_FORMAT="{}";
+/// An identifier for a particular source within the compiler
+/// workspace. The internal representation of a [SourceId]
+/// uses a 4byte identifier which reserves a single bit to
+/// denotes whether this points to a "module" or an "interactive"
+/// block. Then, it can be used to index any value within the source
+/// map.
+///
+/// The first 31 bits are used to store the actual value of the
+/// [SourceId]. The last bit is used to denote whether this is a
+/// module or an interactive block.
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub struct SourceId {
+    /// The raw value of the identifier.
+    _id: u32,
 }
 
-define_index_type! {
-    pub struct InteractiveId = u32;
-
-    MAX_INDEX = i32::max_value() as usize;
-    DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
-
-    DEBUG_FORMAT = "interactive#{}";
-
-    DISPLAY_FORMAT="{}";
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum SourceId {
-    /// An Id pointing to a specific interactive block entry.
-    Interactive(InteractiveId),
-    /// An Id pointing to a specific module entry.
-    Module(ModuleId),
+impl fmt::Debug for SourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_module() {
+            write!(f, "module:{}", self.value())
+        } else {
+            write!(f, "interactive:{}", self.value())
+        }
+    }
 }
 
 impl Default for SourceId {
-    /// Creates a [SourceId::Module] with a null key
+    /// Creates a default [SourceId] which points to the `prelude` module.
     fn default() -> Self {
-        Self::Module(ModuleId::new(0))
+        Self { _id: SOURCE_KIND_MASK }
     }
 }
 
 impl SourceId {
+    /// Create a new "module" [SourceId] from the given value.
+    pub fn new_module(id: u32) -> Self {
+        // Value cannot be greater than 2^31 - 1
+        debug_assert!(id < SOURCE_KIND_MASK);
+        Self { _id: id | SOURCE_KIND_MASK }
+    }
+
+    /// Create a new "interactive" [SourceId] from the given value.
+    pub fn new_interactive(id: u32) -> Self {
+        // Value cannot be greater than 2^31 - 1
+        debug_assert!(id < SOURCE_KIND_MASK);
+        Self { _id: id }
+    }
+
     /// Check whether the [SourceId] points to a module.
     pub fn is_module(&self) -> bool {
-        matches!(self, Self::Module(_))
+        self._id >> 31 == 1
     }
 
     /// Check whether the [SourceId] points to a interactive block.
     pub fn is_interactive(&self) -> bool {
-        matches!(self, Self::Interactive(_))
+        self._id >> 31 == 0
+    }
+
+    /// Get the actual value of the [SourceId].
+    #[inline]
+    pub fn value(&self) -> u32 {
+        // clear the last bit
+        self._id & 0x7fff_ffff
+    }
+
+    /// Get the actual value of [SourceId] as a usize.
+    #[inline]
+    pub fn value_usize(&self) -> usize {
+        self.value() as usize
     }
 }
 
@@ -86,14 +113,14 @@ pub enum ModuleKind {
 pub struct SourceMap {
     /// A map between [ModuleId] and [PathBuf]. This is a bi-directional map
     /// and such value and key lookups are available.
-    module_paths: BiMap<ModuleId, PathBuf>,
+    module_paths: BiMap<u32, PathBuf>,
     ///  A map between [ModuleId] and the actual sources of the module.
-    module_content_map: IndexVec<ModuleId, String>,
+    module_content_map: Vec<String>,
     /// A map between [ModuleId] and the kind of module
-    module_kind_map: HashMap<ModuleId, ModuleKind>,
+    module_kind_map: Vec<ModuleKind>,
     /// A map between [InteractiveId] and the actual sources of the interactive
     /// block.
-    interactive_content_map: IndexVec<InteractiveId, String>,
+    interactive_content_map: Vec<String>,
 }
 
 impl SourceMap {
@@ -101,18 +128,20 @@ impl SourceMap {
     pub fn new() -> Self {
         Self {
             module_paths: BiMap::new(),
-            module_kind_map: HashMap::new(),
-            module_content_map: index_vec![],
-            interactive_content_map: index_vec![],
+            module_kind_map: vec![],
+            module_content_map: vec![],
+            interactive_content_map: vec![],
         }
     }
 
     /// Get a [Path] by a specific [SourceId]. If it is interactive, the path
     /// is always set as `<interactive>`.
     pub fn path_by_id(&self, source_id: SourceId) -> &Path {
-        match source_id {
-            SourceId::Interactive(_) => Path::new("<interactive>"),
-            SourceId::Module(id) => self.module_paths.get_by_left(&id).unwrap().as_path(),
+        if source_id.is_interactive() {
+            Path::new("<interactive>")
+        } else {
+            let value = source_id.value();
+            self.module_paths.get_by_left(&value).unwrap().as_path()
         }
     }
 
@@ -120,9 +149,11 @@ impl SourceMap {
     /// interactive, the path is always set as `<interactive>`. The function
     /// automatically converts the value into a string.
     pub fn canonicalised_path_by_id(&self, source_id: SourceId) -> String {
-        match source_id {
-            SourceId::Interactive(_) => String::from("<interactive>"),
-            SourceId::Module(_) => adjust_canonicalisation(self.path_by_id(source_id)),
+        if source_id.is_interactive() {
+            String::from("<interactive>")
+        } else {
+            let value = source_id.value();
+            adjust_canonicalisation(self.module_paths.get_by_left(&value).unwrap())
         }
     }
 
@@ -157,41 +188,47 @@ impl SourceMap {
 
     /// Get a [ModuleId] by a specific [Path]. The function checks if there
     /// is an entry for the specified `path` yielding a [ModuleId]
-    pub fn get_module_id_by_path(&self, path: &Path) -> Option<ModuleId> {
-        self.module_paths.get_by_right(path).copied()
+    pub fn get_module_id_by_path(&self, path: &Path) -> Option<SourceId> {
+        self.module_paths.get_by_right(path).copied().map(SourceId::new_module)
     }
 
     /// Get the raw contents of a module or interactive block by the
     /// specified [SourceId]
     pub fn contents_by_id(&self, source_id: SourceId) -> &str {
-        match source_id {
-            SourceId::Interactive(id) => self.interactive_content_map.get(id).unwrap(),
-            SourceId::Module(id) => self.module_content_map.get(id).unwrap(),
+        if source_id.is_interactive() {
+            self.interactive_content_map.get(source_id.value() as usize).unwrap()
+        } else {
+            self.module_content_map.get(source_id.value() as usize).unwrap()
         }
     }
 
     /// Get the [ModuleKind] by [SourceId]. If the `id` is
     /// [SourceId::Interactive], then the resultant [ModuleKind] is [None].
     pub fn module_kind_by_id(&self, source_id: SourceId) -> Option<ModuleKind> {
-        match source_id {
-            SourceId::Interactive(_) => None,
-            SourceId::Module(id) => self.module_kind_map.get(&id).cloned(),
+        if source_id.is_interactive() {
+            return None;
         }
+
+        let value = source_id.value();
+        self.module_kind_map.get(value as usize).copied()
     }
 
     /// Add a module to the [SourceMap]
-    pub fn add_module(&mut self, path: PathBuf, contents: String, kind: ModuleKind) -> ModuleId {
-        let id = self.module_content_map.push(contents);
+    pub fn add_module(&mut self, path: PathBuf, contents: String, kind: ModuleKind) -> SourceId {
+        let id = self.module_content_map.len() as u32;
+        self.module_content_map.push(contents);
 
         // Create references for the paths reverse
         self.module_paths.insert(id, path);
-        self.module_kind_map.insert(id, kind);
-        id
+        self.module_kind_map.push(kind);
+        SourceId::new_module(id)
     }
 
     /// Add an interactive block to the [SourceMap]
-    pub fn add_interactive_block(&mut self, contents: String) -> InteractiveId {
-        self.interactive_content_map.push(contents)
+    pub fn add_interactive_block(&mut self, contents: String) -> SourceId {
+        let id = self.interactive_content_map.len() as u32;
+        self.interactive_content_map.push(contents);
+        SourceId::new_interactive(id)
     }
 
     /// Function to get a friendly representation of the [SourceLocation] in

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -15,7 +15,7 @@ use hash_reporting::{diagnostic::Diagnostics, macros::panic_on_span};
 use hash_source::{
     identifier::{Identifier, IDENTS},
     location::{SourceLocation, Span},
-    ModuleKind, SourceId,
+    ModuleKind,
 };
 use hash_types::{
     args::Arg,
@@ -1336,11 +1336,9 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
 
     fn visit_import(&self, node: AstNodeRef<ast::Import>) -> Result<Self::ImportRet, Self::Error> {
         // Try resolve the path of the import to a SourceId:
-        let import_module_id = self.source_map().get_module_id_by_path(&node.resolved_path);
-        match import_module_id {
-            Some(import_module_id) => {
-                let id = SourceId::Module(import_module_id);
-
+        let source_id = self.source_map().get_module_id_by_path(&node.resolved_path);
+        match source_id {
+            Some(id) => {
                 // Resolve the ModDef corresponding to the SourceId if it exists:
                 match self.checked_sources().source_mod_def(id) {
                     Some(already_checked_mod_term) => {

--- a/compiler/hash-typecheck/src/traverse/visitor.rs
+++ b/compiler/hash-typecheck/src/traverse/visitor.rs
@@ -1336,7 +1336,7 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
 
     fn visit_import(&self, node: AstNodeRef<ast::Import>) -> Result<Self::ImportRet, Self::Error> {
         // Try resolve the path of the import to a SourceId:
-        let source_id = self.source_map().get_module_id_by_path(&node.resolved_path);
+        let source_id = self.source_map().get_id_by_path(&node.resolved_path);
         match source_id {
             Some(id) => {
                 // Resolve the ModDef corresponding to the SourceId if it exists:

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -48,7 +48,7 @@ impl<Ctx: SemanticAnalysisCtx> CompilerStage<Ctx> for SemanticAnalysis {
             if !source_stage_info.get(entry_point).is_semantics_checked()
                 && entry_point.is_interactive()
             {
-                let source = node_map.get_interactive_block(entry_point);
+                let source = node_map.get_interactive_block(entry_point.into());
 
                 // setup a visitor and the context
                 let mut visitor = SemanticAnalyser::new(source_map, entry_point);

--- a/compiler/hash-untyped-semantics/src/lib.rs
+++ b/compiler/hash-untyped-semantics/src/lib.rs
@@ -45,22 +45,22 @@ impl<Ctx: SemanticAnalysisCtx> CompilerStage<Ctx> for SemanticAnalysis {
         let source_stage_info = &mut workspace.source_stage_info;
 
         pool.scope(|scope| {
-            if !source_stage_info.get(entry_point).is_semantics_checked() {
-                if let SourceId::Interactive(id) = entry_point {
-                    let source = node_map.get_interactive_block(id);
+            if !source_stage_info.get(entry_point).is_semantics_checked()
+                && entry_point.is_interactive()
+            {
+                let source = node_map.get_interactive_block(entry_point);
 
-                    // setup a visitor and the context
-                    let mut visitor = SemanticAnalyser::new(source_map, entry_point);
+                // setup a visitor and the context
+                let mut visitor = SemanticAnalyser::new(source_map, entry_point);
 
-                    visitor.visit_body_block(source.node_ref()).unwrap();
-                    visitor.send_generated_messages(&sender);
-                }
+                visitor.visit_body_block(source.node_ref()).unwrap();
+                visitor.send_generated_messages(&sender);
             }
 
             // Iterate over all of the modules and add the expressions
             // to the queue so it can be distributed over the threads
-            for (id, module) in node_map.iter_modules() {
-                let source_id = SourceId::Module(*id);
+            for (id, module) in node_map.iter_modules().enumerate() {
+                let source_id = SourceId::new_module(id as u32);
                 let stage_info = source_stage_info.get(source_id);
 
                 // Skip any modules that have already been checked

--- a/compiler/hash-vm/src/stack.rs
+++ b/compiler/hash-vm/src/stack.rs
@@ -23,8 +23,10 @@ impl Stack {
     /// is sane and safe.
     pub fn verify_access(&self, access_kind: StackAccessKind, size: u8) -> RuntimeResult<()> {
         match access_kind {
-            StackAccessKind::Pop if self.stack_pointer > size.into() => Ok(()),
-            StackAccessKind::Push if self.data.len() - self.stack_pointer > size.into() => Ok(()),
+            StackAccessKind::Pop if self.stack_pointer > (size as usize) => Ok(()),
+            StackAccessKind::Push if self.data.len() - self.stack_pointer > (size as usize) => {
+                Ok(())
+            }
             _ => Err(RuntimeError::StackViolationAccess {
                 kind: access_kind,
                 size,


### PR DESCRIPTION
This patch simplifies the logic of how sources are identified within the compiler, and significantly cuts down on the memory usage of the representation. Previously, the `SourceId` was defined as:
```rs
enum SourceId {
   Module(ModuleId),
   Interactive(InteractiveId)
}
```
with each sub-id being 8 bytes (which is too big) in size. This design is somewhat wasteful because it forces `SourceId` to be aligned to 12 bytes. Now, `SourceId` is
defined as the following:
```rs
struct SourceId {
    _raw: u32
}
```
This `_raw` value uses the leftmost bit to represent the kind of source it is (either `module` or `interactive`), and the rest of the bits are used to describe the Id of the actual source. This is a reasonable size reduction because the compiler isn't expecting the total amount of sources to exceed $2^{31} - 1$.

This is an effort to reduce the overall memory usage of `SourceLocation` from 20 bytes to 12 bytes. 

This patch also gets rid of a bunch of hashmaps and slotmaps that aren't really needed to represent the `SourceMap` or the `NodeMap`.
