### PR TITLE
layout+lower: improvements and documentation clean

### DIFF
--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -68,7 +68,7 @@ fn cast_shift_value<'b, Builder: BlockBuilderMethods<'b>>(
     let lhs_size = builder.int_width(lhs_ty);
     let rhs_size = builder.int_width(rhs_ty);
 
-    // If the size of `lhs` is smallar than `rhs`, we need
+    // If the size of `lhs` is smaller than `rhs`, we need
     // to truncate `rhs` to the size of `lhs`.
     match lhs_size.cmp(&rhs_size) {
         std::cmp::Ordering::Less => builder.truncate(rhs, lhs_ty),
@@ -113,7 +113,7 @@ fn build_unchecked_rshift<'b, Builder: BlockBuilderMethods<'b>>(
     let is_signed = builder.ctx().ir_ctx().tys().map_fast(ty, |ty| ty.is_signed());
 
     if is_signed {
-        // Arithemetic right shift
+        // Arithmetic right shift
         builder.ashr(lhs, rhs)
     } else {
         // Logical right shift

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -3,7 +3,7 @@
 
 use hash_ir::{
     ir::{self, BinOp},
-    ty::{self, IrTyId, VariantIdx},
+    ty::{self, IrTyId, RefKind, VariantIdx},
 };
 use hash_utils::store::Store;
 
@@ -301,7 +301,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             }
             ir::RValue::Ref(_, place, kind) => {
                 match kind {
-                    ir::AddressMode::Raw => {
+                    RefKind::Normal | RefKind::Raw => {
                         let ty = rvalue.ty(&self.body.declarations, self.ctx.ir_ctx());
                         let place = self.codegen_place(builder, place);
 
@@ -316,7 +316,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                     // @@Pointers: decide more clearly on what this means, and
                     // when they are used/rules, etc.
-                    ir::AddressMode::Smart => unimplemented!(),
+                    RefKind::Rc => unimplemented!(),
                 }
             }
             ir::RValue::Discriminant(place) => {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -25,7 +25,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::{
     basic_blocks::BasicBlocks,
-    ty::{AdtId, IrTy, IrTyId, Mutability, PlaceTy, ToIrTy, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, Mutability, PlaceTy, RefKind, ToIrTy, VariantIdx},
     IrCtx,
 };
 
@@ -454,16 +454,6 @@ impl LocalDecl {
     }
 }
 
-/// The addressing mode of the [RValue::Ref].
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum AddressMode {
-    /// Take the `&raw` reference of something.
-    Raw,
-    /// Take the `&` reference of something, meaning that it is reference
-    /// counted.
-    Smart,
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PlaceProjection {
     /// When we want to narrow down the union type to some specific
@@ -688,7 +678,7 @@ pub enum RValue {
 
     /// An expression which is taking the address of another expression with an
     /// mutability modifier e.g. `&mut x`.
-    Ref(Mutability, Place, AddressMode),
+    Ref(Mutability, Place, RefKind),
     /// Used for initialising structs, tuples and other aggregate
     /// data structures
     Aggregate(AggregateKind, Vec<Operand>),

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -7,6 +7,7 @@
 use std::{cmp, fmt};
 
 use bitflags::bitflags;
+use hash_ast::ast;
 use hash_source::{
     constant::{FloatTy, IntTy, SIntTy, UIntTy},
     identifier::Identifier,
@@ -57,13 +58,11 @@ impl Mutability {
     }
 }
 
-impl From<hash_ast::ast::Mutability> for Mutability {
-    fn from(value: hash_ast::ast::Mutability) -> Self {
-        use hash_ast::ast::Mutability::*;
-
+impl From<ast::Mutability> for Mutability {
+    fn from(value: ast::Mutability) -> Self {
         match value {
-            Mutable => Mutability::Mutable,
-            Immutable => Mutability::Immutable,
+            ast::Mutability::Mutable => Mutability::Mutable,
+            ast::Mutability::Immutable => Mutability::Immutable,
         }
     }
 }

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -15,11 +15,11 @@
 //!    code for nodes that don't need to be dealt with.
 use crate::{
     ir::{
-        AddressMode, AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, Body, ConstKind,
-        ConstOp, IrRef, Local, Operand, Place, PlaceProjection, RValue, Statement, SwitchTargets,
+        AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, Body, ConstKind, ConstOp,
+        IrRef, Local, Operand, Place, PlaceProjection, RValue, Statement, SwitchTargets,
         Terminator, UnaryOp,
     },
-    ty::{IrTyId, Mutability, VariantIdx},
+    ty::{IrTyId, Mutability, RefKind, VariantIdx},
     IrCtx,
 };
 
@@ -163,7 +163,7 @@ pub trait IrVisitorMut<'ir>: Sized {
         &mut self,
         mutability: Mutability,
         value: &Place,
-        mode: AddressMode,
+        mode: RefKind,
         reference: IrRef,
     ) {
         walk_mut::walk_ref_rvalue(self, mutability, value, mode, reference);
@@ -459,7 +459,7 @@ pub mod walk_mut {
         visitor: &mut V,
         mutability: Mutability,
         place: &Place,
-        _: AddressMode,
+        _: RefKind,
         reference: IrRef,
     ) {
         // @@Todo: do we need to have different contexts for different
@@ -608,7 +608,7 @@ pub trait ModifyingIrVisitor<'ir>: Sized {
         &self,
         mutability: &mut Mutability,
         value: &mut Place,
-        mode: &mut AddressMode,
+        mode: &mut RefKind,
         reference: IrRef,
     ) {
         walk_modifying::walk_ref_rvalue(self, mutability, value, mode, reference);
@@ -915,7 +915,7 @@ pub mod walk_modifying {
         visitor: &V,
         mutability: &mut Mutability,
         place: &mut Place,
-        _: &mut AddressMode,
+        _: &mut RefKind,
         reference: IrRef,
     ) {
         // @@Todo: do we need to have different contexts for different

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -251,7 +251,12 @@ impl fmt::Display for ForFormatting<'_, &Terminator> {
                 Ok(())
             }
             TerminatorKind::Assert { condition, expected, kind, target } => {
-                write!(f, "assert({}, {expected:?}, {kind:?})", condition.for_fmt(self.ctx))?;
+                write!(
+                    f,
+                    "assert({}, {expected:?}, \"{}\")",
+                    condition.for_fmt(self.ctx),
+                    kind.for_fmt(self.ctx)
+                )?;
 
                 if self.with_edges {
                     write!(f, " -> {target:?}")?;

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -313,7 +313,7 @@ impl BoxRow {
     /// Create a new [BoxRow] with the given contents.
     pub fn new(contents: Vec<BoxContent>) -> Self {
         let widths = contents.iter().map(|c| c.width()).collect();
-        let max_height = contents.iter().map(|c| c.height()).max().unwrap_or(0);
+        let max_height = contents.iter().map(|c| c.height()).max().unwrap_or(1);
 
         Self { contents, widths, max_height }
     }
@@ -323,6 +323,18 @@ impl BoxRow {
     /// box in the row.
     pub fn width(&self) -> usize {
         self.widths.iter().sum::<usize>() + self.widths.len() + 1
+    }
+
+    /// Get the width of a[BoxContent] at the given index.
+    pub fn width_at(&self, index: usize) -> Option<usize> {
+        self.widths.get(index).copied()
+    }
+
+    /// Set the width of a [BoxContent] at the given index.
+    pub fn set_width_at(&mut self, index: usize, width: usize) {
+        if let Some(w) = self.widths.get_mut(index) {
+            *w = width;
+        }
     }
 
     /// Potentially adjust the width of the [BoxRow] to fit the given
@@ -571,19 +583,29 @@ impl<'l> LayoutWriter<'l> {
         self.with_info(|this, ty, layout| this.create_box_contents(ty, layout, None))
     }
 
+    /// Create all of the [BoxContent]s that represent the inner layout of a
+    /// variant within the [LayoutShape].
+    ///
+    /// N.B. This inserts an initial box at the start of each row to identify
+    /// the variant of the enum.
     pub fn create_box_contents_for_variant(
         &self,
         variant: VariantIdx,
+        tag_size: Size,
+        tag_box_width: usize,
         layout: LayoutId,
-    ) -> Vec<BoxContent> {
+    ) -> BoxRow {
         self.ctx.ir_ctx().tys().map_fast(self.ty_info.ty, |ty| {
-            let mut contents = self
-                .ctx
-                .map_fast(layout, |layout| self.create_box_contents(ty, layout, Some(variant)));
+            let mut contents = self.ctx.map_fast(layout, |layout| {
+                self.create_box_contents(ty, layout, Some((tag_size, variant)))
+            });
 
             // we also insert an initial box with the variant name
             contents.insert(0, BoxContent::new(variant.to_string(), "".to_string()));
-            contents
+
+            let mut row = BoxRow::new(contents);
+            row.set_width_at(0, tag_box_width);
+            row
         })
     }
 
@@ -597,7 +619,7 @@ impl<'l> LayoutWriter<'l> {
         &self,
         ty: &IrTy,
         layout: &Layout,
-        variant: Option<VariantIdx>,
+        variant: Option<(Size, VariantIdx)>,
     ) -> Vec<BoxContent> {
         let mut boxes = Vec::new();
 
@@ -649,7 +671,9 @@ impl<'l> LayoutWriter<'l> {
                             // "layouts" of the type.
                             let variant = match layout.variants {
                                 Variants::Single { index } => index,
-                                Variants::Multiple { .. } => variant.unwrap(),
+                                Variants::Multiple { .. } => {
+                                    variant.map(|(_, variant)| variant).unwrap()
+                                }
                             };
 
                             adt.variant(variant)
@@ -677,22 +701,30 @@ impl<'l> LayoutWriter<'l> {
                 // The current computed size of the aggregate disregarding the last padding
                 // on the field (if any).
                 let mut current_size = Size::ZERO;
+                let tag_size = variant.map(|(tag_size, _)| tag_size).unwrap_or(Size::ZERO);
 
-                for index in layout.shape.iter_increasing_offsets() {
-                    let FieldLayout { offset, size } = fields[index];
+                for (order_index, offset_index) in
+                    layout.shape.iter_increasing_offsets().enumerate()
+                {
+                    let FieldLayout { offset, size } = fields[offset_index];
 
                     // we skip the first field, as the padding before this field
                     // maybe as the result of being within a variant, and therefore
                     // the padding will be handled by the variant printing.
-                    if current_size < offset && index != 0 {
-                        let pad_size = offset - current_size;
+                    let true_offset = if order_index == 0 { offset - tag_size } else { offset };
+
+                    if current_size < true_offset {
+                        let pad_size = true_offset - current_size;
 
                         // we need to add this as padding to the content
                         boxes.push(BoxContent::new_pad(pad_size));
                     }
 
                     boxes.push(BoxContent::new(
-                        format!("{}: {}", field_titles[index].0, field_titles[index].1),
+                        format!(
+                            "{}: {}",
+                            field_titles[offset_index].0, field_titles[offset_index].1
+                        ),
                         format!(
                             "  size: {}\noffset: {}\n align: {}",
                             size, offset, layout.alignment.abi
@@ -704,7 +736,7 @@ impl<'l> LayoutWriter<'l> {
 
                 // If the `current_size` isn't equal to the size of the layout, then
                 // we need to add padding box to the content.
-                if current_size < layout.size {
+                if current_size != Size::ZERO && current_size < layout.size {
                     let pad_size = layout.size - current_size;
 
                     // we need to add this as padding to the content
@@ -714,6 +746,24 @@ impl<'l> LayoutWriter<'l> {
         }
 
         boxes
+    }
+
+    /// For multi-variant layouts, we want to create a row that represents
+    /// the tag of the variant. This function will construct the tag variant
+    /// and return the [BoxRow] for this.
+    fn compute_tag_box_row(&self, tag_size: Size, layout: &Layout) -> BoxRow {
+        let offset = layout.shape.offset(0);
+
+        if tag_size < offset {
+            // we need to print the tag box first, and then the
+            // variants.
+            BoxRow::new(vec![
+                BoxContent::new(format!("{tag_size} tag"), "".to_string()),
+                BoxContent::new_pad(offset - tag_size),
+            ])
+        } else {
+            BoxRow::new(vec![BoxContent::new(format!("{tag_size} tag"), "".to_string())])
+        }
     }
 }
 
@@ -770,23 +820,22 @@ impl fmt::Display for LayoutWriter<'_> {
                     Ok(())
                 }
                 Variants::Multiple { tag, field: _, ref variants } => {
+                    let tag_size = tag.size(self.ctx.data_layout());
+                    let tag_row = self.compute_tag_box_row(tag_size, layout);
+                    let tag_box_width = tag_row.width_at(0).unwrap();
+
                     // firstly, deal with the tag box which is just essentially,
                     // a title with the size of the tag, possible padding and then
                     // the variants proceed after it.
-                    let mut content_table = variants
-                        .iter_enumerated()
-                        .map(|(index, layout)| {
-                            let contents = self.create_box_contents_for_variant(index, *layout);
-                            let max_height = contents
-                                .iter()
-                                .map(|box_content| box_content.height())
-                                .max()
-                                .unwrap_or(1);
-                            let widths: Vec<_> =
-                                contents.iter().map(|box_content| box_content.width()).collect();
-
-                            BoxRow { contents, widths, max_height }
-                        })
+                    let mut content_table = iter::once(tag_row)
+                        .chain(variants.iter_enumerated().map(|(index, layout)| {
+                            self.create_box_contents_for_variant(
+                                index,
+                                tag_size,
+                                tag_box_width,
+                                *layout,
+                            )
+                        }))
                         .collect::<Vec<_>>();
 
                     // Now, we might need to adjust the last content boxes in order to
@@ -807,29 +856,6 @@ impl fmt::Display for LayoutWriter<'_> {
 
                     debug_assert!(content_table.iter().all(|row| { row.width() == max_row_width }));
 
-                    // Now we will insert the "tag" row above all of the other rows.
-                    // Deal with the tag box or boxes first...
-                    let tag_size = tag.size(self.ctx.data_layout());
-
-                    let offset = layout.shape.offset(0);
-                    let mut tag_row = if tag_size < offset {
-                        // we need to print the tag box first, and then the
-                        // variants.
-                        BoxRow::new(vec![
-                            BoxContent::new(format!("{tag_size} tag"), "".to_string()),
-                            BoxContent::new_pad(offset - tag_size),
-                        ])
-                    } else {
-                        BoxRow::new(vec![BoxContent::new(
-                            format!("{tag_size} tag"),
-                            "".to_string(),
-                        )])
-                    };
-
-                    // adjust the row to the maximum row size and insert it into the table contents
-                    tag_row.adjust_to_width(max_row_width);
-                    content_table.insert(0, tag_row);
-
                     let helper = LayoutWriterHelper { config: &self.config };
 
                     // First draw the horizontal edge of the start
@@ -837,12 +863,12 @@ impl fmt::Display for LayoutWriter<'_> {
 
                     let write_row = |f: &mut fmt::Formatter<'_>, row: &BoxRow| -> fmt::Result {
                         for line in 0..row.max_height {
-                            for content_box in row.contents.iter() {
+                            for (index, content_box) in row.contents.iter().enumerate() {
                                 write!(
                                     f,
                                     "{}{}",
                                     self.config.vertical,
-                                    content_box.line_contents(line, None)
+                                    content_box.line_contents(line, row.width_at(index))
                                 )?;
                             }
 

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -1,7 +1,26 @@
 //! Contains logic for displaying a computed [Layout] in a pretty format
 //! that can be queried by users.
 //!
-//! @@Todo(feds01): add unit tests for these layouts.
+//! @@Improvements:
+//!
+//! 1. Since the layout printer is only a shallow printer, an improvement could
+//! be made to print the layout of the types that are nested within the type,
+//! and possibly exploring the nested structure:
+//! ```ignore
+//! struct Item (
+//!    item: ( #layout_of (y: i32, x: i32), z: [i32; 3]
+//!     ...
+//! )
+//! ```
+//!
+//! And it will print the layout of the inner type, but this requires to support
+//! @@UniversalParserDirectives.
+//!
+//!
+//! 2. Add unit tests for some layout printing
+//!
+//! 3. Scale each field in the layout print to the size of the largest field, to
+//! more accurately represent the layout of the type.
 
 use std::{fmt, iter};
 

--- a/compiler/hash-lower/src/build/category.rs
+++ b/compiler/hash-lower/src/build/category.rs
@@ -1,9 +1,9 @@
 //! Defines a category of AST expressions which can be used to determine how to
 //! lower them throughout the lowering stage.
 
-use hash_ast::ast::{AstNodeRef, Expr, LitExpr};
+use hash_ast::ast;
 
-/// A [Category] represents what category [Expr]s belong to
+/// A [Category] represents what category [ast::Expr]s belong to
 /// when they are being lowered. Depending on the category, we
 /// might emit different code when dealing with temporaries, etc.
 #[derive(Debug, PartialEq)]
@@ -25,17 +25,17 @@ pub(crate) enum Category {
 /// Determines the category for a given expression. Note that scope
 /// and paren expressions have no category.
 impl Category {
-    pub(crate) fn of(expr: AstNodeRef<'_, Expr>) -> Self {
+    pub(crate) fn of(expr: ast::AstNodeRef<'_, ast::Expr>) -> Self {
         match expr.body() {
             // Constants that are not primitive are dealt with as
             // RValues.
-            Expr::Lit(LitExpr { data }) if data.is_primitive() => Self::Constant,
+            ast::Expr::Lit(ast::LitExpr { data }) if data.is_primitive() => Self::Constant,
 
-            Expr::Access(..)
-            | Expr::Index(..)
-            | Expr::Ref(..)
-            | Expr::Deref(..)
-            | Expr::Variable(..) => Self::Place,
+            ast::Expr::Access(..)
+            | ast::Expr::Index(..)
+            | ast::Expr::Ref(..)
+            | ast::Expr::Deref(..)
+            | ast::Expr::Variable(..) => Self::Place,
 
             // Everything else is considered as an RValue of some kind.
             _ => Self::RValue,

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -4,7 +4,7 @@
 
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 
-use hash_ast::ast::{AstNodeRef, Expr, Lit, LitExpr};
+use hash_ast::ast;
 use hash_ir::ir::{self, BinOp, Const, ConstKind};
 use hash_reporting::macros::panic_on_span;
 use hash_source::constant::{
@@ -16,14 +16,14 @@ use super::Builder;
 impl<'tcx> Builder<'tcx> {
     /// Lower a simple literal into an [ir::Const], this does not deal
     /// with literals that are arrays or other compound data structures.
-    pub(crate) fn as_constant(&mut self, lit: AstNodeRef<'tcx, Lit>) -> ConstKind {
+    pub(crate) fn as_constant(&mut self, lit: ast::AstNodeRef<'tcx, ast::Lit>) -> ConstKind {
         ConstKind::Value(match lit.body {
-            Lit::Str(literal) => ir::Const::Str(literal.data),
-            Lit::Char(literal) => ir::Const::Char(literal.data),
-            Lit::Int(literal) => ir::Const::Int(literal.value),
-            Lit::Float(literal) => ir::Const::Float(literal.value),
-            Lit::Bool(literal) => ir::Const::Bool(literal.data),
-            Lit::Set(_) | Lit::Map(_) | Lit::List(_) | Lit::Tuple(_) => {
+            ast::Lit::Str(literal) => ir::Const::Str(literal.data),
+            ast::Lit::Char(literal) => ir::Const::Char(literal.data),
+            ast::Lit::Int(literal) => ir::Const::Int(literal.value),
+            ast::Lit::Float(literal) => ir::Const::Float(literal.value),
+            ast::Lit::Bool(literal) => ir::Const::Bool(literal.data),
+            ast::Lit::Set(_) | ast::Lit::Map(_) | ast::Lit::List(_) | ast::Lit::Tuple(_) => {
                 panic_on_span!(
                     lit.span().into_location(self.source_id),
                     self.source_map,
@@ -34,9 +34,12 @@ impl<'tcx> Builder<'tcx> {
     }
 
     /// Lower a constant expression, i.e. a literal value.
-    pub(crate) fn lower_constant_expr(&mut self, expr: AstNodeRef<'tcx, Expr>) -> ConstKind {
+    pub(crate) fn lower_constant_expr(
+        &mut self,
+        expr: ast::AstNodeRef<'tcx, ast::Expr>,
+    ) -> ConstKind {
         match expr.body {
-            Expr::Lit(LitExpr { data }) => self.as_constant(data.ast_ref()),
+            ast::Expr::Lit(ast::LitExpr { data }) => self.as_constant(data.ast_ref()),
             _ => panic_on_span!(
                 expr.span().into_location(self.source_id),
                 self.source_map,

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -1,5 +1,5 @@
-//! Implementation for lowering [Expr]s into Hash IR. This module contains the
-//! core logic of converting expressions into IR, other auxiliary conversion
+//! Implementation for lowering [ast::Expr]s into Hash IR. This module contains
+//! the core logic of converting expressions into IR, other auxiliary conversion
 //! `strategies` can be found in [crate::build::rvalue] and
 //! [crate::build::temp].
 
@@ -21,8 +21,8 @@ use hash_utils::store::{SequenceStoreKey, Store};
 use super::{unpack, BlockAnd, BlockAndExtend, Builder, LoopBlockInfo};
 
 impl<'tcx> Builder<'tcx> {
-    /// Compile the given [Expr] and place the value of the [Expr] into
-    /// the specified destination [Place].
+    /// Compile the given [ast::Expr] and place the value of the [ast::Expr]
+    /// into the specified destination [Place].
     pub(crate) fn expr_into_dest(
         &mut self,
         destination: Place,

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -5,17 +5,13 @@
 
 use std::collections::HashMap;
 
-use hash_ast::ast::{
-    AccessExpr, AccessKind, AssignExpr, AssignOpExpr, AstNodeRef, AstNodes, BinOp, BinaryExpr,
-    BlockExpr, ConstructorCallArg, ConstructorCallExpr, Expr, ListLit, Lit, PropertyKind, RefExpr,
-    RefKind, ReturnStatement, TupleLit, UnsafeExpr, VariableExpr,
-};
+use hash_ast::ast;
 use hash_ir::{
     ir::{
-        self, AddressMode, AggregateKind, BasicBlock, Const, ConstKind, Place, RValue, Statement,
-        StatementKind, TerminatorKind, UnevaluatedConst,
+        self, AggregateKind, BasicBlock, Const, ConstKind, Place, RValue, Statement, StatementKind,
+        TerminatorKind, UnevaluatedConst,
     },
-    ty::{AdtId, IrTy, Mutability, VariantIdx},
+    ty::{AdtId, IrTy, Mutability, RefKind, VariantIdx},
 };
 use hash_reporting::macros::panic_on_span;
 use hash_source::{identifier::Identifier, location::Span};
@@ -31,12 +27,12 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         destination: Place,
         mut block: BasicBlock,
-        expr: AstNodeRef<'tcx, Expr>,
+        expr: ast::AstNodeRef<'tcx, ast::Expr>,
     ) -> BlockAnd<()> {
         let span = expr.span();
 
         let block_and = match expr.body {
-            Expr::ConstructorCall(ConstructorCallExpr { subject, args }) => {
+            ast::Expr::ConstructorCall(ast::ConstructorCallExpr { subject, args }) => {
                 // Check the type of the subject, and if we need to
                 // handle it as a constructor initialisation, or if it is a
                 // function call.
@@ -67,18 +63,18 @@ impl<'tcx> Builder<'tcx> {
                     unreachable!()
                 }
             }
-            Expr::Directive(expr) => {
+            ast::Expr::Directive(expr) => {
                 self.expr_into_dest(destination, block, expr.subject.ast_ref())
             }
-            Expr::Index(..)
-            | Expr::Deref(..)
-            | Expr::Access(AccessExpr { kind: AccessKind::Property, .. }) => {
+            ast::Expr::Index(..)
+            | ast::Expr::Deref(..)
+            | ast::Expr::Access(ast::AccessExpr { kind: ast::AccessKind::Property, .. }) => {
                 let place = unpack!(block = self.as_place(block, expr, Mutability::Immutable));
                 self.control_flow_graph.push_assign(block, destination, place.into(), span);
 
                 block.unit()
             }
-            Expr::Variable(VariableExpr { name }) => {
+            ast::Expr::Variable(ast::VariableExpr { name }) => {
                 let name = name.ident;
                 let (scope, _, scope_kind) = self.lookup_item_scope(name).unwrap();
 
@@ -103,13 +99,17 @@ impl<'tcx> Builder<'tcx> {
 
                 block.unit()
             }
-            Expr::Access(AccessExpr { subject, kind: AccessKind::Namespace, property }) => {
+            ast::Expr::Access(ast::AccessExpr {
+                subject,
+                kind: ast::AccessKind::Namespace,
+                property,
+            }) => {
                 // This is a special case, since we are creating an enum variant here with
                 // no arguments.
                 let subject_ty = self.ty_id_of_node(subject.id());
                 let index = self.ctx.map_on_adt(subject_ty, |adt, _| match property.body() {
-                    PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
-                    PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
+                    ast::PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
+                    ast::PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
                 });
 
                 self.control_flow_graph.push(
@@ -119,7 +119,7 @@ impl<'tcx> Builder<'tcx> {
 
                 block.unit()
             }
-            Expr::Ref(RefExpr { inner_expr, kind, mutability }) => {
+            ast::Expr::Ref(ast::RefExpr { inner_expr, kind, mutability }) => {
                 let mutability = if let Some(specified_mut) = mutability {
                     (*specified_mut.body()).into()
                 } else {
@@ -131,8 +131,8 @@ impl<'tcx> Builder<'tcx> {
                 // the type of the expression, and where the expression comes
                 // from.
                 let kind = match kind {
-                    RefKind::Normal => AddressMode::Smart,
-                    RefKind::Raw => AddressMode::Raw,
+                    ast::RefKind::Normal => RefKind::Normal,
+                    ast::RefKind::Raw => RefKind::Raw,
                 };
 
                 let place = unpack!(block = self.as_place(block, inner_expr.ast_ref(), mutability));
@@ -142,43 +142,43 @@ impl<'tcx> Builder<'tcx> {
                 self.control_flow_graph.push_assign(block, destination, addr_of, span);
                 block.unit()
             }
-            Expr::Unsafe(UnsafeExpr { data }) => {
+            ast::Expr::Unsafe(ast::UnsafeExpr { data }) => {
                 self.expr_into_dest(destination, block, data.ast_ref())
             }
 
             // For declarations, we have to perform some bookkeeping in regards
             // to locals..., but this expression should never return any value
             // so we should just return a unit block here
-            Expr::Declaration(decl) => self.lower_declaration(block, decl, span),
+            ast::Expr::Declaration(decl) => self.lower_declaration(block, decl, span),
 
             // Traverse the lhs of the cast, and then apply the cast
             // to the result... although this should be a no-op?
-            Expr::Cast(..) => unimplemented!(),
+            ast::Expr::Cast(..) => unimplemented!(),
 
             // This includes `loop { ... } `, `{ ... }`, `match { ... }`
-            Expr::Block(BlockExpr { data }) => {
+            ast::Expr::Block(ast::BlockExpr { data }) => {
                 self.block_into_dest(destination, block, data.ast_ref())
             }
 
             // We never do anything for these anyway...
-            Expr::Import { .. }
-            | Expr::StructDef { .. }
-            | Expr::EnumDef { .. }
-            | Expr::TyFnDef { .. }
-            | Expr::TraitDef { .. }
-            | Expr::ImplDef { .. }
-            | Expr::ModDef { .. }
-            | Expr::TraitImpl { .. }
-            | Expr::MergeDeclaration { .. }
-            | Expr::Ty { .. } => block.unit(),
+            ast::Expr::Import { .. }
+            | ast::Expr::StructDef { .. }
+            | ast::Expr::EnumDef { .. }
+            | ast::Expr::TyFnDef { .. }
+            | ast::Expr::TraitDef { .. }
+            | ast::Expr::ImplDef { .. }
+            | ast::Expr::ModDef { .. }
+            | ast::Expr::TraitImpl { .. }
+            | ast::Expr::MergeDeclaration { .. }
+            | ast::Expr::Ty { .. } => block.unit(),
 
             // @@Todo: we need be able to check here if this function is a closure,
             // and if so lower it as a closure. Similarly, any variables that are being
             // referenced from the environment above need special treatment when it comes
             // to a closure.
-            Expr::FnDef(..) => block.unit(),
+            ast::Expr::FnDef(..) => block.unit(),
 
-            Expr::Assign { .. } | Expr::AssignOp { .. } => {
+            ast::Expr::Assign { .. } | ast::Expr::AssignOp { .. } => {
                 // Deal with the actual assignment
                 block = unpack!(self.handle_statement_expr(block, expr));
 
@@ -189,7 +189,7 @@ impl<'tcx> Builder<'tcx> {
                 block.unit()
             }
 
-            Expr::Return(ReturnStatement { expr }) => {
+            ast::Expr::Return(ast::ReturnStatement { expr }) => {
                 // In either case, we want to mark that the function has reached the
                 // **terminating** statement of this block and we needn't continue looking
                 // for more statements beyond this point.
@@ -228,7 +228,7 @@ impl<'tcx> Builder<'tcx> {
                 self.control_flow_graph.start_new_block().unit()
             }
 
-            Expr::Continue { .. } | Expr::Break { .. } => {
+            ast::Expr::Continue { .. } | ast::Expr::Break { .. } => {
                 // Specify that we have reached the terminator of this block...
                 self.reached_terminator = true;
 
@@ -245,10 +245,10 @@ impl<'tcx> Builder<'tcx> {
 
                 // Add terminators to this block to specify where this block will jump...
                 match expr.body {
-                    Expr::Continue { .. } => {
+                    ast::Expr::Continue { .. } => {
                         self.control_flow_graph.goto(block, loop_body, span);
                     }
-                    Expr::Break { .. } => {
+                    ast::Expr::Break { .. } => {
                         self.control_flow_graph.goto(block, next_block, span);
                     }
                     _ => unreachable!(),
@@ -257,12 +257,12 @@ impl<'tcx> Builder<'tcx> {
                 block.unit()
             }
 
-            Expr::Lit(literal) => {
+            ast::Expr::Lit(literal) => {
                 // We lower primitive (integrals, strings, etc) literals as constants, and
                 // other literals like `sets`, `maps`, `lists`, and `tuples` as aggregates.
                 match literal.data.body() {
-                    Lit::Map(_) | Lit::Set(_) => unimplemented!(),
-                    Lit::List(ListLit { elements }) => {
+                    ast::Lit::Map(_) | ast::Lit::Set(_) => unimplemented!(),
+                    ast::Lit::List(ast::ListLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
                         let el_ty = self.map_ty(ty, |ty| match ty {
                             IrTy::Slice(ty) | IrTy::Array { ty, .. } => *ty,
@@ -278,7 +278,7 @@ impl<'tcx> Builder<'tcx> {
 
                         self.aggregate_into_dest(destination, block, aggregate_kind, &args, span)
                     }
-                    Lit::Tuple(TupleLit { elements }) => {
+                    ast::Lit::Tuple(ast::TupleLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
                         let adt = self.ctx.map_on_adt(ty, |_, id| id);
                         let aggregate_kind = AggregateKind::Tuple(adt);
@@ -298,7 +298,11 @@ impl<'tcx> Builder<'tcx> {
 
                         self.aggregate_into_dest(destination, block, aggregate_kind, &args, span)
                     }
-                    Lit::Str(_) | Lit::Char(_) | Lit::Int(_) | Lit::Float(_) | Lit::Bool(_) => {
+                    ast::Lit::Str(_)
+                    | ast::Lit::Char(_)
+                    | ast::Lit::Int(_)
+                    | ast::Lit::Float(_)
+                    | ast::Lit::Bool(_) => {
                         let constant = self.as_constant(literal.data.ast_ref());
                         self.control_flow_graph.push_assign(
                             block,
@@ -342,7 +346,7 @@ impl<'tcx> Builder<'tcx> {
             //  | dest = true  |----------------+-->| join |
             //  +--------------+                    +------+
             // ```
-            Expr::BinaryExpr(BinaryExpr { lhs, rhs, operator }) if operator.is_lazy() => {
+            ast::Expr::BinaryExpr(ast::BinaryExpr { lhs, rhs, operator }) if operator.is_lazy() => {
                 let (short_circuiting_block, mut else_block, join_block) = (
                     self.control_flow_graph.start_new_block(),
                     self.control_flow_graph.start_new_block(),
@@ -353,8 +357,8 @@ impl<'tcx> Builder<'tcx> {
                     unpack!(block = self.as_operand(block, lhs.ast_ref(), Mutability::Mutable));
 
                 let blocks = match *operator.body() {
-                    BinOp::And => (else_block, short_circuiting_block),
-                    BinOp::Or => (short_circuiting_block, else_block),
+                    ast::BinOp::And => (else_block, short_circuiting_block),
+                    ast::BinOp::Or => (short_circuiting_block, else_block),
                     _ => unreachable!(),
                 };
 
@@ -363,8 +367,8 @@ impl<'tcx> Builder<'tcx> {
 
                 // Create the constant that we will assign in the `short_circuiting` block.
                 let constant = match *operator.body() {
-                    BinOp::And => Const::Bool(false),
-                    BinOp::Or => Const::Bool(true),
+                    ast::BinOp::And => Const::Bool(false),
+                    ast::BinOp::Or => Const::Bool(true),
                     _ => unreachable!(),
                 };
 
@@ -389,7 +393,7 @@ impl<'tcx> Builder<'tcx> {
                 join_block.unit()
             }
 
-            Expr::BinaryExpr(..) | Expr::UnaryExpr(..) => {
+            ast::Expr::BinaryExpr(..) | ast::Expr::UnaryExpr(..) => {
                 let rvalue = unpack!(block = self.as_rvalue(block, expr));
                 self.control_flow_graph.push_assign(block, destination, rvalue, span);
 
@@ -403,10 +407,10 @@ impl<'tcx> Builder<'tcx> {
     pub(crate) fn handle_statement_expr(
         &mut self,
         mut block: BasicBlock,
-        statement: AstNodeRef<'tcx, Expr>,
+        statement: ast::AstNodeRef<'tcx, ast::Expr>,
     ) -> BlockAnd<()> {
         match statement.body {
-            Expr::Assign(AssignExpr { lhs, rhs }) => {
+            ast::Expr::Assign(ast::AssignExpr { lhs, rhs }) => {
                 let place =
                     unpack!(block = self.as_place(block, lhs.ast_ref(), Mutability::Mutable));
                 let value = unpack!(block = self.as_rvalue(block, rhs.ast_ref()));
@@ -414,7 +418,7 @@ impl<'tcx> Builder<'tcx> {
 
                 block.unit()
             }
-            Expr::AssignOp(AssignOpExpr { lhs: _, rhs: _, operator: _ }) => {
+            ast::Expr::AssignOp(ast::AssignOpExpr { lhs: _, rhs: _, operator: _ }) => {
                 // @@Todo: implement this when operators work properly
                 block.unit()
             }
@@ -429,9 +433,9 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         destination: Place,
         mut block: BasicBlock,
-        subject: AstNodeRef<'tcx, Expr>,
+        subject: ast::AstNodeRef<'tcx, ast::Expr>,
         fn_ty: IrTy,
-        args: &'tcx AstNodes<ConstructorCallArg>,
+        args: &'tcx ast::AstNodes<ast::ConstructorCallArg>,
         span: Span,
     ) -> BlockAnd<()> {
         // First we want to lower the subject of the function call
@@ -491,27 +495,28 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         destination: Place,
         mut block: BasicBlock,
-        subject: AstNodeRef<'tcx, Expr>,
+        subject: ast::AstNodeRef<'tcx, ast::Expr>,
         adt_id: AdtId,
-        args: &'tcx AstNodes<ConstructorCallArg>,
+        args: &'tcx ast::AstNodes<ast::ConstructorCallArg>,
         span: Span,
     ) -> BlockAnd<()> {
         let aggregate_kind = self.ctx.adts().map_fast(adt_id, |adt| {
             if adt.flags.is_enum() || adt.flags.is_union() {
                 // here, we have to work out which variant is being used, so we look at the
                 // subject type as an `enum variant` value, and extract the index
-                let index =
-                    if let Expr::Access(AccessExpr {
-                        property, kind: AccessKind::Namespace, ..
-                    }) = &subject.body
-                    {
-                        match property.body() {
-                            PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
-                            PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
-                        }
-                    } else {
-                        panic!("expected an enum variant")
-                    };
+                let index = if let ast::Expr::Access(ast::AccessExpr {
+                    property,
+                    kind: ast::AccessKind::Namespace,
+                    ..
+                }) = &subject.body
+                {
+                    match property.body() {
+                        ast::PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
+                        ast::PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
+                    }
+                } else {
+                    panic!("expected an enum variant")
+                };
 
                 AggregateKind::Enum(adt_id, index)
             } else {
@@ -551,7 +556,7 @@ impl<'tcx> Builder<'tcx> {
         destination: Place,
         mut block: BasicBlock,
         aggregate_kind: AggregateKind,
-        args: &[(Identifier, AstNodeRef<'tcx, Expr>)],
+        args: &[(Identifier, ast::AstNodeRef<'tcx, ast::Expr>)],
         span: Span,
     ) -> BlockAnd<()> {
         // @@Todo: deal with the situation where we need to fill in default

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -19,7 +19,7 @@
 
 use std::{borrow::Borrow, mem};
 
-use hash_ast::ast::{AstNodeRef, MatchCase, RangeEnd};
+use hash_ast::ast;
 use hash_ir::{
     ir::{BasicBlock, Place, PlaceProjection},
     ty::{AdtId, IrTy, Mutability},
@@ -84,7 +84,7 @@ pub(super) struct MatchPair {
     pub place: PlaceBuilder,
 }
 
-pub(super) type Candidates<'tcx> = (AstNodeRef<'tcx, MatchCase>, Candidate);
+pub(super) type Candidates<'tcx> = (ast::AstNodeRef<'tcx, ast::MatchCase>, Candidate);
 
 impl Candidate {
     /// Create a new [Candidate].
@@ -321,7 +321,7 @@ impl<'tcx> Builder<'tcx> {
 
                             // In this situation, we have an irrefutable pattern, so we can
                             // always go down this path
-                            if hi_val > max || hi_val == max && *end == RangeEnd::Excluded {
+                            if hi_val > max || hi_val == max && *end == ast::RangeEnd::Excluded {
                                 return Ok(());
                             }
                         }

--- a/compiler/hash-lower/src/build/matches/const_range.rs
+++ b/compiler/hash-lower/src/build/matches/const_range.rs
@@ -1,15 +1,16 @@
-//! Various utilities used for lowering `match` blocks.
+//! Defines the [ConstRange] type which is used for constructing comparison
+//! ranges and jump tables when lowering `match` blocks.
 
 use std::cmp::Ordering;
 
-use hash_ast::ast::RangeEnd;
+use hash_ast::ast;
 use hash_ir::ir::{compare_constant_values, Const};
 use hash_types::pats::RangePat;
 
 use crate::build::Builder;
 
 /// A constant range which is a representation of a range pattern, but
-/// instead of using [TermId]s, we directly store these with [Const]s.
+/// instead of using literals, we directly store these with [Const]s.
 ///
 /// N.B. These [Const]s must be of the same type, and must be integral
 ///      types.
@@ -20,7 +21,7 @@ pub(super) struct ConstRange {
     /// The upper value of the range.
     pub hi: Const,
     /// If the range includes the `hi` or not.
-    pub end: RangeEnd,
+    pub end: ast::RangeEnd,
 }
 
 impl ConstRange {
@@ -42,7 +43,7 @@ impl ConstRange {
             matches!(compare_constant_values(self.lo, value)?, Less | Equal)
                 && matches!(
                     (compare_constant_values(self.hi, value)?, self.end),
-                    (Less, _) | (Equal, RangeEnd::Included)
+                    (Less, _) | (Equal, ast::RangeEnd::Included)
                 ),
         )
     }
@@ -56,7 +57,7 @@ impl ConstRange {
             matches!(compare_constant_values(self.lo, other.hi)?, Less | Equal)
                 && matches!(
                     (compare_constant_values(self.hi, other.lo)?, self.end),
-                    (Less, _) | (Equal, RangeEnd::Included)
+                    (Less, _) | (Equal, ast::RangeEnd::Included)
                 ),
         )
     }

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -12,8 +12,8 @@ use std::mem;
 
 use hash_ast::ast::{self, AstNodeRef, AstNodes, BinOp, BinaryExpr, Expr, MatchCase, MatchOrigin};
 use hash_ir::{
-    ir::{self, AddressMode, BasicBlock, Place, RValue, TerminatorKind},
-    ty::Mutability,
+    ir::{self, BasicBlock, Place, RValue, TerminatorKind},
+    ty::{Mutability, RefKind},
 };
 use hash_source::location::Span;
 use hash_types::pats::Pat;
@@ -681,7 +681,7 @@ impl<'tcx> Builder<'tcx> {
 
             // @@Todo: we might have to do some special rules for the `by-ref` case
             //         when we start to think about reference rules more concretely.
-            let rvalue = RValue::Ref(binding.mutability, binding.source, AddressMode::Raw);
+            let rvalue = RValue::Ref(binding.mutability, binding.source, RefKind::Raw);
             self.control_flow_graph.push_assign(block, value_place, rvalue, binding.span);
         }
     }
@@ -697,7 +697,7 @@ impl<'tcx> Builder<'tcx> {
             let rvalue = match binding.mode {
                 candidate::BindingMode::ByValue => binding.source.into(),
                 candidate::BindingMode::ByRef => {
-                    RValue::Ref(binding.mutability, binding.source, AddressMode::Raw)
+                    RValue::Ref(binding.mutability, binding.source, RefKind::Raw)
                 }
             };
 

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -3,14 +3,14 @@
 //! we have to create essentially a *jump* table each case that is specified in
 //! the `match` arms, which might also have `if` guards, `or` patterns, etc.
 mod candidate;
+mod const_range;
 mod declarations;
 mod optimise;
 mod test;
-mod utils;
 
 use std::mem;
 
-use hash_ast::ast::{self, AstNodeRef, AstNodes, BinOp, BinaryExpr, Expr, MatchCase, MatchOrigin};
+use hash_ast::ast;
 use hash_ir::{
     ir::{self, BasicBlock, Place, RValue, TerminatorKind},
     ty::{Mutability, RefKind},
@@ -37,15 +37,15 @@ impl<'tcx> Builder<'tcx> {
         destination: Place,
         mut block: BasicBlock,
         span: Span,
-        subject: AstNodeRef<'tcx, Expr>,
-        arms: &'tcx AstNodes<MatchCase>,
-        origin: MatchOrigin,
+        subject: ast::AstNodeRef<'tcx, ast::Expr>,
+        arms: &'tcx ast::AstNodes<ast::MatchCase>,
+        origin: ast::MatchOrigin,
     ) -> BlockAnd<()> {
         // @@Hack: if the match-origin is an `if`-chain, then we don't bother
         // lowering the place since we always know that the branches are
         // always matching, and it's only guards that are being tested. Therefore,
         // we use the `subject_place` as the `return_place` in this instance.
-        let subject_place = if matches!(origin, MatchOrigin::If) {
+        let subject_place = if matches!(origin, ast::MatchOrigin::If) {
             PlaceBuilder::from(ir::RETURN_PLACE)
         } else {
             unpack!(block = self.as_place_builder(block, subject, Mutability::Mutable))
@@ -68,7 +68,7 @@ impl<'tcx> Builder<'tcx> {
     fn create_match_candidates(
         &mut self,
         subject_place: &PlaceBuilder,
-        arms: &'tcx AstNodes<MatchCase>,
+        arms: &'tcx ast::AstNodes<ast::MatchCase>,
     ) -> Vec<Candidates<'tcx>> {
         arms.iter()
             .map(|arm| {
@@ -88,13 +88,13 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         mut block: BasicBlock,
         else_block: BasicBlock,
-        expr: AstNodeRef<'tcx, Expr>,
+        expr: ast::AstNodeRef<'tcx, ast::Expr>,
     ) -> BlockAnd<()> {
         let span = expr.span();
 
         match expr.body {
-            Expr::BinaryExpr(BinaryExpr { lhs, rhs, operator })
-                if *operator.body() == BinOp::And =>
+            ast::Expr::BinaryExpr(ast::BinaryExpr { lhs, rhs, operator })
+                if *operator.body() == ast::BinOp::And =>
             {
                 let lhs_then_block =
                     unpack!(self.then_else_break(block, else_block, lhs.ast_ref()));
@@ -578,7 +578,7 @@ impl<'tcx> Builder<'tcx> {
     fn bind_pat(
         &mut self,
         span: Span,
-        pat: AstNodeRef<'tcx, ast::Pat>,
+        pat: ast::AstNodeRef<'tcx, ast::Pat>,
         candidate: Candidate,
     ) -> BasicBlock {
         let guard = match &pat.body {
@@ -626,7 +626,7 @@ impl<'tcx> Builder<'tcx> {
     fn bind_and_guard_matched_candidate(
         &mut self,
         candidate: Candidate,
-        guard: Option<AstNodeRef<'tcx, Expr>>,
+        guard: Option<ast::AstNodeRef<'tcx, ast::Expr>>,
         parent_bindings: &[Vec<Binding>],
         span: Span,
     ) -> BasicBlock {

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -5,7 +5,7 @@
 use std::cmp::Ordering;
 
 use fixedbitset::FixedBitSet;
-use hash_ast::ast::RangeEnd;
+use hash_ast::ast;
 use hash_ir::{
     ir::{
         BasicBlock, BinOp, Const, Operand, PlaceProjection, RValue, SwitchTargets, TerminatorKind,
@@ -27,7 +27,7 @@ use indexmap::IndexMap;
 
 use super::{
     candidate::{Candidate, MatchPair},
-    utils::ConstRange,
+    const_range::ConstRange,
 };
 use crate::build::{place::PlaceBuilder, ty::constify_lit_term, Builder};
 
@@ -722,8 +722,8 @@ impl<'tcx> Builder<'tcx> {
                 self.compare(block, lb_success, fail, BinOp::LtEq, lo, val, span);
 
                 let op = match end {
-                    RangeEnd::Included => BinOp::LtEq,
-                    RangeEnd::Excluded => BinOp::Lt,
+                    ast::RangeEnd::Included => BinOp::LtEq,
+                    ast::RangeEnd::Excluded => BinOp::Lt,
                 };
 
                 self.compare(lb_success, success, fail, op, val, hi, span);

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -1,6 +1,6 @@
-//! Lowering logic for compiling an [Expr] into a temporary [Local].
+//! Lowering logic for compiling an [ast::Expr] into a temporary [Local].
 
-use hash_ast::ast::{AstNodeRef, Expr};
+use hash_ast::ast;
 use hash_ir::{
     ir::{BasicBlock, Local, LocalDecl, Place},
     ty::{IrTyId, Mutability},
@@ -10,17 +10,17 @@ use super::{BlockAnd, Builder};
 use crate::build::{unpack, BlockAndExtend};
 
 impl<'tcx> Builder<'tcx> {
-    /// Compile an [Expr] into a freshly created temporary [Place].
+    /// Compile an [ast::Expr] into a freshly created temporary [Place].
     pub(crate) fn expr_into_temp(
         &mut self,
         mut block: BasicBlock,
-        expr: AstNodeRef<'tcx, Expr>,
+        expr: ast::AstNodeRef<'tcx, ast::Expr>,
         mutability: Mutability,
     ) -> BlockAnd<Local> {
         let temp = {
             // @@Hack: for now literal expressions don't get their type set on the node, it
             // is the underlying literal that has the type, so we read that in this case.
-            let id = if let Expr::Lit(lit) = expr.body { lit.data.id() } else { expr.id() };
+            let id = if let ast::Expr::Lit(lit) = expr.body { lit.data.id() } else { expr.id() };
             let ty = self.ty_id_of_node(id);
 
             let local = LocalDecl::new_auxiliary(ty, mutability);

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -1,9 +1,9 @@
 //! Contains utility functions that perform resolutions on
-//! [PatId]s, [TermId]s, [AstNodeId]s. This will read the
+//! [PatId]s, [TermId]s, [ast::AstNodeId]s. This will read the
 //! provided mappings between nodes to locations, patterns, and
 //! types.
 
-use hash_ast::ast::{AstNodeId, AstNodeRef};
+use hash_ast::ast;
 use hash_ir::{
     ir::{AssertKind, BasicBlock, LocalDecl, Operand, Place, TerminatorKind},
     ty::{IrTy, IrTyId, Mutability},
@@ -16,9 +16,9 @@ use super::Builder;
 
 impl<'tcx> Builder<'tcx> {
     /// Function to get the associated [TermId] with the
-    /// provided [AstNodeId].
+    /// provided [ast::AstNodeId].
     #[inline]
-    pub(crate) fn ty_id_of_node(&self, id: AstNodeId) -> IrTyId {
+    pub(crate) fn ty_id_of_node(&self, id: ast::AstNodeId) -> IrTyId {
         // We need to try and look up the type within the cache, if not
         // present then we create the type by converting the term into
         // the type.
@@ -26,22 +26,22 @@ impl<'tcx> Builder<'tcx> {
     }
 
     /// Function to get the associated [IrTy] with the
-    /// provided [AstNodeId]. This does not attempt to cache the
+    /// provided [ast::AstNodeId]. This does not attempt to cache the
     /// type.
     #[inline]
-    pub(crate) fn ty_of_node(&self, id: AstNodeId) -> IrTy {
+    pub(crate) fn ty_of_node(&self, id: ast::AstNodeId) -> IrTy {
         self.lower_term(self.term_of_node(id))
     }
 
     /// Function to get the associated [PatId] with the
-    /// provided [AstNodeId].
+    /// provided [ast::AstNodeId].
     #[inline]
-    pub(crate) fn pat_id_of_node(&self, id: AstNodeId) -> PatId {
+    pub(crate) fn pat_id_of_node(&self, id: ast::AstNodeId) -> PatId {
         self.tcx.node_info_store.node_info(id).map(|f| f.pat_id()).unwrap()
     }
 
-    /// Lookup the corresponding [AstNodeId] of [PatId], and then compute
-    /// the type associated with this [AstNodeId].
+    /// Lookup the corresponding [ast::AstNodeId] of [PatId], and then compute
+    /// the type associated with this [ast::AstNodeId].
     pub(crate) fn ty_of_pat(&self, id: PatId) -> IrTyId {
         self.tcx.node_info_store.pat_to_node_id(id).map(|id| self.ty_id_of_node(id)).unwrap()
     }
@@ -55,8 +55,8 @@ impl<'tcx> Builder<'tcx> {
             .unwrap()
     }
 
-    /// Lookup the corresponding [TermId] of a [AstNodeId] and return it.
-    pub(crate) fn term_of_node(&self, id: AstNodeId) -> TermId {
+    /// Lookup the corresponding [TermId] of a [ast::AstNodeId] and return it.
+    pub(crate) fn term_of_node(&self, id: ast::AstNodeId) -> TermId {
         self.tcx.node_info_store.node_info(id).unwrap().term_id()
     }
 
@@ -102,12 +102,12 @@ impl<'tcx> Builder<'tcx> {
     }
 
     /// Run a lowering operation whilst entering a new scope which is derived
-    /// from the provided [AstNodeRef<Expr>].
+    /// from the provided [ast::AstNodeRef<ast::Expr>].
     ///
     /// N.B. It is assumed that the related expression has an associated scope.
     pub(crate) fn with_scope<T, U>(
         &mut self,
-        expr: AstNodeRef<U>,
+        expr: ast::AstNodeRef<U>,
         f: impl FnOnce(&mut Self) -> T,
     ) -> T {
         let scope_id = self.tcx.node_info_store.node_info(expr.id()).map(|f| f.scope_id()).unwrap();
@@ -124,7 +124,7 @@ impl<'tcx> Builder<'tcx> {
     /// Run some function whilst reading a [IrTy] from a provided [IrTyId].
     ///
     /// N.B. The closure that is passed into this should not attempt to create
-    ///      new [IrTy]s, whislt this is checking, this is only meant as a
+    ///      new [IrTy]s, whilst this is checking, this is only meant as a
     /// read-only      context over the whole type storage.
     pub(crate) fn map_ty<T>(&mut self, ty: IrTyId, f: impl FnOnce(&IrTy) -> T) -> T {
         self.ctx.tys().map_fast(ty, f)

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -6,8 +6,7 @@
 use std::{collections::HashSet, convert::Infallible, mem};
 
 use hash_ast::{
-    ast::{self, AstNodeId},
-    ast_visitor_mut_self_default_impl,
+    ast, ast_visitor_mut_self_default_impl,
     origin::BlockOrigin,
     visitor::{walk_mut_self, AstVisitorMutSelf},
 };
@@ -25,16 +24,16 @@ use crate::build::{BuildItem, Builder};
 /// binds. This is needed because declarations can bind multiple variables in
 /// a single expression. For example, `let (a, b) = (1, 2);` binds both `a` and
 /// `b` to the values `1` and `2` respectively. The [Binding] stores the name
-/// that it binds, and an [AstNodeId] which points to which [AstNode] it binds
-/// to. The `id` of node is stored so that the [Builder] can later use it to
-/// look up which declarations it should and shouldn't attempt to lower.
+/// that it binds, and an [ast::AstNodeId] which points to which [ast::AstNode]
+/// it binds to. The `id` of node is stored so that the [Builder] can later use
+/// it to look up which declarations it should and shouldn't attempt to lower.
 #[derive(Clone, Copy)]
 pub struct Binding {
     /// The name that the binding is specifying
     name: Identifier,
 
-    /// The relevant [AstNodeId] that this binding points too.
-    node: AstNodeId,
+    /// The relevant [ast::AstNodeId] that this binding points too.
+    node: ast::AstNodeId,
 }
 
 fn extract_binds_from_bind(pat: ast::AstNodeRef<ast::Pat>, binds: &mut Vec<Binding>) {
@@ -161,12 +160,12 @@ pub(crate) struct LoweringVisitor<'ir> {
     /// the `#layout_of` directive. This means that once the
     /// lowering process has finished, these ids will be used
     /// to query the type layouts.
-    pub(crate) layout_to_generate: Vec<AstNodeId>,
+    pub(crate) layout_to_generate: Vec<ast::AstNodeId>,
 
     /// Dead ends that a particular [Builder] should not attempt to traverse
     /// and build IR from. This is needed to avoid trying to lower declarations
     /// that have function declarations in them.
-    dead_ends: HashSet<AstNodeId>,
+    dead_ends: HashSet<ast::AstNodeId>,
 }
 
 impl<'ir> LoweringVisitor<'ir> {
@@ -202,7 +201,7 @@ impl<'ir> LoweringVisitor<'ir> {
     /// is set every time a new scope is entered. This is used to determine
     /// whether a particular node is a constant or a function, and whether
     /// it should be lowered.
-    fn with_scope<F, T>(&mut self, node: AstNodeId, origin: BlockOrigin, f: F) -> T
+    fn with_scope<F, T>(&mut self, node: ast::AstNodeId, origin: BlockOrigin, f: F) -> T
     where
         F: FnOnce(&mut Self) -> T,
     {
@@ -274,7 +273,7 @@ impl<'ir> LoweringVisitor<'ir> {
     }
 
     /// Convert the [LoweringVisitor] into the bodies that have been generated.
-    pub(crate) fn into_components(self) -> (Vec<Body>, Vec<AstNodeId>) {
+    pub(crate) fn into_components(self) -> (Vec<Body>, Vec<ast::AstNodeId>) {
         (self.bodies, self.layout_to_generate)
     }
 }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -12,7 +12,10 @@ mod optimise;
 mod ty;
 
 use discover::LoweringVisitor;
-use hash_ast::ast::{AstNodeId, AstVisitorMutSelf, OwnsAstNode};
+use hash_ast::{
+    ast::{self, OwnsAstNode},
+    visitor::AstVisitorMutSelf,
+};
 use hash_ir::{
     write::{graphviz, pretty},
     IrStorage,
@@ -36,11 +39,11 @@ pub struct IrGen {
     /// directives on type declarations. This is a collection of all of the
     /// type definitions that were found and require a layout to be
     /// generated.
-    layouts_to_generate: Vec<AstNodeId>,
+    layouts_to_generate: Vec<ast::AstNodeId>,
 }
 
 /// The [LoweringCtx] represents all of the required information
-/// that the [AstLowerer] stage needs to query from the pipeline
+/// that the [IrGen] stage needs to query from the pipeline
 /// in order to perform its lowering operations.
 pub struct LoweringCtx<'ir> {
     /// Reference to the current compiler workspace.

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -19,7 +19,7 @@ use hash_ir::{
 use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
 use index_vec::{index_vec, IndexVec};
 
-use super::IrOptimisation;
+use super::IrOptimisationPass;
 
 /// The [CleanupLocalPass] is responsible for removing un-used [Local]s
 /// from a given [Body]. This removes any assignments to dead locals, and
@@ -27,7 +27,7 @@ use super::IrOptimisation;
 /// pass is completed.
 pub struct CleanupLocalPass;
 
-impl IrOptimisation for CleanupLocalPass {
+impl IrOptimisationPass for CleanupLocalPass {
     fn name(&self) -> &'static str {
         "cleanup_locals"
     }

--- a/compiler/hash-lower/src/optimise/mod.rs
+++ b/compiler/hash-lower/src/optimise/mod.rs
@@ -14,7 +14,7 @@ use hash_source::SourceMap;
 mod cleanup_locals;
 mod simplify;
 
-pub trait IrOptimisation {
+pub trait IrOptimisationPass {
     /// Get the name of the particular optimisation pass.
     fn name(&self) -> &'static str;
 
@@ -43,7 +43,7 @@ pub struct Optimiser<'ir> {
 
     /// The various passes that have been added to the optimisation
     /// pipeline.
-    passes: Vec<Box<dyn IrOptimisation + Send>>,
+    passes: Vec<Box<dyn IrOptimisationPass + Send>>,
 }
 
 impl<'ir> Optimiser<'ir> {

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -19,7 +19,7 @@ use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
 use index_vec::{index_vec, Idx, IndexVec};
 use smallvec::{smallvec, SmallVec};
 
-use super::IrOptimisation;
+use super::IrOptimisationPass;
 
 /// Function that will iterate over all of the blocks and remove them
 /// from the body source.
@@ -90,7 +90,7 @@ fn compute_predecessor_counts(body: &Body) -> IndexVec<BasicBlock, u32> {
 
 pub struct SimplifyGraph;
 
-impl IrOptimisation for SimplifyGraph {
+impl IrOptimisationPass for SimplifyGraph {
     fn name(&self) -> &'static str {
         "simplify-graph"
     }

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -23,8 +23,8 @@ impl FloatTy {
     pub fn size(self) -> Size {
         use FloatTy::*;
         match self {
-            F32 => Size::from_bytes(2),
-            F64 => Size::from_bytes(4),
+            F32 => Size::from_bytes(4),
+            F64 => Size::from_bytes(8),
         }
     }
 


### PR DESCRIPTION
This patch ensures that all AST items references in the lowering and IR logic are prefixed with `ast::` to disambiguate whether it is an AST item or an IR item.

Furthermore, this patch brings a small improvement to layout visualisation which removes the "ghost" padding for enum variants, and aligns the enum variant labels with the tag box for clarity.