### PR TITLE
codegen(llvm): add trait implementation methods for LLVM backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,19 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v2
+        with: 
+          path: ./llvm
+          key: llvm-15
+
+      - name: Install LLVM
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "15.0"
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -26,17 +39,14 @@ jobs:
       - name: "Dependency caching"
         uses: Swatinem/rust-cache@v1
 
+      - uses: actions-rs/cargo@v1
+      
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --verbose
-   
+        run: "LLVM_SYS_150_PREFIX=$LLVM_PATH cargo test --all --verbose"
+
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D warnings
+        run: "LLVM_SYS_150_PREFIX=$LLVM_PATH cargo clippy --all -- -D warnings"
+
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,9 +524,11 @@ version = "0.1.0"
 dependencies = [
  "hash-codegen",
  "hash-ir",
+ "hash-pipeline",
  "hash-source",
  "hash-target",
  "hash-utils",
+ "inkwell",
  "rayon",
 ]
 
@@ -705,6 +707,7 @@ dependencies = [
  "hash-ast-desugaring",
  "hash-ast-expand",
  "hash-backend",
+ "hash-codegen",
  "hash-interactive",
  "hash-ir",
  "hash-layout",
@@ -950,6 +953,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.1.0"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#c77d05639c9b73d9bede713789b9707d45863530"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.6.0"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#c77d05639c9b73d9bede713789b9707d45863530"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1023,19 @@ name = "linux-raw-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
+name = "llvm-sys"
+version = "150.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab12165825f9fe4a9afa32c17bf55a4014a7f0385c5969975f2d04d36cd611c"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver",
+]
 
 [[package]]
 name = "lock_api"
@@ -1169,6 +1208,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,50 @@
+# Installing tools and dependencies
+
+## Rust
+
+The Rust Programming language and `cargo` are required to build the Hash compiler. The easiest way to install Rust is using [rustup](https://rustup.rs/).
+
+## LLVM
+
+One of the Hash compiler code generation backends is LLVM, so you will need to install LLVM on your system.
+Currently, the compiler used LLVM 15.0.x, which can be installed using the following instructions 
+(specific to each OS):
+
+### MacOS
+
+To install on MacOS, the simplest way to install it is using [Homebrew](https://brew.sh/):
+
+```bash
+brew install llvm@15
+``` 
+**Note**: If you are unsure of where LLVM has been installed, you can query 
+the installation path using `brew --prefix llvm@15`.
+
+
+### Windows
+
+To install on Windows, the simplest way to install it is using [Chocolatey](https://chocolatey.org/):
+
+```pwsh
+choco install llvm --version 15.0.0
+```
+
+Alternatively, you can download the pre-built binaries from the [LLVM website](https://releases.llvm.org/download.html).
+
+### Linux
+
+To install on Linux, the simplest way to install it is using a package manager, such as `apt`, `yum`, `dnf`, etc. With `apt` it 
+can be installed using the following command:
+```bash
+apt install llvm-15 llvm-15-* liblld-15* libclang-common-13-dev
+```
+
+### After installation
+
+Once the tools are installed, the LLVM binaries need to be either added to the `PATH` environment variable, or specified to `cargo` using the `LLVM_SYS_15_PREFIX` before the `cargo` command:
+```
+LLVM_SYS_15_PREFIX=<path_to_llvm> cargo run
+``` 
+
+However, if LLVM is added to the path, then building and testing
+can be done with a simple `cargo` invocation:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 The Hash Programming Language compiler and standard library sources.
 Get started by reading [the Hash book](https://hash-org.github.io/lang).
 
+## Installation
+
+Instructions are available in the [INSTALL.md](./INSTALL.md) file.
+
 ## Build and Run
 
-Building and running the project is fairly simple as the project is built on top of cargo.
+Before building the compiler, make sure you have installed the required dependencies.
 
 - To build the project, run `cargo build`
 - To run the interactive mode, run `cargo run`

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -4,11 +4,10 @@
 //! code generation process.
 #![allow(dead_code)] // @@Temporary: until the codegen general purpose logic is completed.
 
-use hash_ir::IrStorage;
+use hash_codegen::BackendCtx;
 use hash_pipeline::{
     interface::{CompilerInterface, CompilerStage},
-    settings::{CodeGenSettings, CompilerStageKind},
-    workspace::Workspace,
+    settings::CompilerStageKind,
     CompilerResult,
 };
 use hash_source::SourceId;
@@ -22,25 +21,6 @@ impl Backend {
     pub fn new() -> Self {
         Self
     }
-}
-
-/// The [BackendCtx] is the context that is needed for any [CodeGen]
-/// backend to generate code for the target backend.
-///
-/// @@Todo: determine how we deal with "code store".
-pub struct BackendCtx<'b> {
-    /// Reference to the current compiler workspace.
-    pub workspace: &'b mut Workspace,
-
-    /// Reference to the IR storage that is used to store
-    /// the lowered IR, and all metadata about the IR.
-    pub ir_storage: &'b IrStorage,
-
-    /// A reference to the backend settings in the current session.
-    pub settings: &'b CodeGenSettings,
-
-    /// Reference to the rayon thread pool.
-    pub _pool: &'b rayon::ThreadPool,
 }
 
 pub trait BackendCtxQuery: CompilerInterface {

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 
 [dependencies]
 rayon = "1.5.0"
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm15-0"] }
 
 hash-codegen = {path = "../hash-codegen" }
 hash-ir = {path = "../hash-ir" }
 hash-source = {path = "../hash-source" }
 hash-target = { path = "../hash-target" }
 hash-utils = {path = "../hash-utils" }
+hash-pipeline = { path = "../hash-pipeline" }

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -1,3 +1,3 @@
-//! Hash compiler LLVM code generation crate. This crate contains all of the
-//! logic of transforming generated Hash IR into LLVM IR so that it can be
-//! compiled by LLVM into a native executable with the specified target triple.
+//! The LLVM code generation backend for Hash.
+
+pub mod translation;

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -1,0 +1,29 @@
+//! This implements all of the ABI specified methods for the [Builder].
+
+use hash_codegen::{abi::ArgAbi, lower::place::PlaceRef, traits::abi::AbiBuilderMethods};
+
+use super::Builder;
+
+impl<'b> AbiBuilderMethods<'b> for Builder<'b> {
+    fn get_param(&mut self, index: usize) -> Self::Value {
+        todo!()
+    }
+
+    fn store_arg(
+        &mut self,
+        arg_abi: &ArgAbi,
+        value: Self::Value,
+        destination: PlaceRef<Self::Value>,
+    ) {
+        todo!()
+    }
+
+    fn store_fn_arg(
+        &mut self,
+        arg_abi: &ArgAbi,
+        index: &mut usize,
+        destination: PlaceRef<Self::Value>,
+    ) {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -1,0 +1,485 @@
+//! Implementation for all of the specified methods of
+//! [hash_codegen::traits::builder::BlockBuilderMethods] using the Inkwell
+//! wrapper around LLVM.
+
+use hash_codegen::{
+    common::MemFlags,
+    lower::{operands::OperandRef, place::PlaceRef},
+    traits::builder::BlockBuilderMethods,
+};
+use hash_target::{abi::ValidScalarRange, alignment::Alignment, size::Size};
+
+use super::Builder;
+
+impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
+    fn build(ctx: &'b Self::CodegenCtx, block: Self::BasicBlock) -> Self {
+        todo!()
+    }
+
+    fn append_block(
+        ctx: &'b Self::CodegenCtx,
+        func: Self::Function,
+        name: &str,
+    ) -> Self::BasicBlock {
+        todo!()
+    }
+
+    fn append_sibling_block(&mut self, name: &str) -> Self::BasicBlock {
+        todo!()
+    }
+
+    fn ctx(&self) -> &Self::CodegenCtx {
+        todo!()
+    }
+
+    fn basic_block(&self) -> Self::BasicBlock {
+        todo!()
+    }
+
+    fn switch_to_block(&mut self, block: Self::BasicBlock) {
+        todo!()
+    }
+
+    fn return_value(&mut self, value: Self::Value) {
+        todo!()
+    }
+
+    fn return_void(&mut self) {
+        todo!()
+    }
+
+    fn branch(&mut self, destination: Self::BasicBlock) {
+        todo!()
+    }
+
+    fn conditional_branch(
+        &mut self,
+        condition: Self::Value,
+        true_block: Self::BasicBlock,
+        false_block: Self::BasicBlock,
+    ) {
+        todo!()
+    }
+
+    fn switch(
+        &mut self,
+        condition: Self::Value,
+        cases: impl ExactSizeIterator<Item = (u128, Self::BasicBlock)>,
+        otherwise_block: Self::BasicBlock,
+    ) {
+        todo!()
+    }
+
+    fn unreachable(&mut self) {
+        todo!()
+    }
+
+    fn checked_call(
+        &mut self,
+        ty: Self::Type,
+        args: &[Self::Value],
+        then_block: Self::BasicBlock,
+        catch_block: Self::BasicBlock,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn call(
+        &mut self,
+        ty: Self::Type,
+        fn_abi: Option<&hash_codegen::abi::FnAbi>,
+        fn_ptr: Self::Value,
+        args: &[Self::Value],
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fadd_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn sub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fsub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fsub_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn mul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fmul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fmul_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn udiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn exactudiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn sdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn exactsdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fdiv_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn urem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn srem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn frem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn frem_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fpow(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn shl(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn lshr(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn ashr(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_sadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_uadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_ssub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_usub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_smul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn unchecked_umul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn and(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn or(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn xor(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn not(&mut self, v: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn neg(&mut self, v: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn fneg(&mut self, v: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn checked_bin_op(
+        &mut self,
+        op: hash_codegen::common::CheckedOp,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> (Self::Value, Self::Value) {
+        todo!()
+    }
+
+    fn icmp(
+        &mut self,
+        op: hash_codegen::common::IntComparisonKind,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn fcmp(
+        &mut self,
+        op: hash_codegen::common::RealComparisonKind,
+        lhs: Self::Value,
+        rhs: Self::Value,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn truncate(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn sign_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn zero_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_to_ui_sat(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_to_si_sat(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_to_ui(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_to_si(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn ui_to_fp(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn si_to_fp(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_truncate(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn fp_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn ptr_to_int(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn int_to_ptr(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn bit_cast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn int_cast(&mut self, val: Self::Value, dest_ty: Self::Type, is_signed: bool) -> Self::Value {
+        todo!()
+    }
+
+    fn pointer_cast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn bool_from_immediate(&mut self, v: Self::Value) -> Self::Value {
+        todo!()
+    }
+
+    fn to_immediate_scalar(
+        &mut self,
+        v: Self::Value,
+        scalar_kind: hash_target::abi::Scalar,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn alloca(&mut self, ty: Self::Type, alignment: Alignment) -> Self::Value {
+        todo!()
+    }
+
+    fn byte_array_alloca(&mut self, len: Self::Value, alignment: Alignment) -> Self::Value {
+        todo!()
+    }
+
+    fn write_operand_repeatedly(
+        &mut self,
+        operand: OperandRef<Self::Value>,
+        count: usize,
+        destination: PlaceRef<Self::Value>,
+    ) {
+        todo!()
+    }
+
+    fn load(&mut self, ty: Self::Type, ptr: Self::Value, alignment: Alignment) -> Self::Value {
+        todo!()
+    }
+
+    fn volatile_load(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        alignment: Alignment,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn atomic_load(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        alignment: Alignment,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn load_operand(&mut self, place: PlaceRef<Self::Value>) -> OperandRef<Self::Value> {
+        todo!()
+    }
+
+    fn store(&mut self, value: Self::Value, ptr: Self::Value, alignment: Alignment) -> Self::Value {
+        todo!()
+    }
+
+    fn store_with_flags(
+        &mut self,
+        value: Self::Value,
+        ptr: Self::Value,
+        alignment: Alignment,
+        flags: hash_codegen::common::MemFlags,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn atomic_store(
+        &mut self,
+        value: Self::Value,
+        ptr: Self::Value,
+        alignment: Alignment,
+        ordering: std::sync::atomic::Ordering,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn get_element_pointer(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        indices: &[Self::Value],
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn bounded_get_element_pointer(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        indices: &[Self::Value],
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn structural_get_element_pointer(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        index: u64,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn memcpy(
+        &mut self,
+        destination: (Self::Value, Alignment),
+        source: (Self::Value, Alignment),
+        size: Self::Value,
+        flags: MemFlags,
+    ) {
+        todo!()
+    }
+
+    fn memmove(
+        &mut self,
+        destination: (Self::Value, Alignment),
+        source: (Self::Value, Alignment),
+        size: Self::Value,
+        flags: MemFlags,
+    ) {
+        todo!()
+    }
+
+    fn memset(
+        &mut self,
+        ptr: Self::Value,
+        fill: Self::Value,
+        size: Self::Value,
+        align: Alignment,
+        flags: MemFlags,
+    ) {
+        todo!()
+    }
+
+    fn select(
+        &mut self,
+        condition: Self::Value,
+        then: Self::Value,
+        otherwise: Self::Value,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn lifetime_start(&mut self, ptr: Self::Value, size: Size) {
+        todo!()
+    }
+
+    fn lifetime_end(&mut self, ptr: Self::Value, size: Size) {
+        todo!()
+    }
+
+    fn add_range_metadata_to(&mut self, value: Self::Value, range: ValidScalarRange) {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -1,0 +1,101 @@
+//! Implements all of the constant building methods.
+use hash_codegen::traits::constants::BuildConstValueMethods;
+use hash_ir::ir::Const;
+use hash_source::constant::InternedStr;
+use hash_target::abi::Scalar;
+
+use super::context::CodeGenCtx;
+
+impl<'b> BuildConstValueMethods<'b> for CodeGenCtx<'b> {
+    fn const_undef(&self, ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn const_null(&self, ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn const_bool(&self, val: bool) -> Self::Value {
+        todo!()
+    }
+
+    fn const_u8(&self, i: u8) -> Self::Value {
+        todo!()
+    }
+
+    fn const_i8(&self, i: i8) -> Self::Value {
+        todo!()
+    }
+
+    fn const_u16(&self, i: i16) -> Self::Value {
+        todo!()
+    }
+
+    fn const_i16(&self, i: i16) -> Self::Value {
+        todo!()
+    }
+
+    fn const_u32(&self, i: u32) -> Self::Value {
+        todo!()
+    }
+
+    fn const_i32(&self, i: i32) -> Self::Value {
+        todo!()
+    }
+
+    fn const_u64(&self, i: u64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_i64(&self, i: i64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_u128(&self, i: u128) -> Self::Value {
+        todo!()
+    }
+
+    fn const_i128(&self, i: i128) -> Self::Value {
+        todo!()
+    }
+
+    fn const_uint(&self, ty: Self::Type, value: u64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_uint_big(&self, ty: Self::Type, i: u128) -> Self::Value {
+        todo!()
+    }
+
+    fn const_int(&self, ty: Self::Type, value: i64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_usize(&self, i: u64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_float(&self, t: Self::Type, val: f64) -> Self::Value {
+        todo!()
+    }
+
+    fn const_str(&self, s: &str) -> (Self::Value, Self::Value) {
+        todo!()
+    }
+
+    fn const_interned_str(&self, s: InternedStr) -> (Self::Value, Self::Value) {
+        todo!()
+    }
+
+    fn const_scalar_value(&self, const_value: Const, abi: Scalar, ty: Self::Type) -> Self::Value {
+        todo!()
+    }
+
+    fn const_to_optional_u128(&self, value: Self::Value, sign_extend: bool) -> Option<u128> {
+        todo!()
+    }
+
+    fn const_to_optional_uint(&self, value: Self::Value) -> Option<u64> {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/context.rs
+++ b/compiler/hash-codegen-llvm/src/translation/context.rs
@@ -1,0 +1,67 @@
+//! This defines the [CodeGenCtx] which is the global context that is
+//! used convert Hash IR into LLVM IR, and to perform various other
+//! tasks to finalise the LLVM IR and compile it into a native executable.
+use hash_codegen::{
+    layout::{compute::LayoutComputer, Layout, LayoutCtx},
+    traits::{ctx::HasCtxMethods, target::HasTargetSpec, Backend, BackendTypes},
+};
+use hash_ir::IrCtx;
+use hash_pipeline::settings::CompilerSettings;
+use inkwell as llvm;
+
+pub struct CodeGenCtx<'ll> {
+    /// The LLVM module that we are putting items into.
+    pub module: &'ll llvm::module::Module<'ll>,
+
+    /// The InkWell context that we are generating code with.
+    pub ll_ctx: llvm::context::ContextRef<'ll>,
+}
+
+impl HasTargetSpec for CodeGenCtx<'_> {
+    fn target_spec(&self) -> &hash_target::Target {
+        todo!()
+    }
+}
+
+/// Implement the types for the [CodeGenCtx].
+impl<'ll> BackendTypes for CodeGenCtx<'ll> {
+    type Value = &'ll llvm::values::AnyValueEnum<'ll>;
+
+    type Function = &'ll llvm::values::FunctionValue<'ll>;
+
+    type Type = &'ll llvm::types::BasicTypeEnum<'ll>;
+
+    type BasicBlock = &'ll llvm::basic_block::BasicBlock<'ll>;
+
+    type DebugInfoScope = &'ll llvm::debug_info::DIScope<'ll>;
+
+    type DebugInfoLocation = &'ll llvm::debug_info::DILocation<'ll>;
+
+    type DebugInfoVariable = &'ll llvm::debug_info::DILocalVariable<'ll>;
+}
+
+impl<'b> Backend<'b> for CodeGenCtx<'b> {}
+
+impl<'b> HasCtxMethods<'b> for CodeGenCtx<'b> {
+    fn settings(&self) -> &CompilerSettings {
+        todo!()
+    }
+
+    fn ir_ctx(&self) -> &IrCtx {
+        todo!()
+    }
+
+    fn layouts(&self) -> &LayoutCtx {
+        todo!()
+    }
+
+    fn layout_computer(&self) -> LayoutComputer<'_> {
+        LayoutComputer::new(self.layouts(), self.ir_ctx())
+    }
+}
+
+impl<'ll> CodeGenCtx<'ll> {
+    pub fn new(module: &'ll llvm::module::Module<'ll>) -> Self {
+        Self { module, ll_ctx: module.get_context() }
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -1,0 +1,40 @@
+//! Implements all of the required functionality for generating debug
+//! information for the LLVM backend.
+
+use hash_codegen::traits::debug::{BuildDebugInfoMethods, VariableKind};
+use hash_source::{identifier::Identifier, location::SourceLocation};
+
+use super::Builder;
+
+impl<'b> BuildDebugInfoMethods for Builder<'b> {
+    fn create_debug_info_scope_for_fn(
+        &self,
+        fn_abi: (),
+        value: Option<Self::Function>,
+    ) -> Self::DebugInfoScope {
+        todo!()
+    }
+
+    fn create_debug_info_for_variable(
+        &self,
+        name: Identifier,
+        ty: hash_ir::ty::IrTyId,
+        scope: Self::DebugInfoScope,
+        kind: VariableKind,
+        span: SourceLocation,
+    ) -> Self::DebugInfoVariable {
+        todo!()
+    }
+
+    fn create_debug_info_location(
+        &self,
+        scope: Self::DebugInfoScope,
+        span: SourceLocation,
+    ) -> Self::DebugInfoLocation {
+        todo!()
+    }
+
+    fn finalise_debug_info(&self) {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -1,0 +1,24 @@
+//! Implements the [BuildIntrinsicCallMethods] trait for [Builder].
+
+use hash_codegen::traits::intrinsics::BuildIntrinsicCallMethods;
+
+use super::Builder;
+
+impl<'b> BuildIntrinsicCallMethods<'b> for Builder<'b> {
+    fn codegen_intrinsic_call(
+        &self,
+        ty: hash_ir::ty::IrTyId,
+        args: &[Self::Value],
+        result: Self::Value,
+    ) -> Self::Value {
+        todo!()
+    }
+
+    fn codegen_abort_intrinsic(&mut self) {
+        todo!()
+    }
+
+    fn codegen_expect_intrinsic(&mut self, value: Self::Value, expected: bool) -> Self::Value {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -1,0 +1,64 @@
+//! Implements all of the required methods for computing the layouts of types.
+
+use hash_codegen::{layout::TyInfo, traits::layout::LayoutMethods};
+use hash_target::data_layout::{HasDataLayout, TargetDataLayout};
+
+use super::{context::CodeGenCtx, Builder};
+
+impl<'b> LayoutMethods<'b> for CodeGenCtx<'b> {
+    fn layout_of_id(&self, ty: hash_ir::ty::IrTyId) -> hash_codegen::layout::TyInfo {
+        todo!()
+    }
+
+    fn layout_of(&self, ty: hash_ir::ty::IrTy) -> hash_codegen::layout::TyInfo {
+        todo!()
+    }
+
+    fn backend_field_index(&self, info: hash_codegen::layout::TyInfo, index: usize) -> u64 {
+        todo!()
+    }
+
+    fn is_backend_immediate(&self, ty: hash_codegen::layout::TyInfo) -> bool {
+        todo!()
+    }
+
+    fn scalar_pair_element_backend_type(
+        &self,
+        info: hash_codegen::layout::TyInfo,
+        index: usize,
+        immediate: bool,
+    ) -> Self::Type {
+        todo!()
+    }
+}
+
+impl HasDataLayout for CodeGenCtx<'_> {
+    fn data_layout(&self) -> &TargetDataLayout {
+        todo!()
+    }
+}
+
+impl<'b> LayoutMethods<'b> for Builder<'b> {
+    fn backend_field_index(&self, info: TyInfo, index: usize) -> u64 {
+        self.ctx.backend_field_index(info, index)
+    }
+
+    fn is_backend_immediate(&self, ty: TyInfo) -> bool {
+        self.ctx.is_backend_immediate(ty)
+    }
+
+    fn scalar_pair_element_backend_type(
+        &self,
+        info: TyInfo,
+        index: usize,
+        immediate: bool,
+    ) -> Self::Type {
+        self.ctx.scalar_pair_element_backend_type(info, index, immediate)
+    }
+}
+
+impl HasDataLayout for Builder<'_> {
+    fn data_layout(&self) -> &TargetDataLayout {
+        self.ctx.data_layout()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -1,0 +1,19 @@
+//! Implements various miscellaneous methods for the LLVM backend.
+
+use hash_codegen::traits::misc::MiscBuilderMethods;
+
+use super::context::CodeGenCtx;
+
+impl<'b> MiscBuilderMethods<'b> for CodeGenCtx<'b> {
+    fn get_fn(&self, instance: hash_ir::ty::Instance) -> Self::Function {
+        todo!()
+    }
+
+    fn get_fn_ptr(&self, instance: hash_ir::ty::Instance) -> Self::Value {
+        todo!()
+    }
+
+    fn declare_entry_point(&self, ty: Self::Type) -> Option<Self::Function> {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -1,0 +1,86 @@
+//! Hash compiler LLVM code generation crate. This crate contains all of the
+//! logic of transforming generated Hash IR into LLVM IR so that it can be
+//! compiled by LLVM into a native executable with the specified target triple.
+#![allow(dead_code, unused)] // @@Temporary: remove this when all items are implemented and the
+                             // codegen is fully functional.
+
+use hash_codegen::{
+    layout::{compute::LayoutComputer, LayoutCtx},
+    traits::{ctx::HasCtxMethods, target::HasTargetSpec, Backend, BackendTypes, Codegen},
+};
+use hash_ir::IrCtx;
+use hash_pipeline::settings::CompilerSettings;
+use hash_target::Target;
+
+use self::context::CodeGenCtx;
+
+mod abi;
+mod builder;
+mod constants;
+mod context;
+mod debug_info;
+mod intrinsics;
+mod layouts;
+mod misc;
+mod ty;
+
+/// A [Builder] is defined as being a context that is used to implement
+/// all of the specified builder methods.
+pub struct Builder<'b> {
+    /// The actual InkWell builder
+    builder: &'b mut inkwell::builder::Builder<'b>,
+
+    /// The context for the builder.
+    ctx: &'b CodeGenCtx<'b>,
+}
+
+/// This specifies that the [Builder] context is [CodegenCtx].
+impl<'b> Codegen<'b> for Builder<'b> {
+    type CodegenCtx = CodeGenCtx<'b>;
+}
+
+/// This specifies all of the common IR type kinds for [Builder].
+impl<'b> BackendTypes for Builder<'b> {
+    type Value = <CodeGenCtx<'b> as BackendTypes>::Value;
+    type Function = <CodeGenCtx<'b> as BackendTypes>::Function;
+    type Type = <CodeGenCtx<'b> as BackendTypes>::Type;
+    type BasicBlock = <CodeGenCtx<'b> as BackendTypes>::BasicBlock;
+
+    type DebugInfoScope = <CodeGenCtx<'b> as BackendTypes>::DebugInfoScope;
+    type DebugInfoLocation = <CodeGenCtx<'b> as BackendTypes>::DebugInfoLocation;
+    type DebugInfoVariable = <CodeGenCtx<'b> as BackendTypes>::DebugInfoVariable;
+}
+
+impl<'b> Backend<'b> for Builder<'b> {}
+
+impl<'b> std::ops::Deref for Builder<'b> {
+    type Target = CodeGenCtx<'b>;
+
+    fn deref(&self) -> &Self::Target {
+        self.ctx
+    }
+}
+
+impl<'b> HasCtxMethods<'b> for Builder<'b> {
+    fn settings(&self) -> &CompilerSettings {
+        self.ctx.settings()
+    }
+
+    fn ir_ctx(&self) -> &IrCtx {
+        self.ctx.ir_ctx()
+    }
+
+    fn layouts(&self) -> &LayoutCtx {
+        self.ctx.layouts()
+    }
+
+    fn layout_computer(&self) -> LayoutComputer<'_> {
+        LayoutComputer::new(self.layouts(), self.ir_ctx())
+    }
+}
+
+impl HasTargetSpec for Builder<'_> {
+    fn target_spec(&self) -> &Target {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -1,0 +1,104 @@
+//! Implements all of the type building methods for the LLVM
+//! backend.
+
+use hash_codegen::traits::ty::BuildTypeMethods;
+
+use super::context::CodeGenCtx;
+
+impl<'b> BuildTypeMethods<'b> for CodeGenCtx<'b> {
+    fn type_i1(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_i8(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_i16(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_i32(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_i64(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_i128(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_isize(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_f32(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_f64(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type {
+        todo!()
+    }
+
+    fn type_function(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type {
+        todo!()
+    }
+
+    fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type {
+        todo!()
+    }
+
+    fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {
+        todo!()
+    }
+
+    fn type_ptr_to_ext(
+        &self,
+        ty: Self::Type,
+        address_space: hash_target::abi::AddressSpace,
+    ) -> Self::Type {
+        todo!()
+    }
+
+    fn element_type(&self, ty: Self::Type) -> Self::Type {
+        todo!()
+    }
+
+    fn vector_length(&self, ty: Self::Type) -> usize {
+        todo!()
+    }
+
+    fn float_width(&self, ty: Self::Type) -> usize {
+        todo!()
+    }
+
+    fn int_width(&self, ty: Self::Type) -> u64 {
+        todo!()
+    }
+
+    fn type_of_value(&self, value: Self::Value) -> Self::Type {
+        todo!()
+    }
+
+    fn kind_of_type(&self, ty: Self::Type) -> hash_codegen::common::TypeKind {
+        todo!()
+    }
+
+    fn immediate_backend_type(&self, info: hash_codegen::layout::TyInfo) -> Self::Type {
+        todo!()
+    }
+
+    fn backend_type(&self, info: hash_codegen::layout::TyInfo) -> Self::Type {
+        todo!()
+    }
+
+    fn backend_type_from_abi(&self, abi: &hash_codegen::abi::FnAbi) -> Self::Type {
+        todo!()
+    }
+}

--- a/compiler/hash-codegen/src/lib.rs
+++ b/compiler/hash-codegen/src/lib.rs
@@ -19,14 +19,33 @@
 //! hand, LLVM backend will emit a runnable executable after the code is
 //! generated.
 #![feature(let_chains, box_patterns)]
-#![allow(dead_code)] // @@Temporary: until the codegen general purpose logic is completed.
 
 pub mod common;
+pub mod lower;
 pub mod traits;
-
-mod lower;
 
 // re-export `abi` and `layout` crates to make them available to the backend
 // implementations.
 pub use hash_abi as abi;
+use hash_ir::IrStorage;
 pub use hash_layout as layout;
+use hash_pipeline::{settings::CompilerSettings, workspace::Workspace};
+
+/// The [BackendCtx] is the context that is needed for any [CodeGen]
+/// backend to generate code for the target backend.
+///
+/// @@Todo: determine how we deal with "code store".
+pub struct BackendCtx<'b> {
+    /// Reference to the current compiler workspace.
+    pub workspace: &'b mut Workspace,
+
+    /// Reference to the IR storage that is used to store
+    /// the lowered IR, and all metadata about the IR.
+    pub ir_storage: &'b IrStorage,
+
+    /// A reference to the backend settings in the current session.
+    pub settings: &'b CompilerSettings,
+
+    /// Reference to the rayon thread pool.
+    pub _pool: &'b rayon::ThreadPool,
+}

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -18,7 +18,7 @@ use index_vec::IndexVec;
 
 use super::{operands::OperandRef, place::PlaceRef, FnBuilder};
 use crate::traits::{
-    builder::BlockBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods, CodeGen, CodeGenObject,
+    builder::BlockBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods, CodeGenObject, Codegen,
 };
 
 /// Defines what kind of reference a local has. A [LocalRef::Place]
@@ -35,7 +35,7 @@ pub enum LocalRef<V> {
 
 impl<'b, V: CodeGenObject> LocalRef<V> {
     /// Create a new [LocalRef::Operand] instance.
-    pub fn new_operand<Builder: CodeGen<'b, Value = V>>(
+    pub fn new_operand<Builder: Codegen<'b, Value = V>>(
         builder: &mut Builder,
         layout: TyInfo,
     ) -> Self {

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -14,17 +14,17 @@ use index_vec::IndexVec;
 use self::{locals::LocalRef, operands::OperandRef, place::PlaceRef};
 use crate::traits::{builder::BlockBuilderMethods, layout::LayoutMethods};
 
-pub(crate) mod abi;
-pub(crate) mod block;
-pub(crate) mod debug_info;
-pub(crate) mod intrinsics;
-pub(crate) mod locals;
-pub(crate) mod operands;
-pub(crate) mod place;
-pub(crate) mod rvalue;
-pub(crate) mod statement;
-pub(crate) mod terminator;
-pub(crate) mod utils;
+pub mod abi;
+pub mod block;
+pub mod debug_info;
+pub mod intrinsics;
+pub mod locals;
+pub mod operands;
+pub mod place;
+pub mod rvalue;
+pub mod statement;
+pub mod terminator;
+pub mod utils;
 
 /// This enum is used to track the status of a basic block during the
 /// lowering process. This is used to avoid creating multiple basic blocks IDs
@@ -82,7 +82,7 @@ pub struct FnBuilder<'b, Builder: BlockBuilderMethods<'b>> {
 
     /// A commonly shared "unreachable" block in order to avoid
     /// having multiple basic blocks that are "unreachable".
-    unreachable_block: Option<Builder::BasicBlock>,
+    _unreachable_block: Option<Builder::BasicBlock>,
 }
 
 impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
@@ -106,7 +106,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             fn_abi,
             block_map: IndexVec::new(),
             locals: IndexVec::with_capacity(body.declarations.len()),
-            unreachable_block: None,
+            _unreachable_block: None,
         }
     }
 }

--- a/compiler/hash-codegen/src/lower/statement.rs
+++ b/compiler/hash-codegen/src/lower/statement.rs
@@ -25,11 +25,13 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                             // @@DebugInfo: we introduced the local here...
                         }
                         LocalRef::Operand(Some(operand)) => {
+                            let is_zst =
+                                builder.map_layout(operand.info.layout, |layout| layout.is_zst());
                             // We can't have another assignment for a local ref since
                             // this implies that it is not in SSA form (unless it is a
                             // ZST for which the rules are slightly bent). However, we
                             // must still codegen the rvalue.
-                            if !builder.layout_info(operand.info.layout).is_zst() {
+                            if !is_zst {
                                 // @@PanicOnSpan: we should be able to provide a panic_on_span
                                 // by allowing the code generation to have access to the source
                                 // map.

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -21,7 +21,7 @@ pub fn mem_copy_ty<'b, Builder: BlockBuilderMethods<'b>>(
     ty: TyInfo,
     flags: MemFlags,
 ) {
-    let size = builder.layout_info(ty.layout).size.bytes();
+    let size = builder.map_layout(ty.layout, |layout| layout.size.bytes());
 
     // we don't copy zsts.
     if size == 0 {

--- a/compiler/hash-codegen/src/traits/abi.rs
+++ b/compiler/hash-codegen/src/traits/abi.rs
@@ -1,8 +1,7 @@
 //! Defines a trait for representing ABI information about function, and
 //! function arguments.
 
-use hash_abi::{ArgAbi, FnAbi};
-use hash_ir::ty::IrTyId;
+use hash_abi::ArgAbi;
 
 use super::BackendTypes;
 use crate::lower::place::PlaceRef;
@@ -28,8 +27,4 @@ pub trait AbiBuilderMethods<'b>: BackendTypes {
         index: &mut usize,
         destination: PlaceRef<Self::Value>,
     );
-}
-
-pub trait FnAbiOf<'b> {
-    fn fn_abi_of_instance(&self, ty: IrTyId) -> &'b FnAbi;
 }

--- a/compiler/hash-codegen/src/traits/ctx.rs
+++ b/compiler/hash-codegen/src/traits/ctx.rs
@@ -3,15 +3,10 @@
 //! context is used to access information about types, layouts, and
 //! other information that is required for code generation.
 
-use hash_ir::{
-    ty::{IrTy, IrTyId},
-    IrCtx,
-};
+use hash_ir::IrCtx;
 use hash_layout::{compute::LayoutComputer, LayoutCtx};
 use hash_pipeline::settings::CompilerSettings;
 use hash_target::data_layout::HasDataLayout;
-
-use crate::layout::{Layout, LayoutId};
 
 pub trait HasCtxMethods<'b>: HasDataLayout {
     /// Return a reference to the current [CompilerSettings] for the
@@ -25,13 +20,6 @@ pub trait HasCtxMethods<'b>: HasDataLayout {
     fn layout_computer(&self) -> LayoutComputer<'_> {
         LayoutComputer::new(self.layouts(), self.ir_ctx())
     }
-
-    /// Returns a reference to an IR type from the context.
-    fn ty_info(&self, ty: IrTyId) -> &IrTy;
-
-    /// Returns a reference to the underling [Layout] information for a
-    /// particular [LayoutId].
-    fn layout_info(&self, layout: LayoutId) -> &Layout;
 
     /// Returns a reference to the [LayoutStore].
     fn layouts(&self) -> &LayoutCtx;

--- a/compiler/hash-codegen/src/traits/layout.rs
+++ b/compiler/hash-codegen/src/traits/layout.rs
@@ -11,10 +11,14 @@ use crate::layout::TyInfo;
 /// Methods for calculating and querying the layout of types within a backend.
 pub trait LayoutMethods<'b>: BackendTypes + HasCtxMethods<'b> {
     /// Compute the layout of a interned type via [IrTyId].
-    fn layout_of_id(&self, ty: IrTyId) -> TyInfo;
+    fn layout_of_id(&self, _ty: IrTyId) -> TyInfo {
+        todo!()
+    }
 
     /// Compute the layout of a [IrTy].
-    fn layout_of(&self, ty: IrTy) -> TyInfo;
+    fn layout_of(&self, _ty: IrTy) -> TyInfo {
+        todo!()
+    }
 
     /// Perform a mapping on a [Layout]
     fn map_layout<T>(&self, id: LayoutId, func: impl FnOnce(&Layout) -> T) -> T {

--- a/compiler/hash-codegen/src/traits/mod.rs
+++ b/compiler/hash-codegen/src/traits/mod.rs
@@ -3,9 +3,8 @@
 use std::fmt;
 
 use self::{
-    abi::FnAbiOf, constants::BuildConstValueMethods, ctx::HasCtxMethods,
-    debug::BuildDebugInfoMethods, layout::LayoutMethods, misc::MiscBuilderMethods,
-    target::HasTargetSpec, ty::BuildTypeMethods,
+    constants::BuildConstValueMethods, ctx::HasCtxMethods, layout::LayoutMethods,
+    misc::MiscBuilderMethods, target::HasTargetSpec, ty::BuildTypeMethods,
 };
 
 pub mod abi;
@@ -54,7 +53,7 @@ impl<T: Copy + PartialEq + fmt::Debug> CodeGenObject for T {}
 
 /// The core trait of the code generation backend which is used to
 /// generate code for a particular backend. This trait provides IR
-pub trait Backend<'b>: Sized + BackendTypes + LayoutMethods<'b> + FnAbiOf<'b> {}
+pub trait Backend<'b>: Sized + BackendTypes + LayoutMethods<'b> {}
 
 pub trait CodeGenMethods<'b>:
     Backend<'b>
@@ -62,7 +61,6 @@ pub trait CodeGenMethods<'b>:
     + HasCtxMethods<'b>
     + BuildTypeMethods<'b>
     + BuildConstValueMethods<'b>
-    + BuildDebugInfoMethods
     + HasTargetSpec
 {
 }
@@ -75,13 +73,12 @@ impl<'b, T> CodeGenMethods<'b> for T where
         + HasCtxMethods<'b>
         + BuildTypeMethods<'b>
         + BuildConstValueMethods<'b>
-        + BuildDebugInfoMethods
         + HasTargetSpec
 {
 }
 
-pub trait CodeGen<'b>:
-    Backend<'b> + std::ops::Deref<Target = <Self as CodeGen<'b>>::CodegenCtx>
+pub trait Codegen<'b>:
+    Backend<'b> + std::ops::Deref<Target = <Self as Codegen<'b>>::CodegenCtx>
 {
     /// The type of the codegen context, all items within the context can access
     /// all of the methods that are provided via [CodeGenMethods]

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -286,6 +286,17 @@ pub struct Layout {
 }
 
 impl Layout {
+    /// Create a new layout with the given information.
+    pub fn new(
+        shape: LayoutShape,
+        variants: Variants,
+        abi: AbiRepresentation,
+        alignment: Alignments,
+        size: Size,
+    ) -> Self {
+        Self { shape, variants, abi, alignment, size }
+    }
+
     /// Create a new [Layout] that represents a scalar.
     pub fn scalar<C: HasDataLayout>(ctx: &C, scalar: Scalar) -> Self {
         let size = scalar.size(ctx);
@@ -329,17 +340,6 @@ impl Layout {
             alignment,
             size,
         }
-    }
-
-    /// Create a new layout with the given information.
-    pub fn new(
-        shape: LayoutShape,
-        variants: Variants,
-        abi: AbiRepresentation,
-        alignment: Alignments,
-        size: Size,
-    ) -> Self {
-        Self { shape, variants, abi, alignment, size }
     }
 
     /// Check whether this particular [Layout] represents a zero-sized type.

--- a/compiler/hash-session/Cargo.toml
+++ b/compiler/hash-session/Cargo.toml
@@ -19,6 +19,7 @@ hash-source = { path = "../hash-source" }
 hash-tree-def = { path = "../hash-tree-def" }
 hash-tir = { path = "../hash-tir" }
 hash-layout = { path = "../hash-layout" }
+hash-codegen = { path = "../hash-codegen" }
 
 # Various stages that the pipeline interfaces with...
 hash-ast-desugaring = { path = "../hash-ast-desugaring" }

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -11,7 +11,8 @@
 use hash_ast::node_map::NodeMap;
 use hash_ast_desugaring::{AstDesugaringCtx, AstDesugaringCtxQuery, AstDesugaringPass};
 use hash_ast_expand::{AstExpansionCtx, AstExpansionCtxQuery, AstExpansionPass};
-use hash_backend::{Backend, BackendCtx, BackendCtxQuery};
+use hash_backend::{Backend, BackendCtxQuery};
+use hash_codegen::BackendCtx;
 use hash_ir::IrStorage;
 use hash_layout::LayoutCtx;
 use hash_lower::{IrGen, IrOptimiser, LoweringCtx, LoweringCtxQuery};
@@ -177,7 +178,7 @@ impl BackendCtxQuery for CompilerSession {
         BackendCtx {
             workspace: &mut self.workspace,
             ir_storage: &self.ir_storage,
-            settings: self.settings.codegen_settings(),
+            settings: &self.settings,
             _pool: &self.pool,
         }
     }


### PR DESCRIPTION
This PR adds the initial scaffolding for the translation between Hash IR into LLVM IR.