### PR TITLE
layout: implement computing the layout for all `IrTy`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,9 @@ dependencies = [
 [[package]]
 name = "hash-target"
 version = "0.1.0"
+dependencies = [
+ "num-bigint",
+]
 
 [[package]]
 name = "hash-testing-internal"

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -152,7 +152,7 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
                 // We use `i1` for bytes that only have a valid range of
                 // `0` or `1`, but it shouldn't interpret the `i1` as signed
                 // because the `1_i1` would then actually be `-1_i8`.
-                let signed = match tag.kind {
+                let signed = match tag.kind() {
                     ScalarKind::Int { signed, .. } => !tag.is_bool() && signed,
                     _ => false,
                 };

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -15,7 +15,7 @@ use hash_ir::{
     ty::IrTy,
 };
 use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
-use hash_target::abi::AbiRepresentation;
+use hash_target::abi::{AbiRepresentation, ValidScalarRange};
 use hash_utils::store::Store;
 
 use super::{
@@ -285,7 +285,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 if let AbiRepresentation::Scalar(scalar_kind) = abi_layout.abi {
                     if scalar_kind.is_bool() {
-                        builder.add_range_metadata_to(value, scalar_kind.valid_range);
+                        builder.add_range_metadata_to(value, ValidScalarRange { start: 0, end: 1 });
                     }
 
                     // @@Performance: we could just pass a ptr to layout here??

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -514,6 +514,12 @@ impl AdtRepresentation {
     pub fn inhibits_struct_field_reordering(&self) -> bool {
         false
     }
+
+    /// Check whether the [AdtRepresentation] (an underlying `union`) permits
+    /// it's ABI to be optimised into a scalar-like form.
+    pub fn inhibits_union_abi_optimisations(&self) -> bool {
+        self.is_c_like()
+    }
 }
 
 /// An [AdtVariant] is a potential variant of an ADT which contains all of the

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -474,6 +474,12 @@ impl AdtRepresentation {
     fn default() -> AdtRepresentation {
         AdtRepresentation {}
     }
+
+    /// Check whether the [AdtRepresentation] permits the re-ordering
+    /// of struct fields in order to optimise for memory layout.
+    pub fn inhibits_struct_field_reordering(&self) -> bool {
+        false
+    }
 }
 
 /// An [AdtVariant] is a potential variant of an ADT which contains all of the

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -1,0 +1,159 @@
+//! Contains all of the logic that computes the layout of an [IrTy].
+//! This logic is also designed to avoid doing as much duplicate work
+//! as possible, thus using a [LayoutCache] in order to cache all the
+//! previously computed layouts, and re-use them as much as possible
+
+use hash_ir::ty::{AdtId, IrTy, IrTyId, RefKind, VariantIdx};
+use hash_target::{
+    abi::{AbiRepresentation, Integer, Scalar, ScalarKind, ValidScalarRange},
+    layout::TargetDataLayout,
+    primitives::{FloatTy, SIntTy, UIntTy},
+    size::Size,
+};
+use hash_utils::store::Store;
+
+use crate::{Layout, LayoutCtx, LayoutId, LayoutShape, Variants};
+
+/// This is an auxiliary implementation of computing the
+/// layouts of primitive types only, this does not handle ADTs
+/// or any more complex types. This function is used to populate
+/// [crate::CommonLayouts] table so that it can be used later.
+pub(crate) fn compute_primitive_ty_layout(ty: IrTy, dl: &TargetDataLayout) -> Layout {
+    let scalar_unit = |value: ScalarKind| {
+        let size = value.size(dl);
+        Scalar { kind: value, valid_range: ValidScalarRange::full(size) }
+    };
+
+    let scalar = |value: ScalarKind| Layout::scalar(dl, scalar_unit(value));
+
+    match ty {
+        IrTy::Int(int_ty) => scalar(ScalarKind::from_signed_int_ty(int_ty, dl)),
+        IrTy::UInt(uint_ty) => scalar(ScalarKind::from_unsigned_int_ty(uint_ty, dl)),
+        IrTy::Float(float_ty) => scalar(float_ty.into()),
+        IrTy::Str => {
+            // `str` is represented as a scalar pair that contains a
+            // pointer to the actual bytes, and then the length of the
+            // characters represented as a `usize`.
+            let ptr = scalar_unit(ScalarKind::Pointer);
+            let len = scalar_unit(ScalarKind::Int { kind: dl.ptr_sized_integer(), signed: false });
+
+            Layout::scalar_pair(dl, ptr, len)
+        }
+        IrTy::Bool => Layout::scalar(
+            dl,
+            Scalar {
+                kind: ScalarKind::Int { kind: Integer::I8, signed: false },
+                valid_range: ValidScalarRange { start: 0, end: 1 },
+            },
+        ),
+        IrTy::Char => Layout::scalar(
+            dl,
+            Scalar {
+                kind: ScalarKind::Int { kind: Integer::I32, signed: false },
+                valid_range: ValidScalarRange { start: 0, end: 0x10FFFF },
+            },
+        ),
+        IrTy::Never => Layout {
+            shape: LayoutShape::Primitive,
+            variants: Variants::Single { index: VariantIdx::new(0) },
+            abi: AbiRepresentation::Uninhabited,
+            alignment: dl.i8_align,
+            size: Size::ZERO,
+        },
+        _ => unreachable!("encountered non-primitive ty in `compute_primitive_ty_layout`"),
+    }
+}
+
+impl<'l> LayoutCtx<'l> {
+    /// This is the entry point of the layout computation engine. From
+    /// here, the [Layout] of a type will be computed all the way recursively
+    /// until all of the leaves of the type are also turned into [Layout]s.
+    pub fn compute_layout_of_ty(&self, ty: IrTyId) -> LayoutId {
+        let dl = self.data_layout;
+
+        let scalar_unit = |value: ScalarKind| {
+            let size = value.size(dl);
+            Scalar { kind: value, valid_range: ValidScalarRange::full(size) }
+        };
+
+        self.ir_ctx.tys().map_fast(ty, |ty| match ty {
+            IrTy::Int(ty) => match ty {
+                SIntTy::I8 => self.common_layouts.i8,
+                SIntTy::I16 => self.common_layouts.i16,
+                SIntTy::I32 => self.common_layouts.i32,
+                SIntTy::I64 => self.common_layouts.i64,
+                SIntTy::I128 => self.common_layouts.i128,
+                SIntTy::ISize => self.common_layouts.isize,
+
+                // @@Layout: for bigints, we will probably use a ScalarPair
+                // to represent a pointer to the digit array, and then a
+                // length of the digits.
+                SIntTy::IBig => todo!(),
+            },
+            IrTy::UInt(ty) => match ty {
+                UIntTy::U8 => self.common_layouts.u8,
+                UIntTy::U16 => self.common_layouts.u16,
+                UIntTy::U32 => self.common_layouts.u32,
+                UIntTy::U64 => self.common_layouts.u64,
+                UIntTy::U128 => self.common_layouts.u128,
+                UIntTy::USize => self.common_layouts.usize,
+                UIntTy::UBig => todo!(),
+            },
+            IrTy::Float(ty) => match ty {
+                FloatTy::F32 => self.common_layouts.f32,
+                FloatTy::F64 => self.common_layouts.f64,
+            },
+            IrTy::Str => self.common_layouts.str,
+            IrTy::Bool => self.common_layouts.bool,
+            IrTy::Char => self.common_layouts.char,
+            IrTy::Never => self.common_layouts.never,
+            IrTy::Ref(_, _, RefKind::Raw | RefKind::Normal) => {
+                let data_ptr = scalar_unit(ScalarKind::Pointer);
+                self.layouts().create(Layout::scalar(dl, data_ptr))
+            }
+
+            // @@Todo: figure out how to handle rc pointers, probably the same
+            // as normal ones, but the underlying type of the pointer may be
+            // wrapped in some kind of `Rc` struct?
+            IrTy::Ref(_, _, RefKind::Rc) => todo!(),
+            IrTy::Slice(_) => todo!(),
+            IrTy::Array { ty, size } => self.compute_layout_of_array(*ty, *size as u64),
+            IrTy::Adt(adt) => self.compute_layout_of_adt(*adt),
+            IrTy::Fn { .. } => todo!(),
+        })
+    }
+
+    /// Compute the layout of a given [AdtId].
+    fn compute_layout_of_adt(&self, _adt: AdtId) -> LayoutId {
+        todo!()
+    }
+
+    /// Compute the layout of a given [`IrTy::Array`].
+    fn compute_layout_of_array(&self, element_ty: IrTyId, element_count: u64) -> LayoutId {
+        // first, we compute the layout of the element type
+
+        let element = self.compute_layout_of_ty(element_ty);
+        let (element_size, element_alignment) =
+            self.layouts().map_fast(element, |element| (element.size, element.alignment));
+
+        // If the size of the array is 0, we can conclude that the
+        // abi representation of the array is uninhabited, like a ZST.
+        let abi = if element_count == 0 {
+            AbiRepresentation::Uninhabited
+        } else {
+            AbiRepresentation::Aggregate
+        };
+
+        // @@LayoutErrors: handle the overflow here as a layout error
+        // and then emit an equivalent diagnostic within the compiler.
+        let size = element_size.checked_mul(element_count, self.data_layout()).unwrap();
+
+        self.layouts().create(Layout {
+            shape: LayoutShape::Array { stride: element_size, elements: element_count },
+            abi,
+            size,
+            alignment: element_alignment,
+            variants: Variants::Single { index: VariantIdx::new(0) },
+        })
+    }
+}

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -3,16 +3,27 @@
 //! as possible, thus using a [LayoutCache] in order to cache all the
 //! previously computed layouts, and re-use them as much as possible
 
-use hash_ir::ty::{AdtId, IrTy, IrTyId, RefKind, VariantIdx};
+use std::cmp;
+
+use hash_ir::ty::{AdtData, AdtId, AdtRepresentation, IrTy, IrTyId, RefKind, VariantIdx};
 use hash_target::{
     abi::{AbiRepresentation, Integer, Scalar, ScalarKind, ValidScalarRange},
+    alignment::{Alignment, Alignments},
     layout::TargetDataLayout,
     primitives::{FloatTy, SIntTy, UIntTy},
     size::Size,
 };
 use hash_utils::store::Store;
+use index_vec::IndexVec;
 
 use crate::{Layout, LayoutCtx, LayoutId, LayoutShape, Variants};
+
+/// This describes the collection of errors that can occur
+/// when computing the layout of a type. This is used to
+/// report that either a type within a layout cannot be
+/// computed because the size is unknown, it is too large, or
+/// it is an invalid type.
+pub(crate) enum LayoutError {}
 
 /// This is an auxiliary implementation of computing the
 /// layouts of primitive types only, this does not handle ADTs
@@ -62,6 +73,21 @@ pub(crate) fn compute_primitive_ty_layout(ty: IrTy, dl: &TargetDataLayout) -> La
         },
         _ => unreachable!("encountered non-primitive ty in `compute_primitive_ty_layout`"),
     }
+}
+
+/// This function is used to invert a provided memory mapping. The
+/// mapping is a [`Vec<u32>`] which is used to map the source field
+/// order to the memory order. The values that are stored within the
+/// mapping are indices in the source order. This function inverts the
+/// mapping so that the values become the memory order, and the indices
+/// become the source order.
+fn invert_memory_mapping(mapping: &[u32]) -> Vec<u32> {
+    let mut result = vec![0; mapping.len()];
+    for i in 0..mapping.len() {
+        result[mapping[i] as usize] = i as u32;
+    }
+
+    result
 }
 
 impl<'l> LayoutCtx<'l> {
@@ -118,13 +144,214 @@ impl<'l> LayoutCtx<'l> {
             IrTy::Ref(_, _, RefKind::Rc) => todo!(),
             IrTy::Slice(_) => todo!(),
             IrTy::Array { ty, size } => self.compute_layout_of_array(*ty, *size as u64),
-            IrTy::Adt(adt) => self.compute_layout_of_adt(*adt),
+            IrTy::Adt(adt) => self.ir_ctx.map_adt(*adt, |id, adt| {
+                // We have to compute the layouts of all of the variants
+                // and all of the fields of the variants
+                let child_layouts = adt
+                    .variants
+                    .iter()
+                    .map(|variant| {
+                        variant
+                            .fields
+                            .iter()
+                            .map(|field| self.compute_layout_of_ty(field.ty))
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<IndexVec<VariantIdx, _>>();
+
+                // This is used to check whether a particular variant of the
+                // ADT is uninhabited or all of the fields are zero-sized-types.
+                let absent = |layouts: &[LayoutId]| {
+                    let (uninhabited, zst) =
+                        self.layouts.map_many_fast(layouts.iter().copied(), |layouts| {
+                            (
+                                layouts.iter().any(|layout| layout.abi.is_uninhabited()),
+                                layouts.iter().all(|layout| layout.is_zst()),
+                            )
+                        });
+
+                    uninhabited && zst
+                };
+
+                // Now we want to find two present variants within the ADT.
+                // We compute this to check whether we can perform some additional optimisations
+                // on the layout of the ADT. For instance, if this is an enum, and
+                // only has one "non-absent" variant, then we can treat it as a
+                // uni-variant enum.
+                let (first_present, second_present) = {
+                    let mut present_variants =
+                        child_layouts.iter_enumerated().filter_map(|(variant, layouts)| {
+                            if absent(&layouts) {
+                                None
+                            } else {
+                                Some(variant)
+                            }
+                        });
+
+                    (present_variants.next(), present_variants.next())
+                };
+
+                // We perform a transformation on the "first_present" in order
+                // to ensure that there is always a `first_present` value even
+                // if all of the variants are non-present.
+                let first_present = match first_present {
+                    Some(variant) => variant,
+                    // In the case of where an enum has no inhabited variants,
+                    // we return early and return the "never" layout.
+                    None if adt.flags.is_enum() => return self.common_layouts.never,
+                    None => VariantIdx::new(0),
+                };
+
+                // If it is a struct, tuple or an enum with a single variant,
+                // then we treat it as a uni-variant.
+                if adt.flags.is_struct()
+                    || adt.flags.is_tuple()
+
+                    // @@Note: if in the future, a specific type can be 
+                    // specified to the discriminant, and or it is in "C" mode,
+                    // then we can't perform this optimisation.
+                    || (adt.flags.is_enum() && second_present.is_none())
+                {
+                    self.layouts().create(self.compute_layout_of_univariant(
+                        first_present,
+                        None,
+                        &child_layouts[first_present],
+                        &adt.representation,
+                    ))
+                } else if adt.flags.is_union() {
+                    self.compute_layout_of_union(id, adt)
+                } else {
+                    // This must be an enum...
+                    self.compute_layout_of_enum(id, adt)
+                }
+            }),
             IrTy::Fn { .. } => todo!(),
         })
     }
 
-    /// Compute the layout of a given [AdtId].
-    fn compute_layout_of_adt(&self, _adt: AdtId) -> LayoutId {
+    /// Compute the layout of a "univariant" type. This is a type which only
+    /// has one variant, but potentially many fields. This function takes a
+    /// [VariantIdx] as an argument since this function may be used to compute
+    /// the layout of a single variant of an enum.
+    ///
+    /// The algorithm for computing the layout of this type is as follows:
+    ///
+    /// 1. Compute the layout of all of the fields of the type.
+    ///
+    /// If the [AdtRepresentation] does not specify any kind of options that
+    /// may prevent layout optimisation, then the following algorithm is used:
+    ///
+    ///
+    /// If the [AdtRepresentation] specifies that the representation should
+    /// follow the standard "C" layout, as specified in the following
+    /// [C standard](https://web.archive.org/web/20181230041359if_/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf).
+    fn compute_layout_of_univariant(
+        &self,
+        index: VariantIdx,
+        tag: Option<(Size, Alignment)>,
+        field_layouts: &[LayoutId],
+        representation: &AdtRepresentation,
+    ) -> Layout {
+        let dl = self.data_layout;
+        let mut abi = AbiRepresentation::Aggregate;
+
+        let mut alignment = dl.aggregate_align;
+        let mut inverse_memory_map: Vec<u32> = (0..field_layouts.len() as u32).collect();
+
+        // If we can perform a re-ordering of the fields based on
+        // the representation, then we do it here.
+        let optimise_field_order = !representation.inhibits_struct_field_reordering();
+
+        if optimise_field_order {
+            // This computes the "effective alignment" of a field. This is basically
+            // computed `log2(effective - alignment)` of the field.
+            let effective_field_alignment = |layout: &Layout| {
+                layout.alignment.abi.bytes().max(layout.size.bytes()).trailing_zeros()
+            };
+
+            // We sort the keys by the effective alignment of the field.
+            self.layouts().map_many_fast(field_layouts.iter().copied(), |layouts| {
+                if tag.is_some() {
+                    // Sort the fields in ascending alignment order so that
+                    // the layout stays optimal regardless of the prefix.
+                    inverse_memory_map.sort_by_key(|&pos| {
+                        let field = layouts[pos as usize];
+                        effective_field_alignment(field)
+                    });
+                } else {
+                    // push all of the ZSTs to the avoid having strange
+                    // offsets later..
+                    inverse_memory_map.sort_by_key(|&pos| {
+                        let field = layouts[pos as usize];
+                        (!field.is_zst(), cmp::Reverse(effective_field_alignment(field)))
+                    })
+                }
+            })
+        }
+
+        let mut offsets = vec![Size::ZERO; field_layouts.len()];
+        let mut offset = Size::ZERO;
+
+        // If the `tag` is present, we need to add the size and align it
+        // at the start of the layout.
+        if let Some((tag_size, tag_alignment)) = tag {
+            alignment = alignment.max(Alignments::new(tag_alignment));
+            offset = tag_size.align_to(tag_alignment);
+        }
+
+        for &i in &inverse_memory_map {
+            self.layouts().map_fast(field_layouts[i as usize], |layout| {
+                let field_alignment = layout.alignment;
+
+                // We can mark the overall structure as un-inhabited if
+                // we've found a field which is un-inhabited.
+                if layout.abi.is_uninhabited() {
+                    abi = AbiRepresentation::Uninhabited;
+                }
+
+                // Update the offset and alignment of the whole layout based
+                // on if the alignment of the field is larger than the current
+                // alignment of the layout.
+                offset = offset.align_to(field_alignment.abi);
+                offsets[i as usize] = offset;
+
+                alignment = alignment.max(field_alignment);
+
+                // Now increase the offset by the size of the field.
+                offset = offset.checked_add(layout.size, dl).unwrap();
+            })
+        }
+
+        // Now we can compute the size of the layout, we take the last
+        // computed "offset" and then align it to the specified ABI
+        // alignment.
+        let size = offset.align_to(alignment.abi);
+        let memory_map = if optimise_field_order {
+            invert_memory_mapping(&inverse_memory_map)
+        } else {
+            inverse_memory_map
+        };
+
+        Layout {
+            variants: Variants::Single { index },
+            shape: LayoutShape::Struct { offsets, memory_map },
+            abi,
+            alignment,
+            size,
+        }
+    }
+
+    /// Compute the layout of a `union` type.
+    fn compute_layout_of_union(&self, _id: AdtId, data: &AdtData) -> LayoutId {
+        debug_assert!(data.flags.is_union());
+
+        todo!()
+    }
+
+    /// Compute the layout of a `enum` type.
+    fn compute_layout_of_enum(&self, _id: AdtId, data: &AdtData) -> LayoutId {
+        debug_assert!(data.flags.is_enum());
+
         todo!()
     }
 

--- a/compiler/hash-target/Cargo.toml
+++ b/compiler/hash-target/Cargo.toml
@@ -3,3 +3,6 @@ name = "hash-target"
 version = "0.1.0"
 authors = ["The Hash Language authors"]
 edition = "2021"
+
+[dependencies]
+num-bigint = "0.4"

--- a/compiler/hash-target/src/layout.rs
+++ b/compiler/hash-target/src/layout.rs
@@ -89,6 +89,17 @@ pub struct TargetDataLayout {
 }
 
 impl TargetDataLayout {
+    /// Get an equivalent [Integer] representation for a pointer
+    /// on the current target.
+    pub fn ptr_sized_integer(&self) -> Integer {
+        match self.pointer_size.bits() {
+            16 => Integer::I16,
+            32 => Integer::I32,
+            64 => Integer::I64,
+            size => unreachable!("unknown pointer size of `{size}`"),
+        }
+    }
+
     /// Returns the exclusive upper bound on an object size. This is the maximum
     /// size of an object that can be allocated on the target.
     ///

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod abi;
 pub mod alignment;
 pub mod layout;
+pub mod primitives;
 pub mod size;
 
 use std::{

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -1,0 +1,301 @@
+//! Defines primitive types that are used to represent
+//! floating-point types, integers, etc. This is located
+//! here so that it can be shared across the entire compiler
+//! source, and is relevant to computing ABI and type
+//! layout information.
+
+use std::fmt;
+
+use num_bigint::BigInt;
+
+use crate::{alignment::Alignments, layout::HasDataLayout, size::Size};
+
+/// A primitive floating-point type, either a `f32` or an `f64`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum FloatTy {
+    F32,
+    F64,
+}
+
+impl FloatTy {
+    /// Compute the [Size] of the [FloatTy].
+    #[inline]
+    pub fn size(self) -> Size {
+        use FloatTy::*;
+        match self {
+            F32 => Size::from_bytes(2),
+            F64 => Size::from_bytes(4),
+        }
+    }
+
+    /// Get the [Alignments] of the [FloatTy].
+    pub fn align<C: HasDataLayout>(self, cx: &C) -> Alignments {
+        use FloatTy::*;
+        let dl = cx.data_layout();
+
+        match self {
+            F32 => dl.f32_align,
+            F64 => dl.f64_align,
+        }
+    }
+}
+
+impl fmt::Display for FloatTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FloatTy::F32 => write!(f, "f32"),
+            FloatTy::F64 => write!(f, "f64"),
+        }
+    }
+}
+
+/// Unsigned integer type variants.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum UIntTy {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    USize,
+    UBig,
+}
+
+impl UIntTy {
+    /// Get the size of [IntTy] in bytes. Returns [None] for
+    /// [UIntTy::UBig] variants
+    pub fn size(&self, ptr_width: usize) -> Option<Size> {
+        match self {
+            UIntTy::U8 => Some(Size::from_bytes(1)),
+            UIntTy::U16 => Some(Size::from_bytes(2)),
+            UIntTy::U32 => Some(Size::from_bytes(4)),
+            UIntTy::U64 => Some(Size::from_bytes(8)),
+            UIntTy::USize => Some(Size::from_bytes(ptr_width)),
+            UIntTy::U128 => Some(Size::from_bytes(16)),
+            UIntTy::UBig => None,
+        }
+    }
+
+    /// Create a new [UnitTy] from a given [Size]. This assumes that
+    /// the maximum passed [Size] can be represented as a [UIntTy::U128].
+    ///
+    /// Additionally, this will never use the `usize` type to avoid confusion
+    /// between different platforms/targets.
+    pub fn from_size(size: Size) -> Self {
+        match size.bytes() {
+            0..=1 => UIntTy::U8,
+            2 => UIntTy::U16,
+            3..=4 => UIntTy::U32,
+            5..=8 => UIntTy::U64,
+            9..=16 => UIntTy::U128,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Function to get the largest possible integer represented within this
+    /// type. For sizes `ibig` and `ubig` there is no defined max and so the
+    /// function returns [None].
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
+        match self {
+            UIntTy::U8 => Some(BigInt::from(u8::MAX)),
+            UIntTy::U16 => Some(BigInt::from(u16::MAX)),
+            UIntTy::U32 => Some(BigInt::from(u32::MAX)),
+            UIntTy::U64 => Some(BigInt::from(u64::MAX)),
+            UIntTy::U128 => Some(BigInt::from(u128::MAX)),
+            UIntTy::USize => {
+                let max = !0u64 >> (64 - (ptr_width * 8));
+                Some(BigInt::from(max))
+            }
+            UIntTy::UBig => None,
+        }
+    }
+
+    /// Function to get the most minimum integer represented within this
+    /// type.
+    pub fn min(&self) -> BigInt {
+        0.into()
+    }
+
+    /// Convert the [UIntTy] into a primitive type name
+    pub fn to_name(&self) -> &'static str {
+        match self {
+            UIntTy::U8 => "u8",
+            UIntTy::U16 => "u16",
+            UIntTy::U32 => "u32",
+            UIntTy::U64 => "u64",
+            UIntTy::U128 => "u128",
+            UIntTy::USize => "usize",
+            UIntTy::UBig => "ubig",
+        }
+    }
+}
+
+impl From<UIntTy> for IntTy {
+    fn from(value: UIntTy) -> Self {
+        IntTy::UInt(value)
+    }
+}
+
+impl fmt::Display for UIntTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_name())
+    }
+}
+
+/// Signed integer type variants.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum SIntTy {
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    ISize,
+    IBig,
+}
+
+impl SIntTy {
+    /// Get the size of [IntTy] in bytes. Returns [None] for
+    /// [UIntTy::UBig] variants
+    pub fn size(&self, ptr_width: usize) -> Option<Size> {
+        match self {
+            SIntTy::I8 => Some(Size::from_bytes(1)),
+            SIntTy::I16 => Some(Size::from_bytes(2)),
+            SIntTy::I32 => Some(Size::from_bytes(4)),
+            SIntTy::I64 => Some(Size::from_bytes(8)),
+            SIntTy::ISize => Some(Size::from_bytes(ptr_width)),
+            SIntTy::I128 => Some(Size::from_bytes(16)),
+            SIntTy::IBig => None,
+        }
+    }
+
+    /// Function to get the largest possible integer represented within this
+    /// type. For sizes `ibig` and `ubig` there is no defined max and so the
+    /// function returns [None].
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
+        match self {
+            SIntTy::I8 => Some(BigInt::from(i8::MAX)),
+            SIntTy::I16 => Some(BigInt::from(i16::MAX)),
+            SIntTy::I32 => Some(BigInt::from(i32::MAX)),
+            SIntTy::I64 => Some(BigInt::from(i64::MAX)),
+            SIntTy::I128 => Some(BigInt::from(i128::MAX)),
+            SIntTy::ISize => {
+                // convert the size to a signed integer
+                let max = (1u64 << (ptr_width * 8 - 1)) - 1;
+                Some(BigInt::from(max))
+            }
+            SIntTy::IBig => None,
+        }
+    }
+
+    /// Function to get the most minimum integer represented within this
+    /// type. For sizes `ibig` and `ubig` there is no defined minimum and so the
+    /// function returns [None].
+    pub fn min(&self, ptr_width: usize) -> Option<BigInt> {
+        match self {
+            SIntTy::I8 => Some(BigInt::from(i8::MIN)),
+            SIntTy::I16 => Some(BigInt::from(i16::MIN)),
+            SIntTy::I32 => Some(BigInt::from(i32::MIN)),
+            SIntTy::I64 => Some(BigInt::from(i64::MIN)),
+            SIntTy::I128 => Some(BigInt::from(i128::MIN)),
+            SIntTy::ISize => {
+                let min = (i64::MAX) << ((ptr_width * 8) - 1);
+                Some(BigInt::from(min))
+            }
+            SIntTy::IBig => None,
+        }
+    }
+
+    /// Convert the [IntTy] into a primitive type name
+    pub fn to_name(&self) -> &'static str {
+        match self {
+            SIntTy::I8 => "i8",
+            SIntTy::I16 => "i16",
+            SIntTy::I32 => "i32",
+            SIntTy::I64 => "i64",
+            SIntTy::I128 => "i128",
+            SIntTy::ISize => "isize",
+            SIntTy::IBig => "ibig",
+        }
+    }
+}
+
+impl From<SIntTy> for IntTy {
+    fn from(value: SIntTy) -> Self {
+        IntTy::Int(value)
+    }
+}
+
+impl fmt::Display for SIntTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_name())
+    }
+}
+
+/// The representation of an integer type.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum IntTy {
+    /// Signed integer variant.
+    Int(SIntTy),
+    /// Unsigned integer variant.
+    UInt(UIntTy),
+}
+
+impl IntTy {
+    /// Convert the type into a name.
+    pub fn to_name(&self) -> &'static str {
+        match self {
+            IntTy::Int(ty) => ty.to_name(),
+            IntTy::UInt(ty) => ty.to_name(),
+        }
+    }
+
+    /// Function to get the largest possible integer represented within this
+    /// type. For sizes `ibig` and `ubig` there is no defined max and so the
+    /// function returns [None].
+    pub fn max(&self, ptr_width: usize) -> Option<BigInt> {
+        match self {
+            IntTy::Int(ty) => ty.max(ptr_width),
+            IntTy::UInt(ty) => ty.max(ptr_width),
+        }
+    }
+
+    /// Function to get the most minimum integer represented within this
+    /// type. For sizes `ibig` there is no defined minimum and so the
+    /// function returns [None].
+    pub fn min(&self, ptr_width: usize) -> Option<BigInt> {
+        match self {
+            IntTy::Int(ty) => ty.min(ptr_width),
+            IntTy::UInt(ty) => Some(ty.min()),
+        }
+    }
+
+    /// Function to get the size of the integer type in bytes.
+    pub fn size(&self, ptr_width: usize) -> Option<Size> {
+        match self {
+            IntTy::Int(ty) => ty.size(ptr_width),
+            IntTy::UInt(ty) => ty.size(ptr_width),
+        }
+    }
+
+    /// Check if the type is signed.
+    pub fn is_signed(&self) -> bool {
+        matches!(self, IntTy::Int(_))
+    }
+
+    /// Check if the type is a pointer integral type, i.e. `isize` or `usize`.
+    pub fn is_ptr_sized_integral(self) -> bool {
+        matches!(self, IntTy::Int(SIntTy::ISize) | IntTy::UInt(UIntTy::USize))
+    }
+
+    /// Check if the type is a [BigInt] variant, i.e. `ibig` or `ubig`.
+    pub fn is_big_sized_integral(self) -> bool {
+        matches!(self, IntTy::Int(SIntTy::IBig) | IntTy::UInt(UIntTy::UBig))
+    }
+}
+
+impl fmt::Display for IntTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_name())
+    }
+}

--- a/compiler/hash-target/src/size.rs
+++ b/compiler/hash-target/src/size.rs
@@ -77,12 +77,31 @@ impl Size {
     }
 
     /// Compute a checked multiplication operation with a provided
-    /// [TargetDataLayout] context;
+    /// [HasDataLayout] context. If the total size exceeds the
+    /// maximum size of the largest target object size, then
+    /// this value cannot be represented for the current target
+    /// and thus the function will return [`None`].
     pub fn checked_mul<C: HasDataLayout>(self, count: u64, ctx: &C) -> Option<Size> {
-        let layout = ctx.data_layout();
+        let dl = ctx.data_layout();
         let bytes = self.bytes().checked_mul(count)?;
 
-        if bytes < layout.obj_size_bound() {
+        if bytes < dl.obj_size_bound() {
+            Some(Size::from_bytes(bytes))
+        } else {
+            None
+        }
+    }
+
+    /// Compute a checked addition operation with a provided
+    /// [HasDataLayout] context. If the total size exceeds the
+    /// maximum size of the largest target object size, then
+    /// this value cannot be represented for the current target
+    /// and thus the function will return [`None`].
+    pub fn checked_add<C: HasDataLayout>(self, value: Size, ctx: &C) -> Option<Size> {
+        let dl = ctx.data_layout();
+        let bytes = self.bytes().checked_add(value.bytes())?;
+
+        if bytes < dl.obj_size_bound() {
             Some(Size::from_bytes(bytes))
         } else {
             None


### PR DESCRIPTION
This PR implements all of the logic responsible for computing a type's layout. 

The basic algorithm for struct-like (univariant) types is to essentially sort the fields by the following rules:

- push all of the ZST-like fields to the start of the struct to avoid dealing with them between other fields
- sort the remaining fields in order of "effective" alignment of each field, essentially the largest fields by
size and alignment are grouped first, and then descending down. 
- try and optimise the ABI of the given type to represent it as a scalar which means it can reach more 
optimisations when code is generated for this kind.

For enum ADTs, the algorithm is the following:
- Compute the layout of the enum tag
- Compute the layout of the inner ADT of each enum variant with the provided enum tag
- Potentially adjust the enum tag if it can be nicely aligned with the rest of the enum variant alignments.
- Attempt to optimise the ABI in order to represent the enum as a scalar or a pair of scalars.

For unions:
- compute the layout of each field
- take the maximum size and alignment of the fields and propagate it to the layout of the union.
- Attempt to optimise the ABI in order to see if the layout can be represented as a scalar.

## Left to do

- Integrate the logic with the general code generation interface to call these methods and query type layouts.
- Add a nice formatter for `Layout` so that layout can be visualised for debugging purposes.
- Add a directive `#layout_of` which will allow the user to print the computed layout of a particular type.

closes #646 