### PR TITLE
codegen(llvm): implement all `BlockBuilderMethods` on `Builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -51,9 +51,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -72,9 +72,9 @@ checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitflags"
@@ -84,9 +84,9 @@ checksum = "e196f430604fcd7503056c5aaa7dfc5bc570582b928240622b075b5cad3b90dd"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bumpalo-herd"
@@ -105,9 +105,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -117,9 +117,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clipboard-win"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
 dependencies = [
  "error-code",
  "str-buf",
@@ -182,7 +182,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
@@ -304,9 +304,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generator"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7"
+checksum = "d266041a359dfa931b370ef684cceb84b166beb14f7f0421f4a6a3d0c446d12e"
 dependencies = [
  "cc",
  "libc",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "hash"
@@ -868,18 +868,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "html-escape"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15315cfa9503e9aa85a477138eff76a1b203a430703548052c330b69d8d8c205"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
 ]
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#c77d05639c9b73d9bede713789b9707d45863530"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#468320973ec40c237ad34e266a680a875605aa3a"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -921,8 +921,8 @@ dependencies = [
 
 [[package]]
 name = "inkwell_internals"
-version = "0.6.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#c77d05639c9b73d9bede713789b9707d45863530"
+version = "0.7.0"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#468320973ec40c237ad34e266a680a875605aa3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -946,9 +946,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "llvm-sys"
@@ -1012,6 +1012,15 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1021,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1039,14 +1048,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 1.2.1",
  "cc",
  "cfg-if",
  "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -1091,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1101,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -1141,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1196,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -1234,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1253,20 +1263,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1280,7 +1289,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -1296,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1343,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rustyline"
@@ -1353,7 +1362,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd4eaf7a7738f76c98e4f0395253ae853be3eb018f7b0bb57fe1b6c17e31874"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 1.2.1",
  "cfg-if",
  "clipboard-win",
  "dirs-next",
@@ -1385,9 +1394,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "sharded-slab"
@@ -1452,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1474,18 +1483,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1616,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1713,15 +1722,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
+checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
 dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
+ "windows_aarch64_msvc 0.39.0",
+ "windows_i686_gnu 0.39.0",
+ "windows_i686_msvc 0.39.0",
+ "windows_x86_64_gnu 0.39.0",
+ "windows_x86_64_msvc 0.39.0",
 ]
 
 [[package]]
@@ -1731,85 +1740,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yansi"

--- a/compiler/hash-abi/src/lib.rs
+++ b/compiler/hash-abi/src/lib.rs
@@ -16,14 +16,14 @@ pub enum CallingConvention {
     /// Equivalent to the `ccc` calling convention in LLVM.
     ///
     /// Ref: <https://llvm.org/docs/LangRef.html#calling-conventions> (ccc)
-    C,
+    C = 0,
 
     /// Cold calling convention for functions that are unlikely to be called.
     ///
     /// Equivalent to the `coldcc` calling convention in LLVM.
     ///
     /// Ref: <https://llvm.org/docs/LangRef.html#calling-conventions> (coldcc)
-    Cold,
+    Cold = 9,
 }
 
 /// Defines what ABI to use when calling a function.

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -1,8 +1,16 @@
 //! This implements all of the ABI specified methods for the [Builder].
 
-use hash_codegen::{abi::ArgAbi, lower::place::PlaceRef, traits::abi::AbiBuilderMethods};
+use hash_codegen::{
+    abi::{ArgAbi, FnAbi},
+    lower::place::PlaceRef,
+    traits::abi::AbiBuilderMethods,
+};
+use inkwell::{
+    types::BasicTypeEnum,
+    values::{CallSiteValue, FunctionValue},
+};
 
-use super::Builder;
+use super::{context::CodeGenCtx, Builder};
 
 impl<'b> AbiBuilderMethods<'b> for Builder<'b> {
     fn get_param(&mut self, index: usize) -> Self::Value {
@@ -24,6 +32,31 @@ impl<'b> AbiBuilderMethods<'b> for Builder<'b> {
         index: &mut usize,
         destination: PlaceRef<Self::Value>,
     ) {
+        todo!()
+    }
+}
+
+pub trait ExtendedFnAbiMethods<'b> {
+    /// Produce an LLVM type for the given [FnAbi].
+    fn llvm_ty(&self) -> BasicTypeEnum<'b>;
+
+    /// Apply the derived ABI attributes to the given [FunctionValue].
+    fn apply_attributes_to_fn(&self, ctx: CodeGenCtx<'b>, func: FunctionValue<'b>);
+
+    /// Apply the derived ABI attributes to the given [CallSiteValue].
+    fn apply_attributes_call_site(&self, builder: &mut Builder<'b>, call_site: CallSiteValue<'b>);
+}
+
+impl<'b> ExtendedFnAbiMethods<'b> for FnAbi {
+    fn llvm_ty(&self) -> BasicTypeEnum<'b> {
+        todo!()
+    }
+
+    fn apply_attributes_to_fn(&self, ctx: CodeGenCtx<'b>, func: FunctionValue<'b>) {
+        todo!()
+    }
+
+    fn apply_attributes_call_site(&self, builder: &mut Builder<'b>, call_site: CallSiteValue<'b>) {
         todo!()
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -2,18 +2,90 @@
 //! [hash_codegen::traits::builder::BlockBuilderMethods] using the Inkwell
 //! wrapper around LLVM.
 
-use hash_codegen::{
-    common::MemFlags,
-    lower::{operands::OperandRef, place::PlaceRef},
-    traits::builder::BlockBuilderMethods,
-};
-use hash_target::{abi::ValidScalarRange, alignment::Alignment, size::Size};
+use std::alloc::alloc;
 
-use super::Builder;
+use hash_codegen::{
+    abi::FnAbi,
+    common::{AtomicOrdering, CheckedOp, IntComparisonKind, MemFlags, RealComparisonKind},
+    layout::TyInfo,
+    lower::{
+        operands::{OperandRef, OperandValue},
+        place::PlaceRef,
+    },
+    traits::{
+        builder::{self, BlockBuilderMethods},
+        constants::BuildConstValueMethods,
+        ctx::HasCtxMethods,
+        layout::LayoutMethods,
+        ty::BuildTypeMethods,
+    },
+};
+use hash_ir::ty::{IrTy, IrTyId, RefKind};
+use hash_source::constant::{IntTy, SIntTy, UIntTy};
+use hash_target::{
+    abi::{AbiRepresentation, Scalar, ScalarKind, ValidScalarRange},
+    alignment::Alignment,
+    size::Size,
+};
+use inkwell::{
+    basic_block::BasicBlock,
+    types::{AnyTypeEnum, BasicTypeEnum},
+    values::{
+        AggregateValueEnum, AnyValueEnum, BasicMetadataValueEnum, BasicValue, BasicValueEnum,
+        IntMathValue, IntValue, PhiValue, UnnamedAddress,
+    },
+};
+use rayon::iter::Either;
+
+use super::{
+    abi::ExtendedFnAbiMethods, layouts::ExtendedLayoutMethods, ty::ExtendedTyBuilderMethods,
+    AtomicOrderingWrapper, Builder, FloatPredicateWrapper, IntPredicateWrapper, MetadataType,
+};
+
+impl<'b> Builder<'b> {
+    /// Create a PHI node in the current block.
+    fn phi(
+        &mut self,
+        ty: AnyTypeEnum<'b>,
+        values: &[&dyn BasicValue<'b>],
+        blocks: &[BasicBlock<'b>],
+    ) -> PhiValue<'b> {
+        debug_assert_eq!(values.len(), blocks.len());
+
+        // Create the PHI value, and then add all of the incoming values.
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let phi = self.builder.build_phi(ty, "phi");
+
+        // @@Efficiency: patch inkwell to allow to provide these references directly...
+        let blocks_and_values = blocks
+            .iter()
+            .zip(values.iter())
+            .map(|(block, value)| (*value, *block))
+            .collect::<Vec<_>>();
+
+        phi.add_incoming(blocks_and_values.as_slice());
+        phi
+    }
+
+    /// Add incoming values to a PHI node.
+    fn add_incoming_to_phi(&mut self, phi: PhiValue, value: BasicValueEnum, block: BasicBlock) {
+        phi.add_incoming(&[(&value, block)]);
+    }
+}
 
 impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
+    fn ctx(&self) -> &Self::CodegenCtx {
+        self.ctx
+    }
+
     fn build(ctx: &'b Self::CodegenCtx, block: Self::BasicBlock) -> Self {
-        todo!()
+        let builder = ctx.ll_ctx.create_builder();
+
+        // We need to set the insertion point to the end of the block
+        // because the builder is created at the beginning of the block.
+        builder.position_at_end(block);
+
+        Builder { builder, ctx }
     }
 
     fn append_block(
@@ -21,35 +93,33 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         func: Self::Function,
         name: &str,
     ) -> Self::BasicBlock {
-        todo!()
+        ctx.ll_ctx.append_basic_block(func, name)
     }
 
     fn append_sibling_block(&mut self, name: &str) -> Self::BasicBlock {
-        todo!()
-    }
-
-    fn ctx(&self) -> &Self::CodegenCtx {
-        todo!()
+        let func = self.builder.get_insert_block().unwrap().get_parent().unwrap();
+        Self::append_block(self.ctx, func, name)
     }
 
     fn basic_block(&self) -> Self::BasicBlock {
-        todo!()
+        self.builder.get_insert_block().unwrap()
     }
 
     fn switch_to_block(&mut self, block: Self::BasicBlock) {
-        todo!()
+        *self = Self::build(self.ctx, block);
     }
 
     fn return_value(&mut self, value: Self::Value) {
-        todo!()
+        let value: BasicValueEnum = value.try_into().unwrap();
+        self.builder.build_return(Some(&value));
     }
 
     fn return_void(&mut self) {
-        todo!()
+        self.builder.build_return(None);
     }
 
     fn branch(&mut self, destination: Self::BasicBlock) {
-        todo!()
+        self.builder.build_unconditional_branch(destination);
     }
 
     fn conditional_branch(
@@ -58,7 +128,9 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         true_block: Self::BasicBlock,
         false_block: Self::BasicBlock,
     ) {
-        todo!()
+        // @@Verify: is it always meant to be an int-value comparison.
+        let value = condition.into_int_value();
+        self.builder.build_conditional_branch(value, true_block, false_block);
     }
 
     fn switch(
@@ -67,282 +139,528 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         cases: impl ExactSizeIterator<Item = (u128, Self::BasicBlock)>,
         otherwise_block: Self::BasicBlock,
     ) {
-        todo!()
+        // @@Verify: is it always meant to be an int-value comparison.
+        let value = condition.into_int_value();
+
+        // Create all of the case-branch pairs.
+        let cases = cases.map(|(value, block)| {
+            let AnyValueEnum::IntValue(val) = self.const_uint_big(condition.get_type(), value) else {
+                unreachable!()
+            };
+
+            (val, block)
+        }).collect::<Vec<_>>();
+
+        self.builder.build_switch(value, otherwise_block, &cases);
     }
 
     fn unreachable(&mut self) {
-        todo!()
-    }
-
-    fn checked_call(
-        &mut self,
-        ty: Self::Type,
-        args: &[Self::Value],
-        then_block: Self::BasicBlock,
-        catch_block: Self::BasicBlock,
-    ) -> Self::Value {
-        todo!()
+        self.builder.build_unreachable();
     }
 
     fn call(
         &mut self,
         ty: Self::Type,
-        fn_abi: Option<&hash_codegen::abi::FnAbi>,
+        fn_abi: Option<&FnAbi>,
         fn_ptr: Self::Value,
         args: &[Self::Value],
     ) -> Self::Value {
-        todo!()
+        let args: Vec<BasicMetadataValueEnum> =
+            args.iter().map(|v| (*v).try_into().unwrap()).collect();
+
+        let site = self.builder.build_call(fn_ptr.into_function_value(), &args, "");
+
+        if let Some(abi) = fn_abi {
+            abi.apply_attributes_call_site(self, site);
+        }
+
+        // Convert the `CallSiteValue` into a `AnyEnumValue`...
+        //
+        // @@Cleanup: maybe patch inkwell with this func?
+        match site.try_as_basic_value() {
+            Either::Left(val) => val.into(),
+            Either::Right(val) => val.into(),
+        }
     }
 
+    // @@Todo: would be nice to make this a macro...
+
     fn add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_add(lhs, rhs, "").into()
     }
 
     fn fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_add(lhs, rhs, "").into()
     }
 
     fn fadd_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        let value = self.builder.build_float_add(lhs, rhs, "");
+
+        // @@Todo: set the `fast` metadata flag on this operation
+        // value.as_instruction().map(|instruction| instruction.set_metadata(metadata,
+        // kind_id));
+        value.into()
     }
 
     fn sub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_sub(lhs, rhs, "").into()
     }
 
     fn fsub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_sub(lhs, rhs, "").into()
     }
 
     fn fsub_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        let value = self.builder.build_float_sub(lhs, rhs, "");
+
+        // @@Todo: set the `fast` metadata flag on this operation
+        // value.as_instruction().map(|instruction| instruction.set_metadata(metadata,
+        // kind_id));
+        value.into()
     }
 
     fn mul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_mul(lhs, rhs, "").into()
     }
 
     fn fmul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_mul(lhs, rhs, "").into()
     }
 
     fn fmul_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        let value = self.builder.build_float_mul(lhs, rhs, "");
+
+        // @@Todo: set the `fast` metadata flag on this operation
+        // value.as_instruction().map(|instruction| instruction.set_metadata(metadata,
+        // kind_id));
+        value.into()
     }
 
     fn udiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_unsigned_div(lhs, rhs, "").into()
     }
 
     fn exactudiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let _lhs = lhs.into_int_value();
+        let _rhs = rhs.into_int_value();
+
+        // @@Todo: patch inkwell to allow for exact unsigned division
+        // self.builder.build_int_exact_unsigned_div(lhs, rhs, "").into()
+        panic!("inkwell doesn't have the ability to emit `exactudiv` yet")
     }
 
     fn sdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_signed_div(lhs, rhs, "").into()
     }
 
     fn exactsdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_exact_signed_div(lhs, rhs, "").into()
     }
 
     fn fdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_div(lhs, rhs, "").into()
     }
 
     fn fdiv_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        let value = self.builder.build_float_div(lhs, rhs, "");
+
+        // @@Todo: set the `fast` metadata flag on this operation
+        // value.as_instruction().map(|instruction| instruction.set_metadata(metadata,
+        // kind_id)).into();
+        value.into()
     }
 
     fn urem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_unsigned_rem(lhs, rhs, "").into()
     }
 
     fn srem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_signed_rem(lhs, rhs, "").into()
     }
 
     fn frem(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_rem(lhs, rhs, "").into()
     }
 
     fn frem_fast(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        let value = self.builder.build_float_rem(lhs, rhs, "");
+
+        // @@Todo: set the `fast` metadata flag on this operation
+        // value.as_instruction().map(|instruction| instruction.set_metadata(metadata,
+        // kind_id)).into();
+        value.into()
     }
 
     fn fpow(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        // @@Todo: more concretely determine which `pow` intrinsic to
+        // call considering it can also be invoked for `f64` and other
+        // vector types.
+        let func: AnyValueEnum = self.module.get_function("llvm.pow.f64").unwrap().into();
+
+        let ty = self.ty_of_value(lhs);
+        let args = &[ty, ty];
+
+        let ty = self.type_function(args, ty);
+        self.call(ty, None, func, &[lhs, rhs])
     }
 
     fn shl(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_left_shift(lhs, rhs, "").into()
     }
 
     fn lshr(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_right_shift(lhs, rhs, true, "").into()
     }
 
     fn ashr(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_right_shift(lhs, rhs, false, "").into()
     }
 
     fn unchecked_sadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nsw_add(lhs, rhs, "").into()
     }
 
     fn unchecked_uadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nuw_add(lhs, rhs, "").into()
     }
 
     fn unchecked_ssub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nsw_sub(lhs, rhs, "").into()
     }
 
     fn unchecked_usub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nuw_sub(lhs, rhs, "").into()
     }
 
     fn unchecked_smul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nsw_mul(lhs, rhs, "").into()
     }
 
     fn unchecked_umul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_nuw_mul(lhs, rhs, "").into()
     }
 
     fn and(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_and(lhs, rhs, "").into()
     }
 
     fn or(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_or(lhs, rhs, "").into()
     }
 
     fn xor(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        todo!()
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_xor(lhs, rhs, "").into()
     }
 
     fn not(&mut self, v: Self::Value) -> Self::Value {
-        todo!()
+        let v = v.into_int_value();
+
+        self.builder.build_not(v, "").into()
     }
 
     fn neg(&mut self, v: Self::Value) -> Self::Value {
-        todo!()
+        let v = v.into_int_value();
+
+        self.builder.build_int_neg(v, "").into()
     }
 
     fn fneg(&mut self, v: Self::Value) -> Self::Value {
-        todo!()
+        let v = v.into_float_value();
+
+        self.builder.build_float_neg(v, "").into()
     }
 
     fn checked_bin_op(
         &mut self,
-        op: hash_codegen::common::CheckedOp,
+        op: CheckedOp,
+        ty: IrTyId,
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {
-        todo!()
+        let ptr_width = self.ctx.settings().codegen_settings().target_info.target().pointer_width;
+
+        let int_ty = self.ir_ctx().map_ty(ty, |ty| match ty {
+            IrTy::Int(ty @ SIntTy::ISize) => IntTy::Int(ty.normalise(ptr_width)),
+            IrTy::Int(int_ty) => IntTy::Int(*int_ty),
+            IrTy::UInt(ty @ UIntTy::USize) => IntTy::UInt(ty.normalise(ptr_width)),
+            IrTy::UInt(int_ty) => IntTy::UInt(*int_ty),
+            _ => unreachable!("tried to perform a checked operation on a non-integer type"),
+        });
+
+        // @@CodeSpeed: for unsigned subtraction we emit manually perform
+        // the computation and check for overflow since it results in potentially
+        // better optimisation...
+        if op == CheckedOp::Sub && !int_ty.is_signed() {
+            return (self.sub(lhs, rhs), self.icmp(IntComparisonKind::Ult, lhs, rhs));
+        }
+
+        let intrinsic_prefix = match (op, int_ty.is_signed()) {
+            (CheckedOp::Add, true) => "llvm.sadd",
+            (CheckedOp::Add, false) => "llvm.sadd",
+            (CheckedOp::Sub, true) => "llvm.ssub",
+            (CheckedOp::Sub, false) => "llvm.usub",
+            (CheckedOp::Mul, true) => "llvm.smul",
+            (CheckedOp::Mul, false) => "llvm.umul",
+        };
+
+        let intrinsic_name = format!("{}.with.overflow.{}", intrinsic_prefix, int_ty.to_name());
+
+        let result = self.call_intrinsic(&intrinsic_name, &[lhs, rhs]);
+        (self.extract_field(result, 0), self.extract_field(result, 1))
     }
 
-    fn icmp(
-        &mut self,
-        op: hash_codegen::common::IntComparisonKind,
-        lhs: Self::Value,
-        rhs: Self::Value,
-    ) -> Self::Value {
-        todo!()
+    fn icmp(&mut self, op: IntComparisonKind, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        let op = IntPredicateWrapper::from(op).0;
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
+
+        self.builder.build_int_compare(op, lhs, rhs, "").into()
     }
 
-    fn fcmp(
-        &mut self,
-        op: hash_codegen::common::RealComparisonKind,
-        lhs: Self::Value,
-        rhs: Self::Value,
-    ) -> Self::Value {
-        todo!()
+    fn fcmp(&mut self, op: RealComparisonKind, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        let op = FloatPredicateWrapper::from(op).0;
+        let lhs = lhs.into_float_value();
+        let rhs = rhs.into_float_value();
+
+        self.builder.build_float_compare(op, lhs, rhs, "").into()
     }
 
     fn truncate(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_int_truncate(val.into_int_value(), dest_ty.into_int_type(), "").into()
     }
 
     fn sign_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_int_s_extend(val.into_int_value(), dest_ty.into_int_type(), "").into()
     }
 
     fn zero_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_int_z_extend(val.into_int_value(), dest_ty.into_int_type(), "").into()
     }
 
-    fn fp_to_ui_sat(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
-    }
+    fn fp_to_int_sat(
+        &mut self,
+        value: Self::Value,
+        dest_ty: Self::Type,
+        is_signed: bool,
+    ) -> Self::Value {
+        let src_ty = self.ty_of_value(value);
 
-    fn fp_to_si_sat(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        // Deal with the source type potentially being a vector type.
+        let (float_ty, int_ty, vec_width): (_, _, Option<usize>) = if src_ty.is_vector_type() {
+            // @@Future: this isn't currently fired but when we work on supporting SIMD,
+            // then we'll need to handle this case.
+            unimplemented!()
+        } else {
+            (src_ty.into_float_type(), dest_ty.into_int_type(), None)
+        };
+
+        let float_width = self.float_width(src_ty);
+        let int_width = self.int_width(dest_ty);
+
+        let instruction = if is_signed { "s" } else { "u" };
+        let name = if let Some(vec_width) = vec_width {
+            format!(
+                "llvm.fpto{instruction}i.sat.v{vec_width}i{int_width}.v{vec_width}f{float_width}"
+            )
+        } else {
+            format!("llvm.fpto{instruction}i.sat.i{int_width}.f{float_width}")
+        };
+
+        let fn_ty = self.type_function(&[src_ty], dest_ty);
+        let func = self.declare_c_fn(&name, UnnamedAddress::None, fn_ty);
+
+        self.call(fn_ty, None, func, &[value])
     }
 
     fn fp_to_ui(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder
+            .build_float_to_unsigned_int(val.into_float_value(), dest_ty.into_int_type(), "")
+            .into()
     }
 
     fn fp_to_si(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder
+            .build_float_to_signed_int(val.into_float_value(), dest_ty.into_int_type(), "")
+            .into()
     }
 
     fn ui_to_fp(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder
+            .build_unsigned_int_to_float(val.into_int_value(), dest_ty.into_float_type(), "")
+            .into()
     }
 
     fn si_to_fp(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder
+            .build_signed_int_to_float(val.into_int_value(), dest_ty.into_float_type(), "")
+            .into()
     }
 
     fn fp_truncate(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_float_trunc(val.into_float_value(), dest_ty.into_float_type(), "").into()
     }
 
     fn fp_extend(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_float_ext(val.into_float_value(), dest_ty.into_float_type(), "").into()
     }
 
     fn ptr_to_int(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_ptr_to_int(val.into_pointer_value(), dest_ty.into_int_type(), "").into()
     }
 
     fn int_to_ptr(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder.build_int_to_ptr(val.into_int_value(), dest_ty.into_pointer_type(), ".").into()
     }
 
     fn bit_cast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        let val: BasicValueEnum = val.try_into().unwrap();
+        let ty: BasicTypeEnum = dest_ty.try_into().unwrap();
+
+        self.builder.build_bitcast(val, ty, "").into()
     }
 
     fn int_cast(&mut self, val: Self::Value, dest_ty: Self::Type, is_signed: bool) -> Self::Value {
-        todo!()
+        self.builder.build_int_cast(val.into_int_value(), dest_ty.into_int_type(), "").into()
     }
 
     fn pointer_cast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value {
-        todo!()
+        self.builder
+            .build_pointer_cast(val.into_pointer_value(), dest_ty.into_pointer_type(), "")
+            .into()
     }
 
-    fn bool_from_immediate(&mut self, v: Self::Value) -> Self::Value {
-        todo!()
+    fn bool_from_immediate(&mut self, value: Self::Value) -> Self::Value {
+        // check if this is an `i1` value, i.e. a `bool`, and then if so
+        // we zero extend the value into an `i8`
+        if self.ctx.ty_of_value(value) == self.ctx.type_i1() {
+            self.zero_extend(value, self.ctx.type_i8())
+        } else {
+            value
+        }
     }
 
-    fn to_immediate_scalar(
-        &mut self,
-        v: Self::Value,
-        scalar_kind: hash_target::abi::Scalar,
-    ) -> Self::Value {
-        todo!()
+    fn to_immediate_scalar(&mut self, value: Self::Value, scalar_kind: Scalar) -> Self::Value {
+        if scalar_kind.is_bool() {
+            self.truncate(value, self.ctx.type_i1())
+        } else {
+            value
+        }
     }
 
     fn alloca(&mut self, ty: Self::Type, alignment: Alignment) -> Self::Value {
-        todo!()
+        // @@Todo: do we need to start a new block here?
+
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let allocated_value = self.builder.build_alloca(ty, "");
+
+        // we need to set the alignment of this value to the specified size.
+        allocated_value
+            .as_instruction()
+            .map(|instruction| instruction.set_alignment(alignment.bytes() as u32));
+
+        allocated_value.into()
     }
 
     fn byte_array_alloca(&mut self, len: Self::Value, alignment: Alignment) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = self.ctx.type_i8().try_into().unwrap();
+        let allocated_value = self.builder.build_array_alloca(ty, len.into_int_value(), "");
+
+        // we need to set the alignment of this value to the specified size.
+        allocated_value
+            .as_instruction()
+            .map(|instruction| instruction.set_alignment(alignment.bytes() as u32));
+
+        allocated_value.into()
     }
 
     fn write_operand_repeatedly(
@@ -351,20 +669,79 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         count: usize,
         destination: PlaceRef<Self::Value>,
     ) {
-        todo!()
+        let zero = self.const_usize(0);
+        let count = self.const_usize(count as u64);
+        let start = destination.project_index(self, zero).value;
+        let end = destination.project_index(self, count).value;
+
+        // setup the blocks to write the operand to...
+        let header_bb = self.append_sibling_block("repeat_loop_header");
+        let body_bb = self.append_sibling_block("repeat_loop_body");
+        let next_bb = self.append_sibling_block("repeat_loop_next");
+
+        // jump to the header block
+        self.branch(header_bb);
+
+        let mut header_builder = Self::build(self.ctx, header_bb);
+
+        let basic_value: BasicValueEnum = start.try_into().unwrap();
+        let current: AnyValueEnum = header_builder
+            .phi(
+                self.ctx.ty_of_value(start),
+                &[&basic_value as &dyn BasicValue],
+                &[self.basic_block()],
+            )
+            .into();
+
+        let keep_going = header_builder.icmp(IntComparisonKind::Ne, current, end);
+        header_builder.conditional_branch(keep_going, body_bb, next_bb);
+
+        let mut body_builder = Self::build(self.ctx, body_bb);
+
+        let field_info = destination.info.field(self.ctx.layout_computer(), 0);
+        let field_size = self.map_layout(field_info.layout, |layout| layout.size);
+
+        let alignment = destination.alignment.restrict_to(field_size);
+
+        // now we want to emit a `store` for the value we are writing
+        operand
+            .value
+            .store(&mut body_builder, PlaceRef { value: current, info: operand.info, alignment });
+
+        // Compute the "next" value...
+        let ty = self.backend_ty_from_info(operand.info);
+        let next: BasicValueEnum = body_builder
+            .bounded_get_element_pointer(ty, current, &[self.const_usize(1)])
+            .try_into()
+            .unwrap();
+
+        // and branch back to the header
+        body_builder.branch(header_bb);
+        header_builder.add_incoming_to_phi(current.into_phi_value(), next, body_bb);
+
+        *self = Self::build(self.ctx, next_bb);
     }
 
     fn load(&mut self, ty: Self::Type, ptr: Self::Value, alignment: Alignment) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let value = self.builder.build_load(ty, ptr.into_pointer_value(), "");
+
+        // we need to set the alignment of this value to the specified size.
+        value
+            .as_instruction_value()
+            .map(|instruction| instruction.set_alignment(alignment.bytes() as u32));
+
+        value.into()
     }
 
-    fn volatile_load(
-        &mut self,
-        ty: Self::Type,
-        ptr: Self::Value,
-        alignment: Alignment,
-    ) -> Self::Value {
-        todo!()
+    fn volatile_load(&mut self, ty: Self::Type, ptr: Self::Value) -> Self::Value {
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let value = self.builder.build_load(ty, ptr.into_pointer_value(), "");
+
+        // we need to set that this data is volatile
+        value.as_instruction_value().map(|instruction| instruction.set_volatile(true));
+
+        value.into()
     }
 
     fn atomic_load(
@@ -372,16 +749,89 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         ty: Self::Type,
         ptr: Self::Value,
         alignment: Alignment,
+        ordering: AtomicOrdering,
     ) -> Self::Value {
-        todo!()
+        let ordering = AtomicOrderingWrapper::from(ordering).0;
+
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let value = self.builder.build_load(ty, ptr.into_pointer_value(), "");
+
+        // we need to set that this data is volatile
+        value.as_instruction_value().map(|instruction| instruction.set_atomic_ordering(ordering));
+
+        value.into()
     }
 
     fn load_operand(&mut self, place: PlaceRef<Self::Value>) -> OperandRef<Self::Value> {
-        todo!()
+        // If the operand is a zst, we return a `()` value
+        self.ctx.map_layout(place.info.layout, |layout| {
+            if layout.is_zst() {
+                return OperandRef::new_zst(self, place.info);
+            }
+
+            let value = if layout.is_llvm_immediate() {
+                let mut const_value = None;
+                let ty = place.info.llvm_ty(self.ctx);
+
+                // Check here if the need to load it in a as global value, i.e.
+                // a constant...
+                // @@Todo: need to patch inkwell to be able to check if things are
+                // global variables, and constant.
+                //
+                // if let Some(global) = self.module.get_global(name) {
+                //     ...
+                // }
+
+                // If this wasn't a global constant value, we'll just load it in
+                // as a normal scalar.
+                let value = const_value.unwrap_or_else(|| {
+                    // Check if the type is pointing to a global constant value
+                    let load_value = self.load(ty, place.value, place.alignment);
+
+                    if let AbiRepresentation::Scalar(scalar) = layout.abi {
+                        load_scalar_value_metadata(
+                            self,
+                            load_value,
+                            scalar,
+                            place.info,
+                            Size::ZERO,
+                        );
+                    }
+
+                    load_value
+                });
+
+                return OperandRef::from_immediate_value(value, place.info);
+            } else if let AbiRepresentation::Pair(scalar_a, scalar_b) = layout.abi {
+                let b_offset = scalar_a.size(self).align_to(scalar_b.align(self).abi);
+                let pair_ty = place.info.llvm_ty(self.ctx);
+
+                // Utility closure to load one of the elements from the pair using
+                // a `struct-gep`.
+                let mut load = |index, scalar: Scalar, info, align, offset| {
+                    let ptr =
+                        self.structural_get_element_pointer(pair_ty, place.value, index as u64);
+                    let ty = place.info.scalar_pair_element_llvm_ty(self.ctx, index, false);
+                    let load_value = self.load(ty, ptr, align);
+
+                    load_scalar_value_metadata(self, load_value, scalar, info, offset);
+                    self.to_immediate_scalar(load_value, scalar)
+                };
+
+                OperandValue::Pair(
+                    load(0, scalar_a, place.info, place.alignment, Size::ZERO),
+                    load(1, scalar_b, place.info, place.alignment.restrict_to(b_offset), b_offset),
+                )
+            } else {
+                OperandValue::Ref(place.value, place.alignment)
+            };
+
+            OperandRef { value, info: place.info }
+        })
     }
 
     fn store(&mut self, value: Self::Value, ptr: Self::Value, alignment: Alignment) -> Self::Value {
-        todo!()
+        self.store_with_flags(value, ptr, alignment, MemFlags::empty())
     }
 
     fn store_with_flags(
@@ -389,9 +839,29 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         value: Self::Value,
         ptr: Self::Value,
         alignment: Alignment,
-        flags: hash_codegen::common::MemFlags,
+        flags: MemFlags,
     ) -> Self::Value {
-        todo!()
+        let operand: BasicValueEnum = value.try_into().unwrap();
+        let store_value = self.builder.build_store(ptr.into_pointer_value(), operand);
+
+        let alignment = if flags.contains(MemFlags::UN_ALIGNED) { 1 } else { alignment.bytes() };
+        store_value.set_alignment(alignment as u32);
+
+        // We need to apply the specified flags
+        if flags.contains(MemFlags::VOLATILE) {
+            store_value.set_volatile(true);
+        }
+
+        if flags.contains(MemFlags::NON_TEMPORAL) {
+            // According to LLVM [1] building a `non-temporal` store must
+            // *always* point to a metadata value of the integer 1.
+            //
+            // [1]: https://llvm.org/docs/LangRef.html#store-instruction
+            let metadata: BasicMetadataValueEnum = self.ctx.const_i32(1).try_into().unwrap();
+            let node = self.ctx.ll_ctx.metadata_node(&[metadata]);
+        }
+
+        store_value.into()
     }
 
     fn atomic_store(
@@ -399,9 +869,19 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         value: Self::Value,
         ptr: Self::Value,
         alignment: Alignment,
-        ordering: std::sync::atomic::Ordering,
+        ordering: AtomicOrdering,
     ) -> Self::Value {
-        todo!()
+        let operand: BasicValueEnum = value.try_into().unwrap();
+        let store_value = self.builder.build_store(ptr.into_pointer_value(), operand);
+
+        // we need to set the atomic ordering for the store.
+        let ordering = AtomicOrderingWrapper::from(ordering).0;
+        store_value.set_atomic_ordering(ordering);
+
+        let alignment = alignment.bytes();
+        store_value.set_alignment(alignment as u32);
+
+        store_value.into()
     }
 
     fn get_element_pointer(
@@ -410,7 +890,13 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         ptr: Self::Value,
         indices: &[Self::Value],
     ) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let indices = indices.iter().map(|i| i.into_int_value()).collect::<Vec<_>>();
+
+        // ## Safety: If the `indices` are invalid or out of bounds, LLVM
+        // is likely to segfault, which is noted by Inkwell and thus labelled
+        // as `unsafe`.
+        unsafe { self.builder.build_gep(ty, ptr.into_pointer_value(), &indices, "").into() }
     }
 
     fn bounded_get_element_pointer(
@@ -419,7 +905,15 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         ptr: Self::Value,
         indices: &[Self::Value],
     ) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let indices = indices.iter().map(|i| i.into_int_value()).collect::<Vec<_>>();
+
+        // ## Safety: If the `indices` are invalid or out of bounds, LLVM
+        // is likely to segfault, which is noted by Inkwell and thus labelled
+        // as `unsafe`.
+        unsafe {
+            self.builder.build_in_bounds_gep(ty, ptr.into_pointer_value(), &indices, "").into()
+        }
     }
 
     fn structural_get_element_pointer(
@@ -428,7 +922,10 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         ptr: Self::Value,
         index: u64,
     ) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let index = index as u32;
+
+        self.builder.build_struct_gep(ty, ptr.into_pointer_value(), index, "").unwrap().into()
     }
 
     fn memcpy(
@@ -438,7 +935,28 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         size: Self::Value,
         flags: MemFlags,
     ) {
-        todo!()
+        // This should be handled by the `codegen_memcpy` function.
+        debug_assert!(!flags.contains(MemFlags::NON_TEMPORAL), "non-temporal memcpy not supported");
+
+        let size = self.int_cast(size, self.ctx.type_isize(), false).into_int_value();
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+
+        let (destination, destination_align) = destination;
+        let (source, source_align) = source;
+
+        // we need to cast the values into pointers...
+        let destination = self.pointer_cast(destination, self.ctx.type_i8p()).into_pointer_value();
+        let source = self.pointer_cast(source, self.ctx.type_i8p()).into_pointer_value();
+
+        self.builder
+            .build_memcpy(
+                destination,
+                destination_align.bytes() as u32,
+                source,
+                source_align.bytes() as u32,
+                size,
+            )
+            .unwrap();
     }
 
     fn memmove(
@@ -448,7 +966,31 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         size: Self::Value,
         flags: MemFlags,
     ) {
-        todo!()
+        // This should be handled by the `codegen_memcpy` function.
+        debug_assert!(
+            !flags.contains(MemFlags::NON_TEMPORAL),
+            "non-temporal memmove not supported"
+        );
+
+        let size = self.int_cast(size, self.ctx.type_isize(), false).into_int_value();
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+
+        let (destination, destination_align) = destination;
+        let (source, source_align) = source;
+
+        // we need to cast the values into pointers...
+        let destination = self.pointer_cast(destination, self.ctx.type_i8p()).into_pointer_value();
+        let source = self.pointer_cast(source, self.ctx.type_i8p()).into_pointer_value();
+
+        self.builder
+            .build_memmove(
+                destination,
+                destination_align.bytes() as u32,
+                source,
+                source_align.bytes() as u32,
+                size,
+            )
+            .unwrap();
     }
 
     fn memset(
@@ -456,10 +998,20 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         ptr: Self::Value,
         fill: Self::Value,
         size: Self::Value,
-        align: Alignment,
+        alignment: Alignment,
         flags: MemFlags,
     ) {
-        todo!()
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+        let ptr = self.pointer_cast(ptr, self.ctx.type_i8p()).into_pointer_value();
+
+        self.builder
+            .build_memset(
+                ptr,
+                alignment.bytes() as u32,
+                fill.into_int_value(),
+                size.into_int_value(),
+            )
+            .unwrap();
     }
 
     fn select(
@@ -468,18 +1020,98 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
         then: Self::Value,
         otherwise: Self::Value,
     ) -> Self::Value {
-        todo!()
+        // @@Deal with potentially non-int values, we need to wrap IntMathValueEnum
+        let value = condition.into_int_value();
+
+        let then: BasicValueEnum = then.try_into().unwrap();
+        let otherwise: BasicValueEnum = otherwise.try_into().unwrap();
+
+        self.builder.build_select(value, then, otherwise, "").into()
     }
 
     fn lifetime_start(&mut self, ptr: Self::Value, size: Size) {
-        todo!()
+        self.emit_lifetime_marker("llvm.lifetime.start.p0i8", ptr, size)
     }
 
     fn lifetime_end(&mut self, ptr: Self::Value, size: Size) {
-        todo!()
+        self.emit_lifetime_marker("llvm.lifetime.end.p0i8", ptr, size)
     }
 
-    fn add_range_metadata_to(&mut self, value: Self::Value, range: ValidScalarRange) {
-        todo!()
+    fn add_range_metadata_to(&mut self, load_value: Self::Value, range: ValidScalarRange) {
+        let ty = self.ctx.ty_of_value(load_value);
+
+        let start: BasicMetadataValueEnum =
+            self.ctx.const_uint_big(ty, range.start).try_into().unwrap();
+
+        let end: BasicMetadataValueEnum =
+            self.ctx.const_uint_big(ty, range.end.wrapping_add(1)).try_into().unwrap();
+
+        let metadata = self.ctx.ll_ctx.metadata_node(&[start, end]);
+
+        let value = load_value.into_instruction_value();
+        value.set_metadata(metadata, MetadataType::Range as u32);
+    }
+
+    fn extract_field(&mut self, value: Self::Value, field_index: usize) -> Self::Value {
+        // @@Cleanup: maybe make this a standalone function?
+        let value: AggregateValueEnum = match value {
+            AnyValueEnum::StructValue(val) => AggregateValueEnum::StructValue(val),
+            AnyValueEnum::ArrayValue(val) => AggregateValueEnum::ArrayValue(val),
+            _ => unreachable!("attempt to extract field from non-aggregate value"),
+        };
+
+        self.builder.build_extract_value(value, field_index as u32, "").unwrap().into()
+    }
+}
+
+/// This will apply all of the stored metadata on the [Scalar] to
+/// the value within the LLVM IR. Here, we emit information about the
+/// [ValidScalarRange], alignment metadata and `non-null`ness.
+fn load_scalar_value_metadata<'ll>(
+    builder: &mut Builder<'ll>,
+    load: AnyValueEnum<'ll>,
+    scalar: Scalar,
+    info: TyInfo,
+    offset: Size,
+) {
+    // If the scalar is not a uninitialised value (`union`), then
+    // we can specify that it will not be non-undef,
+    if !scalar.is_union() {
+        builder.set_no_undef(load);
+    }
+
+    match scalar.kind() {
+        ScalarKind::Int { kind, signed } => {
+            // If the scalar has a particular value range, then we can emit
+            // additional information to LLVM about this range using the `range!`
+            // metadata.
+            if !scalar.is_always_valid(builder.ctx) {
+                builder.add_range_metadata_to(load, scalar.valid_range(builder.ctx));
+            }
+        }
+        ScalarKind::Float { .. } => {}
+        ScalarKind::Pointer => {
+            // If we know that the pointer cannot be non-null,
+            // then we emit this metadata.
+            if scalar.valid_range(builder.ctx).contains(0) {
+                builder.set_non_null(load);
+            }
+
+            // if we know that the pointer is now raw, we can
+            // set the alignment of the load to the same alignment value
+            // as the pointee type.
+            let (safe, pointee_ty) = builder.ctx.ir_ctx().map_ty(info.ty, |ty| match ty {
+                IrTy::Ref(pointee_ty, _, RefKind::Normal) => (true, *pointee_ty),
+                IrTy::Ref(pointee_ty, _, _) => (false, *pointee_ty),
+                _ => unreachable!(),
+            });
+
+            if safe {
+                let pointee_info = builder.layout_of_id(pointee_ty);
+                let alignment =
+                    builder.map_layout(pointee_info.layout, |layout| layout.alignment.abi);
+                builder.set_alignment(load, alignment);
+            }
+        }
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/context.rs
+++ b/compiler/hash-codegen-llvm/src/translation/context.rs
@@ -25,19 +25,19 @@ impl HasTargetSpec for CodeGenCtx<'_> {
 
 /// Implement the types for the [CodeGenCtx].
 impl<'ll> BackendTypes for CodeGenCtx<'ll> {
-    type Value = &'ll llvm::values::AnyValueEnum<'ll>;
+    type Value = llvm::values::AnyValueEnum<'ll>;
 
-    type Function = &'ll llvm::values::FunctionValue<'ll>;
+    type Function = llvm::values::FunctionValue<'ll>;
 
-    type Type = &'ll llvm::types::BasicTypeEnum<'ll>;
+    type Type = llvm::types::AnyTypeEnum<'ll>;
 
-    type BasicBlock = &'ll llvm::basic_block::BasicBlock<'ll>;
+    type BasicBlock = llvm::basic_block::BasicBlock<'ll>;
 
-    type DebugInfoScope = &'ll llvm::debug_info::DIScope<'ll>;
+    type DebugInfoScope = llvm::debug_info::DIScope<'ll>;
 
-    type DebugInfoLocation = &'ll llvm::debug_info::DILocation<'ll>;
+    type DebugInfoLocation = llvm::debug_info::DILocation<'ll>;
 
-    type DebugInfoVariable = &'ll llvm::debug_info::DILocalVariable<'ll>;
+    type DebugInfoVariable = llvm::debug_info::DILocalVariable<'ll>;
 }
 
 impl<'b> Backend<'b> for CodeGenCtx<'b> {}

--- a/compiler/hash-codegen-llvm/src/translation/declare.rs
+++ b/compiler/hash-codegen-llvm/src/translation/declare.rs
@@ -1,0 +1,70 @@
+//! Utilities for emitting declarations.
+
+use hash_codegen::abi::CallingConvention;
+use inkwell::{
+    types::AnyTypeEnum,
+    values::{AnyValueEnum, UnnamedAddress},
+    GlobalVisibility,
+};
+
+use super::Builder;
+
+impl<'b> Builder<'b> {
+    /// Standard function to declare a C-like function. This should only be used
+    /// for declaring FFI functions or various LLVM intrinsics.
+    ///
+    /// N.B. An [UnnamedAddress] specifies the significance of the global
+    /// value's address. Functions are treated as global values in LLVM IR.
+    /// The options are specified within the [documentation](https://llvm.org/doxygen/group__LLVMCCoreTypes.html#gaa12598f8d5c36303fae1e1192cbb1b33).
+    ///
+    /// Also, from the language reference:
+    /// ```text
+    /// Global variables can be marked with unnamed_addr which indicates that the
+    /// address is not significant, only the content. Constants marked like this can
+    /// be merged with other constants if they have the same initializer. Note that a
+    /// constant with significant address can be merged with a unnamed_addr constant,
+    /// the result being a constant whose address is significant.
+    /// ```
+    ///
+    /// Ref: <https://llvm.org/docs/LangRef.html#global-variables>
+    pub(crate) fn declare_c_fn(
+        &self,
+        name: &str,
+        addr: UnnamedAddress,
+        ty: AnyTypeEnum<'b>,
+    ) -> AnyValueEnum<'b> {
+        self.declare_fn(
+            name,
+            ty,
+            CallingConvention::C,
+            addr,
+            // @@Todo: maybe make this configurable through the target?
+            GlobalVisibility::Default,
+        )
+    }
+
+    /// Declare a function within the current [inkwell::module::Module]. If the
+    /// function name already exists, the existing function is updated with the
+    /// specified [CallingConvention], [UnnamedAddress], and [GlobalVisibility].
+    pub(crate) fn declare_fn(
+        &self,
+        name: &str,
+        ty: AnyTypeEnum<'b>,
+        calling_convention: CallingConvention,
+        addr: UnnamedAddress,
+        visibility: GlobalVisibility,
+    ) -> AnyValueEnum<'b> {
+        let func = if let Some(func) = self.module.get_function(name) {
+            func
+        } else {
+            self.module.add_function(name, ty.into_function_type(), None)
+        };
+
+        // We need to apply the calling convention to the function
+        func.set_call_conventions(calling_convention as u32);
+        func.as_global_value().set_unnamed_address(addr);
+        func.as_global_value().set_visibility(visibility);
+
+        func.into()
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -1,8 +1,41 @@
 //! Implements the [BuildIntrinsicCallMethods] trait for [Builder].
 
-use hash_codegen::traits::intrinsics::BuildIntrinsicCallMethods;
+use hash_codegen::traits::{
+    builder::BlockBuilderMethods, intrinsics::BuildIntrinsicCallMethods, BackendTypes,
+};
+use inkwell::values::AnyValueEnum;
 
 use super::Builder;
+
+impl<'b> Builder<'b> {
+    /// Call an intrinsic function with the specified arguments.
+    pub(crate) fn call_intrinsic(
+        &mut self,
+        name: &str,
+        args: &[AnyValueEnum<'b>],
+    ) -> <Self as BackendTypes>::Value {
+        let (ty, func) = self.get_intrinsic_function(name);
+        self.call(ty, None, func, args)
+    }
+
+    /// Get an intrinsic function type and function pointer value
+    /// for the given intrinsic name.
+    pub(crate) fn get_intrinsic_function(
+        &self,
+        name: &str,
+    ) -> (<Self as BackendTypes>::Type, <Self as BackendTypes>::Value) {
+        todo!()
+    }
+
+    fn insert_instruction(
+        &self,
+        name: &str,
+        args: &[<Self as BackendTypes>::Type],
+        return_ty: <Self as BackendTypes>::Type,
+    ) -> (<Self as BackendTypes>::Type, <Self as BackendTypes>::Value) {
+        todo!()
+    }
+}
 
 impl<'b> BuildIntrinsicCallMethods<'b> for Builder<'b> {
     fn codegen_intrinsic_call(

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -1,0 +1,61 @@
+//! Contains utility methods for emitting LLVM metadata about
+//! values, functions, and types.
+
+use hash_codegen::traits::{
+    builder::BlockBuilderMethods, constants::BuildConstValueMethods, ty::BuildTypeMethods,
+    BackendTypes,
+};
+use hash_target::{alignment::Alignment, size::Size};
+use inkwell as llvm;
+use llvm::{
+    intrinsics::Intrinsic,
+    values::{AnyValueEnum, BasicMetadataValueEnum, BasicValueEnum},
+};
+
+use super::{Builder, MetadataType};
+
+impl<'b> Builder<'b> {
+    /// Emit a `no-undef` metadata attribute on a specific value.
+    pub fn set_no_undef(&mut self, value: AnyValueEnum<'b>) {
+        let value = value.into_instruction_value();
+
+        let metadata = self.ctx.ll_ctx.metadata_node(&[]);
+        value.set_metadata(metadata, MetadataType::NoUndef as u32);
+    }
+
+    /// Emit a `nonnull` metadata attribute on a specific value.
+    pub fn set_non_null(&mut self, value: AnyValueEnum<'b>) {
+        let value = value.into_instruction_value();
+
+        let metadata = self.ctx.ll_ctx.metadata_node(&[]);
+        value.set_metadata(metadata, MetadataType::NonNull as u32);
+    }
+
+    /// Specify the alignment for a particular value.
+    pub fn set_alignment(&mut self, value: AnyValueEnum<'b>, alignment: Alignment) {
+        let value = value.into_instruction_value();
+
+        let alignment_metadata: BasicMetadataValueEnum =
+            self.ctx.const_u64(alignment.bytes()).try_into().unwrap();
+
+        let metadata = self.ctx.ll_ctx.metadata_node(&[alignment_metadata]);
+
+        value.set_metadata(metadata, MetadataType::Align as u32);
+    }
+
+    /// Emit lifetime marker information to LLVM via a `llvm.lifetime.start`
+    /// or `llvm.lifetime.end` intrinsic.
+    pub fn emit_lifetime_marker(&mut self, intrinsic: &str, ptr: AnyValueEnum<'b>, size: Size) {
+        let size = size.bytes();
+
+        // We don't do anything if this is a unit.
+        if size == 0 {
+            return;
+        }
+
+        let size = self.ctx.const_u64(size);
+        let ptr = self.pointer_cast(ptr, self.ctx.type_i8p());
+
+        self.call_intrinsic(intrinsic, &[size, ptr]);
+    }
+}

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -1,7 +1,10 @@
 //! Implements all of the type building methods for the LLVM
 //! backend.
 
-use hash_codegen::traits::ty::BuildTypeMethods;
+use hash_codegen::{abi::FnAbi, common::TypeKind, layout::TyInfo, traits::ty::BuildTypeMethods};
+use hash_ir::ty::IrTyId;
+use hash_target::{abi::Scalar, size::Size};
+use inkwell as llvm;
 
 use super::context::CodeGenCtx;
 
@@ -82,23 +85,82 @@ impl<'b> BuildTypeMethods<'b> for CodeGenCtx<'b> {
         todo!()
     }
 
-    fn type_of_value(&self, value: Self::Value) -> Self::Type {
+    fn ty_of_value(&self, value: Self::Value) -> Self::Type {
         todo!()
     }
 
-    fn kind_of_type(&self, ty: Self::Type) -> hash_codegen::common::TypeKind {
+    fn kind_of_ty(&self, ty: Self::Type) -> TypeKind {
         todo!()
     }
 
-    fn immediate_backend_type(&self, info: hash_codegen::layout::TyInfo) -> Self::Type {
+    fn immediate_backend_ty(&self, info: TyInfo) -> Self::Type {
         todo!()
     }
 
-    fn backend_type(&self, info: hash_codegen::layout::TyInfo) -> Self::Type {
+    fn backend_ty_from_ir_ty(&self, ty: IrTyId) -> Self::Type {
         todo!()
     }
 
-    fn backend_type_from_abi(&self, abi: &hash_codegen::abi::FnAbi) -> Self::Type {
+    fn backend_ty_from_info(&self, info: TyInfo) -> Self::Type {
+        todo!()
+    }
+
+    fn backend_ty_from_abi(&self, abi: &FnAbi) -> Self::Type {
+        todo!()
+    }
+}
+
+/// Define a trait that provides additional methods on the [CodeGenCtx]
+/// for computing types as LLVM types, and various other related LLVM
+/// specific type utilities.
+pub trait ExtendedTyBuilderMethods<'ll> {
+    /// Convert the [IrTyId] into the equivalent [llvm::types::AnyTypeEnum].
+    fn llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll>;
+
+    /// Create an immediate type.
+    fn immediate_llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll>;
+
+    /// Load the type of a [Scalar] with a specific offset.
+    fn scalar_llvm_type_at(
+        &self,
+        ctx: &CodeGenCtx<'ll>,
+        scalar: Scalar,
+        offset: Size,
+    ) -> llvm::types::AnyTypeEnum<'ll>;
+
+    /// Create a type for a [`ScalarKind::Pair`].
+    fn scalar_pair_element_llvm_ty(
+        &self,
+        ctx: &CodeGenCtx<'ll>,
+        index: usize,
+        immediate: bool,
+    ) -> llvm::types::AnyTypeEnum<'ll>;
+}
+
+impl<'ll> ExtendedTyBuilderMethods<'ll> for TyInfo {
+    fn llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll> {
+        todo!()
+    }
+
+    fn immediate_llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll> {
+        todo!()
+    }
+
+    fn scalar_llvm_type_at(
+        &self,
+        ctx: &CodeGenCtx<'ll>,
+        scalar: Scalar,
+        offset: Size,
+    ) -> llvm::types::AnyTypeEnum<'ll> {
+        todo!()
+    }
+
+    fn scalar_pair_element_llvm_ty(
+        &self,
+        ctx: &CodeGenCtx<'ll>,
+        index: usize,
+        immediate: bool,
+    ) -> llvm::types::AnyTypeEnum<'ll> {
         todo!()
     }
 }

--- a/compiler/hash-codegen/src/common.rs
+++ b/compiler/hash-codegen/src/common.rs
@@ -266,5 +266,33 @@ bitflags! {
         ///
         /// Ref: https://llvm.org/docs/LangRef.html#store-instruction
         const NON_TEMPORAL = 1 << 1;
+
+        /// When the referred place is considered to be unaligned.
+        const UN_ALIGNED = 1 << 2;
     }
+}
+
+/// Represents the atomic ordering of an atomic operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicOrdering {
+    /// No ordering constraints.
+    NotAtomic,
+
+    /// No ordering constraints.
+    Unordered,
+
+    /// Monotonic ordering.
+    Monotonic,
+
+    /// Acquire ordering.
+    Acquire,
+
+    /// Release ordering.
+    Release,
+
+    /// Acquire and release ordering.
+    AcquireRelease,
+
+    /// Sequentially consistent ordering.
+    SequentiallyConsistent,
 }

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -35,7 +35,7 @@ fn shift_mask_value<'b, Builder: BlockBuilderMethods<'b>>(
     mask_ty: Builder::Type,
     invert: bool,
 ) -> Builder::Value {
-    match builder.kind_of_type(ty) {
+    match builder.kind_of_ty(ty) {
         TypeKind::IntegerTy => {
             let bits = builder.int_width(ty) - 1;
 
@@ -61,8 +61,8 @@ fn cast_shift_value<'b, Builder: BlockBuilderMethods<'b>>(
     lhs: Builder::Value,
     rhs: Builder::Value,
 ) -> Builder::Value {
-    let lhs_ty = builder.type_of_value(lhs);
-    let rhs_ty = builder.type_of_value(rhs);
+    let lhs_ty = builder.ty_of_value(lhs);
+    let rhs_ty = builder.ty_of_value(rhs);
 
     let lhs_size = builder.int_width(lhs_ty);
     let rhs_size = builder.int_width(rhs_ty);
@@ -90,7 +90,7 @@ fn apply_shift_mask<'b, Builder: BlockBuilderMethods<'b>>(
     builder: &mut Builder,
     shift_value: Builder::Value,
 ) -> Builder::Value {
-    let value_ty = builder.type_of_value(shift_value);
+    let value_ty = builder.ty_of_value(shift_value);
     let mask = shift_mask_value(builder, value_ty, value_ty, false);
     builder.and(shift_value, mask)
 }
@@ -456,13 +456,13 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 };
 
                 let (value, overflow) =
-                    builder.checked_bin_op(checked_operator, lhs_value, rhs_value);
+                    builder.checked_bin_op(checked_operator, ty, lhs_value, rhs_value);
 
                 (value, overflow)
             }
             BinOp::Shl | BinOp::Shr => {
-                let lhs_ty = builder.type_of_value(lhs_value);
-                let rhs_ty = builder.type_of_value(rhs_value);
+                let lhs_ty = builder.ty_of_value(lhs_value);
+                let rhs_ty = builder.ty_of_value(rhs_value);
 
                 let invert_mask = shift_mask_value(builder, lhs_ty, rhs_ty, true);
                 let outer_bits = builder.and(rhs_value, invert_mask);

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -281,7 +281,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             // don't do anything and it's just a NOP).
             //
             if matches!(arg_abi.mode, PassMode::Direct(..)) {
-                value = builder.load(builder.backend_type(arg_abi.info), value, alignment);
+                value = builder.load(builder.backend_ty_from_info(arg_abi.info), value, alignment);
 
                 let layout_abi = builder.map_layout(arg_abi.info.layout, |layout| layout.abi);
 
@@ -384,7 +384,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                     .codegen_consume_operand(builder, ir::Place::return_place(self.ctx.ir_ctx()));
 
                 if let OperandValue::Ref(value, alignment) = op.value {
-                    let ty = builder.backend_type(op.info);
+                    let ty = builder.backend_ty_from_info(op.info);
                     builder.load(ty, value, alignment)
                 } else {
                     // @@Todo: deal with `Pair` operand refs
@@ -440,7 +440,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 // If this isn't a boolean type, then we have to emit an
                 // `icmp` instruction to compare the subject value with
                 // the target value.
-                let subject_ty = builder.backend_type(subject.info);
+                let subject_ty = builder.backend_ty_from_info(subject.info);
                 let target_value = builder.const_uint_big(subject_ty, value);
                 let comparison =
                     builder.icmp(IntComparisonKind::Eq, subject.immediate_value(), target_value);
@@ -471,7 +471,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             let target_block_1 = self.get_codegen_block_id(target_1);
             let target_block_2 = self.get_codegen_block_id(target_2);
 
-            let subject_ty = builder.immediate_backend_type(builder.layout_of_id(ty));
+            let subject_ty = builder.immediate_backend_ty(builder.layout_of_id(ty));
             let target_value = builder.const_uint_big(subject_ty, value);
             let comparison =
                 builder.icmp(IntComparisonKind::Eq, subject.immediate_value(), target_value);
@@ -556,7 +556,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         destination: Option<(ir::BasicBlock, ReturnDestinationKind<Builder::Value>)>,
         can_merge: bool,
     ) -> bool {
-        let fn_ty = builder.backend_type_from_abi(fn_abi);
+        let fn_ty = builder.backend_ty_from_abi(fn_abi);
 
         //@@Future: when we deal with unwinding functions, we will have to use the
         // `builder::invoke()` API in order to instruct the backends to emit relevant

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -1,6 +1,7 @@
 //! Trait methods to do with emitting types for the backend.
 
 use hash_abi::FnAbi;
+use hash_ir::ty::IrTyId;
 use hash_layout::TyInfo;
 use hash_target::abi::AddressSpace;
 
@@ -67,19 +68,22 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
     fn int_width(&self, ty: Self::Type) -> u64;
 
     /// Compute the type of a particular backend value.
-    fn type_of_value(&self, value: Self::Value) -> Self::Type;
+    fn ty_of_value(&self, value: Self::Value) -> Self::Type;
 
     /// Get the [TypeKind] of a particular type.
-    fn kind_of_type(&self, ty: Self::Type) -> TypeKind;
+    fn kind_of_ty(&self, ty: Self::Type) -> TypeKind;
 
     /// Create a new "immediate" backend type. This is mainly
     /// used for constants and ZSTs.
-    fn immediate_backend_type(&self, info: TyInfo) -> Self::Type;
+    fn immediate_backend_ty(&self, info: TyInfo) -> Self::Type;
+
+    /// Create a backend specific type from an [IrTyId].
+    fn backend_ty_from_ir_ty(&self, ty: IrTyId) -> Self::Type;
 
     /// Create a backend specific type from a [TyInfo].
-    fn backend_type(&self, info: TyInfo) -> Self::Type;
+    fn backend_ty_from_info(&self, info: TyInfo) -> Self::Type;
 
     /// Create a backend type that represents the provided [FnAbi]. This
     /// is used to compute a function type from a [FnAbi].
-    fn backend_type_from_abi(&self, abi: &FnAbi) -> Self::Type;
+    fn backend_ty_from_abi(&self, abi: &FnAbi) -> Self::Type;
 }

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -76,8 +76,8 @@ impl UIntTy {
         }
     }
 
-    /// Create a new [UnitTy] from a given [Size]. This assumes that
-    /// the maximum passed [Size] can be represented as a [UIntTy::U128].
+    /// Create a new [UIntTy] from a given [Size]. This assumes that
+    /// the maximum passed [Size] can be represented as a [`UIntTy::U128`].
     ///
     /// Additionally, this will never use the `usize` type to avoid confusion
     /// between different platforms/targets.
@@ -126,6 +126,15 @@ impl UIntTy {
             UIntTy::U128 => "u128",
             UIntTy::USize => "usize",
             UIntTy::UBig => "ubig",
+        }
+    }
+
+    /// Normalise the [UIntTy], i.e. convert the [`UIntTy::USize`] variant
+    /// into the normalised type equivalent.
+    pub fn normalise(&self, ptr_width: usize) -> Self {
+        match self {
+            UIntTy::USize => UIntTy::from_size(Size::from_bytes(ptr_width)),
+            _ => *self,
         }
     }
 }
@@ -181,6 +190,22 @@ impl SIntTy {
         }
     }
 
+    /// Create a new [SIntTy] from a given [Size]. This assumes that
+    /// the maximum passed [Size] can be represented as a [`SIntTy::I128`].
+    ///
+    /// Additionally, this will never use the `usize` type to avoid confusion
+    /// between different platforms/targets.
+    pub fn from_size(size: Size) -> Self {
+        match size.bytes() {
+            0..=1 => SIntTy::I8,
+            2 => SIntTy::I16,
+            3..=4 => SIntTy::I32,
+            5..=8 => SIntTy::I64,
+            9..=16 => SIntTy::I128,
+            _ => unreachable!(),
+        }
+    }
+
     /// Function to get the largest possible integer represented within this
     /// type. For sizes `ibig` and `ubig` there is no defined max and so the
     /// function returns [None].
@@ -228,6 +253,15 @@ impl SIntTy {
             SIntTy::I128 => "i128",
             SIntTy::ISize => "isize",
             SIntTy::IBig => "ibig",
+        }
+    }
+
+    /// Normalise the [UIntTy], i.e. convert the [`UIntTy::USize`] variant
+    /// into the normalised type equivalent.
+    pub fn normalise(&self, ptr_width: usize) -> Self {
+        match self {
+            SIntTy::ISize => SIntTy::from_size(Size::from_bytes(ptr_width)),
+            _ => *self,
         }
     }
 }


### PR DESCRIPTION
This PR is an initial progress checkpoint on implementing all of the required code generation methods for the LLVM backend. This patch implements all of the methods in `BlockBuilderMethods`. The next things to implement are the `BuildConstValueMethods` and `BuildTypeMethods`.