### PR TITLE
lowering: fix bug with `bool` literals in `match` cases not being handled

### DIFF
--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -119,8 +119,8 @@ impl AstVisitor for AstTreeGenerator {
         &self,
         node: ast::AstNodeRef<ast::FloatLit>,
     ) -> Result<Self::FloatLitRet, Self::Error> {
-        let FloatLit { value, kind } = node.body();
-        Ok(TreeNode::leaf(labelled("float", format!("{value}{kind}"), "")))
+        let FloatLit { value, .. } = node.body();
+        Ok(TreeNode::leaf(labelled("float", format!("{value}"), "")))
     }
 
     type BoolLitRet = TreeNode;
@@ -136,9 +136,9 @@ impl AstVisitor for AstTreeGenerator {
         &self,
         node: ast::AstNodeRef<ast::IntLit>,
     ) -> Result<Self::IntLitRet, Self::Error> {
-        let IntLit { value, kind } = node.body();
+        let IntLit { value, .. } = node.body();
 
-        Ok(TreeNode::leaf(labelled("int", format!("{value}{kind}"), "")))
+        Ok(TreeNode::leaf(labelled("int", format!("{value}"), "")))
     }
 
     type BinOpRet = TreeNode;

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -15,9 +15,9 @@ use hash_source::SourceId;
 
 /// The Hash compiler code generator.
 #[derive(Default)]
-pub struct HashBackend;
+pub struct Backend;
 
-impl HashBackend {
+impl Backend {
     /// Creates a new instance of the Hash backend.
     pub fn new() -> Self {
         Self
@@ -47,7 +47,7 @@ pub trait BackendCtxQuery: CompilerInterface {
     fn data(&mut self) -> BackendCtx<'_>;
 }
 
-impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for HashBackend {
+impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for Backend {
     fn kind(&self) -> CompilerStageKind {
         CompilerStageKind::CodeGen
     }

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -111,7 +111,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// Emit code for a [`TerminatorKind::Goto`]. This function will
     /// attempt to avoid emitting a `branch` if the blocks can be merged.
     ///
-    /// Furthermore, this funciton can be used a general purpose method
+    /// Furthermore, this function can be used a general purpose method
     /// to emit code for unconditionally jumping from a block to another.
     fn codegen_goto_terminator(
         &mut self,
@@ -160,13 +160,13 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         let fn_ptr = builder.get_fn_ptr(instance);
 
         // If the return ABI pass mode is "indirect", then this means that
-        // we have to create a temporary in order to represent the "outptr"
+        // we have to create a temporary in order to represent the "out_ptr"
         // of the function.
         let mut args = Vec::with_capacity(fn_args.len() + (fn_abi.ret_abi.is_indirect() as usize));
 
         // compute the return destination of the function. If the function
         // return is indirect, `compute_fn_return_destination` will push
-        // an operand which represents the "outptr" as the first argument.
+        // an operand which represents the "out_ptr" as the first argument.
         let return_destination = if target.is_some() {
             self.compute_fn_return_destination(
                 builder,
@@ -311,7 +311,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         destination: ir::Place,
         return_abi: &ArgAbi,
         fn_args: &mut Vec<Builder::Value>,
-        is_instrinsic: bool,
+        is_intrinsic: bool,
     ) -> ReturnDestinationKind<Builder::Value> {
         // We don't need to do anything if the return value is ignored.
         if return_abi.is_ignored() {
@@ -328,7 +328,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                     // Or, intrinsics need a place to store their result due to it being
                     // unclear on how to transfer the result directly...
                     //
-                    return if return_abi.is_indirect() || is_instrinsic {
+                    return if return_abi.is_indirect() || is_intrinsic {
                         let temp = PlaceRef::new_stack(builder, return_abi.info);
                         temp.storage_live(builder);
                         ReturnDestinationKind::IndirectOperand(temp, local)
@@ -458,7 +458,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             //
             // Ref: https://cs.github.com/rust-lang/rust/blob/3020239de947ec52677e9b4e853a6a9fc073d1f9/compiler/rustc_codegen_ssa/src/mir/block.rs#L335
         } else if targets_iter.len() == 2
-            && self.body.blocks()[targets.otherwise()].is_empty_and_unreacheable()
+            && self.body.blocks()[targets.otherwise()].is_empty_and_unreachable()
             && self.ctx.settings().optimisation_level == OptimisationLevel::Debug
             && self.ctx.settings().codegen_settings().backend == CodeGenBackend::LLVM
         {
@@ -513,7 +513,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         // Add a hint for the condition as "expecting" the provided value
         let condition = builder.codegen_expect_intrinsic(condition, expected);
 
-        // Create a failure blockm and a conditional branch to it.
+        // Create a failure block and a conditional branch to it.
         let failure_block = builder.append_sibling_block("assert_failure");
         let target = self.get_codegen_block_id(target);
 
@@ -530,7 +530,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         let message = builder.const_str(assert_kind.message());
         let args = &[message.0, message.1];
 
-        // @@Todo: we need to create a call to `panic`, as in resolve the funciton
+        // @@Todo: we need to create a call to `panic`, as in resolve the function
         // abi to `panic` and the relative function pointer.
         let (fn_abi, fn_ptr) = self.resolve_intrinsic(builder, Intrinsic::Panic);
 

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1154,7 +1154,7 @@ impl BasicBlockData {
 
     /// Check if the [BasicBlockData] is empty, i.e. has no statements and
     /// the terminator is of kind [TerminatorKind::Unreachable].
-    pub fn is_empty_and_unreacheable(&self) -> bool {
+    pub fn is_empty_and_unreachable(&self) -> bool {
         self.statements.is_empty()
             && self.terminator.as_ref().map_or(false, |t| t.kind == TerminatorKind::Unreachable)
     }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -199,7 +199,7 @@ impl IrTy {
 
     /// Check if the [IrTy] is an integral type.
     pub fn is_integral(&self) -> bool {
-        matches!(self, Self::Int(_) | Self::UInt(_) | Self::Float(_) | Self::Char)
+        matches!(self, Self::Int(_) | Self::UInt(_) | Self::Float(_) | Self::Char | Self::Bool)
     }
 
     /// Check if the [IrTy] is a floating point type.
@@ -238,7 +238,7 @@ impl IrTy {
     pub fn as_adt(&self) -> AdtId {
         match self {
             Self::Adt(adt_id) => *adt_id,
-            _ => panic!("expected ADT"),
+            ty => panic!("expected ADT, but got {ty:?}"),
         }
     }
 
@@ -412,12 +412,12 @@ impl AdtData {
     /// Compute the representation of the discriminant of this [AdtData]
     /// in terms of a [abi::Integer].
     ///
-    /// @@Future(discriminants): we would need to acount for different
+    /// @@Future(discriminants): we would need to account for different
     /// representations of the discriminant, e.g. `repr(u8)`, and specified
     /// values on the discriminant.
     ///
     /// For now, we always use the "unsigned" integer representation, and try
-    /// to minimuse the size of the discriminant.
+    /// to minimise the size of the discriminant.
     pub fn discriminant_representation<C: HasDataLayout>(&self, ctx: &C) -> abi::Integer {
         let max = self.variants.len() as u128;
         let computed_fit = abi::Integer::fit_unsigned(max);

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -32,7 +32,7 @@ use hash_types::pats::{
 use hash_utils::store::Store;
 use smallvec::{smallvec, SmallVec};
 
-use crate::build::{place::PlaceBuilder, ty::evaluate_int_lit_term, Builder};
+use crate::build::{place::PlaceBuilder, Builder};
 
 /// A [Candidate] is a representation of a single `match` arm that
 /// is used to generate code for a `match` block. [Candidate]s store
@@ -188,7 +188,7 @@ impl<'tcx> Builder<'tcx> {
             // Check if the bindings has a single or-pattern
             if let [pair] = &*match_pairs {
                 if self.tcx.pat_store.map_fast(pair.pat, Pat::is_or) {
-                    // append all the new bindings, and then swap the two vecs around
+                    // append all the new bindings, and then swap the two vectors around
                     existing_bindings.extend_from_slice(&new_bindings);
                     mem::swap(&mut candidate.bindings, &mut existing_bindings);
 
@@ -227,7 +227,7 @@ impl<'tcx> Builder<'tcx> {
             candidate.bindings.clear();
 
             if !changed {
-                // append all the new bindings, and then swap the two vecs around
+                // append all the new bindings, and then swap the two vectors around
                 existing_bindings.extend_from_slice(&new_bindings);
                 mem::swap(&mut candidate.bindings, &mut existing_bindings);
 
@@ -314,10 +314,10 @@ impl<'tcx> Builder<'tcx> {
                         // we have to convert the `lo` term into the actual value, by getting
                         // the literal term from this term, and then converting the stored value
                         // into a u128...
-                        let lo_val = evaluate_int_lit_term(*lo, self.tcx).1 ^ bias;
+                        let lo_val = self.evaluate_const_pat_term(*lo).1 ^ bias;
 
                         if lo_val <= min {
-                            let hi_val = evaluate_int_lit_term(*hi, self.tcx).1 ^ bias;
+                            let hi_val = self.evaluate_const_pat_term(*hi).1 ^ bias;
 
                             // In this situation, we have an irrefutable pattern, so we can
                             // always go down this path
@@ -396,7 +396,7 @@ impl<'tcx> Builder<'tcx> {
                         // @@FixMe: this is not the correct place to use, since we might encounter
                         //           a spread pattern in various locations which means we might
                         //           affect the actual place that is being referenced. This process
-                        //           should be alot simpler to do we switch to the new pattern
+                        //           should be a lot simpler to do we switch to the new pattern
                         //           representation. This is because, the spreads are now on each
                         //           specific pattern, which means that we can more precisely
                         // determine           the place that we are

--- a/compiler/hash-lower/src/build/matches/utils.rs
+++ b/compiler/hash-lower/src/build/matches/utils.rs
@@ -4,9 +4,9 @@ use std::cmp::Ordering;
 
 use hash_ast::ast::RangeEnd;
 use hash_ir::ir::{compare_constant_values, Const};
-use hash_types::{pats::RangePat, storage::GlobalStorage};
+use hash_types::pats::RangePat;
 
-use crate::build::ty::evaluate_int_lit_term;
+use crate::build::Builder;
 
 /// A constant range which is a representation of a range pattern, but
 /// instead of using [TermId]s, we directly store these with [Const]s.
@@ -24,10 +24,10 @@ pub(super) struct ConstRange {
 }
 
 impl ConstRange {
-    /// Create a [ConstRange] from [PatRange].
-    pub fn from_range(range: &RangePat, tcx: &GlobalStorage) -> Self {
-        let (lo, _) = evaluate_int_lit_term(range.lo, tcx);
-        let (hi, _) = evaluate_int_lit_term(range.hi, tcx);
+    /// Create a [ConstRange] from [RangePat].
+    pub fn from_range(range: &RangePat, builder: &Builder) -> Self {
+        let (lo, _) = builder.evaluate_const_pat_term(range.lo);
+        let (hi, _) = builder.evaluate_const_pat_term(range.hi);
 
         Self { lo, hi, end: range.end }
     }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -7,11 +7,11 @@
 
 use hash_ir::{
     ir::Const,
-    ty::{AdtData, IrTy, IrTyId, VariantIdx},
+    ty::{IrTy, IrTyId, VariantIdx},
 };
-use hash_source::constant::CONSTANT_MAP;
+use hash_source::{constant::CONSTANT_MAP, identifier::IDENTS};
 use hash_types::{
-    nominals::EnumVariantValue,
+    nominals::{EnumVariantValue, NominalDefId},
     storage::GlobalStorage,
     terms::{FnLit, FnTy, Level0Term, Level1Term, LitTerm, Term, TermId},
 };
@@ -25,22 +25,6 @@ pub(super) fn get_fn_ty_from_term(term_id: TermId, tcx: &GlobalStorage) -> FnTy 
     tcx.term_store.map_fast(term_id, |term| match term {
         Term::Level0(Level0Term::FnLit(FnLit { fn_ty, .. })) => get_fn_ty_from_term(*fn_ty, tcx),
         Term::Level1(Level1Term::Fn(fn_ty)) => *fn_ty,
-        _ => unreachable!(),
-    })
-}
-
-/// Assuming that the provided [TermId] is a literal term, we essentially
-/// convert the term into a [Const] and return the value of the constant
-/// as a [u128]. This literal term must be an integral type.
-pub(crate) fn evaluate_int_lit_term(term: TermId, tcx: &GlobalStorage) -> (Const, u128) {
-    tcx.term_store.map_fast(term, |term| match term {
-        Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => CONSTANT_MAP
-            .map_int_constant(*value, |val| {
-                (Const::Int(*value), u128::from_be_bytes(val.get_bytes()))
-            }),
-        Term::Level0(Level0Term::Lit(LitTerm::Char(char))) => {
-            (Const::Char(*char), u128::from(*char))
-        }
         _ => unreachable!(),
     })
 }
@@ -70,15 +54,63 @@ impl<'tcx> Builder<'tcx> {
         ctx.ty_from_term(term)
     }
 
-    /// This function will attempt to lower a provided [TermId] into a specified
-    /// variant of a [AdtData]. This function assumed that the specified term is
+    /// Get the [IrTyId] from the given [NominalDefId].
+    pub(super) fn lower_nominal_as_id(&self, nominal: NominalDefId) -> IrTyId {
+        let ctx = TyLoweringCtx { tcx: self.tcx, lcx: self.ctx };
+        ctx.ty_id_from_nominal(nominal)
+    }
+
+    /// Assuming that the provided [TermId] is a literal term, we essentially
+    /// convert the term into a [Const] and return the value of the constant
+    /// as a [u128]. This literal term must be an integral type.
+    pub(crate) fn evaluate_const_pat_term(&self, term: TermId) -> (Const, u128) {
+        self.tcx.term_store.map_fast(term, |ty| match ty {
+            Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => CONSTANT_MAP
+                .map_int_constant(*value, |val| {
+                    (Const::Int(*value), u128::from_be_bytes(val.get_bytes()))
+                }),
+            Term::Level0(Level0Term::Lit(LitTerm::Char(char))) => {
+                (Const::Char(*char), u128::from(*char))
+            }
+            Term::Level0(Level0Term::EnumVariant(_)) => {
+                let variant_value = self.evaluate_enum_variant_as_index(term);
+                let bool_value = variant_value.index() == 1;
+                (Const::Bool(bool_value), u128::from(bool_value))
+            }
+            _ => unreachable!(),
+        })
+    }
+
+    /// This function will attempt to lower a provided [TermId] into a
+    /// [VariantIdx]. This function assumed that the specified term is
     /// a [Term::Level0] enum variant which belongs to the specified adt,
     /// otherwise the function will panic.
-    pub(crate) fn lower_enum_variant_ty(&self, adt: &AdtData, term: TermId) -> VariantIdx {
+    pub(crate) fn evaluate_enum_variant_as_index(&self, term: TermId) -> VariantIdx {
         self.tcx.term_store.map_fast(term, |term| match term {
             Term::Level0(level0_term) => match level0_term {
-                Level0Term::EnumVariant(EnumVariantValue { name: variant_name, .. }) => {
-                    adt.variant_idx(variant_name).unwrap()
+                Level0Term::EnumVariant(EnumVariantValue { name, def_id }) => {
+                    // we essentially re-compute the variant type, and then
+                    // compute the variant name index. This should be done
+                    // reasonably cheaply since the type of the nominal has
+                    // already been lowered, and then it is just a matter of
+                    // looking up the cached type.
+                    let ty = self.lower_nominal_as_id(*def_id);
+
+                    self.ctx.tys().map_fast(ty, |ty| {
+                        match ty {
+                            IrTy::Adt(adt) => {
+                                self.ctx.map_adt(*adt, |_, adt| adt.variant_idx(name).unwrap())
+                            }
+                            // @@Hack: The only case this could be is boolean type, since we don't
+                            // represent it as an ADT, but it's own type.  So we just match on the
+                            // variant name and return the correct index.
+                            _ => match *name {
+                                i if i == IDENTS.r#true => VariantIdx::new(1),
+                                i if i == IDENTS.r#false => VariantIdx::new(0),
+                                _ => unreachable!(),
+                            },
+                        }
+                    })
                 }
                 term => panic!("expected enum variant, but got: {term:?}"),
             },

--- a/compiler/hash-reporting/src/macros.rs
+++ b/compiler/hash-reporting/src/macros.rs
@@ -21,3 +21,23 @@ pub macro panic_on_span {
         panic_on_span!($location, $sources, format!($fmt, $($arg)*))
     }
 }
+
+/// This macro will produce a [crate::report::Report] and then print it to the
+/// standard output, this does not panic, it is intended as a debugging utility
+/// to quickly print the `span` of something and the `message` associated with
+/// it.
+pub macro compiler_note {
+    ($location:expr, $sources:expr, $fmt: expr) => {
+        {
+            let mut reporter = $crate::reporter::Reporter::new();
+            reporter.info()
+                .title($fmt)
+                .add_labelled_span($location, "here");
+
+            eprintln!("{}", $crate::writer::ReportWriter::new(reporter.into_reports(), $sources));
+        }
+    },
+    ($location:expr, $sources:expr, $fmt: expr, $($arg:tt)*) => {
+        compiler_note!($location, $sources, format!($fmt, $($arg)*))
+    }
+}

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -11,7 +11,7 @@
 use hash_ast::node_map::NodeMap;
 use hash_ast_desugaring::{AstDesugaringCtx, AstDesugaringCtxQuery, AstDesugaringPass};
 use hash_ast_expand::{AstExpansionCtx, AstExpansionCtxQuery, AstExpansionPass};
-use hash_backend::{BackendCtx, BackendCtxQuery, HashBackend};
+use hash_backend::{Backend, BackendCtx, BackendCtxQuery};
 use hash_ir::IrStorage;
 use hash_layout::LayoutCtx;
 use hash_lower::{IrGen, IrOptimiser, LoweringCtx, LoweringCtxQuery};
@@ -31,13 +31,13 @@ use hash_untyped_semantics::{SemanticAnalysis, SemanticAnalysisCtx, SemanticAnal
 pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
     vec![
         Box::new(Parser),
-        Box::new(AstExpansionPass),
         Box::new(AstDesugaringPass),
+        Box::new(AstExpansionPass),
         Box::new(SemanticAnalysis),
         Box::new(Typechecker::new()),
         Box::<IrGen>::default(),
         Box::new(IrOptimiser),
-        Box::new(HashBackend::new()),
+        Box::new(Backend::new()),
     ]
 }
 


### PR DESCRIPTION
This patch fixes a bug with `bool` patterns not being lowered within the match jump table construction logic. 

Additionally, this patch does the following:
- fixes a printing of integer/float literal in the AST, since their suffix was being printed twice.
- introduces `compiler_note!` macro for emitting a _note_ for a given span, which is useful for
debugging things that have a `Span` on them.