### PR TITLE
Hook up typechecking to the semantic pipeline

### DIFF
--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -1,0 +1,58 @@
+//! The third pass of the typechecker, which infers all remaining terms and
+//! types in the program.
+//!
+//! Typing errors are reported during this pass.
+
+use derive_more::Constructor;
+use hash_ast::ast::{self};
+use hash_tir::new::environment::env::AccessToEnv;
+
+use super::ast_utils::{AstPass, AstUtils};
+use crate::{
+    impl_access_to_tc_env,
+    new::{
+        environment::tc_env::{AccessToTcEnv, TcEnv},
+        ops::AccessToOps,
+    },
+};
+
+/// The third pass of the typechecker, which infers all remaining terms and
+/// types.
+#[derive(Constructor)]
+pub struct InferencePass<'tc> {
+    tc_env: &'tc TcEnv<'tc>,
+}
+
+impl_access_to_tc_env!(InferencePass<'tc>);
+
+impl<'tc> AstPass for InferencePass<'tc> {
+    fn pass_interactive(
+        &self,
+        node: ast::AstNodeRef<ast::BodyBlock>,
+    ) -> crate::new::diagnostics::error::TcResult<()> {
+        // Just infer the term corresponding to the body block, and then print it
+        // (@@Temp)
+        let term = self.ast_info().terms().get_data_by_node(node.id()).unwrap();
+        let ty = self.infer_ops().infer_term(term)?;
+        let ty_str = match ty {
+            Some(ty) => self.env().with(ty).to_string(),
+            None => "<unknown>".to_string(),
+        };
+        println!("{}: {}", self.env().with(term), ty_str);
+        Ok(())
+    }
+
+    fn pass_module(
+        &self,
+        node: ast::AstNodeRef<ast::Module>,
+    ) -> crate::new::diagnostics::error::TcResult<()> {
+        // Infer the whole module, which includes each member, and then print it
+        // (@@Temp)
+        let mod_def_id = self.ast_info().mod_defs().get_data_by_node(node.id()).unwrap();
+        self.infer_ops().infer_mod_def(mod_def_id)?;
+        println!("{}", self.env().with(mod_def_id));
+        Ok(())
+    }
+}
+
+impl AstUtils for InferencePass<'_> {}

--- a/compiler/hash-semantics/src/new/passes/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/mod.rs
@@ -1,9 +1,15 @@
-use self::{ast_utils::AstPass, discovery::DiscoveryPass, resolution::ResolutionPass};
+use hash_tir::new::environment::env::AccessToEnv;
+
+use self::{
+    ast_utils::AstPass, discovery::DiscoveryPass, inference::InferencePass,
+    resolution::ResolutionPass,
+};
 use super::environment::tc_env::{AccessToTcEnv, TcEnv};
 use crate::impl_access_to_tc_env;
 
 pub mod ast_utils;
 pub mod discovery;
+pub mod inference;
 pub mod resolution;
 
 /// The base TC visitor, which runs each typechecking pass in order on the AST.
@@ -20,11 +26,18 @@ impl<'tc> TcVisitor<'tc> {
 
     /// Visits the source passed in as an argument to [Self::new_in_source]
     pub fn visit_source(&self) {
+        self.context().clear_all();
+
         DiscoveryPass::new(self.tc_env).pass_source();
         if self.diagnostics().has_errors() {
             return;
         }
 
         ResolutionPass::new(self.tc_env).pass_source();
+        if self.diagnostics().has_errors() {
+            return;
+        }
+
+        InferencePass::new(self.tc_env).pass_source();
     }
 }

--- a/compiler/hash-semantics/src/new/passes/resolution/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/mod.rs
@@ -5,7 +5,6 @@
 //! Any scoping errors are reported here.
 
 use hash_ast::ast::{self};
-use hash_tir::new::environment::env::AccessToEnv;
 
 use self::scoping::{ContextKind, Scoping};
 use super::ast_utils::{AstPass, AstUtils};
@@ -37,29 +36,21 @@ impl<'tc> AstPass for ResolutionPass<'tc> {
         &self,
         node: ast::AstNodeRef<ast::BodyBlock>,
     ) -> crate::new::diagnostics::error::TcResult<()> {
-        self.bootstrap_ops().bootstrap(|prim_mod| {
-            self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
-            let term = self.make_term_from_ast_body_block(node)?;
-            let term_ty = self.infer_ops().infer_term(term)?;
-            if let Some(term_ty) = term_ty {
-                println!("Inferred type: {}", self.env().with(term_ty));
-            } else {
-                println!("Inferred type: <unknown>");
-            }
-            Ok(())
-        })
+        // @@Todo: add intrinsics to the environment
+        let (prim_mod, _) = self.bootstrap_ops().bootstrap();
+        self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
+        let _ = self.make_term_from_ast_body_block(node)?;
+        Ok(())
     }
 
     fn pass_module(
         &self,
         node: ast::AstNodeRef<ast::Module>,
     ) -> crate::new::diagnostics::error::TcResult<()> {
-        self.bootstrap_ops().bootstrap(|prim_mod| {
-            self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
-            let mod_def_id = self.resolve_ast_module_inner_terms(node)?;
-            println!("Resolved module: {}", self.env().with(mod_def_id));
-            Ok(())
-        })
+        let (prim_mod, _) = self.bootstrap_ops().bootstrap();
+        self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
+        let _ = self.resolve_ast_module_inner_terms(node)?;
+        Ok(())
     }
 }
 

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -277,6 +277,12 @@ impl Context {
         self.scopes.borrow_mut().truncate(constant_scope_level_index);
         self.members.borrow_mut().truncate(constant_scope_level);
     }
+
+    /// Clear all the scopes and bindings in the context.
+    pub fn clear_all(&self) {
+        self.scopes.borrow_mut().clear();
+        self.members.borrow_mut().clear();
+    }
 }
 
 impl fmt::Display for WithEnv<'_, &BoundVarOrigin> {


### PR DESCRIPTION
This PR adds the final step of inference to the typechecking pipeline, All this does is just infer the term or module corresponding to the node, and then print the result.

Note that the typechecking is still not quite functional yet, there are some bits left to implement: substitutions, hole filling, (normalisation).

Closes #708 