### PR TITLE
codegen+ir: tie up loose ends and un-implemented items

### DIFF
--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -259,7 +259,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             ir::Operand::Place(place) => self.codegen_consume_operand(builder, *place),
             ir::Operand::Const(ref constant) => {
                 let ty = constant.ty(builder.ir_ctx());
-                let info = builder.layout_of(ty);
+                let info = builder.layout_of_id(ty);
 
                 let value = match constant {
                     ir::ConstKind::Value(const_value) => match const_value {

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -3,7 +3,7 @@
 
 use hash_ir::{
     ir,
-    ty::{IrTy, PlaceTy, VariantIdx},
+    ty::{IrTyId, PlaceTy, VariantIdx},
 };
 use hash_layout::{LayoutShape, Variants};
 use hash_target::{
@@ -119,9 +119,9 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
     pub fn codegen_get_discriminant<Builder: BlockBuilderMethods<'b, Value = V>>(
         self,
         builder: &mut Builder,
-        cast_to: IrTy,
+        cast_to: IrTyId,
     ) -> V {
-        let cast_info = builder.layout_of(cast_to);
+        let cast_info = builder.layout_of_id(cast_to);
         let cast_to_ty = builder.immediate_backend_type(cast_info);
 
         let (variants, is_uninhabited) = builder.map_layout(self.info.layout, |layout| {
@@ -289,7 +289,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Compute the type and layout of a [Place]. This deals with
     /// all projections that occur on the [Place].
     pub fn compute_place_ty_info(&self, builder: &mut Builder, place: ir::Place) -> TyInfo {
-        let place_ty = PlaceTy::from_place(place, self.body, self.ctx.ir_ctx());
+        let place_ty = PlaceTy::from_place(place, &self.body.declarations, self.ctx.ir_ctx());
         builder.layout_of_id(place_ty.ty)
     }
 

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -65,8 +65,7 @@ impl From<Const> for ConstKind {
 impl Const {
     /// Create a [Const::Zero] with a unit type, the total zero.
     pub fn zero(ctx: &IrCtx) -> Self {
-        let unit = ctx.tys().create(IrTy::unit(ctx));
-        Self::Zero(unit)
+        Self::Zero(ctx.tys().common_tys.unit)
     }
 
     /// Check if a [Const] is of integral kind.
@@ -159,10 +158,10 @@ pub enum ConstKind {
 impl ConstKind {
     /// Compute the type of the [ConstKind] provided
     /// with an IR context.
-    pub fn ty(&self, ctx: &IrCtx) -> IrTy {
+    pub fn ty(&self, _ctx: &IrCtx) -> IrTy {
         match self {
             Self::Value(value) => match value {
-                Const::Zero(_) => IrTy::unit(ctx),
+                Const::Zero(_) => IrTy::Adt(AdtId::UNIT),
                 Const::Bool(_) => IrTy::Bool,
                 Const::Char(_) => IrTy::Char,
                 Const::Int(interned_int) => {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -9,7 +9,7 @@ use std::{
 
 use hash_ast::ast;
 use hash_source::{
-    constant::{IntConstant, IntTy, InternedFloat, InternedInt, InternedStr, CONSTANT_MAP},
+    constant::{IntConstant, InternedFloat, InternedInt, InternedStr, CONSTANT_MAP},
     identifier::Identifier,
     location::{SourceLocation, Span},
     SourceId,
@@ -25,7 +25,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::{
     basic_blocks::BasicBlocks,
-    ty::{AdtId, IrTy, IrTyId, Mutability, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, Mutability, PlaceTy, ToIrTy, VariantIdx},
     IrCtx,
 };
 
@@ -158,22 +158,19 @@ pub enum ConstKind {
 impl ConstKind {
     /// Compute the type of the [ConstKind] provided
     /// with an IR context.
-    pub fn ty(&self, _ctx: &IrCtx) -> IrTy {
+    pub fn ty(&self, ctx: &IrCtx) -> IrTyId {
         match self {
             Self::Value(value) => match value {
-                Const::Zero(_) => IrTy::Adt(AdtId::UNIT),
-                Const::Bool(_) => IrTy::Bool,
-                Const::Char(_) => IrTy::Char,
+                Const::Zero(ty) => *ty,
+                Const::Bool(_) => ctx.tys().common_tys.bool,
+                Const::Char(_) => ctx.tys().common_tys.char,
                 Const::Int(interned_int) => {
-                    CONSTANT_MAP.map_int_constant(*interned_int, |int| match int.ty {
-                        IntTy::Int(int_ty) => IrTy::Int(int_ty),
-                        IntTy::UInt(uint_ty) => IrTy::UInt(uint_ty),
-                    })
+                    CONSTANT_MAP.map_int_constant(*interned_int, |int| int.ty.to_ir_ty(ctx))
                 }
                 Const::Float(interned_float) => {
-                    CONSTANT_MAP.map_float_constant(*interned_float, |float| IrTy::Float(float.ty))
+                    CONSTANT_MAP.map_float_constant(*interned_float, |float| float.ty.to_ir_ty(ctx))
                 }
-                Const::Str(_) => IrTy::Str,
+                Const::Str(_) => ctx.tys().common_tys.str,
             },
             Self::Unevaluated(UnevaluatedConst { .. }) => {
                 // @@Todo: This will be implemented when constants are clearly
@@ -540,6 +537,12 @@ impl Place {
         Self { local: RETURN_PLACE, projections: ctx.projections().create_empty() }
     }
 
+    /// Deduce the type of the [Place] from the [IrCtx] and the local
+    /// declarations.
+    pub fn ty(&self, locals: &LocalDecls, ctx: &IrCtx) -> IrTyId {
+        PlaceTy::from_place(*self, locals, ctx).ty
+    }
+
     /// Create a new [Place] from a [Local] with no projections.
     pub fn from_local(local: Local, ctx: &IrCtx) -> Self {
         Self { local, projections: ctx.projections().create_empty() }
@@ -634,6 +637,17 @@ pub enum Operand {
     Place(Place),
 }
 
+impl Operand {
+    /// Compute the type of the [Operand] based on
+    /// the IrCtx.
+    pub fn ty(&self, locals: &LocalDecls, ctx: &IrCtx) -> IrTyId {
+        match self {
+            Operand::Const(kind) => kind.ty(ctx),
+            Operand::Place(place) => place.ty(locals, ctx),
+        }
+    }
+}
+
 impl From<Operand> for RValue {
     fn from(value: Operand) -> Self {
         Self::Use(value)
@@ -711,21 +725,25 @@ impl RValue {
     }
 
     /// Get the [IrTy] of the [RValue].
-    pub fn ty(&self, store: &IrCtx) -> IrTy {
+    pub fn ty(&self, locals: &LocalDecls, ctx: &IrCtx) -> IrTyId {
         match self {
-            RValue::Use(Operand::Const(const_kind)) => const_kind.ty(store),
-            RValue::Use(Operand::Place(_)) => todo!(),
-            RValue::ConstOp(ConstOp::AlignOf | ConstOp::SizeOf, _) => IrTy::usize(),
+            RValue::Use(operand) => operand.ty(locals, ctx),
+            RValue::ConstOp(ConstOp::AlignOf | ConstOp::SizeOf, _) => ctx.tys().common_tys.usize,
             RValue::UnaryOp(_, _) => todo!(),
-            RValue::BinaryOp(_, _) => todo!(),
-            RValue::CheckedBinaryOp(_, _) => todo!(),
-            RValue::Len(_) => IrTy::usize(),
+            RValue::BinaryOp(op, box (lhs, rhs)) => {
+                op.ty(ctx, lhs.ty(locals, ctx), rhs.ty(locals, ctx))
+            }
+            RValue::CheckedBinaryOp(op, box (lhs, rhs)) => {
+                let ty = op.ty(ctx, lhs.ty(locals, ctx), rhs.ty(locals, ctx));
+                ctx.tys().create(IrTy::tuple(ctx, &[ty, ctx.tys().common_tys.bool]))
+            }
+            RValue::Len(_) => ctx.tys().common_tys.usize,
             RValue::Ref(_, _, _) => todo!(),
             RValue::Aggregate(kind, _) => match kind {
                 AggregateKind::Enum(id, _)
                 | AggregateKind::Struct(id)
-                | AggregateKind::Tuple(id) => IrTy::Adt(*id),
-                AggregateKind::Array(ty) => IrTy::Slice(*ty),
+                | AggregateKind::Tuple(id) => ctx.tys().create(IrTy::Adt(*id)),
+                AggregateKind::Array(ty) => ctx.tys().create(IrTy::Slice(*ty)),
             },
             RValue::Discriminant(_) => todo!(),
         }
@@ -1196,6 +1214,8 @@ impl fmt::Display for BodySource {
     }
 }
 
+pub type LocalDecls = IndexVec<Local, LocalDecl>;
+
 /// Represents a lowered IR body, which stores the created declarations,
 /// blocks and various other metadata about the lowered body.
 pub struct Body {
@@ -1204,8 +1224,6 @@ pub struct Body {
 
     /// Declarations of local variables:
     ///
-    /// Not final:
-    ///
     /// - The first local is used a representation of the function return value
     ///   if any.
     ///
@@ -1213,7 +1231,7 @@ pub struct Body {
     ///   function arguments.
     ///
     /// - the remaining are temporaries that are used within the function.
-    pub declarations: IndexVec<Local, LocalDecl>,
+    pub declarations: LocalDecls,
 
     /// Constants that need to be resolved after IR building and pre-codegen.
     pub needed_constants: Vec<UnevaluatedConst>,

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -1,5 +1,12 @@
 //! Hash Compiler Intermediate Representation (IR) crate.
-#![feature(let_chains, once_cell, associated_type_defaults, type_alias_impl_trait, decl_macro)]
+#![feature(
+    let_chains,
+    once_cell,
+    associated_type_defaults,
+    type_alias_impl_trait,
+    decl_macro,
+    box_patterns
+)]
 
 pub mod basic_blocks;
 pub mod ir;

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -75,7 +75,7 @@ impl IrCtx {
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::new(),
             ty_list_store: TyListStore::default(),
-            adt_store: AdtStore::default(),
+            adt_store: AdtStore::new(),
             ty_cache: RefCell::new(HashMap::new()),
         }
     }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -23,7 +23,7 @@ use hash_utils::{
 use index_vec::{index_vec, IndexVec};
 
 use crate::{
-    ir::{Body, Place, PlaceProjection},
+    ir::{LocalDecls, Place, PlaceProjection},
     write::{ForFormatting, WriteIr},
     IrCtx,
 };
@@ -861,9 +861,9 @@ impl PlaceTy {
     }
 
     /// Create a [PlaceTy] from a [Place].
-    pub fn from_place(place: Place, body: &Body, ctx: &IrCtx) -> Self {
+    pub fn from_place(place: Place, locals: &LocalDecls, ctx: &IrCtx) -> Self {
         // get the type of the local from the body.
-        let mut base = PlaceTy { ty: body.declarations[place.local].ty, index: None };
+        let mut base = PlaceTy { ty: locals[place.local].ty, index: None };
 
         ctx.projections().map_fast(place.projections, |projections| {
             for projection in projections {
@@ -906,6 +906,15 @@ impl ToIrTy for IntTy {
                 UIntTy::USize => ctx.tys().common_tys.usize,
                 _ => unimplemented!(),
             },
+        }
+    }
+}
+
+impl ToIrTy for FloatTy {
+    fn to_ir_ty(&self, ctx: &IrCtx) -> IrTyId {
+        match self {
+            FloatTy::F32 => ctx.tys().common_tys.f32,
+            FloatTy::F64 => ctx.tys().common_tys.f64,
         }
     }
 }

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -70,10 +70,8 @@ impl<'tcx> Builder<'tcx> {
         match &self.tmp_place {
             Some(tmp) => *tmp,
             None => {
-                let ty = IrTy::unit(self.ctx);
-                let ty_id = self.ctx.tys().create(ty);
-
-                let local = LocalDecl::new_auxiliary(ty_id, Mutability::Immutable);
+                let local =
+                    LocalDecl::new_auxiliary(self.ctx.tys().common_tys.unit, Mutability::Immutable);
                 let local_id = self.declarations.push(local);
 
                 let place = Place::from_local(local_id, self.ctx);

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -357,7 +357,7 @@ impl PartialOrd for IntConstant {
                     Some(left_val.cmp(&right_val))
                 } else {
                     // Deal with bigints...
-                    todo!()
+                    unimplemented!()
                 }
             }
             (IntTy::UInt(left), IntTy::UInt(right)) if left == right => {
@@ -368,7 +368,7 @@ impl PartialOrd for IntConstant {
                     Some(left_val.cmp(&right_val))
                 } else {
                     // Deal with bigints...
-                    todo!()
+                    unimplemented!()
                 }
             }
             _ => None,

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -237,7 +237,7 @@ pub enum Scalar {
         kind: ScalarKind,
 
         /// The valid range of the scalar, this is used
-        /// to provide aditional information about values
+        /// to provide additional information about values
         /// that might be encoded as scalars (for efficiency
         /// purposes), but are not actually scalars, e.g. `bool`s
         /// will be encoded as [`ScalarKind::Int`], and have

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 use num_bigint::BigInt;
 
-use crate::{alignment::Alignments, layout::HasDataLayout, size::Size};
+use crate::{abi::Integer, alignment::Alignments, layout::HasDataLayout, size::Size};
 
 /// A primitive floating-point type, either a `f32` or an `f64`.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -130,6 +130,18 @@ impl UIntTy {
     }
 }
 
+impl From<Integer> for UIntTy {
+    fn from(value: Integer) -> Self {
+        match value {
+            Integer::I8 => UIntTy::U8,
+            Integer::I16 => UIntTy::U16,
+            Integer::I32 => UIntTy::U32,
+            Integer::I64 => UIntTy::U64,
+            Integer::I128 => UIntTy::U128,
+        }
+    }
+}
+
 impl From<UIntTy> for IntTy {
     fn from(value: UIntTy) -> Self {
         IntTy::UInt(value)
@@ -220,6 +232,18 @@ impl SIntTy {
     }
 }
 
+impl From<Integer> for SIntTy {
+    fn from(value: Integer) -> Self {
+        match value {
+            Integer::I8 => SIntTy::I8,
+            Integer::I16 => SIntTy::I16,
+            Integer::I32 => SIntTy::I32,
+            Integer::I64 => SIntTy::I64,
+            Integer::I128 => SIntTy::I128,
+        }
+    }
+}
+
 impl From<SIntTy> for IntTy {
     fn from(value: SIntTy) -> Self {
         IntTy::Int(value)
@@ -242,6 +266,15 @@ pub enum IntTy {
 }
 
 impl IntTy {
+    /// Convert a [Integer] with signed-ness into a [IntTy]
+    pub fn from_integer(integer: Integer, signed: bool) -> Self {
+        if signed {
+            IntTy::Int(SIntTy::from(integer))
+        } else {
+            IntTy::UInt(UIntTy::from(integer))
+        }
+    }
+
     /// Convert the type into a name.
     pub fn to_name(&self) -> &'static str {
         match self {


### PR DESCRIPTION
This patch implements the missing functionality of deducing types from IR constructs like `RValue`s, `Place`s, `Operand`s. 

Additionally, this implements missing functionality within `hash-layout`, specifically logic for computing the layout of a field within a type.

 