### PR TITLE
Resolve AST types during resolution

### DIFF
--- a/compiler/hash-typecheck/src/new/ops/common.rs
+++ b/compiler/hash-typecheck/src/new/ops/common.rs
@@ -23,6 +23,14 @@ use crate::new::{diagnostics::error::TcResult, environment::tc_env::AccessToTcEn
 /// Assert that the given term is of the given variant, and return it.
 #[macro_export]
 macro_rules! term_as_variant {
+    ($self:expr, value $term:expr, $variant:ident) => {{
+        let term = $term;
+        if let hash_types::new::terms::Term::$variant(term) = term {
+            term
+        } else {
+            panic!("Expected term to be a {}", stringify!($variant))
+        }
+    }};
     ($self:expr, $term:expr, $variant:ident) => {{
         let term = $term;
         if let hash_types::new::terms::Term::$variant(term) =
@@ -38,6 +46,14 @@ macro_rules! term_as_variant {
 /// Assert that the given type is of the given variant, and return it.
 #[macro_export]
 macro_rules! ty_as_variant {
+    ($self:expr, value $ty:expr, $variant:ident) => {{
+        let ty = $ty;
+        if let hash_types::new::tys::Ty::$variant(ty) = ty {
+            ty
+        } else {
+            panic!("Expected type to be a {}", stringify!($variant))
+        }
+    }};
     ($self:expr, $ty:expr, $variant:ident) => {{
         let ty = $ty;
         if let hash_types::new::tys::Ty::$variant(ty) =
@@ -96,13 +112,13 @@ pub trait CommonOps: AccessToTcEnv {
     }
 
     /// Create a new type.
-    fn new_ty(&self, ty: Ty) -> TyId {
-        self.stores().ty().create(ty)
+    fn new_ty(&self, ty: impl Into<Ty>) -> TyId {
+        self.stores().ty().create(ty.into())
     }
 
     /// Create a new term.
-    fn new_term(&self, term: Term) -> TermId {
-        self.stores().term().create(term)
+    fn new_term(&self, term: impl Into<Term>) -> TermId {
+        self.stores().term().create(term.into())
     }
 
     /// Create a new term list.

--- a/compiler/hash-typecheck/src/new/ops/common.rs
+++ b/compiler/hash-typecheck/src/new/ops/common.rs
@@ -110,17 +110,6 @@ pub trait CommonOps: AccessToTcEnv {
         self.stores().symbol().create_with(|symbol| SymbolData { name: Some(name.into()), symbol })
     }
 
-    /// Create a new symbol with the given name, at the given location.
-    fn new_symbol_at_location(
-        &self,
-        name: impl Into<Identifier>,
-        location: SourceLocation,
-    ) -> Symbol {
-        let symbol = self.new_symbol(name);
-        self.stores().location().add_location_to_target(symbol, location);
-        symbol
-    }
-
     /// Create a new internal symbol.
     fn new_fresh_symbol(&self) -> Symbol {
         self.stores().symbol().create_with(|symbol| SymbolData { name: None, symbol })

--- a/compiler/hash-typecheck/src/new/ops/common.rs
+++ b/compiler/hash-typecheck/src/new/ops/common.rs
@@ -25,10 +25,27 @@ use crate::new::{diagnostics::error::TcResult, environment::tc_env::AccessToTcEn
 macro_rules! term_as_variant {
     ($self:expr, $term:expr, $variant:ident) => {{
         let term = $term;
-        if let Term::$variant(term) = $self.get_term(term) {
+        if let hash_types::new::terms::Term::$variant(term) =
+            $crate::new::ops::common::CommonOps::get_term($self, term)
+        {
             term
         } else {
             panic!("Expected term to be a {}", stringify!($variant))
+        }
+    }};
+}
+
+/// Assert that the given type is of the given variant, and return it.
+#[macro_export]
+macro_rules! ty_as_variant {
+    ($self:expr, $ty:expr, $variant:ident) => {{
+        let ty = $ty;
+        if let hash_types::new::tys::Ty::$variant(ty) =
+            $crate::new::ops::common::CommonOps::get_ty($self, ty)
+        {
+            ty
+        } else {
+            panic!("Expected type to be a {}", stringify!($variant))
         }
     }};
 }

--- a/compiler/hash-typecheck/src/new/ops/context.rs
+++ b/compiler/hash-typecheck/src/new/ops/context.rs
@@ -11,7 +11,7 @@ use hash_types::new::{
 };
 use hash_utils::store::{SequenceStore, Store};
 
-use crate::{impl_access_to_tc_env, new::environment::tc_env::TcEnv};
+use crate::{impl_access_to_tc_env, new::environment::tc_env::TcEnv, ty_as_variant};
 
 /// Context-related operations.
 #[derive(Constructor)]
@@ -174,6 +174,13 @@ impl<'env> ContextOps<'env> {
                             // No-op
                         }
                     }
+                })
+            }
+            ScopeKind::FnTy(fn_ty_id) => {
+                // Add all the parameters
+                let fn_ty = ty_as_variant!(self, fn_ty_id, Fn);
+                self.add_params_to_context(fn_ty.params, |param_id| {
+                    BoundVarOrigin::FnTy(fn_ty_id, param_id)
                 })
             }
         }

--- a/compiler/hash-typecheck/src/new/passes/ast_utils.rs
+++ b/compiler/hash-typecheck/src/new/passes/ast_utils.rs
@@ -1,8 +1,9 @@
 use hash_ast::{
-    ast::{AstNodeRef, BodyBlock, Module, OwnsAstNode},
+    ast::{self, AstNodeRef, BodyBlock, Module, OwnsAstNode},
     node_map::SourceRef,
 };
 use hash_source::location::{SourceLocation, Span};
+use hash_types::new::symbols::Symbol;
 
 use crate::new::{
     diagnostics::error::TcResult, environment::tc_env::AccessToTcEnv, ops::common::CommonOps,
@@ -24,7 +25,7 @@ pub trait AstPass: AccessToTcEnv {
     }
 }
 
-pub trait AstUtils: AccessToTcEnv {
+pub trait AstUtils: AccessToTcEnv + Sized {
     /// Create a [SourceLocation] from a [Span].
     fn source_location(&self, span: Span) -> SourceLocation {
         SourceLocation { span, id: self.current_source_info().source_id }
@@ -34,5 +35,14 @@ pub trait AstUtils: AccessToTcEnv {
     fn node_location<N>(&self, node: AstNodeRef<N>) -> SourceLocation {
         let node_span = node.span();
         self.source_location(node_span)
+    }
+
+    /// Create a [`Symbol`] for the given [`ast::Name`], or a fresh symbol if no
+    /// name is provided.
+    fn new_symbol_from_ast_name(&self, name: &Option<ast::AstNode<ast::Name>>) -> Symbol {
+        match name {
+            Some(name) => self.new_symbol(name.ident),
+            None => self.new_fresh_symbol(),
+        }
     }
 }

--- a/compiler/hash-typecheck/src/new/passes/discovery/params.rs
+++ b/compiler/hash-typecheck/src/new/passes/discovery/params.rs
@@ -38,12 +38,26 @@ impl<'tc> DiscoveryPass<'tc> {
         def_params
     }
 
+    /// Create a parameter list from the given AST generic parameter list, where
+    /// the type of each parameter is a hole.
+    pub(super) fn create_hole_params_from<T>(
+        &self,
+        params: &ast::AstNodes<T>,
+        name: impl Fn(&T) -> &Option<ast::AstNode<ast::Name>>,
+    ) -> ParamsId {
+        let params_id = self.param_ops().create_hole_params(
+            params.iter().map(|param| self.create_symbol_from_ast_name(name(param))),
+        );
+        self.stores()
+            .location()
+            .add_locations_to_targets(params_id, |i| Some(self.source_location(params[i].span())));
+        params_id
+    }
+
     /// Create a parameter list from the given AST parameter list, where the
     /// type of each parameter is a hole.
     pub(super) fn create_hole_params(&self, params: &ast::AstNodes<ast::Param>) -> ParamsId {
-        self.param_ops().create_hole_params(
-            params.iter().map(|param| self.create_symbol_from_ast_name(&param.name)),
-        )
+        self.create_hole_params_from(params, |param| &param.name)
     }
 
     /// Create a parameter data list from the given AST parameter list, where

--- a/compiler/hash-typecheck/src/new/passes/resolution/exprs.rs
+++ b/compiler/hash-typecheck/src/new/passes/resolution/exprs.rs
@@ -354,14 +354,13 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         node: AstNodeRef<ast::ConstructorCallExpr>,
     ) -> TcResult<TermId> {
+        // This is either a path or a computed function call
         match self.constructor_call_as_ast_path(node)? {
             Some(path) => {
-                // Check if we can resolve the subject as a path
                 let resolved_path = self.resolve_ast_path(&path)?;
                 self.make_term_from_resolved_ast_path(&resolved_path, node.span())
             }
             None => {
-                // Otherwise, it must be a computed function call
                 let subject =
                     self.try_or_add_error(self.make_term_from_ast_expr(node.subject.ast_ref()));
                 let args =

--- a/compiler/hash-typecheck/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-typecheck/src/new/passes/resolution/scoping.rs
@@ -11,6 +11,7 @@ use hash_types::new::{
     mods::ModDefId,
     scopes::{StackId, StackMemberId},
     symbols::Symbol,
+    tys::TyId,
 };
 use hash_utils::{
     state::HeavyState,
@@ -322,6 +323,26 @@ impl<'tc> Scoping<'tc> {
         self.ast_info().stacks().get_data_by_node(node.id()).map(|stack_id| {
             self.enter_scope(ScopeKind::Stack(stack_id), ContextKind::Environment, || f(stack_id))
         })
+    }
+
+    /// Enter the scope of a type function type
+    pub(super) fn enter_ty_fn_ty<T>(
+        &self,
+        node: ast::AstNodeRef<ast::TyFn>,
+        f: impl FnOnce(TyId) -> T,
+    ) -> T {
+        let fn_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
+        self.enter_scope(ScopeKind::FnTy(fn_ty_id), ContextKind::Environment, || f(fn_ty_id))
+    }
+
+    /// Enter the scope of a function type
+    pub(super) fn enter_fn_ty<T>(
+        &self,
+        node: ast::AstNodeRef<ast::FnTy>,
+        f: impl FnOnce(TyId) -> T,
+    ) -> T {
+        let fn_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
+        self.enter_scope(ScopeKind::FnTy(fn_ty_id), ContextKind::Environment, || f(fn_ty_id))
     }
 
     /// Register a declaration, which will add it to the current stack scope.

--- a/compiler/hash-types/src/new/terms.rs
+++ b/compiler/hash-types/src/new/terms.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 use std::fmt::Debug;
 
+use derive_more::From;
 use hash_utils::{
     new_sequence_store_key, new_store_key,
     store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore},
@@ -48,7 +49,7 @@ pub struct RuntimeTerm {
 /// constructors, etc. This is because they might have extra data attached to
 /// them; for example, function definitions might have AST node IDs attached to
 /// them through some secondary map.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, From)]
 pub enum Term {
     // Runtime
     Runtime(RuntimeTerm),

--- a/compiler/hash-types/src/new/tys.rs
+++ b/compiler/hash-types/src/new/tys.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 use std::fmt::Debug;
 
+use derive_more::From;
 use hash_utils::{
     new_store_key,
     store::{CloneStore, DefaultStore},
@@ -28,7 +29,7 @@ pub struct UniverseTy {
 }
 
 /// Represents a type in a Hash program.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, From)]
 pub enum Ty {
     /// A term which evaluates to a type.
     Eval(TermId),


### PR DESCRIPTION
This PR is the same as #676, but for types. Now all type annotations in the AST get resolved. Any remaining holes will be filled by unification at a later stage.

Closes #680 