### PR TITLE
abi+layout: implement ABI deduction and parsing data layouts

### DIFF
--- a/compiler/hash-abi/src/lib.rs
+++ b/compiler/hash-abi/src/lib.rs
@@ -3,7 +3,9 @@
 //! and to be able to call functions from other languages, but to also provide
 //! information to code generation backends about how values are represented.
 
-use hash_layout::TyInfo;
+use hash_layout::{compute::LayoutComputer, TyInfo};
+use hash_target::abi::{AbiRepresentation, Scalar};
+use hash_utils::store::Store;
 
 /// Defines the available calling conventions that can be
 /// used when invoking functions with the ABI.
@@ -55,6 +57,25 @@ pub struct ArgAbi {
 }
 
 impl ArgAbi {
+    /// Create a new [ArgAbi] with the provided [TyInfo].
+    pub fn new(
+        ctx: &LayoutComputer,
+        info: TyInfo,
+        attributes_from_scalar: impl Fn(Scalar) -> ArgAttributes,
+    ) -> Self {
+        let mode = ctx.map_fast(info.layout, |layout| match layout.abi {
+            AbiRepresentation::Uninhabited => PassMode::Ignore,
+            AbiRepresentation::Scalar(scalar) => PassMode::Direct(attributes_from_scalar(scalar)),
+            AbiRepresentation::Pair(scalar_a, scalar_b) => {
+                PassMode::Pair(attributes_from_scalar(scalar_a), attributes_from_scalar(scalar_b))
+            }
+            AbiRepresentation::Vector { .. } => PassMode::Direct(ArgAttributes::new()),
+            AbiRepresentation::Aggregate => PassMode::Direct(ArgAttributes::new()),
+        });
+
+        Self { info, mode }
+    }
+
     /// Check if the [PassMode] of the [ArgAbi] is "indirect".
     pub fn is_indirect(&self) -> bool {
         matches!(self.mode, PassMode::Indirect { .. })
@@ -68,8 +89,8 @@ impl ArgAbi {
 
 bitflags::bitflags! {
     /// Defines the relevant attributes to ABI arguments.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct ArgAttributeFlags: u16 {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ArgAttributeFlag: u16 {
         /// This specifies that this pointer argument does not alias
         /// any other arguments or the return value.
         const NO_ALIAS = 1 << 1;
@@ -109,7 +130,7 @@ bitflags::bitflags! {
 /// ABI defines whether the value should be sign-extended or zero-extended.
 ///
 /// If this is not required, this should be set to [`ArgExtension::NoExtend`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArgExtension {
     /// The argument should be zero-extended.
     ZeroExtend,
@@ -121,24 +142,57 @@ pub enum ArgExtension {
     NoExtend,
 }
 
+impl Default for ArgExtension {
+    fn default() -> Self {
+        Self::NoExtend
+    }
+}
+
 /// [ArgAttributes] provides all of the attributes that a
 /// particular argument has, as in additional information that
 /// can be used by the compiler to generate better code, or
 /// if it is targetting a specific ABI which requires certain
 /// operations to be performed on the argument in order to
 /// properly pass it to the function.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ArgAttributes {
     /// Additional information about the argument in the form
-    /// of bit flags. The [ArgAttributeFlags] resemble a similar
+    /// of bit flags. The [ArgAttributeFlag] resemble a similar
     /// naming convention to LLVM's function parameter attributes
     /// but they are intended to be used regardless of which
     /// backend is being targeted.
-    pub flags: ArgAttributeFlags,
+    pub flags: ArgAttributeFlag,
 
     /// Depending on the ABI, the argument may need to be zero/sign-extended
     /// to a certain size.
     pub extension: ArgExtension,
+}
+
+impl ArgAttributes {
+    /// Create a new [ArgAttributes].
+    pub fn new() -> Self {
+        Self { flags: ArgAttributeFlag::default(), extension: ArgExtension::NoExtend }
+    }
+
+    /// Apply a [ArgAttributeFlag] to the [ArgAttributes].
+    pub fn set(&mut self, attribute: ArgAttributeFlag) {
+        self.flags |= attribute;
+    }
+
+    /// Check if a particular [ArgAttributeFlag] exists on a
+    /// [ArgAttributes].
+    pub fn contains(&self, attribute: ArgAttributeFlag) -> bool {
+        self.flags.contains(attribute)
+    }
+
+    /// Apply an argument extension to the [ArgAttributes].
+    pub fn extend_with(&mut self, extension: ArgExtension) {
+        debug_assert!(
+            self.extension == ArgExtension::NoExtend || self.extension == extension,
+            "extension already set"
+        );
+        self.extension = extension;
+    }
 }
 
 /// Defines how an argument should be passed to a function.
@@ -155,6 +209,11 @@ pub enum PassMode {
     /// [`AbiRepresentation::Aggregate`] if the ABI allows for "small"
     /// structures to be passed as just integers.
     Direct(ArgAttributes),
+
+    /// Pass a pair's elements directly in two arguments.
+    ///
+    /// The argument has a layout abi of `ScalarPair`.
+    Pair(ArgAttributes, ArgAttributes),
 
     /// Pass the argument indirectly via a pointer. This corresponds to
     /// passing arguments "by value". The "by value" semantics implies that

--- a/compiler/hash-abi/src/lib.rs
+++ b/compiler/hash-abi/src/lib.rs
@@ -26,6 +26,17 @@ pub enum CallingConvention {
     Cold,
 }
 
+/// Defines what ABI to use when calling a function.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Abi {
+    /// The C ABI.
+    C,
+
+    /// The default ABI, which attempts to perform optimisations
+    /// that are not possible with the C ABI.
+    Hash,
+}
+
 /// Defines ABI specific information about a function.
 ///
 /// @@TODO: Do we need to record information about variadics here (when we add

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -1,0 +1,112 @@
+//! Contains logic for computing ABIs of function types and their
+//! arguments.
+
+use hash_abi::{ArgAbi, ArgAttributeFlag, ArgAttributes, ArgExtension, CallingConvention, FnAbi};
+use hash_ir::ty::{IrTy, IrTyId, Mutability, RefKind};
+use hash_layout::compute::LayoutComputer;
+use hash_target::abi::{Scalar, ScalarKind};
+use hash_utils::store::SequenceStore;
+
+use super::FnBuilder;
+use crate::traits::{builder::BlockBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods};
+
+/// Adjust the attributes of an argument ABI based on the provided
+/// [Layout] and [Scalar] information. This is required to do since
+/// the scalar maybe a pair of values.
+fn adjust_arg_attributes(
+    ctx: &LayoutComputer,
+    attributes: &mut ArgAttributes,
+    ty: IrTyId,
+    scalar: Scalar,
+) {
+    // Booleans are always "noundef" values...
+    if scalar.is_bool() {
+        attributes.extend_with(ArgExtension::ZeroExtend);
+        attributes.set(ArgAttributeFlag::NO_UNDEF);
+        return;
+    }
+
+    // If this scalar should always be initialised then we can set the "noundef"
+    // attribute.
+    if !scalar.is_union() {
+        attributes.set(ArgAttributeFlag::NO_UNDEF);
+    }
+
+    // If this scalar represents a pointer, then we can deduce more
+    // information about this particular argument.
+    let Scalar::Initialised { kind: ScalarKind::Pointer { .. }, valid_range } = scalar else {
+        return;
+    };
+
+    // If the pointer is never null, then we can set the "non_null" attribute.
+    if !valid_range.contains(0) {
+        attributes.set(ArgAttributeFlag::NON_NULL);
+    }
+
+    // If the pointer type is a read-only, then we can set the "read_only"
+    // attribute.
+    ctx.ir_ctx().map_ty(ty, |ty| {
+        let IrTy::Ref(_, mutability, kind) = ty else {
+            return;
+        };
+
+        // @@Future: can we deduce the same thing for an `Rc` pointer?
+        if matches!(kind, RefKind::Raw | RefKind::Normal) && *mutability == Mutability::Immutable {
+            attributes.set(ArgAttributeFlag::READ_ONLY);
+        }
+    });
+
+    // @@Todo: we currently can't deduce any information about aliasing of
+    // pointer data, so we can't really derive the "no_alias" attribute. If
+    // we become stricter with these rules, then we can possibly emit more
+    // useful information here.
+}
+
+impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+    /// Compute an [FnAbi] from a provided [IrTyId]. If the ABI
+    /// has already been computed for the particular instance, then
+    /// the cached version of the ABI is returned.
+    ///
+    /// N.B. the passed "ty" must be a function type.
+    pub fn compute_fn_abi_from_ty(&mut self, ty: IrTyId) -> Result<FnAbi, ()> {
+        // @@Todo: add caching for the ABI computation...
+        // @@Todo: add support for specifying more calling conventions, but for now
+        // we only support the C calling convention.
+        let calling_convention = CallingConvention::C;
+
+        self.ctx.ir_ctx().map_ty(ty, |ty| {
+            let IrTy::Fn { params, return_ty, .. } = ty else {
+                unreachable!("expected a function type")
+            };
+
+            let make_arg_abi = |ty: IrTyId, _index: Option<usize>| {
+                let lc = self.ctx.layout_computer();
+                let info = self.ctx.layout_of_id(ty);
+                let arg = ArgAbi::new(&lc, info, |scalar| {
+                    let mut attributes = ArgAttributes::new();
+                    adjust_arg_attributes(&lc, &mut attributes, ty, scalar);
+                    attributes
+                });
+
+                // @@Todo: we might have to adjust the attribute pass mode
+                // for ZSTs on specific platforms since they don't ignore them?
+                // if is_return && info.is_zst() {}
+
+                Ok(arg)
+            };
+
+            let fn_abi = FnAbi {
+                args: self.ctx.ir_ctx().tls().map_fast(*params, |tys| {
+                    tys.iter()
+                        .enumerate()
+                        .map(|(i, ty)| make_arg_abi(*ty, Some(i)))
+                        .collect::<Result<_, _>>()
+                })?,
+                ret_abi: make_arg_abi(*return_ty, None)?,
+                calling_convention,
+            };
+
+            Ok(fn_abi)
+        })
+    }
+}

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -14,6 +14,7 @@ use index_vec::IndexVec;
 use self::{locals::LocalRef, operands::OperandRef, place::PlaceRef};
 use crate::traits::{builder::BlockBuilderMethods, layout::LayoutMethods};
 
+pub(crate) mod abi;
 pub(crate) mod block;
 pub(crate) mod debug_info;
 pub(crate) mod intrinsics;

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -375,7 +375,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 builder.return_void();
                 return;
             }
-            PassMode::Direct(_) => {
+            PassMode::Direct(_) | PassMode::Pair(..) => {
                 let op = self
                     .codegen_consume_operand(builder, ir::Place::return_place(self.ctx.ir_ctx()));
 

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -1,15 +1,12 @@
 //! Various utilities that are used within the IR lowering logic
 //! to help with code generation.
 
-use hash_abi::FnAbi;
-use hash_ir::ty::{IrTy, IrTyId};
 use hash_layout::TyInfo;
 use hash_target::alignment::Alignment;
 
-use super::FnBuilder;
 use crate::{
     common::MemFlags,
-    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods},
+    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods},
 };
 
 /// Emit a `memcpy` instruction for a particular value with the provided
@@ -32,23 +29,4 @@ pub fn mem_copy_ty<'b, Builder: BlockBuilderMethods<'b>>(
     }
 
     builder.memcpy(destination, source, builder.ctx().const_usize(size), flags)
-}
-
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
-    /// Compute an [FnAbi] from a provided [IrTyId]. If the ABI
-    /// has already been computed for the particular instance, then
-    /// the cached version of the ABI is returned.
-    ///
-    /// N.B. the passed "ty" must be a function type.
-    pub fn compute_fn_abi_from_ty(&mut self, ty: IrTyId) -> &FnAbi {
-        // @@Todo: add caching for the ABI computation...
-
-        self.ctx.ir_ctx().map_ty(ty, |ty| {
-            let IrTy::Fn { .. } = ty else {
-                unreachable!("expected a function type")
-            };
-
-            todo!()
-        })
-    }
 }

--- a/compiler/hash-codegen/src/traits/ctx.rs
+++ b/compiler/hash-codegen/src/traits/ctx.rs
@@ -9,7 +9,7 @@ use hash_ir::{
 };
 use hash_layout::{compute::LayoutComputer, LayoutCtx};
 use hash_pipeline::settings::CompilerSettings;
-use hash_target::layout::HasDataLayout;
+use hash_target::data_layout::HasDataLayout;
 
 use crate::layout::{Layout, LayoutId};
 

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -14,7 +14,7 @@ use hash_source::{
 };
 use hash_target::{
     abi::{self, Integer, ScalarKind},
-    layout::HasDataLayout,
+    data_layout::HasDataLayout,
     size::Size,
 };
 use hash_utils::{

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -12,7 +12,7 @@ use hash_ir::{
 use hash_target::{
     abi::{AbiRepresentation, Integer, Scalar, ScalarKind, ValidScalarRange},
     alignment::{Alignment, Alignments},
-    layout::TargetDataLayout,
+    data_layout::TargetDataLayout,
     primitives::{FloatTy, SIntTy, UIntTy},
     size::Size,
 };

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -16,7 +16,7 @@ use hash_ir::ty::{IrTy, IrTyId, ToIrTy, VariantIdx};
 use hash_target::{
     abi::{AbiRepresentation, Scalar},
     alignment::Alignments,
-    layout::{HasDataLayout, TargetDataLayout},
+    data_layout::{HasDataLayout, TargetDataLayout},
     primitives::{FloatTy, SIntTy, UIntTy},
     size::Size,
 };

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -4,7 +4,7 @@
 use std::fmt::Display;
 
 use clap_derive::ValueEnum;
-use hash_target::{layout::TargetDataLayout, TargetInfo};
+use hash_target::{data_layout::TargetDataLayout, TargetInfo};
 
 /// Various settings that are present on the compiler pipeline when initially
 /// launching.

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -280,6 +280,11 @@ impl Scalar {
         Scalar::Union { kind: self.kind() }
     }
 
+    /// Check if the [Scalar] is a [`Scalar::Union`].
+    pub fn is_union(&self) -> bool {
+        matches!(self, Scalar::Union { .. })
+    }
+
     /// Align the [Scalar] with the current data layout
     /// specification.
     pub fn align<L: HasDataLayout>(&self, ctx: &L) -> Alignments {

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use crate::{
     alignment::{Alignment, Alignments},
-    layout::HasDataLayout,
+    data_layout::HasDataLayout,
     primitives::{FloatTy, SIntTy, UIntTy},
     size::Size,
 };

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub mod abi;
 pub mod alignment;
-pub mod layout;
+pub mod data_layout;
 pub mod primitives;
 pub mod size;
 

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 use num_bigint::BigInt;
 
-use crate::{abi::Integer, alignment::Alignments, layout::HasDataLayout, size::Size};
+use crate::{abi::Integer, alignment::Alignments, data_layout::HasDataLayout, size::Size};
 
 /// A primitive floating-point type, either a `f32` or an `f64`.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/compiler/hash-target/src/size.rs
+++ b/compiler/hash-target/src/size.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 
-use crate::{alignment::Alignment, layout::HasDataLayout};
+use crate::{alignment::Alignment, data_layout::HasDataLayout};
 
 /// Represents the size of some constant in bytes. [Size] is a
 /// utility type that allows one to perform various conversions


### PR DESCRIPTION
This patch implements logic for parsing data layout strings, and some basic logic to compute the `FnAbi` of a function. The logic to compute `FnAbi`s is missing a lot of features and currently doesn't support annotating functions with potentially different ABIs which is something we should look into in the future (possibly with directives or additional syntax like `extern <abi> func := () => { ... }`.