### PR TITLE
codegen: handle code generation for operands and places

### DIFF
--- a/compiler/hash-codegen/src/common.rs
+++ b/compiler/hash-codegen/src/common.rs
@@ -251,9 +251,17 @@ bitflags! {
         /// The memory slot is marked as a volatile region.
         const VOLATILE = 1 << 0;
 
-        /// This flag specifies to the LLVM Optimiser that the memory is
-        /// not expected to be re-used and thus should not be cached. This
-        /// is useful for things like atomic operations
+        /// This flag specifies to the code generation backend that
+        /// this data is not to be re-used and thus should not be cached.
+        /// This is useful for things like atomic operations.
+        ///
+        /// Extract from documentation:
+        /// ```text
+        /// The existence of the `!nontemporal` metadata on the instruction tells the
+        /// optimizer and code generator that this load is not expected to be reused
+        /// in the cache. The code generator may select special instructions to save
+        /// cache bandwidth, such as the `MOVNT` instruction on x86.
+        /// ```
         ///
         /// Ref: https://llvm.org/docs/LangRef.html#store-instruction
         const NON_TEMPORAL = 1 << 1;

--- a/compiler/hash-codegen/src/lower/constants.rs
+++ b/compiler/hash-codegen/src/lower/constants.rs
@@ -1,7 +1,0 @@
-//! Contains logic for lowering Hash IR constants into
-//! backend specific constant representations.
-
-use super::FnBuilder;
-use crate::traits::builder::BlockBuilderMethods;
-
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {}

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -39,7 +39,7 @@ impl<'b, V: CodeGenObject> LocalRef<V> {
         builder: &mut Builder,
         layout: TyInfo,
     ) -> Self {
-        if layout.is_zst(builder.layouts()) {
+        if layout.is_zst(builder.layout_ctx()) {
             LocalRef::Operand(Some(OperandRef::new_zst(builder, layout)))
         } else {
             LocalRef::Operand(None)
@@ -62,7 +62,7 @@ pub fn compute_non_ssa_locals<'b, Builder: BlockBuilderMethods<'b>>(
             let ty = local.ty();
             let layout = fn_builder.ctx.layout_of_id(ty);
 
-            if layout.is_zst(fn_builder.ctx.layouts()) {
+            if layout.is_zst(fn_builder.ctx.layout_ctx()) {
                 LocalMemoryKind::Zst
             } else if fn_builder.ctx.is_backend_immediate(layout) {
                 LocalMemoryKind::Unused
@@ -203,7 +203,7 @@ impl<'ir, 'b, Builder: BlockBuilderMethods<'b>> IrVisitorMut<'b>
         let base_ty = self.fn_builder.body.declarations[place.local].ty;
         let base_layout = self.fn_builder.ctx.layout_of_id(base_ty);
 
-        if base_layout.is_zst(self.fn_builder.ctx.layouts()) {
+        if base_layout.is_zst(self.fn_builder.ctx.layout_ctx()) {
             return;
         }
 

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -62,7 +62,17 @@ impl<'b, V: CodeGenObject> OperandValue<V> {
                 // need to load the value from the source, and then store
                 // it into the destination.
                 if flags.contains(MemFlags::NON_TEMPORAL) {
-                    todo!()
+                    let ty = builder.backend_type(destination.info);
+                    let ptr = builder.pointer_cast(value, builder.type_ptr_to(ty));
+                    let value = builder.load(ty, ptr, source_alignment);
+
+                    builder.store_with_flags(
+                        value,
+                        destination.value,
+                        destination.alignment,
+                        flags,
+                    );
+                    return;
                 }
 
                 utils::mem_copy_ty(

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -2,13 +2,17 @@
 //! IR.
 
 use hash_ir::{
-    ir::Place,
-    ty::{IrTy, TyOfPlace, VariantIdx},
+    ir,
+    ty::{IrTy, PlaceTy, VariantIdx},
 };
-use hash_layout::LayoutShape;
-use hash_target::alignment::Alignment;
+use hash_layout::{LayoutShape, Variants};
+use hash_target::{
+    abi::{AbiRepresentation, ScalarKind},
+    alignment::Alignment,
+};
+use hash_utils::store::{SequenceStore, Store};
 
-use super::FnBuilder;
+use super::{locals::LocalRef, FnBuilder};
 use crate::{
     layout::TyInfo,
     traits::{
@@ -78,58 +82,192 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
     /// Apply a "discriminant" onto the [PlaceRef].
     pub fn codegen_set_discriminant<Builder: BlockBuilderMethods<'b, Value = V>>(
         &self,
-        _builder: &mut Builder,
-        _discriminant: VariantIdx,
+        builder: &mut Builder,
+        discriminant: VariantIdx,
     ) {
-        todo!()
+        let variant_info = self.info.for_variant(builder.layout_ctx(), discriminant);
+        let variant_layout = builder.layout_info(variant_info.layout);
+
+        // If an attempt is made to set the discriminant for a variant type
+        // that is un-inhabited, this is a panic.
+        if variant_layout.abi.is_uninhabited() {
+            builder.codegen_abort_intrinsic();
+            return;
+        }
+
+        match variant_layout.variants {
+            Variants::Single { index } => {
+                debug_assert_eq!(index, discriminant);
+            }
+            Variants::Multiple { field, .. } => {
+                let ptr = self.project_field(builder, field);
+                let (_, value) = builder.ir_ctx().tys().map_fast(self.info.ty, |ty| {
+                    ty.discriminant_for_variant(builder.ir_ctx(), discriminant).unwrap()
+                });
+
+                builder.store(
+                    builder.const_uint_big(builder.backend_type(ptr.info), value),
+                    ptr.value,
+                    ptr.alignment,
+                );
+            }
+        }
     }
 
     /// Get the "discriminant" of the [PlaceRef] and cast it
     /// to a specified type (which must be an integer type).
     pub fn codegen_get_discriminant<Builder: BlockBuilderMethods<'b, Value = V>>(
         self,
-        _builder: &mut Builder,
-        _cast_to: IrTy,
+        builder: &mut Builder,
+        cast_to: IrTy,
     ) -> V {
-        todo!()
+        let cast_info = builder.layout_of(cast_to);
+        let cast_to_ty = builder.immediate_backend_type(cast_info);
+
+        let (variants, is_uninhabited) = builder.map_layout(self.info.layout, |layout| {
+            (layout.variants.clone(), layout.abi.is_uninhabited())
+        });
+
+        // Check if this place is represented as "uninhabited" then we
+        // simply set the result of this as an undefined value of the `cast_to`
+        // type...
+        if is_uninhabited {
+            return builder.const_undef(cast_to_ty);
+        }
+
+        match variants {
+            Variants::Single { index } => {
+                let value = builder.ir_ctx().tys().map_fast(self.info.ty, |ty| {
+                    ty.discriminant_for_variant(builder.ir_ctx(), index)
+                        .map_or(index.raw() as u128, |(_, value)| value)
+                });
+
+                builder.const_uint_big(cast_to_ty, value)
+            }
+            Variants::Multiple { field, tag, .. } => {
+                let tag_ptr = self.project_field(builder, field);
+                let tag_operand = builder.load_operand(tag_ptr);
+                let tag_immediate = tag_operand.immediate_value();
+
+                // We use `i1` for bytes that only have a valid range of
+                // `0` or `1`, but it shouldn't interpret the `i1` as signed
+                // because the `1_i1` would then actually be `-1_i8`.
+                let signed = match tag.kind {
+                    ScalarKind::Int { signed, .. } => !tag.is_bool() && signed,
+                    _ => false,
+                };
+
+                builder.int_cast(tag_immediate, cast_to_ty, signed)
+            }
+        }
     }
 
     /// Apply a downcasting (selecting an `enum` variant on a place) projection
     /// onto the [PlaceRef].
     pub fn project_downcast<Builder: BlockBuilderMethods<'b, Value = V>>(
         &self,
-        _builder: &mut Builder,
-        _variant: VariantIdx,
+        builder: &mut Builder,
+        variant: VariantIdx,
     ) -> Self {
-        todo!()
+        let mut downcast = *self;
+        downcast.info = self.info.for_variant(builder.layout_ctx(), variant);
+
+        // Cast the downcast value to the appropriate type
+        let variant_ty = builder.backend_type(downcast.info);
+        downcast.value = builder.pointer_cast(downcast.value, builder.type_ptr_to(variant_ty));
+        downcast
     }
 
     /// Apply a indexing projection onto the [PlaceRef].
     pub fn project_index<Builder: BlockBuilderMethods<'b, Value = V>>(
         &self,
-        _builder: &mut Builder,
-        _index: V,
+        builder: &mut Builder,
+        index: V,
     ) -> Self {
-        todo!()
+        // compute the offset if possible, or just use the element
+        // size as it will yield the lowest alignment.
+        let field_info = self.info.field(builder.layout_ctx(), 0);
+        let field_size = builder.map_layout(field_info.layout, |layout| layout.size);
+
+        let offset = if let Some(index) = builder.const_to_optional_uint(index) {
+            field_size.checked_mul(index, builder).unwrap_or(field_size)
+        } else {
+            field_size
+        };
+
+        Self {
+            value: builder.bounded_get_element_pointer(
+                builder.backend_type(self.info),
+                self.value,
+                &[builder.const_usize(0), index],
+            ),
+            info: field_info,
+            alignment: self.alignment.restrict_to(offset),
+        }
     }
 
     /// Apply a field projection on a [PlaceRef].
     pub fn project_field<Builder: BlockBuilderMethods<'b, Value = V>>(
         &self,
-        _builder: &mut Builder,
-        _field: usize,
+        builder: &mut Builder,
+        field: usize,
     ) -> Self {
-        todo!()
-    }
+        let abi = builder.map_layout(self.info.layout, |layout| layout.abi);
 
-    /// Cast the [PlaceRef] value to the provided type
-    /// (which must be a pointer type).
-    pub fn cast_to<Builder: BlockBuilderMethods<'b, Value = V>>(
-        &self,
-        _builder: &mut Builder,
-        _cast_to: IrTy,
-    ) -> Self {
-        todo!()
+        let field_info = self.info.field(builder.layout_ctx(), field);
+        let (field_offset, is_zst) = builder
+            .map_layout(field_info.layout, |layout| (layout.shape.offset(field), layout.is_zst()));
+
+        let field_alignment = self.alignment.restrict_to(field_offset);
+
+        let value = match abi {
+            _ if field_offset.bytes() == 0 => self.value,
+
+            // If the offset matches the second field, then we can
+            // just get the `get_element_ptr` of the second field
+            AbiRepresentation::Pair(scalar_a, scalar_b)
+                if field_offset == scalar_a.size(builder).align_to(scalar_b.align(builder).abi) =>
+            {
+                let ty = builder.backend_type(self.info);
+                builder.structural_get_element_pointer(ty, self.value, 1)
+            }
+            AbiRepresentation::Scalar(_)
+            | AbiRepresentation::Pair(..)
+            | AbiRepresentation::Vector { .. }
+                if is_zst =>
+            {
+                // If this is a zst field, we have to manually offset the pointer.
+                let byte_ptr = builder.pointer_cast(self.value, builder.type_i8p());
+                builder.get_element_pointer(
+                    builder.type_i8(),
+                    byte_ptr,
+                    &[builder.const_usize(field_offset.bytes())],
+                )
+            }
+            AbiRepresentation::Scalar(_) | AbiRepresentation::Pair(..) => {
+                // @@Todo: implement `ForFormatting` equivalent for `info` and `layout`.
+                panic!(
+                    "offset of non-ZST field `{:?}` which does not match `{:?}`",
+                    field_info, self.info
+                )
+            }
+            // This must be a struct..
+            _ => {
+                let ty = builder.backend_type(self.info);
+                builder.structural_get_element_pointer(
+                    ty,
+                    self.value,
+                    builder.backend_field_index(self.info, field),
+                )
+            }
+        };
+
+        // @@PointerCasts: this can be removed if we use LLVM 15 where it is
+        // not needed to pointer cast.
+        let value =
+            builder.pointer_cast(value, builder.type_ptr_to(builder.backend_type(field_info)));
+
+        PlaceRef { value, info: field_info, alignment: field_alignment }
     }
 
     /// Emit a hint to the code generation backend that this [PlaceRef] is
@@ -150,8 +288,8 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
 impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Compute the type and layout of a [Place]. This deals with
     /// all projections that occur on the [Place].
-    pub fn compute_place_ty_info(&self, builder: &mut Builder, place: Place) -> TyInfo {
-        let place_ty = TyOfPlace::from_place(place, self.body, self.ctx.ir_ctx());
+    pub fn compute_place_ty_info(&self, builder: &mut Builder, place: ir::Place) -> TyInfo {
+        let place_ty = PlaceTy::from_place(place, self.body, self.ctx.ir_ctx());
         builder.layout_of_id(place_ty.ty)
     }
 
@@ -162,9 +300,86 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// to `store` a value into the place.
     pub fn codegen_place(
         &mut self,
-        _builder: &mut Builder,
-        _place: Place,
+        builder: &mut Builder,
+        place: ir::Place,
     ) -> PlaceRef<Builder::Value> {
-        todo!()
+        // copy the projections from the place.
+        let projections = builder.ir_ctx().projections().get_vec(place.projections);
+
+        let mut base = 0;
+
+        let mut codegen_base = match self.locals[place.local] {
+            LocalRef::Place(place) => place,
+            LocalRef::Operand(..) => {
+                if projections.first() == Some(&ir::PlaceProjection::Deref) {
+                    base = 1;
+
+                    // we have to copy a slice of the projections where
+                    // we omit the first projection (which is a deref).
+                    let projections =
+                        builder.ir_ctx().projections().create_from_slice(&projections[1..]);
+
+                    let codegen_base = self.codegen_consume_operand(
+                        builder,
+                        ir::Place { local: place.local, projections },
+                    );
+
+                    codegen_base.deref(builder)
+                } else {
+                    panic!("using operand local `{place:?}` as place")
+                }
+            }
+        };
+
+        // Apply all of the projections on the initial base
+        // producing a modified place reference.
+        for projection in projections[base..].iter() {
+            codegen_base = match *projection {
+                ir::PlaceProjection::Downcast(variant) => {
+                    codegen_base.project_downcast(builder, variant)
+                }
+                ir::PlaceProjection::Field(index) => codegen_base.project_field(builder, index),
+                ir::PlaceProjection::Index(index) => {
+                    let index_operand: ir::Operand =
+                        ir::Place::from_local(index, builder.ir_ctx()).into();
+                    let index = self.codegen_operand(builder, &index_operand);
+
+                    let value = index.immediate_value();
+                    codegen_base.project_index(builder, value)
+                }
+                ir::PlaceProjection::ConstantIndex { from_end: false, offset, .. } => {
+                    let offset_value = builder.const_usize(offset as u64);
+                    codegen_base.project_index(builder, offset_value)
+                }
+                ir::PlaceProjection::ConstantIndex { from_end: true, offset, .. } => {
+                    let offset_value = builder.const_usize(offset as u64);
+                    let len_value = codegen_base.len(builder);
+                    let index_value = builder.sub(len_value, offset_value);
+                    codegen_base.project_index(builder, index_value)
+                }
+                ir::PlaceProjection::SubSlice { from, .. } => {
+                    let mut sub_slice =
+                        codegen_base.project_index(builder, builder.const_usize(from as u64));
+                    let projected_ty = PlaceTy::from_ty(codegen_base.info.ty)
+                        .projection_ty(builder.ir_ctx(), *projection);
+
+                    // @@Verify: if the size of the array is not known, do we
+                    // have to do record the size of this slice using `extra_value`?
+
+                    sub_slice.info = builder.layout_of_id(projected_ty);
+                    sub_slice.value = builder.pointer_cast(
+                        sub_slice.value,
+                        builder.type_ptr_to(builder.backend_type(sub_slice.info)),
+                    );
+
+                    sub_slice
+                }
+                ir::PlaceProjection::Deref => {
+                    builder.load_operand(codegen_base).deref(builder.ctx())
+                }
+            }
+        }
+
+        codegen_base
     }
 }

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -497,7 +497,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 // check if the type is a ZST, and if so this satisfies the
                 // case that the rvalue creates an operand...
-                self.ctx.layout_of(ty).is_zst(self.ctx.layouts())
+                self.ctx.layout_of(ty).is_zst(self.ctx.layout_ctx())
             }
         }
     }

--- a/compiler/hash-codegen/src/lower/statement.rs
+++ b/compiler/hash-codegen/src/lower/statement.rs
@@ -4,14 +4,13 @@
 use hash_ir::ir::{Statement, StatementKind};
 
 use super::{locals::LocalRef, FnBuilder};
-use crate::traits::{builder::BlockBuilderMethods, ctx::HasCtxMethods};
+use crate::traits::builder::BlockBuilderMethods;
 
 impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Lower a Hash IR [Statement] into a target backend code.
     pub fn codegen_statement(&mut self, builder: &mut Builder, statement: &Statement) {
         // @@DebugInfo: deal with debug information here for the location
         // of the statement.
-
         match statement.kind {
             StatementKind::Assign(place, ref value) => {
                 if let Some(local) = place.as_local() {

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -283,9 +283,9 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 // @@Future: we will probably introduce as `with_layout`
                 let abi_layout = builder.layout_info(arg_abi.info.layout);
 
-                if let AbiRepresentation::Scalar { kind } = abi_layout.abi {
-                    if kind.is_bool() {
-                        builder.add_range_metadata_to(value, kind.valid_range);
+                if let AbiRepresentation::Scalar(scalar_kind) = abi_layout.abi {
+                    if scalar_kind.is_bool() {
+                        builder.add_range_metadata_to(value, scalar_kind.valid_range);
                     }
 
                     // @@Performance: we could just pass a ptr to layout here??

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -9,7 +9,7 @@ use hash_target::alignment::Alignment;
 use super::FnBuilder;
 use crate::{
     common::MemFlags,
-    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods},
+    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods},
 };
 
 /// Emit a `memcpy` instruction for a particular value with the provided

--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -13,8 +13,8 @@ use hash_target::{
 };
 
 use super::{
-    abi::AbiBuilderMethods, ctx::HasCtxMethods, debug::BuildDebugInfoMethods,
-    intrinsics::BuildIntrinsicCallMethods, target::HasTargetSpec, CodeGen,
+    abi::AbiBuilderMethods, debug::BuildDebugInfoMethods, intrinsics::BuildIntrinsicCallMethods,
+    target::HasTargetSpec, CodeGen,
 };
 use crate::{
     common::{CheckedOp, IntComparisonKind, MemFlags, RealComparisonKind},

--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -357,15 +357,15 @@ pub trait BlockBuilderMethods<'b>:
 
     /// Convert a value to an immediate value of the given layout.
     fn to_immediate(&mut self, v: Self::Value, layout: LayoutId) -> Self::Value {
-        if let AbiRepresentation::Scalar { kind } = self.layout_info(layout).abi {
-            self.to_immediate_scalar(v, kind)
+        if let AbiRepresentation::Scalar(scalar) = self.layout_info(layout).abi {
+            self.to_immediate_scalar(v, scalar)
         } else {
             v
         }
     }
 
     /// Convert the given value to a [Scalar] value.
-    fn to_immediate_scalar(&mut self, v: Self::Value, kind: Scalar) -> Self::Value;
+    fn to_immediate_scalar(&mut self, v: Self::Value, scalar_kind: Scalar) -> Self::Value;
 
     /// Create a store operation on the stack to given type and [Alignment]
     /// specification, returning a reference to the data location.

--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -472,7 +472,12 @@ pub trait BlockBuilderMethods<'b>:
     /// element pointer with the specified field index.
     ///
     /// Ref: <https://llvm.org/docs/LangRef.html#getelementptr-instruction>
-    fn structural_get_element_pointer(ty: Self::Type, ptr: Self::Value, index: u64) -> Self::Value;
+    fn structural_get_element_pointer(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        index: u64,
+    ) -> Self::Value;
 
     /// Emit an instruction for a `memcpy` operation.
     ///

--- a/compiler/hash-codegen/src/traits/constants.rs
+++ b/compiler/hash-codegen/src/traits/constants.rs
@@ -2,6 +2,10 @@
 //! backend builder to emit constants of all primitive types when converting
 //! Hash IR into the target backend.
 
+use hash_ir::ir;
+use hash_source::constant::InternedStr;
+use hash_target::abi::Scalar;
+
 use super::BackendTypes;
 
 /// Trait that represents methods for emitting constants
@@ -75,6 +79,21 @@ pub trait BuildConstValueMethods<'b>: BackendTypes {
     /// }
     /// ```
     fn const_str(&self, s: &str) -> (Self::Value, Self::Value);
+
+    /// Emit a constant string value from an interned string. This returns
+    /// a value representing the pointer to the string characters, and a
+    /// second value representing the length of the string.
+    fn const_interned_str(&self, s: InternedStr) -> (Self::Value, Self::Value);
+
+    /// Emit a constant value from a `Const` value. This only deals with
+    /// constant "scalar" values, for string values, there is specific code
+    /// to emit this constant.
+    fn const_scalar_value(
+        &self,
+        const_value: ir::Const,
+        abi: Scalar,
+        ty: Self::Type,
+    ) -> Self::Value;
 
     /// Attempt to convert a constant value into a `u128` value. If
     /// the conversion fails, then [`None`] is returned.

--- a/compiler/hash-codegen/src/traits/constants.rs
+++ b/compiler/hash-codegen/src/traits/constants.rs
@@ -97,5 +97,9 @@ pub trait BuildConstValueMethods<'b>: BackendTypes {
 
     /// Attempt to convert a constant value into a `u128` value. If
     /// the conversion fails, then [`None`] is returned.
-    fn const_to_optional_u128(&self, val: Self::Value, sign_extend: bool) -> Option<u128>;
+    fn const_to_optional_u128(&self, value: Self::Value, sign_extend: bool) -> Option<u128>;
+
+    /// Attempt to convert a constant calue into a unsigned integer `u64`
+    /// value.
+    fn const_to_optional_uint(&self, value: Self::Value) -> Option<u64>;
 }

--- a/compiler/hash-codegen/src/traits/ctx.rs
+++ b/compiler/hash-codegen/src/traits/ctx.rs
@@ -23,7 +23,7 @@ pub trait HasCtxMethods<'b>: HasDataLayout {
 
     /// Create a [LayoutCtx]
     fn layout_ctx(&self) -> LayoutCtx<'_> {
-        LayoutCtx::new(self.layouts(), self.ir_ctx())
+        LayoutCtx::new(self.layouts(), self.data_layout(), self.ir_ctx())
     }
 
     /// Returns a reference to an IR type from the context.

--- a/compiler/hash-codegen/src/traits/ctx.rs
+++ b/compiler/hash-codegen/src/traits/ctx.rs
@@ -7,7 +7,7 @@ use hash_ir::{
     ty::{IrTy, IrTyId},
     IrCtx,
 };
-use hash_layout::LayoutStore;
+use hash_layout::{LayoutCtx, LayoutStore};
 use hash_pipeline::settings::CompilerSettings;
 use hash_target::layout::HasDataLayout;
 
@@ -20,6 +20,11 @@ pub trait HasCtxMethods<'b>: HasDataLayout {
 
     /// Returns a reference to the IR [IrCtx].
     fn ir_ctx(&self) -> &IrCtx;
+
+    /// Create a [LayoutCtx]
+    fn layout_ctx(&self) -> LayoutCtx<'_> {
+        LayoutCtx::new(self.layouts(), self.ir_ctx())
+    }
 
     /// Returns a reference to an IR type from the context.
     fn ty_info(&self, ty: IrTyId) -> &IrTy;

--- a/compiler/hash-codegen/src/traits/layout.rs
+++ b/compiler/hash-codegen/src/traits/layout.rs
@@ -2,18 +2,27 @@
 //! within a backend.
 
 use hash_ir::ty::{IrTy, IrTyId};
-use hash_target::layout::HasDataLayout;
+use hash_layout::{Layout, LayoutId};
+use hash_utils::store::Store;
 
-use super::BackendTypes;
+use super::{ctx::HasCtxMethods, BackendTypes};
 use crate::layout::TyInfo;
 
 /// Methods for calculating and querying the layout of types within a backend.
-pub trait LayoutMethods<'b>: BackendTypes + HasDataLayout {
+pub trait LayoutMethods<'b>: BackendTypes + HasCtxMethods<'b> {
     /// Compute the layout of a interned type via [IrTyId].
     fn layout_of_id(&self, ty: IrTyId) -> TyInfo;
 
     /// Compute the layout of a [IrTy].
     fn layout_of(&self, ty: IrTy) -> TyInfo;
+
+    /// Perform a mapping on a [Layout]
+    fn map_layout<T>(&self, id: LayoutId, func: impl FnOnce(&Layout) -> T) -> T {
+        self.layouts().map_fast(id, func)
+    }
+
+    /// Compute the field index from the backend specific type.
+    fn backend_field_index(&self, info: TyInfo, index: usize) -> u64;
 
     /// Check whether the [TyInfo] layout can be represented as an
     /// immediate value.

--- a/compiler/hash-codegen/src/traits/layout.rs
+++ b/compiler/hash-codegen/src/traits/layout.rs
@@ -18,4 +18,13 @@ pub trait LayoutMethods<'b>: BackendTypes + HasDataLayout {
     /// Check whether the [TyInfo] layout can be represented as an
     /// immediate value.
     fn is_backend_immediate(&self, ty: TyInfo) -> bool;
+
+    /// Get the type of an element from a sclar pair, and assume
+    /// if it "immediate".
+    fn scalar_pair_element_backend_type(
+        &self,
+        info: TyInfo,
+        index: usize,
+        immediate: bool,
+    ) -> Self::Type;
 }

--- a/compiler/hash-codegen/src/traits/mod.rs
+++ b/compiler/hash-codegen/src/traits/mod.rs
@@ -67,6 +67,19 @@ pub trait CodeGenMethods<'b>:
 {
 }
 
+// Dummy implementation for `CodeGenMethods` for any T that implements
+// those methods too.
+impl<'b, T> CodeGenMethods<'b> for T where
+    Self: Backend<'b>
+        + MiscBuilderMethods<'b>
+        + HasCtxMethods<'b>
+        + BuildTypeMethods<'b>
+        + BuildConstValueMethods<'b>
+        + BuildDebugInfoMethods
+        + HasTargetSpec
+{
+}
+
 pub trait CodeGen<'b>:
     Backend<'b> + std::ops::Deref<Target = <Self as CodeGen<'b>>::CodegenCtx>
 {

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -44,6 +44,11 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
     /// Create a struct type.
     fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type;
 
+    /// Create a `&i8` pointer type.
+    fn type_i8p(&self) -> Self::Type {
+        self.type_ptr_to_ext(self.type_i8(), AddressSpace::DATA)
+    }
+
     /// Create a pointer type to `ty`.
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type;
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -123,6 +123,12 @@ impl IrCtx {
         self.projections().map_fast(projections, |projections| map(local, projections))
     }
 
+    /// Apply a function on a [IrTy::Adt].
+    pub fn map_on_adt<T>(&self, ty: IrTyId, f: impl FnOnce(&AdtData, AdtId) -> T) -> T {
+        self.ty_store
+            .map_fast(ty, |ty| self.adt_store.map_fast(ty.as_adt(), |adt| f(adt, ty.as_adt())))
+    }
+
     /// Perform a map on a [AdtId] by reading the [AdtData] that is associated
     /// with the [AdtId] and then applying the provided function.
     pub fn map_adt<T>(&self, id: AdtId, map: impl FnOnce(AdtId, &AdtData) -> T) -> T {

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -266,6 +266,36 @@ impl IrTy {
             _ => None,
         }
     }
+
+    /// Compute the discriminant value for a particular [IrTy] and
+    /// evaluate it to a raw value.
+    pub fn discriminant_for_variant(
+        &self,
+        ctx: &IrCtx,
+        variant: VariantIdx,
+    ) -> Option<(UIntTy, u128)> {
+        match self {
+            IrTy::Adt(id) => {
+                ctx.adts().map_fast(*id, |data| {
+                    if !data.flags.is_enum() || data.variants.is_empty() {
+                        None
+                    } else {
+                        // We get the offset of the current discriminant and then
+                        // we also compute the "initial" value of the discriminant
+                        // for this type. Currently, this is quite trivial to do
+                        // since the user cannot (yet) modify what the discriminant
+                        // of each enum variant is, and thus we don't need to account
+                        // for this.
+                        let discriminant_value = data.discriminant_value_for(variant);
+                        let discriminant_type = data.discriminant_ty();
+
+                        Some((discriminant_type, discriminant_value as u128))
+                    }
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 impl From<IntTy> for IrTy {
@@ -354,7 +384,7 @@ impl AdtData {
     /// @@Future(discriminants): This is incomplete because it does not account
     /// for the `repr` attribute, and the fact that enums might have
     /// explicit discriminants specified on them.
-    pub fn discriminant_ty(&self) -> IntTy {
+    pub fn discriminant_ty(&self) -> UIntTy {
         debug_assert!(self.flags.is_enum() || self.flags.is_union());
 
         // Compute the maximum number of bits needed for the discriminant.
@@ -362,7 +392,17 @@ impl AdtData {
         let bits = max.leading_zeros();
         let size = Size::from_bits(cmp::max(1, 64 - bits));
 
-        IntTy::UInt(UIntTy::from_size(size))
+        UIntTy::from_size(size)
+    }
+
+    /// Compute the discriminant value for a particular variant.
+    pub fn discriminant_value_for(&self, variant: VariantIdx) -> u32 {
+        debug_assert!(self.flags.is_enum());
+
+        // @@Future(discriminants): We don't account for user specified
+        // discriminants just yet, so this is simply the index of the
+        // variant.
+        variant._raw
     }
 
     /// Create an iterator of all of the discriminants of this ADT.
@@ -670,7 +710,7 @@ impl fmt::Display for ForFormatting<'_, IrTyListId> {
 /// An auxilliary data structure that is used to compute the
 /// [IrTy] of a [Place].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TyOfPlace {
+pub struct PlaceTy {
     /// The [IrTy] of the place.
     pub ty: IrTyId,
 
@@ -679,58 +719,75 @@ pub struct TyOfPlace {
     pub index: Option<VariantIdx>,
 }
 
-impl TyOfPlace {
-    /// Create a [TyPlace] from a [Place].
-    pub fn from_place(place: Place, body: &Body, ctx: &IrCtx) -> TyOfPlace {
+impl PlaceTy {
+    /// Create a [PlaceTy] from a base [IrTy]. This is useful for when
+    /// you want to apply a single projection on the current type
+    /// and create a new [PlaceTy] from the projection.
+    pub fn from_ty(ty: IrTyId) -> Self {
+        Self { ty, index: None }
+    }
+
+    /// Apply a projection to the current [PlaceTy].
+    fn apply_projection(self, ctx: &IrCtx, projection: PlaceProjection) -> Self {
+        match projection {
+            PlaceProjection::Downcast(index) => PlaceTy { ty: self.ty, index: Some(index) },
+            PlaceProjection::Field(index) => {
+                let ty = ctx
+                    .tys()
+                    .map_fast(self.ty, |ty| ty.on_field_access(index, self.index, ctx))
+                    .unwrap_or_else(|| panic!("expected an ADT, got {self:?}"));
+
+                PlaceTy { ty, index: None }
+            }
+            PlaceProjection::Deref => {
+                let ty = ctx
+                    .tys()
+                    .map_fast(self.ty, |ty| ty.on_deref())
+                    .unwrap_or_else(|| panic!("expected a reference, got {self:?}"));
+
+                PlaceTy { ty, index: None }
+            }
+            PlaceProjection::Index(_) | PlaceProjection::ConstantIndex { .. } => {
+                let ty = ctx
+                    .tys()
+                    .map_fast(self.ty, |ty| ty.on_index())
+                    .unwrap_or_else(|| panic!("expected an array or slice, got {self:?}"));
+
+                PlaceTy { ty, index: None }
+            }
+            PlaceProjection::SubSlice { from, to, from_end } => {
+                let base_ty = ctx.tys().get(self.ty);
+                let ty = match base_ty {
+                    IrTy::Slice(_) => self.ty,
+                    IrTy::Array { ty, .. } if !from_end => {
+                        ctx.tys().create(IrTy::Array { ty, size: to - from })
+                    }
+                    IrTy::Array { ty, size } if from_end => {
+                        ctx.tys().create(IrTy::Array { ty, size: size - from - to })
+                    }
+                    _ => panic!("expected an array or slice, got {self:?}"),
+                };
+
+                PlaceTy { ty, index: None }
+            }
+        }
+    }
+
+    /// Apply a projection on [PlaceTy] and convert it into
+    /// the underlying type.
+    pub fn projection_ty(self, ctx: &IrCtx, projection: PlaceProjection) -> IrTyId {
+        let projected_place = self.apply_projection(ctx, projection);
+        projected_place.ty
+    }
+
+    /// Create a [PlaceTy] from a [Place].
+    pub fn from_place(place: Place, body: &Body, ctx: &IrCtx) -> Self {
         // get the type of the local from the body.
-        let mut base = TyOfPlace { ty: body.declarations[place.local].ty, index: None };
+        let mut base = PlaceTy { ty: body.declarations[place.local].ty, index: None };
 
         ctx.projections().map_fast(place.projections, |projections| {
             for projection in projections {
-                match *projection {
-                    PlaceProjection::Downcast(index) => {
-                        base = TyOfPlace { ty: base.ty, index: Some(index) }
-                    }
-                    PlaceProjection::Field(index) => {
-                        let ty = ctx
-                            .tys()
-                            .map_fast(base.ty, |ty| ty.on_field_access(index, base.index, ctx))
-                            .unwrap_or_else(|| panic!("expected an ADT, got {base:?}"));
-
-                        base = TyOfPlace { ty, index: None }
-                    }
-                    PlaceProjection::Deref => {
-                        let ty = ctx
-                            .tys()
-                            .map_fast(base.ty, |ty| ty.on_deref())
-                            .unwrap_or_else(|| panic!("expected a reference, got {base:?}"));
-
-                        base = TyOfPlace { ty, index: None }
-                    }
-                    PlaceProjection::Index(_) | PlaceProjection::ConstantIndex { .. } => {
-                        let ty = ctx
-                            .tys()
-                            .map_fast(base.ty, |ty| ty.on_index())
-                            .unwrap_or_else(|| panic!("expected an array or slice, got {base:?}"));
-
-                        base = TyOfPlace { ty, index: None }
-                    }
-                    PlaceProjection::SubSlice { from, to, from_end } => {
-                        let base_ty = ctx.tys().get(base.ty);
-                        let ty = match base_ty {
-                            IrTy::Slice(_) => base.ty,
-                            IrTy::Array { ty, .. } if !from_end => {
-                                ctx.tys().create(IrTy::Array { ty, size: to - from })
-                            }
-                            IrTy::Array { ty, size } if from_end => {
-                                ctx.tys().create(IrTy::Array { ty, size: size - from - to })
-                            }
-                            _ => panic!("expected an array or slice, got {base:?}"),
-                        };
-
-                        base = TyOfPlace { ty, index: None }
-                    }
-                }
+                base = base.apply_projection(ctx, *projection);
             }
         });
 

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -107,7 +107,7 @@ impl<'tcx> Builder<'tcx> {
                 // This is a special case, since we are creating an enum variant here with
                 // no arguments.
                 let subject_ty = self.ty_id_of_node(subject.id());
-                let index = self.map_on_adt(subject_ty, |adt, _| match property.body() {
+                let index = self.ctx.map_on_adt(subject_ty, |adt, _| match property.body() {
                     PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
                     PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
                 });
@@ -280,7 +280,7 @@ impl<'tcx> Builder<'tcx> {
                     }
                     Lit::Tuple(TupleLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
-                        let adt = self.map_on_adt(ty, |_, id| id);
+                        let adt = self.ctx.map_on_adt(ty, |_, id| id);
                         let aggregate_kind = AggregateKind::Tuple(adt);
 
                         let args = elements

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -340,7 +340,8 @@ impl<'tcx> Builder<'tcx> {
                 }
                 Pat::Constructor(ConstructorPat { subject, args }) => {
                     let ty = self.convert_term_into_ir_ty(*subject);
-                    let adt = self.map_on_adt(ty, |adt, id| adt.flags.is_struct().then_some(id));
+                    let adt =
+                        self.ctx.map_on_adt(ty, |adt, id| adt.flags.is_struct().then_some(id));
 
                     // If this is a struct then we need to match on the fields of
                     // the struct since it is an *irrefutable* pattern.

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -709,7 +709,7 @@ impl<'tcx> Builder<'tcx> {
             TestKind::Len { len, op } => {
                 let target_blocks = make_target_blocks(self);
 
-                let usize_ty = self.ctx.tys().create(self.ctx.tys().make_usize());
+                let usize_ty = self.ctx.tys().common_tys.usize;
                 let actual = self.temp_place(usize_ty);
 
                 // Assign `actual = length(place)`

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -182,7 +182,7 @@ impl<'tcx> Builder<'tcx> {
                 Pat::Access(AccessPat { .. }) => {
                     let ty = self.ty_of_pat(pair.pat);
                     let (variant_count, adt) =
-                        self.map_on_adt(ty, |adt, id| (adt.variants.len(), id));
+                        self.ctx.map_on_adt(ty, |adt, id| (adt.variants.len(), id));
 
                     Test {
                         kind: TestKind::Switch {
@@ -271,7 +271,7 @@ impl<'tcx> Builder<'tcx> {
                 // variant patterns, bu nothing else.
                 let test_adt = self.convert_term_into_ir_ty(*subject);
 
-                let variant_index = self.map_on_adt(test_adt, |adt, _| {
+                let variant_index = self.ctx.map_on_adt(test_adt, |adt, _| {
                     // If this is a struct, then we don't do anything
                     // since we're expecting an enum. Although, this case shouldn't happen?
                     if adt.flags.is_struct() {
@@ -297,7 +297,7 @@ impl<'tcx> Builder<'tcx> {
                 // variant patterns, bu nothing else.
                 let test_adt = self.ty_of_pat(pair.pat);
 
-                let variant_index = self.map_on_adt(test_adt, |adt, _| {
+                let variant_index = self.ctx.map_on_adt(test_adt, |adt, _| {
                     // If this is a struct, then we don't do anything
                     // since we're expecting an enum. Although, this case shouldn't happen?
                     if adt.flags.is_struct() {
@@ -560,7 +560,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Here we want to create a switch statement that will match on all of the
                 // specified discriminants of the ADT.
-                let discriminant_ty = self.ctx.tys().create(discriminant_ty.into());
+                let discriminant_ty = self.ctx.tys().create(IrTy::UInt(discriminant_ty));
                 let targets = SwitchTargets::new(
                     self.ctx.adts().map_fast(adt, |adt| {
                         // Map over all of the discriminants of the ADT, and filter out those that
@@ -797,7 +797,7 @@ impl<'tcx> Builder<'tcx> {
                     // variant index of the property.
                     let ty = self.ty_of_pat(match_pair.pat);
 
-                    self.map_on_adt(ty, |adt, _| {
+                    self.ctx.map_on_adt(ty, |adt, _| {
                         let variant_index = adt.variant_idx(property).unwrap();
                         variants.insert(variant_index.index());
                         true

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -189,7 +189,7 @@ impl<'tcx> Builder<'tcx> {
     /// a [PropertyKind]. This function assumes that the underlying type is
     /// a [IrTy::Adt].
     fn lookup_field_index(&mut self, ty: IrTyId, field: PropertyKind) -> usize {
-        self.map_on_adt(ty, |adt, _| {
+        self.ctx.map_on_adt(ty, |adt, _| {
             // @@Todo: deal with unions here.
             if adt.flags.is_struct() || adt.flags.is_tuple() {
                 // So we get the first variant of the ADT since structs, tuples always

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -6,7 +6,7 @@
 use hash_ast::ast::{AstNodeId, AstNodeRef};
 use hash_ir::{
     ir::{AssertKind, BasicBlock, LocalDecl, Operand, Place, TerminatorKind},
-    ty::{AdtData, AdtId, IrTy, IrTyId, Mutability},
+    ty::{IrTy, IrTyId, Mutability},
 };
 use hash_source::location::Span;
 use hash_types::{pats::PatId, terms::TermId};
@@ -62,13 +62,6 @@ impl<'tcx> Builder<'tcx> {
 
     pub(crate) fn span_of_pat(&self, id: PatId) -> Span {
         self.tcx.location_store.get_span(id).unwrap()
-    }
-
-    /// Apply a function on a [IrTy::Adt].
-    pub(crate) fn map_on_adt<T>(&self, ty: IrTyId, f: impl FnOnce(&AdtData, AdtId) -> T) -> T {
-        self.ctx
-            .tys()
-            .map_fast(ty, |ty| self.ctx.adts().map_fast(ty.as_adt(), |adt| f(adt, ty.as_adt())))
     }
 
     /// Function to create a new [Place] that is used to ignore

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -209,7 +209,7 @@ pub enum AbiRepresentation {
     Uninhabited,
 
     /// A scalar value.
-    Scalar { kind: Scalar },
+    Scalar(Scalar),
 
     /// A vector value.
     Vector {

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -149,6 +149,8 @@ impl fmt::Debug for ValidScalarRange {
     }
 }
 
+/// The representation of a scalar-like value within an
+/// ABI, what type it is, and what its valid range is.
 #[derive(Clone, Copy, Debug)]
 pub struct Scalar {
     /// The kind of the scalar.
@@ -158,7 +160,7 @@ pub struct Scalar {
     /// to provide aditional information about values
     /// that might be encoded as scalars (for efficiency
     /// purposes), but are not actually scalars, e.g. `bool`s
-    /// will be encoded as [ScalarKind::Int{..}], and have
+    /// will be encoded as [`ScalarKind::Int`], and have
     /// a valid range of `0..1`.
     pub valid_range: ValidScalarRange,
 }
@@ -202,7 +204,7 @@ impl Scalar {
 
 /// This defined how values are being represented and are passed by target
 /// ABIs in the terms of c-type categories.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum AbiRepresentation {
     /// A value that is not represented in memory, but is instead passed
     /// by value. This is used for values that are smaller than a pointer.
@@ -210,6 +212,15 @@ pub enum AbiRepresentation {
 
     /// A scalar value.
     Scalar(Scalar),
+
+    /// A pair of two scalar values, this is useful to group
+    /// operations or types that produce a pair of values, i.e.
+    /// `str` is a pointer to char bytes and an associated length,
+    /// thus:
+    /// ```ignore
+    /// AbiRepresentation::Pair(<...bytes_scalar>..., ...<length_scalar>...)
+    /// ```
+    Pair(Scalar, Scalar),
 
     /// A vector value.
     Vector {

--- a/compiler/hash-target/src/layout.rs
+++ b/compiler/hash-target/src/layout.rs
@@ -88,6 +88,25 @@ pub struct TargetDataLayout {
     pub c_style_enum_min_size: Integer,
 }
 
+impl TargetDataLayout {
+    /// Returns the exclusive upper bound on an object size. This is the maximum
+    /// size of an object that can be allocated on the target.
+    ///
+    /// The upper bound on 64-bit currently needs to be lower because LLVM uses
+    /// a 64-bit integer to represent object size in bits. It would need to
+    /// be 1 << 61 to account for this, but is currently conservatively
+    /// bounded to 1 << 47 as that is enough to cover the current usable
+    /// address space on 64-bit ARMv8 and x86_64.
+    pub fn obj_size_bound(&self) -> u64 {
+        match self.pointer_size.bits() {
+            16 => 1 << 15,
+            32 => 1 << 31,
+            64 => 1 << 47,
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl Default for TargetDataLayout {
     /// Create a default value for [`TargetDataLayout`] based on the
     /// LLVM specification for the default data layout

--- a/compiler/hash-target/src/size.rs
+++ b/compiler/hash-target/src/size.rs
@@ -3,6 +3,8 @@
 
 use std::ops::{Add, Mul};
 
+use crate::alignment::Alignment;
+
 /// Represents the size of some constant in bytes. [Size] is a
 /// utility type that allows one to perform various conversions
 /// on the size (bits and bytes), and to derive .
@@ -62,6 +64,16 @@ impl Size {
     #[inline]
     pub fn unsigned_int_max(&self) -> u128 {
         u128::MAX >> (128 - self.bits())
+    }
+
+    /// Take the current [Size] and align it to a
+    /// specified [Alignment].
+    pub fn align_to(&self, alignment: Alignment) -> Size {
+        // Create a mask for the alignment, add it to the
+        // current size to account for the alignment, and then
+        // trim the size to remove any slack.
+        let mask = alignment.bytes() - 1;
+        Size::from_bytes((self.bytes() + mask) & !mask)
     }
 }
 


### PR DESCRIPTION
This patch implements handling of code generation for `Operand`, and places (including all projections that can occur on a `Place`).

This means that all of the code to convert IR into backend IR (#649) is now complete, which means now the next things to tackle are:
- computing type layouts (#646)
- checking the semantics of the entry point (#647)
- figure out how we glue everything together at the end (#651) i.e. linking

closes #649 
