### PR TITLE
lowering: implement emitting overflow checks for unary ops and `BinOp::Div` and `BinOp::Mod`

### DIFF
--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -4,7 +4,7 @@
 use hash_ir::ir;
 use hash_layout::TyInfo;
 use hash_target::{abi::AbiRepresentation, alignment::Alignment};
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::SequenceStore;
 
 use super::{locals::LocalRef, place::PlaceRef, utils, FnBuilder};
 use crate::{
@@ -152,8 +152,7 @@ impl<'b, V: CodeGenObject> OperandRef<V> {
     /// Apply a dereference operation on a [OperandRef], effectively
     /// producing a [PlaceRef].
     pub fn deref<Builder: LayoutMethods<'b>>(self, builder: &Builder) -> PlaceRef<V> {
-        let projected_ty =
-            builder.ir_ctx().tys().map_fast(self.info.ty, |ty| ty.on_deref()).unwrap();
+        let projected_ty = builder.ir_ctx().map_ty(self.info.ty, |ty| ty.on_deref()).unwrap();
 
         // If we have a pair, then we move the extra data into the place ref.
         let ptr_value = match self.value {

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -10,7 +10,7 @@ use hash_target::{
     abi::{AbiRepresentation, ScalarKind},
     alignment::Alignment,
 };
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::SequenceStore;
 
 use super::{locals::LocalRef, FnBuilder};
 use crate::{
@@ -101,7 +101,7 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
             }
             Variants::Multiple { field, .. } => {
                 let ptr = self.project_field(builder, field);
-                let (_, value) = builder.ir_ctx().tys().map_fast(self.info.ty, |ty| {
+                let (_, value) = builder.ir_ctx().map_ty(self.info.ty, |ty| {
                     ty.discriminant_for_variant(builder.ir_ctx(), discriminant).unwrap()
                 });
 
@@ -137,7 +137,7 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
 
         match variants {
             Variants::Single { index } => {
-                let value = builder.ir_ctx().tys().map_fast(self.info.ty, |ty| {
+                let value = builder.ir_ctx().map_ty(self.info.ty, |ty| {
                     ty.discriminant_for_variant(builder.ir_ctx(), index)
                         .map_or(index.raw() as u128, |(_, value)| value)
                 });

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -16,7 +16,6 @@ use hash_ir::{
 };
 use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
 use hash_target::abi::{AbiRepresentation, ValidScalarRange};
-use hash_utils::store::Store;
 
 use super::{
     intrinsics::Intrinsic,
@@ -150,7 +149,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         // generate the operand as the function call...
         let callee = self.codegen_operand(builder, op);
 
-        let instance = self.ctx.ir_ctx().tys().map_fast(callee.info.ty, |ty| match ty {
+        let instance = self.ctx.ir_ctx().map_ty(callee.info.ty, |ty| match ty {
             IrTy::Fn { instance, .. } => *instance,
             _ => panic!("item is not callable"),
         });

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -2,14 +2,14 @@
 //! to help with code generation.
 
 use hash_abi::FnAbi;
-use hash_ir::ty::IrTyId;
+use hash_ir::ty::{IrTy, IrTyId};
 use hash_layout::TyInfo;
 use hash_target::alignment::Alignment;
 
 use super::FnBuilder;
 use crate::{
     common::MemFlags,
-    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods},
+    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods},
 };
 
 /// Emit a `memcpy` instruction for a particular value with the provided
@@ -35,12 +35,20 @@ pub fn mem_copy_ty<'b, Builder: BlockBuilderMethods<'b>>(
 }
 
 impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
-    /// Compute an [FnAbi] from a provided [ty::IrTy]. If the ABI
+    /// Compute an [FnAbi] from a provided [IrTyId]. If the ABI
     /// has already been computed for the particular instance, then
     /// the cached version of the ABI is returned.
     ///
     /// N.B. the passed "ty" must be a function type.
-    pub fn compute_fn_abi_from_ty(&mut self, _ty: IrTyId) -> &FnAbi {
-        todo!()
+    pub fn compute_fn_abi_from_ty(&mut self, ty: IrTyId) -> &FnAbi {
+        // @@Todo: add caching for the ABI computation...
+
+        self.ctx.ir_ctx().map_ty(ty, |ty| {
+            let IrTy::Fn { .. } = ty else {
+                unreachable!("expected a function type")
+            };
+
+            todo!()
+        })
     }
 }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -68,8 +68,10 @@ impl Const {
         Self::Zero(ctx.tys().common_tys.unit)
     }
 
-    /// Check if a [Const] is of integral kind.
-    pub fn is_integral(&self) -> bool {
+    /// Check if a [Const] is "switchable", meaning that it can be used
+    /// in a `match` expression and a jump table can be generated rather
+    /// than emitting a equality check for each case.
+    pub fn is_switchable(&self) -> bool {
         matches!(self, Self::Char(_) | Self::Int(_) | Self::Bool(_))
     }
 
@@ -692,17 +694,6 @@ impl RValue {
     /// Check if an [RValue] is a constant.
     pub fn is_const(&self) -> bool {
         matches!(self, RValue::Use(Operand::Const(_)))
-    }
-
-    /// Check if an [RValue] is a constant operation and involves a constant
-    /// that is of an integral kind...
-    pub fn is_integral_const(&self) -> bool {
-        matches!(
-            self,
-            RValue::Use(Operand::Const(ConstKind::Value(
-                Const::Int(_) | Const::Float(_) | Const::Char(_)
-            )))
-        )
     }
 
     /// Convert the RValue into a constant, having previously

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -78,7 +78,7 @@ impl Const {
     /// Create a new [Const] from a scalar value, with the appropriate
     /// type.
     pub fn from_scalar(value: u128, ty: IrTyId, ctx: &IrCtx) -> Self {
-        ctx.tys().map_fast(ty, |ty| match ty {
+        ctx.map_ty(ty, |ty| match ty {
             IrTy::Int(int_ty) => {
                 let interned_value = IntConstant::from_uint(value, (*int_ty).into());
                 Self::Int(CONSTANT_MAP.create_int_constant(interned_value))
@@ -734,7 +734,7 @@ impl RValue {
 
                 // @@Safety: this does not create any new types, and thus
                 // we can map_fast over the types.
-                ctx.tys().map_fast(ty, |ty| ty.discriminant_ty(ctx))
+                ctx.map_ty(ty, |ty| ty.discriminant_ty(ctx))
             }
         }
     }

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
 use hash_types::{nominals::NominalDefId, terms::TermId};
 use hash_utils::store::{SequenceStore, Store};
 use ir::{Body, Local, Place, PlaceProjection, ProjectionStore};
-use ty::{AdtData, AdtId, AdtStore, IrTyId, TyListStore, TyStore};
+use ty::{AdtData, AdtId, AdtStore, IrTy, IrTyId, TyListStore, TyStore};
 
 /// Storage that is used by the lowering stage. This stores all of the
 /// generated [Body]s and all of the accompanying data for the bodies.
@@ -160,8 +160,14 @@ impl IrCtx {
         self.projections().map_fast(projections, |projections| map(local, projections))
     }
 
-    /// Apply a function on a [IrTy::Adt].
-    pub fn map_on_adt<T>(&self, ty: IrTyId, f: impl FnOnce(&AdtData, AdtId) -> T) -> T {
+    /// Map an [IrTyId] by reading the [IrTy] that is associated with the
+    /// [IrTyId] and then applying the provided function.
+    pub fn map_ty<T>(&self, ty: IrTyId, f: impl FnOnce(&IrTy) -> T) -> T {
+        self.ty_store.map_fast(ty, f)
+    }
+
+    /// Apply a function on an type assuming that it is a [`IrTy::Adt`].
+    pub fn map_ty_as_adt<T>(&self, ty: IrTyId, f: impl FnOnce(&AdtData, AdtId) -> T) -> T {
         self.ty_store
             .map_fast(ty, |ty| self.adt_store.map_fast(ty.as_adt(), |adt| f(adt, ty.as_adt())))
     }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -219,9 +219,9 @@ impl IrTy {
     }
 
     /// Check if a type is a scalar, i.e. it cannot be divided into
-    /// further components. [IrTy::RawRef] is also considered as a scalar since
-    /// the components of the reference are *opaque* to the compiler because it
-    /// isn't managed.
+    /// further components. [`IrTy::Ref(..)`] with non-[`RefKind::Rc`] is also
+    /// considered as a scalar since the components of the reference are
+    /// *opaque* to the compiler because it isn't managed.
     pub fn is_scalar(&self) -> bool {
         matches!(
             self,
@@ -293,7 +293,7 @@ impl IrTy {
         &self,
         ctx: &IrCtx,
         variant: VariantIdx,
-    ) -> Option<(UIntTy, u128)> {
+    ) -> Option<(IntTy, u128)> {
         match self {
             IrTy::Adt(id) => {
                 ctx.adts().map_fast(*id, |data| {
@@ -314,6 +314,33 @@ impl IrTy {
                 })
             }
             _ => None,
+        }
+    }
+
+    /// Compute the discriminant type for the given type. This computes
+    /// the specific "discriminant" for `enum` ADTs, and simply returns a
+    /// `u8` for all other types. This is because the discriminant type of
+    /// all other types is considered to be `0`, and thus a `u8` is sufficient.
+    pub fn discriminant_ty(&self, ctx: &IrCtx) -> IrTyId {
+        match self {
+            IrTy::Adt(id) => ctx.map_adt(*id, |_, data| {
+                if data.flags.is_enum() {
+                    data.discriminant_ty().to_ir_ty(ctx)
+                } else {
+                    ctx.tys().common_tys.u8
+                }
+            }),
+            IrTy::Int(_)
+            | IrTy::UInt(_)
+            | IrTy::Float(_)
+            | IrTy::Str
+            | IrTy::Bool
+            | IrTy::Char
+            | IrTy::Never
+            | IrTy::Ref(_, _, _)
+            | IrTy::Slice(_)
+            | IrTy::Array { .. }
+            | IrTy::Fn { .. } => ctx.tys().common_tys.u8,
         }
     }
 }
@@ -414,7 +441,7 @@ impl AdtData {
     /// @@Future(discriminants): This is incomplete because it does not account
     /// for the `repr` attribute, and the fact that enums might have
     /// explicit discriminants specified on them.
-    pub fn discriminant_ty(&self) -> UIntTy {
+    pub fn discriminant_ty(&self) -> IntTy {
         debug_assert!(self.flags.is_enum() || self.flags.is_union());
 
         // Compute the maximum number of bits needed for the discriminant.
@@ -422,7 +449,7 @@ impl AdtData {
         let bits = max.leading_zeros();
         let size = Size::from_bits(cmp::max(1, 64 - bits));
 
-        UIntTy::from_size(size)
+        IntTy::UInt(UIntTy::from_size(size))
     }
 
     /// Compute the representation of the discriminant of this [AdtData]

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -198,7 +198,7 @@ impl IrTy {
 
     /// Check if the [IrTy] is an integral type.
     pub fn is_integral(&self) -> bool {
-        matches!(self, Self::Int(_) | Self::UInt(_) | Self::Float(_) | Self::Char | Self::Bool)
+        matches!(self, Self::Int(_) | Self::UInt(_))
     }
 
     /// Check if the [IrTy] is a floating point type.
@@ -316,6 +316,16 @@ impl From<IntTy> for IrTy {
         match value {
             IntTy::Int(ty) => Self::Int(ty),
             IntTy::UInt(ty) => Self::UInt(ty),
+        }
+    }
+}
+
+impl From<IrTy> for IntTy {
+    fn from(ty: IrTy) -> Self {
+        match ty {
+            IrTy::Int(ty) => Self::Int(ty),
+            IrTy::UInt(ty) => Self::UInt(ty),
+            _ => panic!("expected integral type, but got {ty:?}"),
         }
     }
 }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -201,6 +201,13 @@ impl IrTy {
         matches!(self, Self::Int(_) | Self::UInt(_))
     }
 
+    /// Check whether the [IrTy] is "switchable", as in if
+    /// it can be compared without any additional work. This
+    /// is primarily used for generating code for `match` statements.
+    pub fn is_switchable(&self) -> bool {
+        matches!(self, Self::Int(_) | Self::UInt(_) | Self::Char | Self::Bool)
+    }
+
     /// Check if the [IrTy] is a floating point type.
     pub fn is_float(&self) -> bool {
         matches!(self, Self::Float(_))

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -165,7 +165,7 @@ impl<'l> LayoutComputer<'l> {
             return Ok(*layout);
         }
 
-        let layout = self.ir_ctx.tys().map_fast(ty_id, |ty| match ty {
+        let layout = self.ir_ctx.map_ty(ty_id, |ty| match ty {
             IrTy::Int(ty) => match ty {
                 SIntTy::I8 => Ok(self.common_layouts().i8),
                 SIntTy::I16 => Ok(self.common_layouts().i16),

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -225,7 +225,7 @@ impl TyInfo {
                 self.layout
             }
             Variants::Single { .. } => {
-                let fields = ctx.ir_ctx().map_on_adt(self.ty, |adt, _| {
+                let fields = ctx.ir_ctx().map_ty_as_adt(self.ty, |adt, _| {
                     if adt.variants.is_empty() {
                         panic!("layout::for_variant called on a zero-variant enum")
                     }

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -573,7 +573,7 @@ impl<'l> LayoutWriter<'l> {
     where
         F: FnOnce(&Self, &IrTy, &Layout) -> T,
     {
-        self.ctx.ir_ctx().tys().map_fast(self.ty_info.ty, |ty| {
+        self.ctx.ir_ctx().map_ty(self.ty_info.ty, |ty| {
             self.ctx.map_fast(self.ty_info.layout, |layout| f(self, ty, layout))
         })
     }
@@ -595,7 +595,7 @@ impl<'l> LayoutWriter<'l> {
         tag_box_width: usize,
         layout: LayoutId,
     ) -> BoxRow {
-        self.ctx.ir_ctx().tys().map_fast(self.ty_info.ty, |ty| {
+        self.ctx.ir_ctx().map_ty(self.ty_info.ty, |ty| {
             let mut contents = self.ctx.map_fast(layout, |layout| {
                 self.create_box_contents(ty, layout, Some((tag_size, variant)))
             });

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -107,7 +107,7 @@ impl<'tcx> Builder<'tcx> {
                 // This is a special case, since we are creating an enum variant here with
                 // no arguments.
                 let subject_ty = self.ty_id_of_node(subject.id());
-                let index = self.ctx.map_on_adt(subject_ty, |adt, _| match property.body() {
+                let index = self.ctx.map_ty_as_adt(subject_ty, |adt, _| match property.body() {
                     ast::PropertyKind::NamedField(name) => adt.variant_idx(name).unwrap(),
                     ast::PropertyKind::NumericField(index) => VariantIdx::from_usize(*index),
                 });
@@ -264,7 +264,7 @@ impl<'tcx> Builder<'tcx> {
                     ast::Lit::Map(_) | ast::Lit::Set(_) => unimplemented!(),
                     ast::Lit::List(ast::ListLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
-                        let el_ty = self.map_ty(ty, |ty| match ty {
+                        let el_ty = self.ctx.map_ty(ty, |ty| match ty {
                             IrTy::Slice(ty) | IrTy::Array { ty, .. } => *ty,
                             _ => unreachable!(),
                         });
@@ -280,7 +280,7 @@ impl<'tcx> Builder<'tcx> {
                     }
                     ast::Lit::Tuple(ast::TupleLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
-                        let adt = self.ctx.map_on_adt(ty, |_, id| id);
+                        let adt = self.ctx.map_ty_as_adt(ty, |_, id| id);
                         let aggregate_kind = AggregateKind::Tuple(adt);
 
                         let args = elements

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -333,7 +333,7 @@ impl<'tcx> Builder<'tcx> {
                     // get the type of the tuple so that we can read all of the
                     // fields
                     let ty = self.ty_of_pat(pair.pat);
-                    let adt = self.ctx.tys().map_fast(ty, IrTy::as_adt);
+                    let adt = self.ctx.map_ty(ty, IrTy::as_adt);
 
                     candidate.pairs.extend(self.match_pat_fields(*pat_args, adt, pair.place));
                     Ok(())
@@ -341,7 +341,7 @@ impl<'tcx> Builder<'tcx> {
                 Pat::Constructor(ConstructorPat { subject, args }) => {
                     let ty = self.lower_term_as_id(*subject);
                     let adt =
-                        self.ctx.map_on_adt(ty, |adt, id| adt.flags.is_struct().then_some(id));
+                        self.ctx.map_ty_as_adt(ty, |adt, id| adt.flags.is_struct().then_some(id));
 
                     // If this is a struct then we need to match on the fields of
                     // the struct since it is an *irrefutable* pattern.

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -64,7 +64,7 @@ impl<'tcx> Builder<'tcx> {
         rest: Option<PatId>,
         suffix: &[PatId],
     ) {
-        let (min_length, exact_size) = self.map_ty(ty, |ty| match ty {
+        let (min_length, exact_size) = self.ctx.map_ty(ty, |ty| match ty {
             IrTy::Array { size, .. } => (*size, true),
             _ => (prefix.len() + suffix.len(), false),
         });

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -10,7 +10,7 @@ use hash_ir::{
     ir::{
         BasicBlock, BinOp, Const, Operand, PlaceProjection, RValue, SwitchTargets, TerminatorKind,
     },
-    ty::{AdtId, IrTy, IrTyId, VariantIdx},
+    ty::{AdtId, IrTy, IrTyId, ToIrTy, VariantIdx},
     IrCtx,
 };
 use hash_reporting::macros::panic_on_span;
@@ -582,7 +582,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Here we want to create a switch statement that will match on all of the
                 // specified discriminants of the ADT.
-                let discriminant_ty = self.ctx.tys().create(IrTy::UInt(discriminant_ty));
+                let discriminant_ty = discriminant_ty.to_ir_ty(self.ctx);
                 let targets = SwitchTargets::new(
                     self.ctx.adts().map_fast(adt, |adt| {
                         // Map over all of the discriminants of the ADT, and filter out those that

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -193,8 +193,7 @@ impl<'tcx> Builder<'tcx> {
                     let ty_id = self.lower_term_as_id(*term);
 
                     self.ctx.tys().map_fast(ty_id, |ty| match ty {
-                        // @@CowBunga
-                        ty if ty.is_integral() => Test {
+                        ty if ty.is_switchable() => Test {
                             kind: TestKind::SwitchInt { ty: ty_id, options: Default::default() },
                             span,
                         },
@@ -219,9 +218,7 @@ impl<'tcx> Builder<'tcx> {
 
                     // If it is not an integral constant, we use an `Eq` test. This will
                     // happen when the constant is either a float or a string.
-
-                    // @@CowBunga
-                    if value.is_integral() {
+                    if value.is_switchable() {
                         Test { kind: TestKind::SwitchInt { ty, options: Default::default() }, span }
                     } else {
                         Test { kind: TestKind::Eq { ty, value }, span }
@@ -350,11 +347,9 @@ impl<'tcx> Builder<'tcx> {
                 TestKind::SwitchInt { ty, ref options },
                 Pat::Lit(term) | Pat::Const(ConstPat { term }),
             ) => {
-                // @@CowBunga
-
                 // We can't really do anything here since we can't compare them with
                 // the switch.
-                if !self.ctx.tys().map_fast(*ty, |ty| ty.is_integral()) {
+                if !self.ctx.tys().map_fast(*ty, |ty| ty.is_switchable()) {
                     return None;
                 }
 

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -193,6 +193,7 @@ impl<'tcx> Builder<'tcx> {
                     let ty_id = self.lower_term_as_id(*term);
 
                     self.ctx.tys().map_fast(ty_id, |ty| match ty {
+                        // @@CowBunga
                         ty if ty.is_integral() => Test {
                             kind: TestKind::SwitchInt { ty: ty_id, options: Default::default() },
                             span,
@@ -218,6 +219,8 @@ impl<'tcx> Builder<'tcx> {
 
                     // If it is not an integral constant, we use an `Eq` test. This will
                     // happen when the constant is either a float or a string.
+
+                    // @@CowBunga
                     if value.is_integral() {
                         Test { kind: TestKind::SwitchInt { ty, options: Default::default() }, span }
                     } else {
@@ -347,6 +350,8 @@ impl<'tcx> Builder<'tcx> {
                 TestKind::SwitchInt { ty, ref options },
                 Pat::Lit(term) | Pat::Const(ConstPat { term }),
             ) => {
+                // @@CowBunga
+
                 // We can't really do anything here since we can't compare them with
                 // the switch.
                 if !self.ctx.tys().map_fast(*ty, |ty| ty.is_integral()) {

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -101,7 +101,7 @@ impl Test {
                 ctx.adts().map_fast(adt, |adt| adt.variants.len() + 1)
             }
             TestKind::SwitchInt { ty, ref options } => {
-                ctx.tys().map_fast(ty, |ty| {
+                ctx.map_ty(ty, |ty| {
                     // The boolean branch is always 2...
                     if let IrTy::Bool = ty {
                         2
@@ -178,7 +178,7 @@ impl<'tcx> Builder<'tcx> {
                 Pat::Access(AccessPat { .. }) => {
                     let ty = self.ty_of_pat(pair.pat);
                     let (variant_count, adt) =
-                        self.ctx.map_on_adt(ty, |adt, id| (adt.variants.len(), id));
+                        self.ctx.map_ty_as_adt(ty, |adt, id| (adt.variants.len(), id));
 
                     Test {
                         kind: TestKind::Switch {
@@ -192,7 +192,7 @@ impl<'tcx> Builder<'tcx> {
                 Pat::Const(ConstPat { term }) => {
                     let ty_id = self.lower_term_as_id(*term);
 
-                    self.ctx.tys().map_fast(ty_id, |ty| match ty {
+                    self.ctx.map_ty(ty_id, |ty| match ty {
                         ty if ty.is_switchable() => Test {
                             kind: TestKind::SwitchInt { ty: ty_id, options: Default::default() },
                             span,
@@ -290,7 +290,7 @@ impl<'tcx> Builder<'tcx> {
                 // variant patterns, bu nothing else.
                 let test_adt = self.lower_term_as_id(*subject);
 
-                let variant_index = self.ctx.map_on_adt(test_adt, |adt, _| {
+                let variant_index = self.ctx.map_ty_as_adt(test_adt, |adt, _| {
                     // If this is a struct, then we don't do anything
                     // since we're expecting an enum. Although, this case shouldn't happen?
                     if adt.flags.is_struct() {
@@ -316,7 +316,7 @@ impl<'tcx> Builder<'tcx> {
                 // variant patterns, bu nothing else.
                 let test_adt = self.ty_of_pat(pair.pat);
 
-                let variant_index = self.ctx.map_on_adt(test_adt, |adt, _| {
+                let variant_index = self.ctx.map_ty_as_adt(test_adt, |adt, _| {
                     // If this is a struct, then we don't do anything
                     // since we're expecting an enum. Although, this case shouldn't happen?
                     if adt.flags.is_struct() {
@@ -349,7 +349,7 @@ impl<'tcx> Builder<'tcx> {
             ) => {
                 // We can't really do anything here since we can't compare them with
                 // the switch.
-                if !self.ctx.tys().map_fast(*ty, |ty| ty.is_switchable()) {
+                if !self.ctx.map_ty(*ty, |ty| ty.is_switchable()) {
                     return None;
                 }
 
@@ -617,7 +617,7 @@ impl<'tcx> Builder<'tcx> {
             TestKind::SwitchInt { ty, ref options } => {
                 let target_blocks = make_target_blocks(self);
 
-                let terminator_kind = if self.map_ty(ty, |ty| *ty == IrTy::Bool) {
+                let terminator_kind = if self.ctx.map_ty(ty, |ty| *ty == IrTy::Bool) {
                     debug_assert!(options.len() == 2);
 
                     let [first_block, second_block]= *target_blocks else {
@@ -648,7 +648,7 @@ impl<'tcx> Builder<'tcx> {
             }
             TestKind::Eq { ty, value } => {
                 let (is_str, is_scalar) =
-                    self.map_ty(ty, |ty| (matches!(ty, IrTy::Str), ty.is_scalar()));
+                    self.ctx.map_ty(ty, |ty| (matches!(ty, IrTy::Str), ty.is_scalar()));
 
                 // If this type is a string, we essentially have to make a call to
                 // a string comparator function (which will be filled in later on
@@ -819,7 +819,7 @@ impl<'tcx> Builder<'tcx> {
                     // variant index of the property.
                     let ty = self.ty_of_pat(match_pair.pat);
 
-                    self.ctx.map_on_adt(ty, |adt, _| {
+                    self.ctx.map_ty_as_adt(ty, |adt, _| {
                         let variant_index = adt.variant_idx(property).unwrap();
                         variants.insert(variant_index.index());
                         true

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -27,7 +27,7 @@ use hash_ir::{
 use hash_pipeline::settings::CompilerSettings;
 use hash_source::{identifier::Identifier, location::Span, SourceId, SourceMap};
 use hash_types::{scope::ScopeId, storage::GlobalStorage, terms::TermId};
-use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
+use hash_utils::store::{SequenceStore, SequenceStoreKey};
 use index_vec::IndexVec;
 
 use self::ty::get_fn_ty_from_term;
@@ -312,7 +312,7 @@ impl<'ctx> Builder<'ctx> {
         // If it is a function type, then we use the return type of the
         // function as the `return_ty`, otherwise we assume the type provided
         // is the `return_ty`
-        let (return_ty, params) = self.ctx.tys().map_fast(ty, |item_ty| match item_ty {
+        let (return_ty, params) = self.ctx.map_ty(ty, |item_ty| match item_ty {
             IrTy::Fn { return_ty, params, .. } => (*return_ty, Some(*params)),
             _ => (ty, None),
         });

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -193,7 +193,7 @@ impl<'tcx> Builder<'tcx> {
     /// a [ast::PropertyKind]. This function assumes that the underlying type is
     /// a [IrTy::Adt].
     fn lookup_field_index(&mut self, ty: IrTyId, field: ast::PropertyKind) -> usize {
-        self.ctx.map_on_adt(ty, |adt, _| {
+        self.ctx.map_ty_as_adt(ty, |adt, _| {
             // @@Todo: deal with unions here.
             if adt.flags.is_struct() || adt.flags.is_tuple() {
                 // So we get the first variant of the ADT since structs, tuples always

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -96,7 +96,7 @@ impl<'tcx> Builder<'tcx> {
                     // looking up the cached type.
                     let ty = self.lower_nominal_as_id(*def_id);
 
-                    self.ctx.tys().map_fast(ty, |ty| {
+                    self.ctx.map_ty(ty, |ty| {
                         match ty {
                             IrTy::Adt(adt) => {
                                 self.ctx.map_adt(*adt, |_, adt| adt.variant_idx(name).unwrap())

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -10,7 +10,6 @@ use hash_ir::{
 };
 use hash_source::location::Span;
 use hash_types::{pats::PatId, terms::TermId};
-use hash_utils::store::Store;
 
 use super::Builder;
 
@@ -119,14 +118,5 @@ impl<'tcx> Builder<'tcx> {
         debug_assert!(popped.is_some() && matches!(popped, Some(id) if id == scope_id));
 
         result
-    }
-
-    /// Run some function whilst reading a [IrTy] from a provided [IrTyId].
-    ///
-    /// N.B. The closure that is passed into this should not attempt to create
-    ///      new [IrTy]s, whilst this is checking, this is only meant as a
-    /// read-only      context over the whole type storage.
-    pub(crate) fn map_ty<T>(&mut self, ty: IrTyId, f: impl FnOnce(&IrTy) -> T) -> T {
-        self.ctx.tys().map_fast(ty, f)
     }
 }

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -269,6 +269,7 @@ impl IntConstant {
         Self { value: IntConstantValue::from(value), ty, suffix }
     }
 
+    /// Create a [IntConstant] from a given value and specified type.
     pub fn from_uint(value: u128, ty: IntTy) -> Self {
         Self { value: IntConstantValue::from_be_bytes(&value.to_be_bytes()), ty, suffix: None }
     }

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -274,6 +274,11 @@ impl IntConstant {
         Self { value: IntConstantValue::from_be_bytes(&value.to_be_bytes()), ty, suffix: None }
     }
 
+    /// Create a [IntConstant] from a given value and specified type.
+    pub fn from_int(value: i128, ty: IntTy) -> Self {
+        Self { value: IntConstantValue::from_be_bytes(&value.to_be_bytes()), ty, suffix: None }
+    }
+
     /// Create a [IntConstant] from Little endian bytes and an [IntTy]. It is
     /// assumed that the correct amount of bytes are provided to this
     /// function.


### PR DESCRIPTION
This patch implements emitting checked operations for unary negation overflow and division/remainder by zero.

Additionally, this patch implements missing logic for computing the type of `RValue`s.