### PR TITLE
Add bootstrapping primitives to TC

### DIFF
--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![feature(decl_macro, slice_pattern, option_result_contains, let_chains, if_let_guard)]
 
+use std::cell::Cell;
+
 use diagnostics::DiagnosticsStore;
 use hash_pipeline::{
     interface::{CompilerInterface, CompilerStage},
@@ -122,6 +124,8 @@ impl<Ctx: TypecheckingCtx> CompilerStage<Ctx> for Typechecker {
             &current_source_info,
         );
 
+        let primitives = Cell::new(None);
+
         // Instantiate a visitor with the source and visit the source, using the
         // previous local storage.
         let storage = StorageRef {
@@ -132,7 +136,7 @@ impl<Ctx: TypecheckingCtx> CompilerStage<Ctx> for Typechecker {
             source_map: &workspace.source_map,
             diagnostics_store: &self.diagnostics_store,
             cache: &self.cache,
-            _new: TcEnv::new(&env, &self._new_diagnostic, &self._new_ast_info),
+            _new: TcEnv::new(&env, &self._new_diagnostic, &self._new_ast_info, &primitives),
         };
 
         // @@Hack: for now we use the `USE_NEW_TC` env variable to switch between the

--- a/compiler/hash-typecheck/src/new/environment/tc_env.rs
+++ b/compiler/hash-typecheck/src/new/environment/tc_env.rs
@@ -2,7 +2,7 @@
 use hash_types::new::environment::env::{AccessToEnv, Env};
 
 use super::ast_info::AstInfo;
-use crate::new::diagnostics::store::DiagnosticsStore;
+use crate::new::{diagnostics::store::DiagnosticsStore, ops::bootstrap::DefinedPrimitivesOrUnset};
 
 macro_rules! tc_env {
     ($($(#$hide:ident)? $name:ident: $ty:ident $(<$lt:lifetime> )?),* $(,)?) => {
@@ -55,6 +55,7 @@ tc_env! {
     #hide env: Env<'tc>,
     diagnostics: DiagnosticsStore,
     ast_info: AstInfo,
+    primitives_or_unset: DefinedPrimitivesOrUnset,
 }
 
 /// Implement [`AccessToEnv`] for some type that has a field `env: Env`.

--- a/compiler/hash-typecheck/src/new/ops/bootstrap.rs
+++ b/compiler/hash-typecheck/src/new/ops/bootstrap.rs
@@ -74,6 +74,7 @@ defined_primitives! {
     str: DataDefId,
     char: DataDefId,
     option: DataDefId,
+    result: DataDefId,
     list: DataDefId,
 }
 
@@ -194,6 +195,53 @@ impl<'tc> BootstrapOps<'tc> {
                             vec![ParamData {
                                 name: self.new_symbol("value"),
                                 ty: self.new_var_ty(t_sym),
+                                default_value: None,
+                            }],
+                        ),
+                    ]
+                })
+            },
+
+            // result
+            result: {
+                let result_sym = self.new_symbol("Result");
+                let ok_sym = self.new_symbol("Ok");
+                let err_sym = self.new_symbol("Err");
+                let t_sym = self.new_symbol("T");
+                let e_sym = self.new_symbol("E");
+                let params = self.param_ops().create_params(
+                    [
+                        ParamData {
+                            name: t_sym,
+                            ty: self.new_small_universe_ty(),
+                            default_value: None,
+                        },
+                        ParamData {
+                            name: e_sym,
+                            ty: self.new_small_universe_ty(),
+                            default_value: None,
+                        },
+                    ]
+                    .into_iter(),
+                );
+                let def_params = self
+                    .param_ops()
+                    .create_def_params(once(DefParamGroupData { implicit: true, params }));
+                self.data_ops().create_enum_def(result_sym, def_params, |_| {
+                    vec![
+                        (
+                            ok_sym,
+                            vec![ParamData {
+                                name: self.new_symbol("value"),
+                                ty: self.new_var_ty(t_sym),
+                                default_value: None,
+                            }],
+                        ),
+                        (
+                            err_sym,
+                            vec![ParamData {
+                                name: self.new_symbol("error"),
+                                ty: self.new_var_ty(e_sym),
                                 default_value: None,
                             }],
                         ),

--- a/compiler/hash-typecheck/src/new/ops/bootstrap.rs
+++ b/compiler/hash-typecheck/src/new/ops/bootstrap.rs
@@ -1,0 +1,184 @@
+use std::iter::once;
+
+use derive_more::Constructor;
+use hash_types::new::{
+    data::{DataDefId, ListCtorInfo, NumericCtorInfo, PrimitiveCtorInfo},
+    defs::DefParamGroupData,
+    environment::{context::ScopeKind, env::AccessToEnv},
+    mods::{ModDefData, ModDefId, ModKind, ModMemberData, ModMemberValue},
+    params::ParamData,
+};
+use hash_utils::store::Store;
+
+use super::{common::CommonOps, AccessToOps};
+use crate::{impl_access_to_tc_env, new::environment::tc_env::TcEnv};
+
+#[derive(Constructor)]
+pub struct BootstrapOps<'tc> {
+    tc_env: &'tc TcEnv<'tc>,
+}
+
+macro_rules! defined_primitives {
+    ($($name:ident: $type:ty),* $(,)?) => {
+        pub struct DefinedPrimitives {
+            $(pub $name: DataDefId),*
+        }
+
+        impl<'tc> BootstrapOps<'tc> {
+            pub fn make_primitive_mod_members(&self) -> Vec<ModMemberData> {
+                let primitives = self.make_primitives();
+                vec![
+                    $(
+                        ModMemberData {
+                            name: self.stores().data_def().map_fast(primitives.$name, |def| def.name),
+                            value: ModMemberValue::Data(primitives.$name)
+                        },
+                    )*
+                ]
+            }
+        }
+    };
+
+}
+
+defined_primitives! {
+    never: DataDefId,
+    bool: DataDefId,
+    u8: DataDefId,
+    u16: DataDefId,
+    u32: DataDefId,
+    u64: DataDefId,
+    i8: DataDefId,
+    i16: DataDefId,
+    i32: DataDefId,
+    i64: DataDefId,
+    f32: DataDefId,
+    f64: DataDefId,
+    str: DataDefId,
+    char: DataDefId,
+    option: DataDefId,
+    list: DataDefId,
+}
+
+impl_access_to_tc_env!(BootstrapOps<'tc>);
+
+impl<'tc> BootstrapOps<'tc> {
+    pub fn bootstrap(&self) {
+        self.make_primitives();
+    }
+
+    pub fn make_and_enter_primitive_mod(&self) {
+        self.context_ops().add_scope(ScopeKind::Mod(self.make_primitive_mod()));
+    }
+
+    pub fn make_primitive_mod(&self) -> ModDefId {
+        self.mod_ops().create_mod_def(ModDefData {
+            name: self.new_symbol("Primitives"),
+            params: self.new_empty_def_params(),
+            kind: ModKind::Transparent,
+            members: self.mod_ops().create_mod_members(self.make_primitive_mod_members()),
+            self_ty_name: None,
+        })
+    }
+
+    pub fn make_primitives(&self) -> DefinedPrimitives {
+        let numeric = |name, bits, signed, float| {
+            self.data_ops().create_primitive_data_def(
+                self.new_symbol(name),
+                PrimitiveCtorInfo::Numeric(NumericCtorInfo {
+                    bits,
+                    is_signed: signed,
+                    is_float: float,
+                }),
+            )
+        };
+        DefinedPrimitives {
+            // Never
+            never: self.data_ops().new_empty_data_def(
+                self.new_symbol("never"),
+                self.param_ops().new_empty_def_params(),
+            ),
+
+            // bool
+            bool: self.data_ops().create_enum_def(
+                self.new_symbol("bool"),
+                self.new_empty_def_params(),
+                |_| vec![(self.new_symbol("true"), vec![]), (self.new_symbol("false"), vec![])],
+            ),
+
+            // numerics
+            i8: numeric("i8", 8, true, false),
+            i16: numeric("i16", 16, true, false),
+            i32: numeric("i32", 32, true, false),
+            i64: numeric("i64", 64, true, false),
+            u8: numeric("u8", 8, false, false),
+            u16: numeric("u16", 16, false, false),
+            u32: numeric("u32", 32, false, false),
+            u64: numeric("u64", 64, false, false),
+            f32: numeric("f32", 32, false, true),
+            f64: numeric("f64", 64, false, true),
+
+            // str and char
+            str: self
+                .data_ops()
+                .create_primitive_data_def(self.new_symbol("str"), PrimitiveCtorInfo::Str),
+            char: self
+                .data_ops()
+                .create_primitive_data_def(self.new_symbol("char"), PrimitiveCtorInfo::Char),
+
+            // list
+            list: {
+                let list_sym = self.new_symbol("List");
+                let t_sym = self.new_symbol("T");
+                self.data_ops().create_primitive_data_def_with_params(
+                    list_sym,
+                    self.param_ops().create_def_params(once(DefParamGroupData {
+                        implicit: true,
+                        params: self.param_ops().create_params(once(ParamData {
+                            name: t_sym,
+                            ty: self.new_small_universe_ty(),
+                            default_value: None,
+                        })),
+                    })),
+                    |id| {
+                        PrimitiveCtorInfo::List(ListCtorInfo {
+                            element_ty: self.new_var_in_data_params(t_sym, id),
+                        })
+                    },
+                )
+            },
+
+            // option
+            option: {
+                let option_sym = self.new_symbol("Option");
+                let none_sym = self.new_symbol("None");
+                let some_sym = self.new_symbol("Some");
+                let t_sym = self.new_symbol("T");
+                self.data_ops().create_enum_def(
+                    option_sym,
+                    self.param_ops().create_def_params(once(DefParamGroupData {
+                        implicit: true,
+                        params: self.param_ops().create_params(once(ParamData {
+                            name: t_sym,
+                            ty: self.new_small_universe_ty(),
+                            default_value: None,
+                        })),
+                    })),
+                    |id| {
+                        vec![
+                            (none_sym, vec![]),
+                            (
+                                some_sym,
+                                vec![ParamData {
+                                    name: self.new_symbol("value"),
+                                    ty: self.new_var_in_data_params(t_sym, id),
+                                    default_value: None,
+                                }],
+                            ),
+                        ]
+                    },
+                )
+            },
+        }
+    }
+}

--- a/compiler/hash-typecheck/src/new/ops/data.rs
+++ b/compiler/hash-typecheck/src/new/ops/data.rs
@@ -7,7 +7,7 @@ use hash_types::new::{
     data::{CtorDef, CtorDefData, CtorDefsId, DataDef, DataDefId},
     defs::{DefArgGroupData, DefArgsId, DefParamGroupData, DefParamsId},
     environment::{context::BoundVarOrigin, env::AccessToEnv},
-    params::{ParamData, ParamTarget},
+    params::{ParamData, ParamIndex},
     scopes::BoundVar,
     symbols::Symbol,
     terms::Term,
@@ -105,7 +105,7 @@ impl<'tc> DataOps<'tc> {
                                             (def_param_group.params, j),
                                         ),
                                     }));
-                                    ArgData { target: ParamTarget::Position(i), value }
+                                    ArgData { target: ParamIndex::Position(i), value }
                                 })
                                 .collect_vec()
                                 .into_iter()

--- a/compiler/hash-typecheck/src/new/ops/data.rs
+++ b/compiler/hash-typecheck/src/new/ops/data.rs
@@ -6,9 +6,8 @@ use hash_types::new::{
     args::ArgData,
     data::{CtorDef, CtorDefData, CtorDefsId, DataDef, DataDefCtors, DataDefId, PrimitiveCtorInfo},
     defs::{DefArgGroupData, DefArgsId, DefParamGroupData, DefParamsId},
-    environment::{context::BoundVarOrigin, env::AccessToEnv},
+    environment::env::AccessToEnv,
     params::{ParamData, ParamIndex},
-    scopes::BoundVar,
     symbols::Symbol,
     terms::Term,
 };
@@ -107,7 +106,7 @@ impl<'tc> DataOps<'tc> {
     /// ```
     pub fn create_forwarded_data_args_from_params(
         &self,
-        data_def_id: DataDefId,
+        _data_def_id: DataDefId,
         def_params_id: DefParamsId,
     ) -> DefArgsId {
         self.stores().def_params().map(def_params_id, |def_params| {
@@ -123,16 +122,9 @@ impl<'tc> DataOps<'tc> {
                             params
                                 .iter()
                                 .enumerate()
-                                .map(|(j, param)| {
-                                    let value = self.new_term(Term::Var(BoundVar {
-                                        name: param.name,
-                                        origin: BoundVarOrigin::Data(
-                                            data_def_id,
-                                            (def_params_id, i),
-                                            (def_param_group.params, j),
-                                        ),
-                                    }));
-                                    ArgData { target: ParamIndex::Position(i), value }
+                                .map(|(_j, param)| ArgData {
+                                    target: ParamIndex::Position(i),
+                                    value: self.new_term(Term::Var(param.name)),
                                 })
                                 .collect_vec()
                                 .into_iter()

--- a/compiler/hash-typecheck/src/new/ops/mod.rs
+++ b/compiler/hash-typecheck/src/new/ops/mod.rs
@@ -1,7 +1,7 @@
 // @@Docs
 use self::{
-    context::ContextOps, data::DataOps, defs::CommonDefOps, fns::FnOps, infer::InferOps,
-    mods::ModOps, params::ParamOps, stack::StackOps, tuple::TupleOps,
+    bootstrap::BootstrapOps, context::ContextOps, data::DataOps, defs::CommonDefOps, fns::FnOps,
+    infer::InferOps, mods::ModOps, params::ParamOps, stack::StackOps, tuple::TupleOps,
 };
 
 pub mod bootstrap;
@@ -42,4 +42,5 @@ ops! {
   param_ops: ParamOps,
   context_ops: ContextOps,
   tuple_ops: TupleOps,
+  bootstrap_ops: BootstrapOps,
 }

--- a/compiler/hash-typecheck/src/new/ops/mod.rs
+++ b/compiler/hash-typecheck/src/new/ops/mod.rs
@@ -4,6 +4,7 @@ use self::{
     mods::ModOps, params::ParamOps, stack::StackOps, tuple::TupleOps,
 };
 
+pub mod bootstrap;
 pub mod common;
 pub mod context;
 pub mod data;
@@ -11,6 +12,7 @@ pub mod defs;
 pub mod fns;
 pub mod infer;
 pub mod mods;
+pub mod normalise;
 pub mod oracle;
 pub mod params;
 pub mod stack;

--- a/compiler/hash-typecheck/src/new/ops/normalise.rs
+++ b/compiler/hash-typecheck/src/new/ops/normalise.rs
@@ -1,0 +1,31 @@
+use derive_more::Constructor;
+use hash_types::new::terms::TermId;
+
+use crate::{
+    impl_access_to_tc_env,
+    new::{diagnostics::error::TcResult, environment::tc_env::TcEnv},
+};
+
+#[derive(Constructor)]
+pub struct NormalisationOps<'tc> {
+    tc_env: &'tc TcEnv<'tc>,
+}
+
+impl_access_to_tc_env!(NormalisationOps<'tc>);
+
+impl<'tc> NormalisationOps<'tc> {
+    /// Turn a term to weak head normal form.
+    pub fn standardise_term(&self, _term_id: TermId) -> TcResult<TermId> {
+        todo!()
+    }
+
+    /// Turn a term to weak head normal form, or return `None` .
+    pub fn potentially_standardise_term(&self, _term_id: TermId) -> TcResult<Option<TermId>> {
+        todo!()
+    }
+
+    /// Reduce a term to normal form.
+    pub fn potentially_normalise_term(&self, _term_id: TermId) -> TcResult<Option<TermId>> {
+        todo!()
+    }
+}

--- a/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
+++ b/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
@@ -128,16 +128,23 @@ impl<'tc> ScopeDiscoveryPass<'tc> {
     /// The iterator elements are `(is_implicit, params)`.
     fn create_hole_def_params<'a>(
         &self,
-        groups: impl Iterator<Item = (bool, &'a ast::AstNodes<ast::Param>)> + ExactSizeIterator,
+        groups: impl Iterator<Item = (bool, &'a ast::AstNodes<ast::Param>)>,
     ) -> DefParamsId {
+        let groups = groups.collect_vec();
         let params = groups
-            .filter(|group| !group.1.is_empty())
+            .iter()
+            .copied()
             .map(|group| {
                 let (implicit, params) = group;
                 DefParamGroupData { params: self.create_hole_params(params), implicit }
             })
             .collect_vec();
-        self.param_ops().create_def_params(params.into_iter())
+
+        let def_params = self.param_ops().create_def_params(params.into_iter());
+        self.stores().location().add_locations_to_targets(def_params, |i| {
+            Some(self.source_location(groups[i].1.span()?))
+        });
+        def_params
     }
 
     /// Create a parameter list from the given AST parameter list, where the
@@ -664,7 +671,9 @@ impl<'tc> ast::AstVisitor for ScopeDiscoveryPass<'tc> {
         // Create a mod block definition, with empty members for now.
         let mod_def_id = self.mod_ops().create_mod_def(ModDefData {
             name: mod_block_name,
-            params: self.create_hole_def_params(once((true, &node.ty_params))),
+            params: self.create_hole_def_params(
+                node.ty_params.first().iter().map(|_| (true, &node.ty_params)),
+            ),
             kind: ModKind::ModBlock,
             members: self.mod_ops().create_empty_mod_members(),
             self_ty_name: None,

--- a/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
+++ b/compiler/hash-typecheck/src/new/passes/scope_discovery.rs
@@ -717,12 +717,17 @@ impl<'tc> ast::AstVisitor for ScopeDiscoveryPass<'tc> {
         let enum_def_id = self.data_ops().create_enum_def(
             enum_name,
             self.create_hole_def_params(once((true, &node.ty_params))),
-            node.entries.iter().map(|variant| {
-                (
-                    self.new_symbol(variant.name.ident),
-                    self.create_param_data_from_ast_params(variant.fields.iter()).into_iter(),
-                )
-            }),
+            |_| {
+                node.entries
+                    .iter()
+                    .map(|variant| {
+                        (
+                            self.new_symbol(variant.name.ident),
+                            self.create_param_data_from_ast_params(variant.fields.iter()),
+                        )
+                    })
+                    .collect_vec()
+            },
         );
 
         // Traverse the enum; the variants have already been created.

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/exprs.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/exprs.rs
@@ -168,9 +168,9 @@ impl<'tc> SymbolResolutionPass<'tc> {
                         // Function call
                         self.new_term(Term::FnCall(fn_call_term))
                     }
-                    TerminalResolvedPathComponent::BoundVar(bound_var) => {
+                    TerminalResolvedPathComponent::Var(bound_var) => {
                         // Bound variable
-                        self.new_term(Term::Var(bound_var))
+                        self.new_term(Term::Var(bound_var.name))
                     }
                 },
             },

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/mod.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/mod.rs
@@ -133,8 +133,16 @@ impl<'tc> SymbolResolutionPass<'tc> {
     /// This will search the current scope and all parent scopes.
     /// If the binding is not found, it will return `None`.
     fn lookup_binding_by_name(&self, name: Identifier) -> Option<Symbol> {
-        // @@Todo: do not iter up if the context kind is access
-        self.bindings_by_name.get().iter().rev().find_map(|b| b.1.get(&name).copied())
+        match self.get_current_context_kind() {
+            ContextKind::Access(_, _) => {
+                // If we are accessing we only want to look in the current scope
+                self.bindings_by_name.get().last().and_then(|binding| binding.1.get(&name).copied())
+            }
+            ContextKind::Environment => {
+                // Look up the scopes
+                self.bindings_by_name.get().iter().rev().find_map(|b| b.1.get(&name).copied())
+            }
+        }
     }
 
     /// Find a binding by name, returning the symbol of the binding.

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/mod.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 pub mod exprs;
+pub mod params;
 pub mod paths;
 pub mod pats;
 pub mod tys;

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
@@ -1,0 +1,334 @@
+//! This module contains functionality to resolve AST parameters and arguments
+//! to terms.
+
+use std::{iter::empty, ops::Range};
+
+use hash_source::location::Span;
+use hash_types::new::{
+    args::{ArgData, ArgsId, PatArgsId},
+    defs::{DefArgGroupData, DefArgsId, DefParamsId, DefPatArgGroupData, DefPatArgsId},
+    environment::env::AccessToEnv,
+    fns::FnCallTerm,
+    params::ParamTarget,
+    pats::Spread,
+    terms::{Term, TermId},
+};
+use hash_utils::store::{SequenceStore, SequenceStoreKey};
+
+use super::{paths::AstArgGroup, SymbolResolutionPass};
+use crate::new::{
+    diagnostics::{
+        error::{TcError, TcResult},
+        params::{SomeArgsId, SomeDefArgsId},
+    },
+    ops::{common::CommonOps, AccessToOps},
+    passes::ast_pass::AstPass,
+};
+
+/// Resolved arguments.
+///
+/// These are either term arguments, or pattern arguments.
+pub enum ResolvedArgs {
+    Term(ArgsId),
+    Pat(PatArgsId, Option<Spread>),
+}
+
+impl ResolvedArgs {
+    /// Get the number of arguments.
+    fn len(&self) -> usize {
+        match self {
+            ResolvedArgs::Term(args) => args.len(),
+            ResolvedArgs::Pat(args, _) => args.len(),
+        }
+    }
+}
+
+impl From<ResolvedArgs> for SomeArgsId {
+    fn from(value: ResolvedArgs) -> Self {
+        match value {
+            ResolvedArgs::Term(args) => SomeArgsId::Args(args),
+            ResolvedArgs::Pat(args, _) => SomeArgsId::PatArgs(args),
+        }
+    }
+}
+
+/// Resolved definition arguments.
+///
+/// These are either term arguments, or pattern arguments.
+pub enum ResolvedDefArgs {
+    Term(DefArgsId),
+    Pat(DefPatArgsId),
+}
+
+impl From<ResolvedDefArgs> for SomeDefArgsId {
+    fn from(value: ResolvedDefArgs) -> Self {
+        match value {
+            ResolvedDefArgs::Term(args) => SomeDefArgsId::Args(args),
+            ResolvedDefArgs::Pat(args) => SomeDefArgsId::PatArgs(args),
+        }
+    }
+}
+
+impl ResolvedDefArgs {
+    /// Get the number of arguments.
+    pub fn len(&self) -> usize {
+        match self {
+            ResolvedDefArgs::Term(args) => args.len(),
+            ResolvedDefArgs::Pat(args) => args.len(),
+        }
+    }
+
+    /// Check if there are no arguments.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the range of indices of the arguments.
+    pub fn to_index_range(&self) -> Range<usize> {
+        match self {
+            ResolvedDefArgs::Term(args) => args.to_index_range(),
+            ResolvedDefArgs::Pat(args) => args.to_index_range(),
+        }
+    }
+}
+
+impl<'tc> SymbolResolutionPass<'tc> {
+    /// Make [`ResolvedArgs`] from an AST argument group, with holes for all the
+    /// arguments.
+    ///
+    /// This will return either pattern arguments or term arguments, depending
+    /// on the kind of the argument group.
+    pub(super) fn make_args_from_ast_arg_group(
+        &self,
+        group: &AstArgGroup,
+    ) -> TcResult<ResolvedArgs> {
+        match group {
+            AstArgGroup::ExplicitArgs(args) => {
+                let args = args
+                    .iter()
+                    .enumerate()
+                    .map(|(i, arg)| {
+                        Ok(ArgData {
+                            target: arg
+                                .name
+                                .as_ref()
+                                .map(|name| ParamTarget::Name(name.ident))
+                                .unwrap_or_else(|| ParamTarget::Position(i)),
+                            value: self.make_term_from_ast_expr(arg.value.ast_ref())?,
+                        })
+                    })
+                    .collect::<TcResult<Vec<_>>>()?;
+                Ok(ResolvedArgs::Term(self.param_ops().create_args(args.into_iter())))
+            }
+            AstArgGroup::ImplicitArgs(args) => {
+                let args = args
+                    .iter()
+                    .enumerate()
+                    .map(|(i, arg)| {
+                        Ok(ArgData {
+                            target: arg
+                                .name
+                                .as_ref()
+                                .map(|name| ParamTarget::Name(name.ident))
+                                .unwrap_or_else(|| ParamTarget::Position(i)),
+                            value: self
+                                .new_term(Term::Ty(self.make_ty_from_ast_ty(arg.ty.ast_ref())?)),
+                        })
+                    })
+                    .collect::<TcResult<Vec<_>>>()?;
+                Ok(ResolvedArgs::Term(self.param_ops().create_args(args.into_iter())))
+            }
+            AstArgGroup::ExplicitPatArgs(pat_args, spread) => {
+                let spread = self.ast_spread_as_spread(spread)?;
+                let args = self.ast_tuple_pat_entries_as_pat_args(pat_args)?;
+                Ok(ResolvedArgs::Pat(args, spread))
+            }
+        }
+    }
+
+    /// Make [`ResolvedDefArgs`] from a list of AST argument groups, using
+    /// `make_args_from_ast_arg_group` to make each argument group.
+    ///
+    /// Panics if the argument group list is empty.
+    ///
+    /// This will either create term arguments or pattern arguments, depending
+    /// on the argument groups given. If they mismatch in kinds, an error is
+    /// returned.
+    pub(super) fn make_def_args_from_ast_arg_groups(
+        &self,
+        groups: &[AstArgGroup],
+        originating_params: DefParamsId,
+    ) -> TcResult<ResolvedDefArgs> {
+        let mut is_pat_args: Option<bool> = None;
+
+        // Ensure that each argument group is of the same kind.
+        for group in groups {
+            match (group, is_pat_args) {
+                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), None) => {
+                    is_pat_args = Some(false);
+                }
+                (AstArgGroup::ExplicitPatArgs(_, _), None) => {
+                    is_pat_args = Some(true);
+                }
+                // Correct cases:
+                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), Some(false))
+                | (AstArgGroup::ExplicitPatArgs(_, _), Some(true)) => {}
+                // Error cases:
+                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), Some(true))
+                | (AstArgGroup::ExplicitPatArgs(_, _), Some(false)) => {
+                    // @@Correctness: should we make this a user error or will it never happen?
+                    panic!("Mixing pattern and non-pattern arguments is not allowed")
+                }
+            }
+        }
+
+        match is_pat_args {
+            Some(is_pat_args) => {
+                if is_pat_args {
+                    // Pattern arguments
+                    let arg_groups = groups
+                        .iter()
+                        .enumerate()
+                        .map(|(index, group)| {
+                            let (pat_args, spread) =
+                                match self.make_args_from_ast_arg_group(group)? {
+                                    ResolvedArgs::Term(_) => unreachable!(),
+                                    ResolvedArgs::Pat(pat_args, spread) => (pat_args, spread),
+                                };
+                            Ok(DefPatArgGroupData {
+                                pat_args,
+                                spread,
+                                param_group: (originating_params, index),
+                            })
+                        })
+                        .collect::<TcResult<Vec<_>>>()?;
+                    Ok(ResolvedDefArgs::Pat(
+                        self.param_ops().create_def_pat_args(arg_groups.into_iter()),
+                    ))
+                } else {
+                    // Term arguments
+                    let arg_groups = groups
+                        .iter()
+                        .enumerate()
+                        .map(|(index, group)| {
+                            let args = match self.make_args_from_ast_arg_group(group)? {
+                                ResolvedArgs::Term(term_args) => term_args,
+                                ResolvedArgs::Pat(_, _) => unreachable!(),
+                            };
+                            Ok(DefArgGroupData { args, param_group: (originating_params, index) })
+                        })
+                        .collect::<TcResult<Vec<_>>>()?;
+                    Ok(ResolvedDefArgs::Term(
+                        self.param_ops().create_def_args(arg_groups.into_iter()),
+                    ))
+                }
+            }
+            // @@Hack: here we assume the args are term args; if they are meant to be pattern args
+            // it will be handled in [`super::pats`].
+            None => Ok(ResolvedDefArgs::Term(self.param_ops().create_def_args(empty()))),
+        }
+    }
+
+    /// Wrap a term in a function call, given a list of arguments as a list of
+    /// [`AstArgGroup`].
+    ///
+    /// Creates a new [`TermId`], which is a term that represents the
+    /// function call, and might be nested depending on `args`.
+    ///
+    /// It is not valid for `args` to be pattern arguments, and it will produce
+    /// an error if it is.
+    ///
+    /// If `args` is empty, this will panic.
+    pub(super) fn wrap_term_in_fn_call_from_ast_args(
+        &self,
+        subject: TermId,
+        args: &[AstArgGroup],
+        original_span: Span,
+    ) -> TcResult<FnCallTerm> {
+        debug_assert!(!args.is_empty());
+        let mut current_subject = subject;
+        for arg_group in args {
+            let args = self.make_args_from_ast_arg_group(arg_group)?;
+
+            match args {
+                ResolvedArgs::Term(args) => {
+                    // Here we are trying to call a function with term arguments.
+                    // Apply the arguments to the current subject and continue.
+                    current_subject = self.new_term(Term::FnCall(FnCallTerm {
+                        subject: current_subject,
+                        args,
+                        implicit: matches!(arg_group, AstArgGroup::ImplicitArgs(_)),
+                    }));
+                }
+                ResolvedArgs::Pat(_, _) => {
+                    // Here we are trying to call a function with pattern arguments.
+                    // This is not allowed.
+                    return Err(TcError::CannotUseFunctionInPatternPosition {
+                        location: self.source_location(original_span),
+                    });
+                }
+            }
+        }
+        match self.get_term(current_subject) {
+            Term::FnCall(call) => Ok(call),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Apply the given list of AST arguments to the given definition
+    /// parameters, checking that the lengths match in the process.
+    ///
+    /// If successful, returns the [`DefArgsId`] that represents the arguments.
+    ///
+    /// Otherwise, returns an error.
+    pub(super) fn apply_ast_args_to_def_params(
+        &self,
+        def_params: DefParamsId,
+        args: &[AstArgGroup],
+    ) -> TcResult<ResolvedDefArgs> {
+        // @@Todo: implicit args
+        // @@Todo: default params
+
+        // First ensure that the number of parameter and argument groups match.
+        let created_def_args = self.make_def_args_from_ast_arg_groups(args, def_params)?;
+        if def_params.len() != created_def_args.len() {
+            return Err(TcError::WrongDefArgLength {
+                def_params_id: def_params,
+                def_args_id: created_def_args.into(),
+            });
+        }
+
+        // Then ensure that the number of parameters and arguments in each group
+        // match.
+        let mut errors: Vec<TcError> = vec![];
+        for (param_group_index, arg_group_index) in
+            def_params.to_index_range().zip(created_def_args.to_index_range())
+        {
+            let def_param_group =
+                self.stores().def_params().get_element((def_params, param_group_index));
+
+            let def_arg_group = match created_def_args {
+                ResolvedDefArgs::Term(args) => ResolvedArgs::Term(
+                    self.stores().def_args().get_element((args, arg_group_index)).args,
+                ),
+                ResolvedDefArgs::Pat(args) => {
+                    let element = self.stores().def_pat_args().get_element((args, arg_group_index));
+                    ResolvedArgs::Pat(element.pat_args, element.spread)
+                }
+            };
+
+            if def_param_group.params.len() != def_arg_group.len() {
+                // Collect errors and only report at the end.
+                errors.push(TcError::WrongArgLength {
+                    params_id: def_param_group.params,
+                    args_id: def_arg_group.into(),
+                });
+            }
+        }
+        if !errors.is_empty() {
+            return Err(TcError::Compound { errors });
+        }
+
+        Ok(created_def_args)
+    }
+}

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
@@ -9,7 +9,7 @@ use hash_types::new::{
     defs::{DefArgGroupData, DefArgsId, DefParamsId, DefPatArgGroupData, DefPatArgsId},
     environment::env::AccessToEnv,
     fns::FnCallTerm,
-    params::ParamTarget,
+    params::ParamIndex,
     pats::Spread,
     terms::{Term, TermId},
 };
@@ -112,8 +112,8 @@ impl<'tc> SymbolResolutionPass<'tc> {
                             target: arg
                                 .name
                                 .as_ref()
-                                .map(|name| ParamTarget::Name(name.ident))
-                                .unwrap_or_else(|| ParamTarget::Position(i)),
+                                .map(|name| ParamIndex::Name(name.ident))
+                                .unwrap_or_else(|| ParamIndex::Position(i)),
                             value: self.make_term_from_ast_expr(arg.value.ast_ref())?,
                         })
                     })
@@ -129,8 +129,8 @@ impl<'tc> SymbolResolutionPass<'tc> {
                             target: arg
                                 .name
                                 .as_ref()
-                                .map(|name| ParamTarget::Name(name.ident))
-                                .unwrap_or_else(|| ParamTarget::Position(i)),
+                                .map(|name| ParamIndex::Name(name.ident))
+                                .unwrap_or_else(|| ParamIndex::Position(i)),
                             value: self
                                 .new_term(Term::Ty(self.make_ty_from_ast_ty(arg.ty.ast_ref())?)),
                         })

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/params.rs
@@ -295,8 +295,6 @@ impl<'tc> SymbolResolutionPass<'tc> {
         // @@Todo: implicit args
         // @@Todo: default params
 
-        println!("apply_ast_args_to_def_params: {} {:?}", self.env().with(def_params), args);
-
         // First ensure that the number of parameter and argument groups match.
         let created_def_args = self.make_def_args_from_ast_arg_groups(args, def_params)?;
         if def_params.len() != created_def_args.len() {

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/paths.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/paths.rs
@@ -175,7 +175,7 @@ impl<'tc> SymbolResolutionPass<'tc> {
     /// current context if no such value is given.
     ///
     /// Returns the binding that the name resolves to.
-    pub fn resolve_ast_name(
+    fn resolve_ast_name(
         &self,
         name: Identifier,
         name_span: Span,
@@ -220,6 +220,7 @@ impl<'tc> SymbolResolutionPass<'tc> {
     ) -> TcResult<ResolvedAstPathComponent> {
         let binding = self.resolve_ast_name(component.name, component.name_span, starting_from)?;
 
+        println!("##Resolving component {:?} \n##to {}", component, self.env().with(binding));
         match binding.kind {
             BindingKind::ModMember(_, mod_member_id) => {
                 let mod_member = self.stores().mod_members().get_element(mod_member_id);
@@ -246,6 +247,9 @@ impl<'tc> SymbolResolutionPass<'tc> {
                     ModMemberValue::Mod(mod_def_id) => {
                         let mod_def_params =
                             self.stores().mod_def().map_fast(mod_def_id, |def| def.params);
+                        println!("Got args: {:?}", component.args);
+                        println!("Params: {}", self.env().with(mod_def_params));
+
                         let args =
                             self.apply_ast_args_to_def_params(mod_def_params, &component.args)?;
 

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/paths.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/paths.rs
@@ -19,35 +19,29 @@
 //! This can then be used to create a term, type, or pattern, with appropriate
 //! restrictions on the arguments and item kind.
 
-use std::{fmt, iter::empty, ops::Range};
+use std::fmt;
 
 use hash_ast::ast;
 use hash_source::{identifier::Identifier, location::Span};
 use hash_types::new::{
-    args::{ArgData, ArgsId, PatArgsId},
     data::{CtorPat, CtorTerm, DataDefId},
-    defs::{DefArgGroupData, DefArgsId, DefParamsId, DefPatArgGroupData, DefPatArgsId},
+    defs::DefArgsId,
     environment::{
         context::{Binding, BindingKind, ScopeKind},
         env::AccessToEnv,
     },
     fns::{FnCallTerm, FnDefId},
     mods::{ModDefId, ModMemberValue},
-    params::ParamTarget,
-    pats::Spread,
     scopes::BoundVar,
-    terms::{Term, TermId},
+    terms::Term,
 };
-use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
+use hash_utils::store::{SequenceStore, Store};
 
-use super::{ContextKind, SymbolResolutionPass};
+use super::{params::ResolvedDefArgs, ContextKind, SymbolResolutionPass};
 use crate::new::{
-    diagnostics::{
-        error::{TcError, TcResult},
-        params::{SomeArgsId, SomeDefArgsId},
-    },
+    diagnostics::error::{TcError, TcResult},
     environment::tc_env::WithTcEnv,
-    ops::{common::CommonOps, AccessToOps},
+    ops::common::CommonOps,
     passes::ast_pass::AstPass,
 };
 /// An argument group in the AST.
@@ -175,73 +169,6 @@ pub enum ResolvedAstPathComponent {
     Terminal(TerminalResolvedPathComponent),
 }
 
-/// Resolved arguments.
-///
-/// These are either term arguments, or pattern arguments.
-pub enum ResolvedArgs {
-    Term(ArgsId),
-    Pat(PatArgsId, Option<Spread>),
-}
-
-impl ResolvedArgs {
-    /// Get the number of arguments.
-    fn len(&self) -> usize {
-        match self {
-            ResolvedArgs::Term(args) => args.len(),
-            ResolvedArgs::Pat(args, _) => args.len(),
-        }
-    }
-}
-
-impl From<ResolvedArgs> for SomeArgsId {
-    fn from(value: ResolvedArgs) -> Self {
-        match value {
-            ResolvedArgs::Term(args) => SomeArgsId::Args(args),
-            ResolvedArgs::Pat(args, _) => SomeArgsId::PatArgs(args),
-        }
-    }
-}
-
-/// Resolved definition arguments.
-///
-/// These are either term arguments, or pattern arguments.
-pub enum ResolvedDefArgs {
-    Term(DefArgsId),
-    Pat(DefPatArgsId),
-}
-
-impl From<ResolvedDefArgs> for SomeDefArgsId {
-    fn from(value: ResolvedDefArgs) -> Self {
-        match value {
-            ResolvedDefArgs::Term(args) => SomeDefArgsId::Args(args),
-            ResolvedDefArgs::Pat(args) => SomeDefArgsId::PatArgs(args),
-        }
-    }
-}
-
-impl ResolvedDefArgs {
-    /// Get the number of arguments.
-    pub fn len(&self) -> usize {
-        match self {
-            ResolvedDefArgs::Term(args) => args.len(),
-            ResolvedDefArgs::Pat(args) => args.len(),
-        }
-    }
-
-    /// Check if there are no arguments.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Get the range of indices of the arguments.
-    pub fn to_index_range(&self) -> Range<usize> {
-        match self {
-            ResolvedDefArgs::Term(args) => args.to_index_range(),
-            ResolvedDefArgs::Pat(args) => args.to_index_range(),
-        }
-    }
-}
-
 /// This block performs resolution of AST paths.
 impl<'tc> SymbolResolutionPass<'tc> {
     /// Resolve a name starting from the given [`ModMemberValue`], or the
@@ -278,242 +205,6 @@ impl<'tc> SymbolResolutionPass<'tc> {
                 Ok(self.context().get_binding(binding_symbol).unwrap())
             }
         }
-    }
-
-    /// Make [`ResolvedArgs`] from an AST argument group, with holes for all the
-    /// arguments.
-    ///
-    /// This will return either pattern arguments or term arguments, depending
-    /// on the kind of the argument group.
-    pub fn make_args_from_ast_arg_group(&self, group: &AstArgGroup) -> TcResult<ResolvedArgs> {
-        match group {
-            AstArgGroup::ExplicitArgs(args) => {
-                let args = args
-                    .iter()
-                    .enumerate()
-                    .map(|(i, arg)| {
-                        Ok(ArgData {
-                            target: arg
-                                .name
-                                .as_ref()
-                                .map(|name| ParamTarget::Name(name.ident))
-                                .unwrap_or_else(|| ParamTarget::Position(i)),
-                            value: self.make_term_from_ast_expr(arg.value.ast_ref())?,
-                        })
-                    })
-                    .collect::<TcResult<Vec<_>>>()?;
-                Ok(ResolvedArgs::Term(self.param_ops().create_args(args.into_iter())))
-            }
-            AstArgGroup::ImplicitArgs(args) => {
-                let args = args
-                    .iter()
-                    .enumerate()
-                    .map(|(i, arg)| {
-                        Ok(ArgData {
-                            target: arg
-                                .name
-                                .as_ref()
-                                .map(|name| ParamTarget::Name(name.ident))
-                                .unwrap_or_else(|| ParamTarget::Position(i)),
-                            value: self
-                                .new_term(Term::Ty(self.make_ty_from_ast_ty(arg.ty.ast_ref())?)),
-                        })
-                    })
-                    .collect::<TcResult<Vec<_>>>()?;
-                Ok(ResolvedArgs::Term(self.param_ops().create_args(args.into_iter())))
-            }
-            AstArgGroup::ExplicitPatArgs(pat_args, spread) => {
-                let spread = self.ast_spread_as_spread(spread)?;
-                let args = self.ast_tuple_pat_entries_as_pat_args(pat_args)?;
-                Ok(ResolvedArgs::Pat(args, spread))
-            }
-        }
-    }
-
-    /// Make [`ResolvedDefArgs`] from a list of AST argument groups, using
-    /// `make_args_from_ast_arg_group` to make each argument group.
-    ///
-    /// Panics if the argument group list is empty.
-    ///
-    /// This will either create term arguments or pattern arguments, depending
-    /// on the argument groups given. If they mismatch in kinds, an error is
-    /// returned.
-    fn make_def_args_from_ast_arg_groups(
-        &self,
-        groups: &[AstArgGroup],
-        originating_params: DefParamsId,
-    ) -> TcResult<ResolvedDefArgs> {
-        let mut is_pat_args: Option<bool> = None;
-
-        // Ensure that each argument group is of the same kind.
-        for group in groups {
-            match (group, is_pat_args) {
-                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), None) => {
-                    is_pat_args = Some(false);
-                }
-                (AstArgGroup::ExplicitPatArgs(_, _), None) => {
-                    is_pat_args = Some(true);
-                }
-                // Correct cases:
-                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), Some(false))
-                | (AstArgGroup::ExplicitPatArgs(_, _), Some(true)) => {}
-                // Error cases:
-                (AstArgGroup::ExplicitArgs(_) | AstArgGroup::ImplicitArgs(_), Some(true))
-                | (AstArgGroup::ExplicitPatArgs(_, _), Some(false)) => {
-                    // @@Correctness: should we make this a user error or will it never happen?
-                    panic!("Mixing pattern and non-pattern arguments is not allowed")
-                }
-            }
-        }
-
-        match is_pat_args {
-            Some(is_pat_args) => {
-                if is_pat_args {
-                    // Pattern arguments
-                    let arg_groups = groups
-                        .iter()
-                        .enumerate()
-                        .map(|(index, group)| {
-                            let (pat_args, spread) =
-                                match self.make_args_from_ast_arg_group(group)? {
-                                    ResolvedArgs::Term(_) => unreachable!(),
-                                    ResolvedArgs::Pat(pat_args, spread) => (pat_args, spread),
-                                };
-                            Ok(DefPatArgGroupData {
-                                pat_args,
-                                spread,
-                                param_group: (originating_params, index),
-                            })
-                        })
-                        .collect::<TcResult<Vec<_>>>()?;
-                    Ok(ResolvedDefArgs::Pat(
-                        self.param_ops().create_def_pat_args(arg_groups.into_iter()),
-                    ))
-                } else {
-                    // Term arguments
-                    let arg_groups = groups
-                        .iter()
-                        .enumerate()
-                        .map(|(index, group)| {
-                            let args = match self.make_args_from_ast_arg_group(group)? {
-                                ResolvedArgs::Term(term_args) => term_args,
-                                ResolvedArgs::Pat(_, _) => unreachable!(),
-                            };
-                            Ok(DefArgGroupData { args, param_group: (originating_params, index) })
-                        })
-                        .collect::<TcResult<Vec<_>>>()?;
-                    Ok(ResolvedDefArgs::Term(
-                        self.param_ops().create_def_args(arg_groups.into_iter()),
-                    ))
-                }
-            }
-            // @@Hack: here we assume the args are term args; if they are meant to be pattern args
-            // it will be handled in [`super::pats`].
-            None => Ok(ResolvedDefArgs::Term(self.param_ops().create_def_args(empty()))),
-        }
-    }
-
-    /// Wrap a term in a function call, given a list of arguments as a list of
-    /// [`AstArgGroup`].
-    ///
-    /// Creates a new [`TermId`], which is a term that represents the
-    /// function call, and might be nested depending on `args`.
-    ///
-    /// It is not valid for `args` to be pattern arguments, and it will produce
-    /// an error if it is.
-    ///
-    /// If `args` is empty, this will panic.
-    fn wrap_term_in_fn_call_from_ast_args(
-        &self,
-        subject: TermId,
-        args: &[AstArgGroup],
-        original_span: Span,
-    ) -> TcResult<FnCallTerm> {
-        debug_assert!(!args.is_empty());
-        let mut current_subject = subject;
-        for arg_group in args {
-            let args = self.make_args_from_ast_arg_group(arg_group)?;
-
-            match args {
-                ResolvedArgs::Term(args) => {
-                    // Here we are trying to call a function with term arguments.
-                    // Apply the arguments to the current subject and continue.
-                    current_subject = self.new_term(Term::FnCall(FnCallTerm {
-                        subject: current_subject,
-                        args,
-                        implicit: matches!(arg_group, AstArgGroup::ImplicitArgs(_)),
-                    }));
-                }
-                ResolvedArgs::Pat(_, _) => {
-                    // Here we are trying to call a function with pattern arguments.
-                    // This is not allowed.
-                    return Err(TcError::CannotUseFunctionInPatternPosition {
-                        location: self.source_location(original_span),
-                    });
-                }
-            }
-        }
-        match self.get_term(current_subject) {
-            Term::FnCall(call) => Ok(call),
-            _ => unreachable!(),
-        }
-    }
-
-    /// Apply the given list of AST arguments to the given definition
-    /// parameters, checking that the lengths match in the process.
-    ///
-    /// If successful, returns the [`DefArgsId`] that represents the arguments.
-    ///
-    /// Otherwise, returns an error.
-    fn apply_ast_args_to_def_params(
-        &self,
-        def_params: DefParamsId,
-        args: &[AstArgGroup],
-    ) -> TcResult<ResolvedDefArgs> {
-        // @@Todo: implicit args
-        // @@Todo: default params
-
-        // First ensure that the number of parameter and argument groups match.
-        let created_def_args = self.make_def_args_from_ast_arg_groups(args, def_params)?;
-        if def_params.len() != created_def_args.len() {
-            return Err(TcError::WrongDefArgLength {
-                def_params_id: def_params,
-                def_args_id: created_def_args.into(),
-            });
-        }
-
-        // Then ensure that the number of parameters and arguments in each group
-        // match.
-        let mut errors: Vec<TcError> = vec![];
-        for (param_group_index, arg_group_index) in
-            def_params.to_index_range().zip(created_def_args.to_index_range())
-        {
-            let def_param_group =
-                self.stores().def_params().get_element((def_params, param_group_index));
-
-            let def_arg_group = match created_def_args {
-                ResolvedDefArgs::Term(args) => ResolvedArgs::Term(
-                    self.stores().def_args().get_element((args, arg_group_index)).args,
-                ),
-                ResolvedDefArgs::Pat(args) => {
-                    let element = self.stores().def_pat_args().get_element((args, arg_group_index));
-                    ResolvedArgs::Pat(element.pat_args, element.spread)
-                }
-            };
-
-            if def_param_group.params.len() != def_arg_group.len() {
-                // Collect errors and only report at the end.
-                errors.push(TcError::WrongArgLength {
-                    params_id: def_param_group.params,
-                    args_id: def_arg_group.into(),
-                });
-            }
-        }
-        if !errors.is_empty() {
-            return Err(TcError::Compound { errors });
-        }
-
-        Ok(created_def_args)
     }
 
     /// Resolve a path component, starting from the given

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
@@ -14,9 +14,9 @@ use hash_types::new::{
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::AccessToEnv,
-    lits::{CharLit, IntLit, LitPat, StrLit},
+    lits::{CharLit, IntLit, ListPat, LitPat, StrLit},
     params::ParamIndex,
-    pats::{ListPat, Pat, PatId, PatListId, RangePat, Spread},
+    pats::{Pat, PatId, PatListId, RangePat, Spread},
     scopes::BindingPat,
     tuples::TuplePat,
 };
@@ -277,10 +277,10 @@ impl SymbolResolutionPass<'_> {
                 original_ty: None,
                 data_spread: self.ast_spread_as_spread(&tuple_pat.spread)?,
             })),
-            ast::Pat::List(list_pat) => self.new_pat(Pat::List(ListPat {
+            ast::Pat::List(list_pat) => self.new_pat(Pat::Lit(LitPat::List(ListPat {
                 pats: self.ast_pats_as_pat_list(&list_pat.fields)?,
                 spread: self.ast_spread_as_spread(&list_pat.spread)?,
-            })),
+            }))),
             ast::Pat::Lit(lit_pat) => {
                 self.new_pat(Pat::Lit(self.make_lit_pat_from_ast_lit(lit_pat.data.ast_ref())))
             }

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
@@ -277,10 +277,10 @@ impl SymbolResolutionPass<'_> {
                 original_ty: None,
                 data_spread: self.ast_spread_as_spread(&tuple_pat.spread)?,
             })),
-            ast::Pat::List(list_pat) => self.new_pat(Pat::Lit(LitPat::List(ListPat {
+            ast::Pat::List(list_pat) => self.new_pat(Pat::List(ListPat {
                 pats: self.ast_pats_as_pat_list(&list_pat.fields)?,
                 spread: self.ast_spread_as_spread(&list_pat.spread)?,
-            }))),
+            })),
             ast::Pat::Lit(lit_pat) => {
                 self.new_pat(Pat::Lit(self.make_lit_pat_from_ast_lit(lit_pat.data.ast_ref())))
             }

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
@@ -15,7 +15,7 @@ use hash_types::new::{
     data::CtorPat,
     environment::env::AccessToEnv,
     lits::{CharLit, IntLit, LitPat, StrLit},
-    params::ParamTarget,
+    params::ParamIndex,
     pats::{ListPat, Pat, PatId, PatListId, RangePat, Spread},
     scopes::BindingPat,
     tuples::TuplePat,
@@ -48,8 +48,8 @@ impl SymbolResolutionPass<'_> {
             .map(|(i, arg)| {
                 Ok(PatArgData {
                     target: match arg.name.as_ref() {
-                        Some(name) => ParamTarget::Name(name.ident),
-                        None => ParamTarget::Position(i),
+                        Some(name) => ParamIndex::Name(name.ident),
+                        None => ParamIndex::Position(i),
                     },
                     pat: self.make_pat_from_ast_pat(arg.pat.ast_ref())?,
                 })

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/pats.rs
@@ -79,7 +79,7 @@ impl SymbolResolutionPass<'_> {
             name: node
                 .name
                 .as_ref()
-                .map(|name| self.lookup_binding_by_name(name.ident).unwrap())
+                .map(|name| self.lookup_symbol_by_name(name.ident).unwrap())
                 .unwrap_or_else(|| self.new_fresh_symbol()),
             index: node.position,
         }))
@@ -190,7 +190,7 @@ impl SymbolResolutionPass<'_> {
                     // Constructor pattern
                     Ok(self.new_pat(Pat::Ctor(*ctor_pat)))
                 }
-                TerminalResolvedPathComponent::BoundVar(bound_var) => {
+                TerminalResolvedPathComponent::Var(bound_var) => {
                     // Binding pattern
                     // @@Todo: is_mutable, perhaps refactor `BindingPat`?
                     Ok(self.new_pat(Pat::Binding(BindingPat {

--- a/compiler/hash-typecheck/src/new/passes/symbol_resolution/tys.rs
+++ b/compiler/hash-typecheck/src/new/passes/symbol_resolution/tys.rs
@@ -145,9 +145,9 @@ impl<'tc> SymbolResolutionPass<'tc> {
                         // Function call
                         self.new_ty(Ty::Eval(self.new_term(Term::FnCall(fn_call_term))))
                     }
-                    TerminalResolvedPathComponent::BoundVar(bound_var) => {
+                    TerminalResolvedPathComponent::Var(bound_var) => {
                         // Bound variable
-                        self.new_ty(Ty::Var(bound_var))
+                        self.new_ty(Ty::Var(bound_var.name))
                     }
                 },
             },

--- a/compiler/hash-types/src/new/access.rs
+++ b/compiler/hash-types/src/new/access.rs
@@ -6,7 +6,7 @@ use hash_ast::ast;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
-    params::ParamTarget,
+    params::ParamIndex,
     terms::TermId,
 };
 
@@ -30,7 +30,7 @@ pub struct AccessTerm {
     // /// The kind of access.
     // pub kind: AccessKind,
     /// The target field of the accessing operation.
-    pub field: ParamTarget,
+    pub field: ParamIndex,
 }
 
 impl fmt::Display for WithEnv<'_, &AccessTerm> {
@@ -49,11 +49,11 @@ impl fmt::Display for WithEnv<'_, &AccessTerm> {
     }
 }
 
-impl From<ast::PropertyKind> for ParamTarget {
+impl From<ast::PropertyKind> for ParamIndex {
     fn from(kind: ast::PropertyKind) -> Self {
         match kind {
-            ast::PropertyKind::NamedField(f) => ParamTarget::Name(f),
-            ast::PropertyKind::NumericField(f) => ParamTarget::Position(f),
+            ast::PropertyKind::NamedField(f) => ParamIndex::Name(f),
+            ast::PropertyKind::NumericField(f) => ParamIndex::Position(f),
         }
     }
 }

--- a/compiler/hash-types/src/new/args.rs
+++ b/compiler/hash-types/src/new/args.rs
@@ -11,7 +11,7 @@ use utility_types::omit;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
-    params::ParamTarget,
+    params::ParamIndex,
     pats::PatId,
 };
 use crate::new::terms::TermId;
@@ -26,7 +26,7 @@ pub struct Arg {
     /// The ID of the argument in the argument list.
     pub id: ArgId,
     /// Argument target (named or positional), if known.
-    pub target: ParamTarget,
+    pub target: ParamIndex,
     /// The term that is the value of the argument.
     pub value: TermId,
 }
@@ -44,7 +44,7 @@ pub struct PatArg {
     /// The ID of the argument in the argument pattern list.
     pub id: PatArgId,
     /// Argument target (named or positional).
-    pub target: ParamTarget,
+    pub target: ParamIndex,
     /// The pattern in place for this argument.
     pub pat: PatId,
 }
@@ -56,10 +56,10 @@ pub type PatArgsStore = DefaultSequenceStore<PatArgsId, PatArg>;
 impl fmt::Display for WithEnv<'_, &Arg> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value.target {
-            ParamTarget::Name(name) => {
+            ParamIndex::Name(name) => {
                 write!(f, "{} = {}", name, self.env().with(self.value.value))
             }
-            ParamTarget::Position(_) => write!(f, "{}", self.env().with(self.value.value)),
+            ParamIndex::Position(_) => write!(f, "{}", self.env().with(self.value.value)),
         }
     }
 }
@@ -87,10 +87,10 @@ impl fmt::Display for WithEnv<'_, ArgsId> {
 impl fmt::Display for WithEnv<'_, &PatArg> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value.target {
-            ParamTarget::Name(name) => {
+            ParamIndex::Name(name) => {
                 write!(f, "{} = {}", name, self.env().with(self.value.pat))
             }
-            ParamTarget::Position(_) => write!(f, "{}", self.env().with(self.value.pat)),
+            ParamIndex::Position(_) => write!(f, "{}", self.env().with(self.value.pat)),
         }
     }
 }

--- a/compiler/hash-types/src/new/data.rs
+++ b/compiler/hash-types/src/new/data.rs
@@ -13,6 +13,7 @@ use utility_types::omit;
 use super::{
     defs::DefPatArgsId,
     environment::env::{AccessToEnv, WithEnv},
+    tys::TyId,
 };
 use crate::new::{
     defs::{DefArgsId, DefParamsId},
@@ -81,6 +82,53 @@ pub struct CtorPat {
     pub args: DefPatArgsId,
 }
 
+/// A numeric constructor definition.
+///
+/// This is a constructor which accepts numeric literals
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NumericCtorInfo {
+    /// The number of bits in the number.
+    pub bits: u16,
+    /// Whether the number is signed or not.
+    pub is_signed: bool,
+    /// Whether the number is floating-point or not.
+    pub is_float: bool,
+    // @@Future: allowable range?
+}
+
+/// A list constructor definition.
+/// This is a constructor which accepts list literals.
+#[derive(Debug, Clone, Copy)]
+pub struct ListCtorInfo {
+    /// The type of the elements in the list.
+    pub element_ty: TyId,
+}
+
+/// A primitive constructor definition.
+///
+/// This is a constructor which accepts a primitive literal.
+#[derive(Debug, Clone, Copy)]
+pub enum PrimitiveCtorInfo {
+    /// A numeric literal constructor.
+    Numeric(NumericCtorInfo),
+    /// A string literal constructor.
+    Str,
+    /// A character literal constructor.
+    Char,
+    /// A list literal constructor.
+    List(ListCtorInfo),
+}
+
+/// The constructors of a data-type definition.
+///
+/// These are either a given set of predefined constructors, or a primitive
+/// constructor (numeric, string, character).
+#[derive(Debug, Clone, Copy)]
+pub enum DataDefCtors {
+    Defined(CtorDefsId),
+    Primitive(PrimitiveCtorInfo),
+}
+
 /// A data-type definition.
 ///
 /// This is a "nominal" inductively defined data type, which is how user-defined
@@ -104,7 +152,7 @@ pub struct DataDef {
     ///
     /// This list is ordered so that a constructor can refer back to its
     /// location in this list using a `usize` index.
-    pub ctors: CtorDefsId,
+    pub ctors: DataDefCtors,
 }
 new_store_key!(pub DataDefId);
 pub type DataDefStore = DefaultStore<DataDefId, DataDef>;
@@ -185,6 +233,38 @@ impl Display for WithEnv<'_, &CtorPat> {
         write!(f, "{}", self.env().with(self.value.args))?;
 
         Ok(())
+    }
+}
+
+impl Display for WithEnv<'_, &PrimitiveCtorInfo> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value {
+            PrimitiveCtorInfo::Numeric(numeric) => {
+                write!(
+                    f,
+                    "numeric [bits={}, float={}, signed={}]",
+                    numeric.bits, numeric.is_float, numeric.is_signed,
+                )
+            }
+            PrimitiveCtorInfo::Str => {
+                write!(f, "str")
+            }
+            PrimitiveCtorInfo::Char => {
+                write!(f, "char")
+            }
+            PrimitiveCtorInfo::List(list) => {
+                write!(f, "list [{}]", self.env().with(list.element_ty))
+            }
+        }
+    }
+}
+
+impl Display for WithEnv<'_, DataDefCtors> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value {
+            DataDefCtors::Primitive(ctor) => write!(f, "{}", self.env().with(&ctor)),
+            DataDefCtors::Defined(ctors) => write!(f, "{}", self.env().with(ctors)),
+        }
     }
 }
 

--- a/compiler/hash-types/src/new/data.rs
+++ b/compiler/hash-types/src/new/data.rs
@@ -88,7 +88,7 @@ pub struct CtorPat {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NumericCtorInfo {
     /// The number of bits in the number.
-    pub bits: u16,
+    pub bits: u8,
     /// Whether the number is signed or not.
     pub is_signed: bool,
     /// Whether the number is floating-point or not.

--- a/compiler/hash-types/src/new/data.rs
+++ b/compiler/hash-types/src/new/data.rs
@@ -240,20 +240,20 @@ impl Display for WithEnv<'_, &PrimitiveCtorInfo> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value {
             PrimitiveCtorInfo::Numeric(numeric) => {
-                write!(
+                writeln!(
                     f,
                     "numeric [bits={}, float={}, signed={}]",
                     numeric.bits, numeric.is_float, numeric.is_signed,
                 )
             }
             PrimitiveCtorInfo::Str => {
-                write!(f, "str")
+                writeln!(f, "str")
             }
             PrimitiveCtorInfo::Char => {
-                write!(f, "char")
+                writeln!(f, "char")
             }
             PrimitiveCtorInfo::List(list) => {
-                write!(f, "list [{}]", self.env().with(list.element_ty))
+                writeln!(f, "list [{}]", self.env().with(list.element_ty))
             }
         }
     }

--- a/compiler/hash-types/src/new/lits.rs
+++ b/compiler/hash-types/src/new/lits.rs
@@ -51,24 +51,30 @@ pub struct ListCtor {
     pub elements: TermListId,
 }
 
+/// A literal
+#[derive(Copy, Clone, Debug)]
+pub enum Lit {
+    Int(IntLit),
+    Str(StrLit),
+    Char(CharLit),
+    Float(FloatLit),
+}
+
 /// A literal pattern
 ///
-/// Floats are not valid patterns, so they are not included here.
+/// This is a literal that can appear in a pattern, which does not include
+/// floats.
 #[derive(Copy, Clone, Debug)]
 pub enum LitPat {
     Int(IntLit),
     Str(StrLit),
     Char(CharLit),
-    List(ListPat),
 }
 
 /// A primitive term
 #[derive(Copy, Clone, Debug)]
 pub enum PrimTerm {
-    Int(IntLit),
-    Str(StrLit),
-    Char(CharLit),
-    Float(FloatLit),
+    Lit(Lit),
     List(ListCtor),
 }
 
@@ -114,7 +120,6 @@ impl Display for WithEnv<'_, &LitPat> {
             LitPat::Int(lit) => write!(f, "{lit}"),
             LitPat::Str(lit) => write!(f, "{lit}"),
             LitPat::Char(lit) => write!(f, "{lit}"),
-            LitPat::List(list_pat) => write!(f, "{}", self.env().with(list_pat)),
         }
     }
 }
@@ -148,13 +153,21 @@ impl Display for WithEnv<'_, &ListCtor> {
     }
 }
 
+impl Display for Lit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Lit::Int(lit) => write!(f, "{lit}"),
+            Lit::Str(lit) => write!(f, "{lit}"),
+            Lit::Char(lit) => write!(f, "{lit}"),
+            Lit::Float(lit) => write!(f, "{lit}"),
+        }
+    }
+}
+
 impl Display for WithEnv<'_, &PrimTerm> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value {
-            PrimTerm::Int(lit) => write!(f, "{lit}"),
-            PrimTerm::Str(lit) => write!(f, "{lit}"),
-            PrimTerm::Char(lit) => write!(f, "{lit}"),
-            PrimTerm::Float(lit) => write!(f, "{lit}"),
+            PrimTerm::Lit(lit) => write!(f, "{lit}"),
             PrimTerm::List(list_term) => write!(f, "{}", self.env().with(list_term)),
         }
     }

--- a/compiler/hash-types/src/new/lits.rs
+++ b/compiler/hash-types/src/new/lits.rs
@@ -1,8 +1,15 @@
 //! Contains structures related to literals, like numbers, strings, etc.
-use std::fmt::Display;
+use std::fmt::{self, Display};
 
 use hash_ast::ast;
 use hash_source::constant::CONSTANT_MAP;
+use hash_utils::store::SequenceStore;
+
+use super::{
+    environment::env::{AccessToEnv, WithEnv},
+    pats::{PatListId, Spread},
+    terms::TermListId,
+};
 
 /// An integer literal.
 ///
@@ -36,6 +43,14 @@ pub struct CharLit {
     pub underlying: ast::CharLit,
 }
 
+/// A list constructor
+///
+/// Contains a sequence of terms.
+#[derive(Copy, Clone, Debug)]
+pub struct ListCtor {
+    pub elements: TermListId,
+}
+
 /// A literal pattern
 ///
 /// Floats are not valid patterns, so they are not included here.
@@ -44,15 +59,29 @@ pub enum LitPat {
     Int(IntLit),
     Str(StrLit),
     Char(CharLit),
+    List(ListPat),
 }
 
-/// A literal term
+/// A primitive term
 #[derive(Copy, Clone, Debug)]
-pub enum LitTerm {
+pub enum PrimTerm {
     Int(IntLit),
     Str(StrLit),
     Char(CharLit),
     Float(FloatLit),
+    List(ListCtor),
+}
+
+/// A list pattern.
+///
+/// This is in the form `[x_1,...,x_n]`, with an optional spread `...(name?)` at
+/// some position.
+#[derive(Copy, Clone, Debug)]
+pub struct ListPat {
+    /// The sequence of patterns in the list pattern.
+    pub pats: PatListId,
+    /// The spread pattern, if any.
+    pub spread: Option<Spread>,
 }
 
 impl Display for IntLit {
@@ -79,23 +108,54 @@ impl Display for FloatLit {
     }
 }
 
-impl Display for LitPat {
+impl Display for WithEnv<'_, &LitPat> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
+        match self.value {
             LitPat::Int(lit) => write!(f, "{lit}"),
             LitPat::Str(lit) => write!(f, "{lit}"),
             LitPat::Char(lit) => write!(f, "{lit}"),
+            LitPat::List(list_pat) => write!(f, "{}", self.env().with(list_pat)),
         }
     }
 }
 
-impl Display for LitTerm {
+impl fmt::Display for WithEnv<'_, &ListPat> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        self.stores().pat_list().map_fast(self.value.pats, |pat_list| {
+            let mut pat_args_formatted =
+                pat_list.iter().map(|arg| self.env().with(*arg).to_string()).collect::<Vec<_>>();
+
+            if let Some(spread) = self.value.spread {
+                pat_args_formatted.insert(spread.index, self.env().with(spread).to_string());
+            }
+
+            for (i, pat_arg) in pat_args_formatted.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{pat_arg}")?;
+            }
+            Ok(())
+        })?;
+        write!(f, "]")
+    }
+}
+
+impl Display for WithEnv<'_, &ListCtor> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LitTerm::Int(lit) => write!(f, "{lit}"),
-            LitTerm::Str(lit) => write!(f, "{lit}"),
-            LitTerm::Char(lit) => write!(f, "{lit}"),
-            LitTerm::Float(lit) => write!(f, "{lit}"),
+        write!(f, "[{}]", self.env().with(self.value.elements))
+    }
+}
+
+impl Display for WithEnv<'_, &PrimTerm> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value {
+            PrimTerm::Int(lit) => write!(f, "{lit}"),
+            PrimTerm::Str(lit) => write!(f, "{lit}"),
+            PrimTerm::Char(lit) => write!(f, "{lit}"),
+            PrimTerm::Float(lit) => write!(f, "{lit}"),
+            PrimTerm::List(list_term) => write!(f, "{}", self.env().with(list_term)),
         }
     }
 }

--- a/compiler/hash-types/src/new/locations.rs
+++ b/compiler/hash-types/src/new/locations.rs
@@ -155,6 +155,20 @@ impl LocationStore {
         self.data.borrow_mut().insert(target.into(), location);
     }
 
+    /// Add a set of [SourceLocation]s to a specified [IndexedLocationTarget]
+    pub fn add_locations_to_targets(
+        &self,
+        targets: impl Into<IndexedLocationTarget>,
+        location: impl Fn(usize) -> Option<SourceLocation>,
+    ) {
+        let targets = targets.into();
+        for target in targets.to_index_range() {
+            if let Some(loc) = location(target) {
+                self.add_location_to_target(LocationTarget::from((targets, target)), loc);
+            }
+        }
+    }
+
     /// Get a [SourceLocation] from a specified [LocationTarget]
     pub fn get_location(&self, target: impl Into<LocationTarget>) -> Option<SourceLocation> {
         self.data.borrow().get_by_left(&target.into()).copied()

--- a/compiler/hash-types/src/new/mods.rs
+++ b/compiler/hash-types/src/new/mods.rs
@@ -45,6 +45,10 @@ pub enum ModKind {
     ModBlock,
     /// Defined as a file module or interactive.
     Source(SourceId),
+    /// Transparent
+    ///
+    /// Added by the compiler, used for primitives
+    Transparent,
 }
 
 /// The right-hand side of a module member definition.
@@ -164,6 +168,15 @@ impl Display for WithEnv<'_, &ModDef> {
                 write!(
                     f,
                     "mod [name={}, type=file, src=\"{source_name}\"] {} {{\n{}}}",
+                    self.env().with(self.value.name),
+                    self.env().with(self.value.params),
+                    indent(&members, "  ")
+                )
+            }
+            ModKind::Transparent => {
+                write!(
+                    f,
+                    "mod [name={}, type=transparent] {} {{\n{}}}",
                     self.env().with(self.value.name),
                     self.env().with(self.value.params),
                     indent(&members, "  ")

--- a/compiler/hash-types/src/new/params.rs
+++ b/compiler/hash-types/src/new/params.rs
@@ -33,11 +33,14 @@ new_sequence_store_key!(pub ParamsId);
 pub type ParamId = (ParamsId, usize);
 pub type ParamsStore = DefaultSequenceStore<ParamsId, Param>;
 
-/// The parameter target of an argument. Either a named parameter or a
-/// positional one.
+/// An index into a parameter list.
+///
+/// Either a named parameter or a positional one.
 #[derive(Debug, Clone, Hash, Copy)]
-pub enum ParamTarget {
+pub enum ParamIndex {
+    /// A named parameter, like `foo(value=3)`.
     Name(Identifier),
+    /// A positional parameter, like `dot(x, y)`.
     Position(usize),
 }
 
@@ -77,11 +80,11 @@ impl fmt::Display for WithEnv<'_, ParamsId> {
     }
 }
 
-impl fmt::Display for WithEnv<'_, ParamTarget> {
+impl fmt::Display for WithEnv<'_, ParamIndex> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
-            ParamTarget::Name(name) => write!(f, "{name}"),
-            ParamTarget::Position(pos) => write!(f, "{pos}"),
+            ParamIndex::Name(name) => write!(f, "{name}"),
+            ParamIndex::Position(pos) => write!(f, "{pos}"),
         }
     }
 }

--- a/compiler/hash-types/src/new/pats.rs
+++ b/compiler/hash-types/src/new/pats.rs
@@ -12,7 +12,7 @@ use super::{
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
-    lits::LitPat,
+    lits::{ListPat, LitPat},
     scopes::BindingPat,
     symbols::Symbol,
     tuples::TuplePat,
@@ -53,6 +53,7 @@ pub enum Pat {
     Range(RangePat),
     Lit(LitPat),
     Tuple(TuplePat),
+    List(ListPat),
     Ctor(CtorPat),
     Or(OrPat),
     If(IfPat),
@@ -96,6 +97,7 @@ impl fmt::Display for WithEnv<'_, &Pat> {
             Pat::Ctor(ctor_pat) => write!(f, "{}", self.env().with(ctor_pat)),
             Pat::Or(or_pat) => write!(f, "{}", self.env().with(or_pat)),
             Pat::If(if_pat) => write!(f, "{}", self.env().with(if_pat)),
+            Pat::List(list_pat) => write!(f, "{}", self.env().with(list_pat)),
         }
     }
 }

--- a/compiler/hash-types/src/new/scopes.rs
+++ b/compiler/hash-types/src/new/scopes.rs
@@ -12,10 +12,7 @@ use hash_utils::{
 use textwrap::indent;
 use utility_types::omit;
 
-use super::environment::{
-    context::BoundVarOrigin,
-    env::{AccessToEnv, WithEnv},
-};
+use super::environment::env::{AccessToEnv, WithEnv};
 use crate::new::{
     pats::PatId,
     symbols::Symbol,
@@ -53,13 +50,6 @@ pub struct DeclStackMemberTerm {
 pub struct AssignTerm {
     pub subject: TermId,
     pub value: TermId,
-}
-
-/// A bound variable, containing a name and an origin.
-#[derive(Debug, Copy, Clone)]
-pub struct BoundVar {
-    pub name: Symbol,
-    pub origin: BoundVarOrigin,
 }
 
 /// A variable on the stack.

--- a/compiler/hash-types/src/new/terms.rs
+++ b/compiler/hash-types/src/new/terms.rs
@@ -13,7 +13,7 @@ use super::{
     environment::env::{AccessToEnv, WithEnv},
     holes::HoleId,
     lits::PrimTerm,
-    scopes::BoundVar,
+    symbols::Symbol,
     tys::TypeOfTerm,
 };
 use crate::new::{
@@ -68,7 +68,7 @@ pub enum Term {
     Block(BlockTerm),
 
     // Variables
-    Var(BoundVar),
+    Var(Symbol),
 
     // Loops
     Loop(LoopTerm),
@@ -135,7 +135,7 @@ impl fmt::Display for WithEnv<'_, &Term> {
             Term::FnCall(fn_call_term) => write!(f, "{}", self.env().with(fn_call_term)),
             Term::FnRef(closure_term) => write!(f, "{}", self.env().with(*closure_term)),
             Term::Block(block_term) => write!(f, "{}", self.env().with(block_term)),
-            Term::Var(resolved_var) => write!(f, "{}", self.env().with(resolved_var.name)),
+            Term::Var(resolved_var) => write!(f, "{}", self.env().with(*resolved_var)),
             Term::Loop(loop_term) => write!(f, "{}", self.env().with(loop_term)),
             Term::LoopControl(loop_control_term) => {
                 write!(f, "{}", self.env().with(loop_control_term))

--- a/compiler/hash-types/src/new/terms.rs
+++ b/compiler/hash-types/src/new/terms.rs
@@ -12,7 +12,7 @@ use super::{
     casting::CastTerm,
     environment::env::{AccessToEnv, WithEnv},
     holes::HoleId,
-    lits::LitTerm,
+    lits::PrimTerm,
     scopes::BoundVar,
     tys::TypeOfTerm,
 };
@@ -55,7 +55,7 @@ pub enum Term {
 
     // Primitives
     Tuple(TupleTerm),
-    Lit(LitTerm),
+    Lit(PrimTerm),
 
     // Constructors
     Ctor(CtorTerm),
@@ -130,7 +130,7 @@ impl fmt::Display for WithEnv<'_, &Term> {
         match self.value {
             Term::Runtime(runtime_term) => write!(f, "{}", self.env().with(runtime_term)),
             Term::Tuple(tuple_term) => write!(f, "{}", self.env().with(tuple_term)),
-            Term::Lit(lit_term) => write!(f, "{lit_term}"),
+            Term::Lit(lit_term) => write!(f, "{}", self.env().with(lit_term)),
             Term::Ctor(ctor_term) => write!(f, "{}", self.env().with(ctor_term)),
             Term::FnCall(fn_call_term) => write!(f, "{}", self.env().with(fn_call_term)),
             Term::FnRef(closure_term) => write!(f, "{}", self.env().with(*closure_term)),

--- a/compiler/hash-types/src/new/tys.rs
+++ b/compiler/hash-types/src/new/tys.rs
@@ -11,7 +11,7 @@ use hash_utils::{
 use super::{
     environment::env::{AccessToEnv, WithEnv},
     holes::HoleId,
-    scopes::BoundVar,
+    symbols::Symbol,
 };
 use crate::new::{data::DataTy, fns::FnTy, refs::RefTy, terms::TermId, tuples::TupleTy};
 
@@ -39,7 +39,7 @@ pub enum Ty {
     Hole(HoleId),
 
     /// Type variable
-    Var(BoundVar),
+    Var(Symbol),
 
     /// Tuple type
     Tuple(TupleTy),
@@ -88,7 +88,7 @@ impl fmt::Display for WithEnv<'_, &Ty> {
                 write!(f, "{{{}}}", self.env().with(*eval_ty))
             }
             Ty::Hole(hole) => write!(f, "{}", self.env().with(*hole)),
-            Ty::Var(resolved_var) => write!(f, "{}", self.env().with(resolved_var.name)),
+            Ty::Var(resolved_var) => write!(f, "{}", self.env().with(*resolved_var)),
             Ty::Tuple(tuple_ty) => write!(f, "{}", self.env().with(tuple_ty)),
             Ty::Fn(fn_ty) => write!(f, "{}", self.env().with(fn_ty)),
             Ty::Ref(ref_ty) => write!(f, "{}", self.env().with(ref_ty)),

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -159,10 +159,11 @@ pub trait Store<Key: StoreKey, Value> {
 
     /// Create a value inside the store, given its key, returning its key.
     fn create_with(&self, value_fn: impl FnOnce(Key) -> Value) -> Key {
-        let mut data = self.internal_data().borrow_mut();
-        let next_index = data.len();
+        let next_index = self.internal_data().borrow().len();
         let key = Key::from_index_unchecked(next_index);
-        data.push(value_fn(key));
+        let value = value_fn(key);
+        let mut data = self.internal_data().borrow_mut();
+        data.push(value);
         key
     }
 


### PR DESCRIPTION
This PR adds functionality to inject primitive definitions (numbers, bool, char, str, list, option, etc) into the context, which is needed for completing resolution (subsequent PR). It also reorganises parameter-related utilities for resolution into its own module. Some TC-related scaffolding is also added, namely normalisation. Finally, vars are now just `Symbol` rather than `BoundVar`, because the rest of the info can be deduced from the context. 

Closes #667 
Fixes #665 
