### PR TITLE
codegen: implement lowering `RValue`s

### DIFF
--- a/compiler/hash-codegen/src/common.rs
+++ b/compiler/hash-codegen/src/common.rs
@@ -228,16 +228,18 @@ pub enum RealComparisonKind {
     True,
 }
 
-impl From<ir::BinOp> for RealComparisonKind {
-    fn from(operator: ir::BinOp) -> Self {
+impl TryFrom<ir::BinOp> for RealComparisonKind {
+    type Error = ();
+
+    fn try_from(operator: ir::BinOp) -> Result<Self, Self::Error> {
         match operator {
-            ir::BinOp::Eq => Self::Oeq,
-            ir::BinOp::Neq => Self::Une,
-            ir::BinOp::Gt => Self::Ogt,
-            ir::BinOp::GtEq => Self::Oge,
-            ir::BinOp::Lt => Self::Olt,
-            ir::BinOp::LtEq => Self::Ole,
-            _ => unreachable!(),
+            ir::BinOp::Eq => Ok(Self::Oeq),
+            ir::BinOp::Neq => Ok(Self::Une),
+            ir::BinOp::Gt => Ok(Self::Ogt),
+            ir::BinOp::GtEq => Ok(Self::Oge),
+            ir::BinOp::Lt => Ok(Self::Olt),
+            ir::BinOp::LtEq => Ok(Self::Ole),
+            _ => Err(()),
         }
     }
 }

--- a/compiler/hash-codegen/src/common.rs
+++ b/compiler/hash-codegen/src/common.rs
@@ -2,6 +2,7 @@
 //! backend and trait definitions.
 
 use bitflags::bitflags;
+use hash_ir::ir;
 
 /// Checked operations that a compiler backend can perform. All of these
 /// operations are checking the correctness of arithmetic operations.
@@ -15,12 +16,6 @@ pub enum CheckedOp {
 
     /// Multiplication
     Mul,
-
-    /// Division
-    Div,
-
-    /// Remainder
-    Rem,
 }
 
 /// This defines all of the type "kinds" that are used by LLVM.
@@ -137,6 +132,46 @@ pub enum IntComparisonKind {
     Sle,
 }
 
+impl IntComparisonKind {
+    /// Create a [IntComparisonKind] from a [ir::BinOp] and
+    /// a boolean flag specifying if the operands are signed.
+    pub fn from_bin_op(operator: ir::BinOp, signed: bool) -> Self {
+        match operator {
+            ir::BinOp::Eq => Self::Eq,
+            ir::BinOp::Neq => Self::Ne,
+            ir::BinOp::Gt => {
+                if signed {
+                    Self::Sgt
+                } else {
+                    Self::Ugt
+                }
+            }
+            ir::BinOp::GtEq => {
+                if signed {
+                    Self::Sge
+                } else {
+                    Self::Uge
+                }
+            }
+            ir::BinOp::Lt => {
+                if signed {
+                    Self::Slt
+                } else {
+                    Self::Ult
+                }
+            }
+            ir::BinOp::LtEq => {
+                if signed {
+                    Self::Sle
+                } else {
+                    Self::Ule
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 /// Represents all of the comparison kinds that can occur between
 /// two floating point operands. This is a backend-agnostic representation
 /// of the comparison kinds.
@@ -191,6 +226,20 @@ pub enum RealComparisonKind {
 
     /// Folded comparison, always equal to "true".
     True,
+}
+
+impl From<ir::BinOp> for RealComparisonKind {
+    fn from(operator: ir::BinOp) -> Self {
+        match operator {
+            ir::BinOp::Eq => Self::Oeq,
+            ir::BinOp::Neq => Self::Une,
+            ir::BinOp::Gt => Self::Ogt,
+            ir::BinOp::GtEq => Self::Oge,
+            ir::BinOp::Lt => Self::Olt,
+            ir::BinOp::LtEq => Self::Ole,
+            _ => unreachable!(),
+        }
+    }
 }
 
 bitflags! {

--- a/compiler/hash-codegen/src/lib.rs
+++ b/compiler/hash-codegen/src/lib.rs
@@ -18,7 +18,7 @@
 //! artifacts since it will run the bytecode directly using the VM. On the other
 //! hand, LLVM backend will emit a runnable executable after the code is
 //! generated.
-#![feature(let_chains)]
+#![feature(let_chains, box_patterns)]
 #![allow(dead_code)] // @@Temporary: until the codegen general purpose logic is completed.
 
 pub mod common;

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -5,13 +5,15 @@ use hash_ir::{
     ir::Place,
     ty::{IrTy, TyOfPlace, VariantIdx},
 };
+use hash_layout::LayoutShape;
 use hash_target::alignment::Alignment;
 
 use super::FnBuilder;
 use crate::{
     layout::TyInfo,
     traits::{
-        builder::BlockBuilderMethods, ctx::HasCtxMethods, ty::BuildTypeMethods, CodeGenObject,
+        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        ty::BuildTypeMethods, CodeGenObject,
     },
 };
 
@@ -56,6 +58,20 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
 
         Self::new(builder, temp, info)
     }
+
+    /// Given that the underlying [PlaceRef] refers to an array
+    /// being stored on the stack, we lookup the layout of the
+    /// array and access the `size` stored on it to get the
+    /// `len` of the place.
+    pub fn len<Builder: BlockBuilderMethods<'b, Value = V>>(&self, builder: &Builder) -> V {
+        let layout = builder.ctx().layout_info(self.info.layout);
+
+        if let LayoutShape::Array { elements, .. } = layout.shape {
+            builder.const_usize(elements)
+        } else {
+            panic!("PlaceRef::len called on non-array type");
+        }
+    }
 }
 
 impl<'b, V: CodeGenObject> PlaceRef<V> {
@@ -75,6 +91,44 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
         _builder: &mut Builder,
         _cast_to: IrTy,
     ) -> V {
+        todo!()
+    }
+
+    /// Apply a downcasting (selecting an `enum` variant on a place) projection
+    /// onto the [PlaceRef].
+    pub fn project_downcast<Builder: BlockBuilderMethods<'b, Value = V>>(
+        &self,
+        _builder: &mut Builder,
+        _variant: VariantIdx,
+    ) -> Self {
+        todo!()
+    }
+
+    /// Apply a indexing projection onto the [PlaceRef].
+    pub fn project_index<Builder: BlockBuilderMethods<'b, Value = V>>(
+        &self,
+        _builder: &mut Builder,
+        _index: V,
+    ) -> Self {
+        todo!()
+    }
+
+    /// Apply a field projection on a [PlaceRef].
+    pub fn project_field<Builder: BlockBuilderMethods<'b, Value = V>>(
+        &self,
+        _builder: &mut Builder,
+        _field: usize,
+    ) -> Self {
+        todo!()
+    }
+
+    /// Cast the [PlaceRef] value to the provided type
+    /// (which must be a pointer type).
+    pub fn cast_to<Builder: BlockBuilderMethods<'b, Value = V>>(
+        &self,
+        _builder: &mut Builder,
+        _cast_to: IrTy,
+    ) -> Self {
         todo!()
     }
 

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -1,10 +1,135 @@
 //! Module that deals with lowering [ir::RValue]s into
 //! backend specific RValues.
 
-use hash_ir::ir;
+use hash_ir::{
+    ir::{self, BinOp},
+    ty::{self, IrTyId, VariantIdx},
+};
+use hash_utils::store::Store;
 
-use super::{operands::OperandRef, place::PlaceRef, FnBuilder};
-use crate::traits::{builder::BlockBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods};
+use super::{
+    locals::LocalRef,
+    operands::{OperandRef, OperandValue},
+    place::PlaceRef,
+    FnBuilder,
+};
+use crate::{
+    common::{CheckedOp, IntComparisonKind, TypeKind},
+    traits::{
+        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        layout::LayoutMethods, ty::BuildTypeMethods,
+    },
+};
+
+/// This computes a bit-shift mask for the provided `mask_ty`. This function
+/// is used to compute the mask for the `shl` and `shr` operations. In
+/// principle, this is used to make bit-shift operations all "safe". In
+/// particular, this deals with the case where the shift amount is greater than
+/// the bit-width of the type. In this event, we take the bit-width of the type,
+/// and subtract 1. This is because it is only valid to shift an integer type by
+/// `bits - 1` places, e.g. shifting an `i8` by 7 places is valid, but shifting
+/// it by 8 places is not. So, the mask is computed, and then applied onto the
+/// shifting value in order to check whether a shift overflow has occurred.
+fn shift_mask_value<'b, Builder: BlockBuilderMethods<'b>>(
+    builder: &mut Builder,
+    ty: Builder::Type,
+    mask_ty: Builder::Type,
+    invert: bool,
+) -> Builder::Value {
+    match builder.kind_of_type(ty) {
+        TypeKind::IntegerTy => {
+            let bits = builder.int_width(ty) - 1;
+
+            if invert {
+                builder.const_int(mask_ty, !bits as i64)
+            } else {
+                builder.const_uint(mask_ty, bits)
+            }
+        }
+        _ => unreachable!("cannot apply bit shift mask on non integer type"),
+    }
+}
+
+/// This adjusts the `shift_value` to the size of `lhs`. This is
+/// necessary because the size of `lhs` and `rhs` may not be the
+/// same. For example, `i8` and `i32` are not the same size, so
+/// we need to adjust the size of `rhs` to the size of `lhs`.
+///
+/// This is done by either truncating or zero extending the
+/// `shift_value` to the size of `lhs`.
+fn cast_shift_value<'b, Builder: BlockBuilderMethods<'b>>(
+    builder: &mut Builder,
+    lhs: Builder::Value,
+    rhs: Builder::Value,
+) -> Builder::Value {
+    let lhs_ty = builder.type_of_value(lhs);
+    let rhs_ty = builder.type_of_value(rhs);
+
+    let lhs_size = builder.int_width(lhs_ty);
+    let rhs_size = builder.int_width(rhs_ty);
+
+    // If the size of `lhs` is smallar than `rhs`, we need
+    // to truncate `rhs` to the size of `lhs`.
+    match lhs_size.cmp(&rhs_size) {
+        std::cmp::Ordering::Less => builder.truncate(rhs, lhs_ty),
+        std::cmp::Ordering::Equal => rhs,
+        std::cmp::Ordering::Greater => {
+            // If the size is larger than `rhs`, we zero extended
+            // the to the size of `lhs`
+            builder.zero_extend(rhs, lhs_ty)
+        }
+    }
+}
+
+/// This function computes the appropriate shifting mask for
+/// the `shift_value` and applies it the value for use. This
+/// is to ensure that the shift value is always valid.
+///
+/// This is equivalent of what x86 machine instructions like `sarl`
+/// perform. More information at <https://en.wikibooks.org/wiki/X86_Assembly/Shift_and_Rotate>.
+fn apply_shift_mask<'b, Builder: BlockBuilderMethods<'b>>(
+    builder: &mut Builder,
+    shift_value: Builder::Value,
+) -> Builder::Value {
+    let value_ty = builder.type_of_value(shift_value);
+    let mask = shift_mask_value(builder, value_ty, value_ty, false);
+    builder.and(shift_value, mask)
+}
+
+/// This function will ensure that the operands to a `>>` (bitwise right-shift)
+/// operator are always valid. This means that if the shifting value is greater
+/// in size than the bit-width of the left-hand side operand, it needs
+/// to be truncated, and similarly in the case where the shifting value is
+/// smaller than the bit-width of the left-hand side operand, it needs to be
+/// zero extended.
+fn build_unchecked_rshift<'b, Builder: BlockBuilderMethods<'b>>(
+    builder: &mut Builder,
+    ty: IrTyId,
+    lhs: Builder::Value,
+    rhs: Builder::Value,
+) -> Builder::Value {
+    let rhs = cast_shift_value(builder, lhs, rhs);
+    let rhs = apply_shift_mask(builder, rhs);
+    let is_signed = builder.ctx().ir_ctx().tys().map_fast(ty, |ty| ty.is_signed());
+
+    if is_signed {
+        // Arithemetic right shift
+        builder.ashr(lhs, rhs)
+    } else {
+        // Logical right shift
+        builder.lshr(lhs, rhs)
+    }
+}
+
+fn build_unchecked_lshift<'b, Builder: BlockBuilderMethods<'b>>(
+    builder: &mut Builder,
+    lhs: Builder::Value,
+    rhs: Builder::Value,
+) -> Builder::Value {
+    let rhs = cast_shift_value(builder, lhs, rhs);
+    let rhs = apply_shift_mask(builder, rhs);
+    builder.shl(lhs, rhs)
+}
 
 impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Emit code for the given [ir::RValue] and store the result in the
@@ -18,9 +143,45 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         // @@Todo: introduce casting, and deal with the code generation
         match *rvalue {
             // specifics here.
-            ir::RValue::Use(_) => todo!(),
-            ir::RValue::Aggregate(_, _) => todo!(),
+            ir::RValue::Use(ref operand) => {
+                let operand = self.codegen_operand(builder, operand);
+                operand.value.store(builder, destination);
+            }
+            ir::RValue::Aggregate(ref kind, ref operands) => {
+                let destination = match *kind {
+                    ir::AggregateKind::Enum(_, variant) => {
+                        destination.codegen_set_discriminant(builder, variant);
+                        destination.project_downcast(builder, variant)
+                    }
+                    ir::AggregateKind::Struct(_) => {
+                        destination.codegen_set_discriminant(builder, VariantIdx::new(0));
+                        destination
+                    }
+                    _ => destination,
+                };
+
+                for (i, operand) in operands.iter().enumerate() {
+                    let operand = self.codegen_operand(builder, operand);
+                    let layout = builder.layout_info(operand.info.layout);
+
+                    // We don't need to do anything for ZSTs...
+                    if !layout.is_zst() {
+                        // Create the field place reference, and then store the
+                        // value in the operand.
+                        let field = if let ir::AggregateKind::Array(_) = *kind {
+                            let value_index = builder.const_usize(i as u64);
+                            destination.project_index(builder, value_index)
+                        } else {
+                            destination.project_field(builder, i)
+                        };
+
+                        operand.value.store(builder, field);
+                    }
+                }
+            }
             _ => {
+                debug_assert!(self.rvalue_creates_operand(rvalue));
+
                 let temp = self.codegen_rvalue_operand(builder, rvalue);
                 temp.value.store(builder, destination);
             }
@@ -30,20 +191,287 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Emit code for a [ir::RValue] that will return an [OperandRef].
     pub fn codegen_rvalue_operand(
         &mut self,
-        _builder: &mut Builder,
+        builder: &mut Builder,
         rvalue: &ir::RValue,
     ) -> OperandRef<Builder::Value> {
         match *rvalue {
-            ir::RValue::Use(_) => todo!(),
-            ir::RValue::Aggregate(_, _) => todo!(),
-            ir::RValue::ConstOp(_, _) => todo!(),
-            ir::RValue::UnaryOp(_, _) => todo!(),
-            ir::RValue::BinaryOp(_, _) => todo!(),
-            ir::RValue::CheckedBinaryOp(_, _) => todo!(),
-            ir::RValue::Len(_) => todo!(),
-            ir::RValue::Ref(_, _, _) => todo!(),
-            ir::RValue::Discriminant(_) => todo!(),
+            ir::RValue::Use(operand) => self.codegen_operand(builder, &operand),
+            ir::RValue::ConstOp(op, ty) => {
+                // compute the layout of the type, and then depending
+                // on the operation it then emits the size or the
+                // alignment.
+                let info = builder.layout_of_id(ty);
+                let layout = builder.layout_info(info.layout);
+
+                let value_bytes = match op {
+                    ir::ConstOp::SizeOf => layout.size.bytes(),
+                    ir::ConstOp::AlignOf => layout.alignment.abi.bytes(),
+                };
+                let value = builder.ctx().const_usize(value_bytes);
+
+                OperandRef {
+                    value: OperandValue::Immediate(value),
+                    info: builder.layout_of_id(self.ctx.ir_ctx().tys().common_tys.usize),
+                }
+            }
+            ir::RValue::UnaryOp(operator, ref operand) => {
+                let operand = self.codegen_operand(builder, operand);
+                let value = operand.immediate_value();
+
+                let value = match operator {
+                    ir::UnaryOp::BitNot | ir::UnaryOp::Not => builder.not(value),
+                    ir::UnaryOp::Neg => {
+                        // check if the underlying value is a floating point...
+                        let ty = rvalue.ty(self.ctx.ir_ctx());
+
+                        if ty.is_float() {
+                            builder.fneg(value)
+                        } else {
+                            builder.neg(value)
+                        }
+                    }
+                };
+
+                OperandRef { value: OperandValue::Immediate(value), info: operand.info }
+            }
+            ir::RValue::BinaryOp(operator, box (ref lhs, ref rhs)) => {
+                let lhs = self.codegen_operand(builder, lhs);
+                let rhs = self.codegen_operand(builder, rhs);
+
+                let result = match (lhs.value, rhs.value) {
+                    // @@Future: Here, we should deal with non-scalar binary operations.
+                    // This occurs when a binary operator is implemented on a non-primitive
+                    // type meaning that there is an implicit function dispatch to compute
+                    // the resultant value.
+                    (OperandValue::Pair(_, _), OperandValue::Pair(_, _)) => {
+                        unimplemented!()
+                    }
+                    (OperandValue::Immediate(lhs_value), OperandValue::Immediate(rhs_value)) => {
+                        self.codegen_scalar_binop(
+                            builder,
+                            operator,
+                            lhs_value,
+                            rhs_value,
+                            lhs.info.ty,
+                        )
+                    }
+                    _ => unreachable!(),
+                };
+
+                OperandRef {
+                    value: OperandValue::Immediate(result),
+                    info: builder.layout_of_id(operator.ty(
+                        self.ctx.ir_ctx(),
+                        lhs.info.ty,
+                        rhs.info.ty,
+                    )),
+                }
+            }
+            ir::RValue::CheckedBinaryOp(operator, box (ref lhs, ref rhs)) => {
+                let lhs = self.codegen_operand(builder, lhs);
+                let rhs = self.codegen_operand(builder, rhs);
+
+                let result = self.codegen_checked_scalar_binop(
+                    builder,
+                    operator,
+                    lhs.immediate_value(),
+                    rhs.immediate_value(),
+                    lhs.info.ty,
+                );
+
+                // This yields the operand ty as `(<lhs_ty>, bool)`.
+                let operand_ty = self.ctx.ir_ctx().tys().create(rvalue.ty(self.ctx.ir_ctx()));
+
+                OperandRef { value: result, info: builder.layout_of_id(operand_ty) }
+            }
+            ir::RValue::Aggregate(_, _) => {
+                // This is only called if the aggregate value is a ZST, so we just
+                // create a new ZST operand...
+                let info = builder.layout_of(rvalue.ty(self.ctx.ir_ctx()));
+                OperandRef::new_zst(builder, info)
+            }
+            ir::RValue::Len(place) => {
+                let size = self.evaluate_array_len(builder, place);
+
+                OperandRef {
+                    value: OperandValue::Immediate(size),
+                    info: builder.layout_of_id(self.ctx.ir_ctx().tys().common_tys.usize),
+                }
+            }
+            ir::RValue::Ref(_, place, kind) => {
+                match kind {
+                    ir::AddressMode::Raw => {
+                        let ty = rvalue.ty(self.ctx.ir_ctx());
+                        let place = self.codegen_place(builder, place);
+
+                        // @@Todo: when slices are passed, we might need to use
+                        // OperandValue::Pair (to pass the actual pointer and then
+                        // the length of the slice as an implicit value using `extra`)
+                        OperandRef {
+                            value: OperandValue::Immediate(place.value),
+                            info: builder.layout_of(ty),
+                        }
+                    }
+
+                    // @@Pointers: decide more clearly on what this means, and
+                    // when they are used/rules, etc.
+                    ir::AddressMode::Smart => unimplemented!(),
+                }
+            }
+            ir::RValue::Discriminant(place) => {
+                let discriminant_ty = rvalue.ty(self.ctx.ir_ctx());
+                let discriminant = self
+                    .codegen_place(builder, place)
+                    .codegen_get_discriminant(builder, discriminant_ty);
+
+                OperandRef {
+                    value: OperandValue::Immediate(discriminant),
+                    info: builder.layout_of(discriminant_ty),
+                }
+            }
         }
+    }
+
+    /// Generate code for a trivial binary operation involving scalar-like
+    /// operands.
+    fn codegen_scalar_binop(
+        &mut self,
+        builder: &mut Builder,
+        operator: ir::BinOp,
+        lhs_value: Builder::Value,
+        rhs_value: Builder::Value,
+        ty: IrTyId,
+    ) -> Builder::Value {
+        let (is_float, is_signed) =
+            self.ctx.ir_ctx().tys().map_fast(ty, |ty| (ty.is_float(), ty.is_signed()));
+
+        match operator {
+            ir::BinOp::Add => {
+                if is_float {
+                    builder.fsub(lhs_value, rhs_value)
+                } else {
+                    builder.sub(lhs_value, rhs_value)
+                }
+            }
+            ir::BinOp::Sub => {
+                if is_float {
+                    builder.fsub(lhs_value, rhs_value)
+                } else {
+                    builder.sub(lhs_value, rhs_value)
+                }
+            }
+            ir::BinOp::Mul => {
+                if is_float {
+                    builder.fmul(lhs_value, rhs_value)
+                } else {
+                    builder.mul(lhs_value, rhs_value)
+                }
+            }
+            ir::BinOp::Div => {
+                if is_float {
+                    builder.fdiv(lhs_value, rhs_value)
+                } else if is_signed {
+                    builder.sdiv(lhs_value, rhs_value)
+                } else {
+                    builder.udiv(lhs_value, rhs_value)
+                }
+            }
+            ir::BinOp::Mod => {
+                if is_float {
+                    builder.frem(lhs_value, rhs_value)
+                } else if is_signed {
+                    builder.srem(lhs_value, rhs_value)
+                } else {
+                    builder.urem(lhs_value, rhs_value)
+                }
+            }
+            ir::BinOp::Exp => {
+                if is_float {
+                    builder.fpow(lhs_value, rhs_value)
+                } else {
+                    // Integer scalars don't support, @@Todo: maybe we can use:
+                    //
+                    // https://llvm.org/docs/LangRef.html#llvm-experimental-constrained-powi-intrinsic
+                    unreachable!("`**` for integer operands is illegal")
+                }
+            }
+
+            ir::BinOp::BitOr => builder.or(lhs_value, rhs_value),
+            ir::BinOp::BitAnd => builder.and(lhs_value, rhs_value),
+            ir::BinOp::BitXor => builder.xor(lhs_value, rhs_value),
+
+            ir::BinOp::Shr => build_unchecked_rshift(builder, ty, lhs_value, rhs_value),
+            ir::BinOp::Shl => build_unchecked_lshift(builder, lhs_value, rhs_value),
+
+            ir::BinOp::Eq
+            | ir::BinOp::Neq
+            | ir::BinOp::Gt
+            | ir::BinOp::GtEq
+            | ir::BinOp::Lt
+            | ir::BinOp::LtEq => {
+                if is_float {
+                    builder.fcmp(operator.into(), lhs_value, rhs_value)
+                } else {
+                    builder.icmp(
+                        IntComparisonKind::from_bin_op(operator, is_signed),
+                        lhs_value,
+                        rhs_value,
+                    )
+                }
+            }
+        }
+    }
+
+    /// Code generate a check binary operation on scalar-like
+    /// operands. For the most part, this will emit the intrinsics
+    /// that are used for "checked" operations, but in some other
+    /// cases additional code is generated to deal with unforseen
+    /// U.B. when it comes to some operators (specifically bit shifts).
+    ///
+    /// N.B. it is an invariant to pass a [ir::BinOp] that is not
+    /// checkable.
+    fn codegen_checked_scalar_binop(
+        &mut self,
+        builder: &mut Builder,
+        operator: ir::BinOp,
+        lhs_value: Builder::Value,
+        rhs_value: Builder::Value,
+        ty: IrTyId,
+    ) -> OperandValue<Builder::Value> {
+        let (value, overflow) = match operator {
+            BinOp::Add | BinOp::Sub | BinOp::Mul => {
+                let checked_operator = match operator {
+                    BinOp::Add => CheckedOp::Add,
+                    BinOp::Sub => CheckedOp::Sub,
+                    BinOp::Mul => CheckedOp::Mul,
+                    _ => unreachable!(),
+                };
+
+                let (value, overflow) =
+                    builder.checked_bin_op(checked_operator, lhs_value, rhs_value);
+
+                (value, overflow)
+            }
+            BinOp::Shl | BinOp::Shr => {
+                let lhs_ty = builder.type_of_value(lhs_value);
+                let rhs_ty = builder.type_of_value(rhs_value);
+
+                let invert_mask = shift_mask_value(builder, lhs_ty, rhs_ty, true);
+                let outer_bits = builder.and(rhs_value, invert_mask);
+
+                // If the outer_bits don't equal to zero, then an overflow will occur
+                // since we know that if the result is non-zero, then it is greater
+                // than the maximum legal bit-shift value.
+                let overflow =
+                    builder.icmp(IntComparisonKind::Ne, outer_bits, builder.const_null(rhs_ty));
+                let value = self.codegen_scalar_binop(builder, operator, lhs_value, rhs_value, ty);
+
+                (value, overflow)
+            }
+            _ => unreachable!("operator `{operator}` is not checkable"),
+        };
+
+        OperandValue::Pair(value, overflow)
     }
 
     /// Check whether the given [RValue] will create an
@@ -66,5 +494,32 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 self.ctx.layout_of(ty).is_zst(self.ctx.layouts())
             }
         }
+    }
+
+    /// Compute the length of a given array stored at the provided
+    /// [Place]. This computes the value and returns a [`Builder::Value`]
+    /// from it.
+    fn evaluate_array_len(&mut self, builder: &mut Builder, place: ir::Place) -> Builder::Value {
+        if let Some(local) = place.as_local() {
+            if let LocalRef::Operand(Some(op)) = self.locals[local] {
+                let size = self.ctx.ir_ctx().tys().map_fast(op.info.ty, |ty| {
+                    if let ty::IrTy::Array { size, .. } = ty {
+                        Some(*size)
+                    } else {
+                        None
+                    }
+                });
+
+                if let Some(size) = size {
+                    return builder.const_usize(size as u64);
+                }
+            }
+        }
+
+        // If this is a reference to a place, we codegen the place
+        // and the compute the `length` using the method available
+        // on PlaceRef
+        let value = self.codegen_place(builder, place);
+        value.len(builder)
     }
 }

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -410,7 +410,13 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             | ir::BinOp::Lt
             | ir::BinOp::LtEq => {
                 if is_float {
-                    builder.fcmp(operator.into(), lhs_value, rhs_value)
+                    builder.fcmp(
+                        operator.try_into().expect(
+                            "cannot convert `BinOp` into floating-point comparison operator",
+                        ),
+                        lhs_value,
+                        rhs_value,
+                    )
                 } else {
                     builder.icmp(
                         IntComparisonKind::from_bin_op(operator, is_signed),

--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -175,6 +175,13 @@ pub trait BlockBuilderMethods<'b>:
     /// Perform a fast floating point remainder operation on the given values.
     fn frem_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
 
+    /// Perform a exponentiation of two given values.
+    ///
+    /// N.B. the values must be floating-point or vector types.
+    ///
+    /// Ref: <https://llvm.org/docs/LangRef.html#llvm-pow-intrinsic>
+    fn fpow(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+
     /// Perform a left shift operation on the given values.
     fn shl(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
 
@@ -224,7 +231,15 @@ pub trait BlockBuilderMethods<'b>:
 
     /// Perform a checked binary operation on the given values. The [CheckedOp]s
     /// include either addition, multiplication, or subtraction.
-    fn checked_bin_op(&mut self, op: CheckedOp, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    ///
+    /// The result of the operation is a tuple of the result of the operation
+    /// and a flag denoting whether the operation trigged an overflow.
+    fn checked_bin_op(
+        &mut self,
+        op: CheckedOp,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> (Self::Value, Self::Value);
 
     /// Integer comparison operation.
     ///

--- a/compiler/hash-codegen/src/traits/constants.rs
+++ b/compiler/hash-codegen/src/traits/constants.rs
@@ -11,6 +11,10 @@ pub trait BuildConstValueMethods<'b>: BackendTypes {
     /// zero-sized types.
     fn const_undef(&self, ty: Self::Type) -> Self::Value;
 
+    /// Emit a constant null value for a particular type. This essentially
+    /// just emits a zero'd out value for the type.
+    fn const_null(&self, ty: Self::Type) -> Self::Value;
+
     /// Emit a constant boolean value.
     fn const_bool(&self, val: bool) -> Self::Value;
 
@@ -44,9 +48,15 @@ pub trait BuildConstValueMethods<'b>: BackendTypes {
     /// Emit a constant `i128` value.
     fn const_i128(&self, i: i128) -> Self::Value;
 
+    /// Emit a constant unsigned integer with a specified size.
+    fn const_uint(&self, ty: Self::Type, value: u64) -> Self::Value;
+
     /// Emit a large integer constant of a particular type. This
     /// is a common function to emit unsigned interger types.
     fn const_uint_big(&self, ty: Self::Type, i: u128) -> Self::Value;
+
+    /// Emit a constant signed integer with a specific size.
+    fn const_int(&self, ty: Self::Type, value: i64) -> Self::Value;
 
     /// Emit a constant `usize` value.
     fn const_usize(&self, i: u64) -> Self::Value;

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -44,9 +44,6 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
     /// Create a struct type.
     fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type;
 
-    /// Get the [TypeKind] of a particular type.
-    fn type_kind(&self, ty: Self::Type) -> TypeKind;
-
     /// Create a pointer type to `ty`.
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type;
 
@@ -63,6 +60,12 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
 
     /// Retrieves the bit width of the integer type `self`.
     fn int_width(&self, ty: Self::Type) -> u64;
+
+    /// Compute the type of a particular backend value.
+    fn type_of_value(&self, value: Self::Value) -> Self::Type;
+
+    /// Get the [TypeKind] of a particular type.
+    fn kind_of_type(&self, ty: Self::Type) -> TypeKind;
 
     /// Create a new "immediate" backend type. This is mainly
     /// used for constants and ZSTs.

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -260,6 +260,34 @@ impl BinOp {
     pub fn is_comparator(&self) -> bool {
         matches!(self, Self::Eq | Self::Neq | Self::Gt | Self::GtEq | Self::Lt | Self::LtEq)
     }
+
+    /// Compute the type of [BinOp] operator when applied to
+    /// a particular [IrTy].
+    pub fn ty(&self, ctx: &IrCtx, lhs: IrTyId, rhs: IrTyId) -> IrTyId {
+        match self {
+            BinOp::BitOr
+            | BinOp::BitAnd
+            | BinOp::BitXor
+            | BinOp::Div
+            | BinOp::Sub
+            | BinOp::Mod
+            | BinOp::Add
+            | BinOp::Mul
+            | BinOp::Exp => {
+                // Both `lhs` and `rhs` should be of the same type...
+                debug_assert_eq!(lhs, rhs);
+                lhs
+            }
+
+            // Always the `lhs`, but `lhs` and `rhs` can be different types.
+            BinOp::Shr | BinOp::Shl => lhs,
+
+            // Comparisons
+            BinOp::Eq | BinOp::Neq | BinOp::Gt | BinOp::GtEq | BinOp::Lt | BinOp::LtEq => {
+                ctx.tys().common_tys.bool
+            }
+        }
+    }
 }
 
 impl fmt::Display for BinOp {

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -178,9 +178,19 @@ impl IrTy {
         Self::Adt(adt_id)
     }
 
-    /// Check if the type is an integral type.
+    /// Check if the [IrTy] is an integral type.
     pub fn is_integral(&self) -> bool {
         matches!(self, Self::Int(_) | Self::UInt(_) | Self::Float(_) | Self::Char)
+    }
+
+    /// Check if the [IrTy] is a floating point type.
+    pub fn is_float(&self) -> bool {
+        matches!(self, Self::Float(_))
+    }
+
+    /// Check if the [IrTy] is a signed integral type.
+    pub fn is_signed(&self) -> bool {
+        matches!(self, Self::Int(_))
     }
 
     /// Check if a type is a scalar, i.e. it cannot be divided into


### PR DESCRIPTION
This patch implements the lowering procedures for all `RValue` kinds.