### PR TITLE
codegen(llvm): Implement `TypeBuilderMethods` and `ConstValueBuilderMethods`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ version = "0.1.0"
 dependencies = [
  "append-only-vec",
  "fixedbitset",
+ "fxhash",
  "index_vec",
  "log",
  "stacker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "hash-target",
  "hash-utils",
  "inkwell",
+ "llvm-sys",
  "rayon",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +479,7 @@ dependencies = [
 name = "hash-codegen-llvm"
 version = "0.1.0"
 dependencies = [
+ "fxhash",
  "hash-codegen",
  "hash-ir",
  "hash-pipeline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "inkwell",
  "llvm-sys",
  "rayon",
+ "smallvec",
 ]
 
 [[package]]

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 rayon = "1.5.0"
+llvm-sys = "150.0.3"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm15-0"] }
 
 hash-codegen = {path = "../hash-codegen" }

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 rayon = "1.5.0"
 llvm-sys = "150.0.3"
+smallvec = "1.9.0"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm15-0"] }
 
 hash-codegen = {path = "../hash-codegen" }

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 rayon = "1.5.0"
 llvm-sys = "150.0.3"
 smallvec = "1.9.0"
+fxhash = "0.2.1"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm15-0"] }
 
 hash-codegen = {path = "../hash-codegen" }

--- a/compiler/hash-codegen-llvm/src/context.rs
+++ b/compiler/hash-codegen-llvm/src/context.rs
@@ -74,8 +74,7 @@ impl<'b> CodeGenCtx<'b> {
         name.push_str(prefix);
         name.push('.');
         push_string_encoded_count(symbol_counter as u128, ALPHANUMERIC_BASE, &mut name);
-
-        format!("{prefix}{symbol_counter}")
+        name
     }
 }
 

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -1,3 +1,4 @@
 //! The LLVM code generation backend for Hash.
+#![feature(let_chains)]
 
 pub mod translation;

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -1,4 +1,6 @@
 //! The LLVM code generation backend for Hash.
-#![feature(let_chains)]
+#![feature(let_chains, hash_raw_entry)]
 
+pub mod context;
+pub mod misc;
 pub mod translation;

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -1,0 +1,100 @@
+//! Contains various mappings and conversions between the generic code
+//! generation types and the LLVM backend specific data types.
+
+use hash_codegen::common::{AtomicOrdering, IntComparisonKind, RealComparisonKind};
+use hash_target::abi::AddressSpace;
+
+/// Wrapper type around [inkwell::IntPredicate] to allow for conversion from
+/// [IntComparisonKind].
+pub struct IntPredicateWrapper(pub inkwell::IntPredicate);
+
+impl From<IntComparisonKind> for IntPredicateWrapper {
+    fn from(value: IntComparisonKind) -> Self {
+        match value {
+            IntComparisonKind::Eq => Self(inkwell::IntPredicate::EQ),
+            IntComparisonKind::Ne => Self(inkwell::IntPredicate::NE),
+            IntComparisonKind::Ugt => Self(inkwell::IntPredicate::UGT),
+            IntComparisonKind::Uge => Self(inkwell::IntPredicate::UGE),
+            IntComparisonKind::Ult => Self(inkwell::IntPredicate::ULT),
+            IntComparisonKind::Ule => Self(inkwell::IntPredicate::ULE),
+            IntComparisonKind::Sgt => Self(inkwell::IntPredicate::SGT),
+            IntComparisonKind::Sge => Self(inkwell::IntPredicate::SGE),
+            IntComparisonKind::Slt => Self(inkwell::IntPredicate::SLT),
+            IntComparisonKind::Sle => Self(inkwell::IntPredicate::SLE),
+        }
+    }
+}
+
+/// Wrapper type around [inkwell::FloatPredicate] to allow for conversion from
+/// [RealComparisonKind].
+pub struct FloatPredicateWrapper(pub inkwell::FloatPredicate);
+
+impl From<RealComparisonKind> for FloatPredicateWrapper {
+    fn from(value: RealComparisonKind) -> Self {
+        match value {
+            RealComparisonKind::False => Self(inkwell::FloatPredicate::PredicateFalse),
+            RealComparisonKind::Oeq => Self(inkwell::FloatPredicate::OEQ),
+            RealComparisonKind::Ogt => Self(inkwell::FloatPredicate::OGT),
+            RealComparisonKind::Oge => Self(inkwell::FloatPredicate::OGE),
+            RealComparisonKind::Olt => Self(inkwell::FloatPredicate::OLT),
+            RealComparisonKind::Ole => Self(inkwell::FloatPredicate::OLE),
+            RealComparisonKind::One => Self(inkwell::FloatPredicate::ONE),
+            RealComparisonKind::Ord => Self(inkwell::FloatPredicate::ORD),
+            RealComparisonKind::Uno => Self(inkwell::FloatPredicate::UNO),
+            RealComparisonKind::Ueq => Self(inkwell::FloatPredicate::UEQ),
+            RealComparisonKind::Ugt => Self(inkwell::FloatPredicate::UGT),
+            RealComparisonKind::Uge => Self(inkwell::FloatPredicate::UGE),
+            RealComparisonKind::Ult => Self(inkwell::FloatPredicate::ULT),
+            RealComparisonKind::Ule => Self(inkwell::FloatPredicate::ULE),
+            RealComparisonKind::Une => Self(inkwell::FloatPredicate::UNE),
+            RealComparisonKind::True => Self(inkwell::FloatPredicate::PredicateTrue),
+        }
+    }
+}
+
+/// Wrapper type around [inkwell::AtomicOrdering] to allow for conversion from
+/// [AtomicOrdering].
+pub struct AtomicOrderingWrapper(pub inkwell::AtomicOrdering);
+
+impl From<AtomicOrdering> for AtomicOrderingWrapper {
+    fn from(value: AtomicOrdering) -> Self {
+        match value {
+            AtomicOrdering::NotAtomic => Self(inkwell::AtomicOrdering::NotAtomic),
+            AtomicOrdering::Unordered => Self(inkwell::AtomicOrdering::Unordered),
+            AtomicOrdering::Monotonic => Self(inkwell::AtomicOrdering::Monotonic),
+            AtomicOrdering::Acquire => Self(inkwell::AtomicOrdering::Acquire),
+            AtomicOrdering::Release => Self(inkwell::AtomicOrdering::Release),
+            AtomicOrdering::AcquireRelease => Self(inkwell::AtomicOrdering::AcquireRelease),
+            AtomicOrdering::SequentiallyConsistent => {
+                Self(inkwell::AtomicOrdering::SequentiallyConsistent)
+            }
+        }
+    }
+}
+
+pub struct AddressSpaceWrapper(pub inkwell::AddressSpace);
+
+impl From<AddressSpace> for AddressSpaceWrapper {
+    fn from(value: AddressSpace) -> Self {
+        AddressSpaceWrapper(inkwell::AddressSpace::try_from(value.0).unwrap())
+    }
+}
+
+/// This defines the ids for the various `MetadataKind`s that are used in LLVM
+/// to annotate values with particular properties.
+///
+/// Defined in <https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/FixedMetadataKinds.def>
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub enum MetadataType {
+    FpMath = 3,
+    Range = 4,
+    InvariantLoad = 6,
+    AliasScope = 7,
+    NoAlias = 8,
+    NonTemporal = 9,
+    NonNull = 11,
+    Align = 17,
+    Type = 19,
+    NoUndef = 29,
+}

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -6,7 +6,7 @@ use hash_codegen::{
     traits::abi::AbiBuilderMethods,
 };
 use inkwell::{
-    types::BasicTypeEnum,
+    types::{AnyTypeEnum, BasicTypeEnum},
     values::{CallSiteValue, FunctionValue},
 };
 
@@ -38,21 +38,21 @@ impl<'b> AbiBuilderMethods<'b> for Builder<'b> {
 
 pub trait ExtendedFnAbiMethods<'b> {
     /// Produce an LLVM type for the given [FnAbi].
-    fn llvm_ty(&self) -> BasicTypeEnum<'b>;
+    fn llvm_ty(&self, ctx: &CodeGenCtx<'b>) -> AnyTypeEnum<'b>;
 
     /// Apply the derived ABI attributes to the given [FunctionValue].
-    fn apply_attributes_to_fn(&self, ctx: CodeGenCtx<'b>, func: FunctionValue<'b>);
+    fn apply_attributes_to_fn(&self, ctx: &CodeGenCtx<'b>, func: FunctionValue<'b>);
 
     /// Apply the derived ABI attributes to the given [CallSiteValue].
     fn apply_attributes_call_site(&self, builder: &mut Builder<'b>, call_site: CallSiteValue<'b>);
 }
 
 impl<'b> ExtendedFnAbiMethods<'b> for FnAbi {
-    fn llvm_ty(&self) -> BasicTypeEnum<'b> {
+    fn llvm_ty(&self, ctx: &CodeGenCtx<'b>) -> AnyTypeEnum<'b> {
         todo!()
     }
 
-    fn apply_attributes_to_fn(&self, ctx: CodeGenCtx<'b>, func: FunctionValue<'b>) {
+    fn apply_attributes_to_fn(&self, ctx: &CodeGenCtx<'b>, func: FunctionValue<'b>) {
         todo!()
     }
 

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -10,7 +10,8 @@ use inkwell::{
     values::{CallSiteValue, FunctionValue},
 };
 
-use super::{context::CodeGenCtx, Builder};
+use super::Builder;
+use crate::context::CodeGenCtx;
 
 impl<'b> AbiBuilderMethods<'b> for Builder<'b> {
     fn get_param(&mut self, index: usize) -> Self::Value {

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -39,7 +39,10 @@ use rayon::iter::Either;
 
 use super::{
     abi::ExtendedFnAbiMethods, layouts::ExtendedLayoutMethods, ty::ExtendedTyBuilderMethods,
-    AtomicOrderingWrapper, Builder, FloatPredicateWrapper, IntPredicateWrapper, MetadataType,
+    Builder,
+};
+use crate::misc::{
+    AtomicOrderingWrapper, FloatPredicateWrapper, IntPredicateWrapper, MetadataType,
 };
 
 impl<'b> Builder<'b> {

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -1107,7 +1107,7 @@ fn load_scalar_value_metadata<'ll>(
             });
 
             if safe {
-                let pointee_info = builder.layout_of_id(pointee_ty);
+                let pointee_info = builder.layout_of(pointee_ty);
                 let alignment =
                     builder.map_layout(pointee_info.layout, |layout| layout.alignment.abi);
                 builder.set_alignment(load, alignment);

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -17,7 +17,7 @@ use hash_codegen::{
         constants::ConstValueBuilderMethods,
         ctx::HasCtxMethods,
         layout::LayoutMethods,
-        ty::BuildTypeMethods,
+        ty::TypeBuilderMethods,
     },
 };
 use hash_ir::ty::{IrTy, IrTyId, RefKind};

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -14,7 +14,7 @@ use hash_codegen::{
     },
     traits::{
         builder::{self, BlockBuilderMethods},
-        constants::BuildConstValueMethods,
+        constants::ConstValueBuilderMethods,
         ctx::HasCtxMethods,
         layout::LayoutMethods,
         ty::BuildTypeMethods,

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -1,82 +1,103 @@
 //! Implements all of the constant building methods.
-use hash_codegen::traits::constants::BuildConstValueMethods;
+use hash_codegen::traits::{constants::ConstValueBuilderMethods, ty::BuildTypeMethods};
 use hash_ir::ir::Const;
 use hash_source::constant::InternedStr;
-use hash_target::abi::Scalar;
+use hash_target::{abi::Scalar, data_layout::HasDataLayout};
+use inkwell::{
+    types::BasicTypeEnum,
+    values::{AnyValueEnum, AsValueRef},
+};
 
 use super::context::CodeGenCtx;
 
-impl<'b> BuildConstValueMethods<'b> for CodeGenCtx<'b> {
+impl<'b> ConstValueBuilderMethods<'b> for CodeGenCtx<'b> {
     fn const_undef(&self, ty: Self::Type) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        match ty {
+            BasicTypeEnum::ArrayType(ty) => ty.get_undef().into(),
+            BasicTypeEnum::FloatType(ty) => ty.get_undef().into(),
+            BasicTypeEnum::IntType(ty) => ty.get_undef().into(),
+            BasicTypeEnum::PointerType(ty) => ty.get_undef().into(),
+            BasicTypeEnum::StructType(ty) => ty.get_undef().into(),
+            BasicTypeEnum::VectorType(ty) => ty.get_undef().into(),
+        }
     }
 
     fn const_null(&self, ty: Self::Type) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        ty.const_zero().into()
     }
 
-    fn const_bool(&self, val: bool) -> Self::Value {
-        todo!()
+    fn const_bool(&self, value: bool) -> Self::Value {
+        self.const_uint(self.type_i1(), value as u64)
     }
 
-    fn const_u8(&self, i: u8) -> Self::Value {
-        todo!()
+    fn const_u8(&self, value: u8) -> Self::Value {
+        self.const_uint(self.type_i8(), value as u64)
     }
 
-    fn const_i8(&self, i: i8) -> Self::Value {
-        todo!()
+    fn const_i8(&self, value: i8) -> Self::Value {
+        self.const_int(self.type_i8(), value as i64)
     }
 
-    fn const_u16(&self, i: i16) -> Self::Value {
-        todo!()
+    fn const_u16(&self, value: i16) -> Self::Value {
+        self.const_uint(self.type_i16(), value as u64)
     }
 
     fn const_i16(&self, i: i16) -> Self::Value {
-        todo!()
+        self.const_int(self.type_i16(), i as i64)
     }
 
     fn const_u32(&self, i: u32) -> Self::Value {
-        todo!()
+        self.const_uint(self.type_i32(), i as u64)
     }
 
     fn const_i32(&self, i: i32) -> Self::Value {
-        todo!()
+        self.const_int(self.type_i32(), i as i64)
     }
 
     fn const_u64(&self, i: u64) -> Self::Value {
-        todo!()
+        self.const_uint(self.type_i64(), i)
     }
 
     fn const_i64(&self, i: i64) -> Self::Value {
-        todo!()
+        self.const_int(self.type_i64(), i)
     }
 
     fn const_u128(&self, i: u128) -> Self::Value {
-        todo!()
-    }
-
-    fn const_i128(&self, i: i128) -> Self::Value {
-        todo!()
+        self.const_uint_big(self.type_i128(), i)
     }
 
     fn const_uint(&self, ty: Self::Type, value: u64) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        ty.into_int_type().const_int(value, false).into()
     }
 
-    fn const_uint_big(&self, ty: Self::Type, i: u128) -> Self::Value {
-        todo!()
+    fn const_uint_big(&self, ty: Self::Type, value: u128) -> Self::Value {
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+
+        let words = [value as u64, (value >> 64) as u64];
+        ty.into_int_type().const_int_arbitrary_precision(&words).into()
     }
 
     fn const_int(&self, ty: Self::Type, value: i64) -> Self::Value {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        ty.into_int_type().const_int(value as u64, true).into()
     }
 
-    fn const_usize(&self, i: u64) -> Self::Value {
-        todo!()
+    fn const_usize(&self, value: u64) -> Self::Value {
+        let bit_size = self.data_layout().pointer_size.bits();
+
+        if bit_size < 64 {
+            debug_assert!(value < (1 << bit_size));
+        }
+
+        self.const_uint(self.size_ty, value)
     }
 
-    fn const_float(&self, t: Self::Type, val: f64) -> Self::Value {
-        todo!()
+    fn const_float(&self, ty: Self::Type, val: f64) -> Self::Value {
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        ty.into_float_type().const_float(val).into()
     }
 
     fn const_str(&self, s: &str) -> (Self::Value, Self::Value) {
@@ -92,10 +113,33 @@ impl<'b> BuildConstValueMethods<'b> for CodeGenCtx<'b> {
     }
 
     fn const_to_optional_u128(&self, value: Self::Value, sign_extend: bool) -> Option<u128> {
-        todo!()
+        if let AnyValueEnum::IntValue(val) = value && val.is_constant_int() {
+            let value = val.get_type().get_bit_width();
+            if value > 128 {
+                return None;
+            }
+
+            // @@Hack: this doesn't properly handle the full range of i128 values, however]
+            // Inkwell doesn't support arbitrary precision integers, so we can't do much better...
+            // unless we @@PatchInkwell
+            if sign_extend {
+                val.get_sign_extended_constant().map(|v| {
+                    // upcast to i128, and then convert into u128
+                    unsafe { std::mem::transmute::<i128, u128>(v as i128) }
+                })
+            } else {
+                val.get_zero_extended_constant().map(|v| v as u128)
+            }
+        } else {
+            None
+        }
     }
 
     fn const_to_optional_uint(&self, value: Self::Value) -> Option<u64> {
-        todo!()
+        if let AnyValueEnum::IntValue(val) = value && val.is_constant_int() {
+            val.get_zero_extended_constant()
+        } else {
+            None
+        }
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -1,7 +1,7 @@
 //! Implements all of the constant building methods.
 use hash_codegen::traits::{
     constants::ConstValueBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods,
-    ty::BuildTypeMethods,
+    ty::TypeBuilderMethods,
 };
 use hash_ir::ir::Const;
 use hash_source::constant::{InternedStr, CONSTANT_MAP};

--- a/compiler/hash-codegen-llvm/src/translation/context.rs
+++ b/compiler/hash-codegen-llvm/src/translation/context.rs
@@ -15,6 +15,7 @@ use hash_ir::{
 use hash_pipeline::settings::CompilerSettings;
 use hash_target::{data_layout::TargetDataLayout, Target};
 use inkwell as llvm;
+use llvm::types::AnyTypeEnum;
 
 use super::ty::TyMemoryRemap;
 
@@ -35,6 +36,10 @@ pub struct CodeGenCtx<'b> {
     /// The LLVM "context" that is used for building and
     /// translating into LLVM IR.
     pub ll_ctx: llvm::context::ContextRef<'b>,
+
+    /// A reference to a platform-specific type that represents the width
+    /// of pointers and pointer offsets.
+    pub size_ty: AnyTypeEnum<'b>,
 
     /// A collection of [TyMemoryRemap]s that have occurred for
     /// all of the types that have been translated. Additionally, this is used

--- a/compiler/hash-codegen-llvm/src/translation/context.rs
+++ b/compiler/hash-codegen-llvm/src/translation/context.rs
@@ -15,6 +15,7 @@ pub struct CodeGenCtx<'ll> {
 
     /// The InkWell context that we are generating code with.
     pub ll_ctx: llvm::context::ContextRef<'ll>,
+    // //// A cache for the conversion between [IrTyId]s and [llvm::types::AnyTypeEnum].
 }
 
 impl HasTargetSpec for CodeGenCtx<'_> {

--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -1,7 +1,10 @@
 //! Implements all of the required functionality for generating debug
 //! information for the LLVM backend.
 
-use hash_codegen::traits::debug::{BuildDebugInfoMethods, VariableKind};
+use hash_codegen::{
+    abi::FnAbi,
+    traits::debug::{BuildDebugInfoMethods, VariableKind},
+};
 use hash_source::{identifier::Identifier, location::SourceLocation};
 
 use super::Builder;
@@ -9,7 +12,7 @@ use super::Builder;
 impl<'b> BuildDebugInfoMethods for Builder<'b> {
     fn create_debug_info_scope_for_fn(
         &self,
-        fn_abi: (),
+        fn_abi: &FnAbi,
         value: Option<Self::Function>,
     ) -> Self::DebugInfoScope {
         todo!()

--- a/compiler/hash-codegen-llvm/src/translation/declare.rs
+++ b/compiler/hash-codegen-llvm/src/translation/declare.rs
@@ -2,14 +2,15 @@
 
 use hash_codegen::abi::CallingConvention;
 use inkwell::{
-    types::AnyTypeEnum,
-    values::{AnyValueEnum, UnnamedAddress},
+    types::{AnyTypeEnum, BasicTypeEnum},
+    values::{AnyValue, AnyValueEnum, GlobalValue, UnnamedAddress},
     GlobalVisibility,
 };
 
 use super::Builder;
+use crate::context::CodeGenCtx;
 
-impl<'b> Builder<'b> {
+impl<'b> CodeGenCtx<'b> {
     /// Standard function to declare a C-like function. This should only be used
     /// for declaring FFI functions or various LLVM intrinsics.
     ///
@@ -66,5 +67,22 @@ impl<'b> Builder<'b> {
         func.as_global_value().set_visibility(visibility);
 
         func.into()
+    }
+
+    /// Declare a global variable within the current [inkwell::module::Module]
+    /// with the intent to define it.
+    ///
+    /// If the global variable name already exists, the function will return
+    /// [`None`].
+    pub(crate) fn declare_global(
+        &self,
+        name: &str,
+        ty: BasicTypeEnum<'b>,
+    ) -> Option<GlobalValue<'b>> {
+        if self.module.get_global(name).is_some() {
+            None
+        } else {
+            Some(self.module.add_global(ty, None, name))
+        }
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -73,7 +73,8 @@ pub trait ExtendedLayoutMethods {
     /// Check if this is type is represented as an immediate value.
     fn is_llvm_immediate(&self) -> bool;
 
-    /// Returns true if this type is a [`Scalar::Pair`]
+    /// Returns true if this [Layout] ABI is represented as is a
+    /// [`AbiRepresentation::Pair(..)`]
     fn is_llvm_scalar_pair(&self) -> bool;
 }
 

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -1,46 +1,46 @@
 //! Implements all of the required methods for computing the layouts of types.
 
 use hash_codegen::{
-    layout::{Layout, TyInfo},
+    layout::{Layout, LayoutShape, TyInfo, Variants},
     traits::layout::LayoutMethods,
+};
+use hash_ir::{
+    ty::{IrTy, IrTyId},
+    write::WriteIr,
 };
 use hash_target::{
     abi::AbiRepresentation,
     data_layout::{HasDataLayout, TargetDataLayout},
 };
 
-use super::{context::CodeGenCtx, Builder};
+use super::{
+    context::CodeGenCtx,
+    ty::{ExtendedTyBuilderMethods, TyMemoryRemap},
+    Builder,
+};
 
 impl<'b> LayoutMethods<'b> for CodeGenCtx<'b> {
-    fn layout_of_id(&self, ty: hash_ir::ty::IrTyId) -> hash_codegen::layout::TyInfo {
-        todo!()
+    fn backend_field_index(&self, info: TyInfo, index: usize) -> u64 {
+        self.map_layout(info.layout, |layout| layout.llvm_field_index(self, info.ty, index))
     }
 
-    fn layout_of(&self, ty: hash_ir::ty::IrTy) -> hash_codegen::layout::TyInfo {
-        todo!()
-    }
-
-    fn backend_field_index(&self, info: hash_codegen::layout::TyInfo, index: usize) -> u64 {
-        todo!()
-    }
-
-    fn is_backend_immediate(&self, ty: hash_codegen::layout::TyInfo) -> bool {
-        todo!()
+    fn is_backend_immediate(&self, info: TyInfo) -> bool {
+        self.map_layout(info.layout, |layout| layout.is_llvm_immediate())
     }
 
     fn scalar_pair_element_backend_type(
         &self,
-        info: hash_codegen::layout::TyInfo,
+        info: TyInfo,
         index: usize,
         immediate: bool,
     ) -> Self::Type {
-        todo!()
+        info.scalar_pair_element_llvm_ty(self, index, immediate)
     }
 }
 
 impl HasDataLayout for CodeGenCtx<'_> {
     fn data_layout(&self) -> &TargetDataLayout {
-        todo!()
+        &self.settings.codegen_settings.data_layout
     }
 }
 
@@ -69,7 +69,10 @@ impl HasDataLayout for Builder<'_> {
     }
 }
 
-pub trait ExtendedLayoutMethods {
+pub trait ExtendedLayoutMethods<'b> {
+    /// Compute the field index from the backend specific type.
+    fn llvm_field_index(&self, cx: &CodeGenCtx<'b>, ty: IrTyId, index: usize) -> u64;
+
     /// Check if this is type is represented as an immediate value.
     fn is_llvm_immediate(&self) -> bool;
 
@@ -78,7 +81,7 @@ pub trait ExtendedLayoutMethods {
     fn is_llvm_scalar_pair(&self) -> bool;
 }
 
-impl ExtendedLayoutMethods for &Layout {
+impl<'b> ExtendedLayoutMethods<'b> for &Layout {
     fn is_llvm_immediate(&self) -> bool {
         match self.abi {
             AbiRepresentation::Scalar(_) | AbiRepresentation::Vector { .. } => true,
@@ -89,5 +92,41 @@ impl ExtendedLayoutMethods for &Layout {
 
     fn is_llvm_scalar_pair(&self) -> bool {
         matches!(self.abi, AbiRepresentation::Pair(..))
+    }
+
+    fn llvm_field_index(&self, ctx: &CodeGenCtx<'b>, ty: IrTyId, index: usize) -> u64 {
+        // Field index of scalar and scalar pairs is not applicable since
+        // it is handled else where.
+        match self.abi {
+            AbiRepresentation::Scalar(_) | AbiRepresentation::Pair(..) => {
+                panic!("cannot get field index of scalar or scalar pair")
+            }
+            _ => {}
+        };
+
+        match self.shape {
+            LayoutShape::Primitive | LayoutShape::Union { .. } => {
+                panic!("cannot get field index of primitive or union")
+            }
+            LayoutShape::Array { .. } => index as u64,
+
+            // Here, we have to rely on the re-mapped version of the layout since
+            // we had to adjust it to account for all of the padding that was added
+            // to the struct/aggregate.
+            LayoutShape::Aggregate { .. } => {
+                let variant_index = match self.variants {
+                    Variants::Single { index } => Some(index),
+                    Variants::Multiple { .. } => None,
+                };
+
+                match ctx.ty_remaps.borrow().get(&(ty, variant_index)) {
+                    Some(TyMemoryRemap { remap: Some(ref remap), .. }) => remap[index] as u64,
+                    Some(TyMemoryRemap { remap: None, .. }) => {
+                        self.shape.memory_index(index) as u64
+                    }
+                    None => panic!("cannot find remapped layout for `{}`", ty.for_fmt(ctx.ir_ctx)),
+                }
+            }
+        }
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -14,10 +14,10 @@ use hash_target::{
 };
 
 use super::{
-    context::CodeGenCtx,
     ty::{ExtendedTyBuilderMethods, TyMemoryRemap},
     Builder,
 };
+use crate::context::CodeGenCtx;
 
 impl<'b> LayoutMethods<'b> for CodeGenCtx<'b> {
     fn backend_field_index(&self, info: TyInfo, index: usize) -> u64 {

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -2,7 +2,7 @@
 //! values, functions, and types.
 
 use hash_codegen::traits::{
-    builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ty::BuildTypeMethods,
+    builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ty::TypeBuilderMethods,
     BackendTypes,
 };
 use hash_target::{alignment::Alignment, size::Size};

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -12,7 +12,8 @@ use llvm::{
     values::{AnyValueEnum, BasicMetadataValueEnum, BasicValueEnum},
 };
 
-use super::{Builder, MetadataType};
+use super::Builder;
+use crate::misc::MetadataType;
 
 impl<'b> Builder<'b> {
     /// Emit a `no-undef` metadata attribute on a specific value.

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -2,7 +2,7 @@
 //! values, functions, and types.
 
 use hash_codegen::traits::{
-    builder::BlockBuilderMethods, constants::BuildConstValueMethods, ty::BuildTypeMethods,
+    builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ty::BuildTypeMethods,
     BackendTypes,
 };
 use hash_target::{alignment::Alignment, size::Size};

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -2,7 +2,7 @@
 
 use hash_codegen::traits::misc::MiscBuilderMethods;
 
-use super::context::CodeGenCtx;
+use crate::context::CodeGenCtx;
 
 impl<'b> MiscBuilderMethods<'b> for CodeGenCtx<'b> {
     fn get_fn(&self, instance: hash_ir::ty::Instance) -> Self::Function {

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -11,7 +11,7 @@ use hash_codegen::{
 };
 use hash_ir::IrCtx;
 use hash_pipeline::settings::CompilerSettings;
-use hash_target::Target;
+use hash_target::{abi::AddressSpace, Target};
 
 use self::context::CodeGenCtx;
 
@@ -153,6 +153,14 @@ impl From<AtomicOrdering> for AtomicOrderingWrapper {
                 Self(inkwell::AtomicOrdering::SequentiallyConsistent)
             }
         }
+    }
+}
+
+pub struct AddressSpaceWrapper(pub inkwell::AddressSpace);
+
+impl From<AddressSpace> for AddressSpaceWrapper {
+    fn from(value: AddressSpace) -> Self {
+        AddressSpaceWrapper(inkwell::AddressSpace::try_from(value.0).unwrap())
     }
 }
 

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -78,13 +78,13 @@ impl<'b> HasCtxMethods<'b> for Builder<'b> {
     }
 
     fn layout_computer(&self) -> LayoutComputer<'_> {
-        LayoutComputer::new(self.layouts(), self.ir_ctx())
+        self.ctx.layout_computer()
     }
 }
 
 impl HasTargetSpec for Builder<'_> {
     fn target_spec(&self) -> &Target {
-        todo!()
+        self.ctx.target_spec()
     }
 }
 

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -13,19 +13,18 @@ use hash_ir::IrCtx;
 use hash_pipeline::settings::CompilerSettings;
 use hash_target::{abi::AddressSpace, Target};
 
-use self::context::CodeGenCtx;
+use crate::context::CodeGenCtx;
 
 mod abi;
 mod builder;
 mod constants;
-mod context;
 mod debug_info;
 mod declare;
 mod intrinsics;
 mod layouts;
 mod metadata;
 mod misc;
-mod ty;
+pub(crate) mod ty;
 
 /// A [Builder] is defined as being a context that is used to implement
 /// all of the specified builder methods.
@@ -37,7 +36,7 @@ pub struct Builder<'b> {
     ctx: &'b CodeGenCtx<'b>,
 }
 
-/// This specifies that the [Builder] context is [CodegenCtx].
+/// This specifies that the [Builder] context is [CodeGenCtx].
 impl<'b> Codegen<'b> for Builder<'b> {
     type CodegenCtx = CodeGenCtx<'b>;
 }
@@ -86,99 +85,4 @@ impl HasTargetSpec for Builder<'_> {
     fn target_spec(&self) -> &Target {
         self.ctx.target_spec()
     }
-}
-
-/// Wrapper type around [inkwell::IntPredicate] to allow for conversion from
-/// [IntComparisonKind].
-pub struct IntPredicateWrapper(pub inkwell::IntPredicate);
-
-impl From<IntComparisonKind> for IntPredicateWrapper {
-    fn from(value: IntComparisonKind) -> Self {
-        match value {
-            IntComparisonKind::Eq => Self(inkwell::IntPredicate::EQ),
-            IntComparisonKind::Ne => Self(inkwell::IntPredicate::NE),
-            IntComparisonKind::Ugt => Self(inkwell::IntPredicate::UGT),
-            IntComparisonKind::Uge => Self(inkwell::IntPredicate::UGE),
-            IntComparisonKind::Ult => Self(inkwell::IntPredicate::ULT),
-            IntComparisonKind::Ule => Self(inkwell::IntPredicate::ULE),
-            IntComparisonKind::Sgt => Self(inkwell::IntPredicate::SGT),
-            IntComparisonKind::Sge => Self(inkwell::IntPredicate::SGE),
-            IntComparisonKind::Slt => Self(inkwell::IntPredicate::SLT),
-            IntComparisonKind::Sle => Self(inkwell::IntPredicate::SLE),
-        }
-    }
-}
-
-/// Wrapper type around [inkwell::FloatPredicate] to allow for conversion from
-/// [RealComparisonKind].
-pub struct FloatPredicateWrapper(pub inkwell::FloatPredicate);
-
-impl From<RealComparisonKind> for FloatPredicateWrapper {
-    fn from(value: RealComparisonKind) -> Self {
-        match value {
-            RealComparisonKind::False => Self(inkwell::FloatPredicate::PredicateFalse),
-            RealComparisonKind::Oeq => Self(inkwell::FloatPredicate::OEQ),
-            RealComparisonKind::Ogt => Self(inkwell::FloatPredicate::OGT),
-            RealComparisonKind::Oge => Self(inkwell::FloatPredicate::OGE),
-            RealComparisonKind::Olt => Self(inkwell::FloatPredicate::OLT),
-            RealComparisonKind::Ole => Self(inkwell::FloatPredicate::OLE),
-            RealComparisonKind::One => Self(inkwell::FloatPredicate::ONE),
-            RealComparisonKind::Ord => Self(inkwell::FloatPredicate::ORD),
-            RealComparisonKind::Uno => Self(inkwell::FloatPredicate::UNO),
-            RealComparisonKind::Ueq => Self(inkwell::FloatPredicate::UEQ),
-            RealComparisonKind::Ugt => Self(inkwell::FloatPredicate::UGT),
-            RealComparisonKind::Uge => Self(inkwell::FloatPredicate::UGE),
-            RealComparisonKind::Ult => Self(inkwell::FloatPredicate::ULT),
-            RealComparisonKind::Ule => Self(inkwell::FloatPredicate::ULE),
-            RealComparisonKind::Une => Self(inkwell::FloatPredicate::UNE),
-            RealComparisonKind::True => Self(inkwell::FloatPredicate::PredicateTrue),
-        }
-    }
-}
-
-/// Wrapper type around [inkwell::AtomicOrdering] to allow for conversion from
-/// [AtomicOrdering].
-pub struct AtomicOrderingWrapper(pub inkwell::AtomicOrdering);
-
-impl From<AtomicOrdering> for AtomicOrderingWrapper {
-    fn from(value: AtomicOrdering) -> Self {
-        match value {
-            AtomicOrdering::NotAtomic => Self(inkwell::AtomicOrdering::NotAtomic),
-            AtomicOrdering::Unordered => Self(inkwell::AtomicOrdering::Unordered),
-            AtomicOrdering::Monotonic => Self(inkwell::AtomicOrdering::Monotonic),
-            AtomicOrdering::Acquire => Self(inkwell::AtomicOrdering::Acquire),
-            AtomicOrdering::Release => Self(inkwell::AtomicOrdering::Release),
-            AtomicOrdering::AcquireRelease => Self(inkwell::AtomicOrdering::AcquireRelease),
-            AtomicOrdering::SequentiallyConsistent => {
-                Self(inkwell::AtomicOrdering::SequentiallyConsistent)
-            }
-        }
-    }
-}
-
-pub struct AddressSpaceWrapper(pub inkwell::AddressSpace);
-
-impl From<AddressSpace> for AddressSpaceWrapper {
-    fn from(value: AddressSpace) -> Self {
-        AddressSpaceWrapper(inkwell::AddressSpace::try_from(value.0).unwrap())
-    }
-}
-
-/// This defines the ids for the various `MetadataKind`s that are used in LLVM
-/// to annotate values with particular properties.
-///
-/// Defined in <https://github.com/llvm-mirror/llvm/blob/master/include/llvm/IR/FixedMetadataKinds.def>
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub enum MetadataType {
-    FpMath = 3,
-    Range = 4,
-    InvariantLoad = 6,
-    AliasScope = 7,
-    NoAlias = 8,
-    NonTemporal = 9,
-    NonNull = 11,
-    Align = 17,
-    Type = 19,
-    NoUndef = 29,
 }

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -3,15 +3,26 @@
 
 use core::panic;
 
-use hash_codegen::{abi::FnAbi, common::TypeKind, layout::TyInfo, traits::ty::BuildTypeMethods};
-use hash_ir::ty::IrTyId;
+use hash_codegen::{
+    abi::FnAbi,
+    common::TypeKind,
+    layout::{Layout, LayoutShape, TyInfo, Variants},
+    traits::{ctx::HasCtxMethods, layout::LayoutMethods, ty::BuildTypeMethods},
+};
+use hash_ir::ty::{IrTy, IrTyId, RefKind};
 use hash_target::{
-    abi::{AddressSpace, Scalar},
+    abi::{AbiRepresentation, AddressSpace, Integer, Scalar, ScalarKind},
+    alignment::Alignment,
     size::Size,
 };
+use hash_utils::store::Store;
 use inkwell as llvm;
-use llvm::types::{AnyTypeEnum, AsTypeRef, BasicType, BasicTypeEnum};
-use llvm_sys::{core::LLVMGetTypeKind, LLVMTypeKind};
+use llvm::types::{AnyType, AnyTypeEnum, AsTypeRef, BasicType, BasicTypeEnum, VectorType};
+use llvm_sys::{
+    core::{LLVMGetTypeKind, LLVMVectorType},
+    LLVMTypeKind,
+};
+use smallvec::SmallVec;
 
 use super::{abi::ExtendedFnAbiMethods, context::CodeGenCtx, AddressSpaceWrapper};
 
@@ -19,7 +30,7 @@ use super::{abi::ExtendedFnAbiMethods, context::CodeGenCtx, AddressSpaceWrapper}
 ///
 /// @@PatchInkwell: maybe patch inkwell in order to support this conversion just
 /// using a `From` trait.
-pub fn convert_basic_ty_to_any<'b>(ty: BasicTypeEnum<'b>) -> AnyTypeEnum<'b> {
+pub fn convert_basic_ty_to_any(ty: BasicTypeEnum) -> AnyTypeEnum {
     match ty {
         BasicTypeEnum::ArrayType(ty) => AnyTypeEnum::ArrayType(ty),
         BasicTypeEnum::FloatType(ty) => AnyTypeEnum::FloatType(ty),
@@ -27,6 +38,40 @@ pub fn convert_basic_ty_to_any<'b>(ty: BasicTypeEnum<'b>) -> AnyTypeEnum<'b> {
         BasicTypeEnum::PointerType(ty) => AnyTypeEnum::PointerType(ty),
         BasicTypeEnum::StructType(ty) => AnyTypeEnum::StructType(ty),
         BasicTypeEnum::VectorType(ty) => AnyTypeEnum::VectorType(ty),
+    }
+}
+
+impl<'b> CodeGenCtx<'b> {
+    /// Create a type that represents the alignment of a particular pointee
+    /// type.
+    pub(crate) fn type_pointee_for_alignment(&self, align: Alignment) -> AnyTypeEnum<'b> {
+        let ity = Integer::approximate_alignment(self, align);
+        self.type_from_integer(ity)
+    }
+
+    /// Create a [VectorType] from a [`AbiRepresentation::Vector`].
+    pub(crate) fn type_vector(&self, element_ty: AnyTypeEnum<'b>, len: u64) -> AnyTypeEnum<'b> {
+        let ty: BasicTypeEnum = element_ty.try_into().unwrap();
+
+        // @@PatchInkwell: we should allow creating a vector type from a
+        // BasicTypeEnum and a length.
+        let vec_ty = unsafe {
+            let ty = LLVMVectorType(element_ty.as_type_ref(), len as u32);
+            VectorType::new(ty)
+        };
+
+        AnyTypeEnum::VectorType(vec_ty)
+    }
+
+    /// Create a type that represents the padding that is needed for a
+    /// particular [Size] and [Alignment].
+    pub(crate) fn type_padding(&self, size: Size, alignment: Alignment) -> AnyTypeEnum<'b> {
+        let unit = Integer::approximate_alignment(self, alignment);
+
+        let size = size.bytes();
+        let unit_size = unit.size().bytes();
+        debug_assert_eq!(size % unit_size, 0);
+        self.type_array(self.type_from_integer(unit), size / unit_size)
     }
 }
 
@@ -209,11 +254,149 @@ pub trait ExtendedTyBuilderMethods<'ll> {
 
 impl<'ll> ExtendedTyBuilderMethods<'ll> for TyInfo {
     fn llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll> {
-        todo!()
+        let abi = ctx.map_layout(self.layout, |layout| layout.abi);
+
+        // @@Todo: Check the cache if we have already computed the lowered type
+        // for this ir-type.
+
+        match abi {
+            AbiRepresentation::Scalar(scalar) => {
+                let ty = ctx.ir_ctx().map_ty(self.ty, |ty| match ty {
+                    IrTy::Ref(ty, _, _) => ctx.type_ptr_to(ctx.layout_of_id(*ty).llvm_ty(ctx)),
+                    _ => self.scalar_llvm_type_at(ctx, scalar, Size::ZERO),
+                });
+
+                ty
+            }
+            AbiRepresentation::Vector { elements, kind } => {
+                ctx.type_vector(self.scalar_llvm_type_at(ctx, kind, Size::ZERO), elements)
+            }
+            AbiRepresentation::Pair(scalar_1, scalar_2) => ctx.type_struct(
+                &[
+                    self.scalar_pair_element_llvm_ty(ctx, 0, false),
+                    self.scalar_pair_element_llvm_ty(ctx, 1, false),
+                ],
+                false,
+            ),
+
+            _ => {
+                ctx.map_layout(self.layout, |layout| {
+                    ctx.ir_ctx().map_ty(self.ty, |ty| {
+                        // Firstly, we want to compute the name of the type that we are going
+                        // to create.
+                        //
+                        // @@Todo: make emitting names optional in order to improve speed
+                        // of LLVM builds.
+                        let name: Option<String> = match ty {
+                            IrTy::Str => Some("str".to_string()),
+                            IrTy::Adt(adt) => {
+                                ctx.ir_ctx().map_adt(*adt, |id, adt| {
+                                    // We don't create a name for tuple types, they are just
+                                    // regarded
+                                    // as opaque structs
+                                    if adt.flags.is_tuple() {
+                                        return None;
+                                    }
+                                    let name = adt.name;
+
+                                    // If we have a specific variant for this layout, then we
+                                    // can be more precise about the type name..
+                                    if let Variants::Single { index } = &layout.variants {
+                                        if adt.flags.is_enum() {
+                                            return Some(format!(
+                                                "{}::{}",
+                                                name, adt.variants[*index].name
+                                            ));
+                                        }
+                                    }
+
+                                    Some(format!("{name}"))
+                                })
+                            }
+
+                            // Everything else is either not a struct or considered to be
+                            // opaque.
+                            _ => None,
+                        };
+
+                        match layout.shape {
+                            LayoutShape::Primitive | LayoutShape::Union { .. } => {
+                                let fill = ctx.type_padding(layout.size, layout.alignment.abi);
+                                let packed = false;
+
+                                match name {
+                                    Some(ref name) => {
+                                        let ty = ctx.ll_ctx.opaque_struct_type(name);
+                                        ty.set_body(&[fill.try_into().unwrap()], packed);
+
+                                        ty.into()
+                                    }
+                                    None => ctx.type_struct(&[fill], packed),
+                                }
+                            }
+                            LayoutShape::Array { elements, .. } => {
+                                // ##Safety: we should be able to assume that `field()` won't create
+                                // any new layouts since the layout of the element field should
+                                // already be known.
+                                let field_ty = self.field(ctx.layout_computer(), 0).llvm_ty(ctx);
+                                ctx.type_array(field_ty, elements)
+                            }
+                            LayoutShape::Aggregate { .. } => {
+                                let mut new_remapping = None;
+
+                                match name {
+                                    Some(ref name) => {
+                                        let (fields, packed, new_field_remapping) =
+                                            create_and_pad_struct_fields_from_layout(
+                                                ctx, *self, layout,
+                                            );
+                                        new_remapping = Some(new_field_remapping);
+
+                                        let ty = ctx.ll_ctx.opaque_struct_type(name);
+
+                                        // @@Cleanup: we're always fucking converting between
+                                        // AnyEnumType and
+                                        // BasicEnumType, there must be a better way to do this.
+                                        let fields = fields
+                                            .into_iter()
+                                            .map(|ty| ty.try_into().unwrap())
+                                            .collect::<Vec<_>>();
+
+                                        ty.set_body(&fields, packed);
+                                        ty.into()
+                                    }
+                                    None => {
+                                        let (fields, packed, new_field_remapping) =
+                                            create_and_pad_struct_fields_from_layout(
+                                                ctx, *self, layout,
+                                            );
+                                        new_remapping = Some(new_field_remapping);
+
+                                        ctx.type_struct(&fields, packed)
+                                    }
+                                }
+                            }
+                        }
+                    })
+                })
+            }
+        }
     }
 
     fn immediate_llvm_ty(&self, ctx: &CodeGenCtx<'ll>) -> llvm::types::AnyTypeEnum<'ll> {
-        todo!()
+        let is_bool = ctx.map_layout(self.layout, |layout| {
+            if let AbiRepresentation::Scalar(scalar) = layout.abi && scalar.is_bool() {
+                true
+            } else {
+                false
+            }
+        });
+
+        if is_bool {
+            ctx.type_i1()
+        } else {
+            self.llvm_ty(ctx)
+        }
     }
 
     fn scalar_llvm_type_at(
@@ -222,7 +405,24 @@ impl<'ll> ExtendedTyBuilderMethods<'ll> for TyInfo {
         scalar: Scalar,
         offset: Size,
     ) -> llvm::types::AnyTypeEnum<'ll> {
-        todo!()
+        match scalar.kind() {
+            ScalarKind::Int { kind, .. } => ctx.type_from_integer(kind),
+            ScalarKind::Float { kind } => ctx.type_from_float(kind),
+            ScalarKind::Pointer => {
+                //@@Todo: account for address space of function pointee type being dependant on the target 
+                // data layout
+                let alignment = ctx.layouts().map_fast(self.layout, |layout| layout.alignment.abi);
+
+                let (ty, addr) = ctx.ir_ctx().map_ty(self.ty, |ty| {
+                    match ty {
+                        IrTy::Ref(ty, _, _) => (ctx.type_pointee_for_alignment(alignment), AddressSpace::DATA),
+                        _ => (ctx.type_i8p(), AddressSpace::DATA)
+                    }
+                });
+
+                ctx.type_ptr_to_ext(ty, addr)
+            }
+        }
     }
 
     fn scalar_pair_element_llvm_ty(
@@ -231,6 +431,103 @@ impl<'ll> ExtendedTyBuilderMethods<'ll> for TyInfo {
         index: usize,
         immediate: bool,
     ) -> llvm::types::AnyTypeEnum<'ll> {
-        todo!()
+        let (scalar_a, scalar_b) = ctx.map_layout(self.layout, |layout| {
+            let AbiRepresentation::Pair(scalar_a, scalar_b) = layout.abi else {
+                panic!("`scalar_pair_element_llvm_ty` called on non-pair type");
+            };
+
+            (scalar_a, scalar_b)
+        });
+
+        let scalar = if index == 0 { scalar_a } else { scalar_b };
+
+        if immediate && scalar.is_bool() {
+            ctx.type_i1()
+        } else {
+            let offset = if index == 0 {
+                Size::ZERO
+            } else {
+                scalar_a.size(ctx).align_to(scalar_b.align(ctx).abi)
+            };
+            self.scalar_llvm_type_at(ctx, scalar, offset)
+        }
     }
+}
+
+/// This function will convert a given [Layout] with the shape of an
+/// [`LayoutShape::Aggregate`] into a collection of fields that have
+/// been padded to the correct alignment and size. In the event that
+/// that fields are padded, the `field_map` will be updated to reflect
+/// the new field index of the original field.
+fn create_and_pad_struct_fields_from_layout<'b>(
+    ctx: &CodeGenCtx<'b>,
+    info: TyInfo,
+    layout: &Layout,
+) -> (Vec<AnyTypeEnum<'b>>, bool, Option<SmallVec<[u32; 4]>>) {
+    let field_count = layout.shape.count();
+
+    let mut packed = false;
+    let mut offset = Size::ZERO;
+    let mut previous_effective_alignment = layout.alignment.abi;
+
+    // Assume that all fields and the last field will need to all be
+    // padded.
+    let mut fields = Vec::with_capacity(1 + field_count * 2);
+    let mut field_map = SmallVec::with_capacity(field_count);
+
+    for i in layout.shape.iter_increasing_offsets() {
+        let target_offset = layout.shape.offset(i);
+        let field = info.field(ctx.layout_computer(), i);
+
+        // @@Todo: maybe re-use the pre-computed padding size here that is available on
+        // the layout?
+        ctx.map_layout(field.layout, |field_layout| {
+            let effective_field_align =
+                layout.alignment.abi.min(field_layout.alignment.abi).restrict_to(target_offset);
+            packed |= effective_field_align < field_layout.alignment.abi;
+
+            let padding = target_offset - offset;
+            if padding != Size::ZERO {
+                let padding_alignment = previous_effective_alignment.min(effective_field_align);
+
+                // Verify that the padding will make the field aligned.
+                debug_assert_eq!(offset.align_to(padding_alignment) + padding, target_offset);
+
+                // Now push the padding into the computed fields
+                let fill = ctx.type_padding(padding, padding_alignment);
+                fields.push(fill);
+            }
+
+            // In the event that we just pushed a pad, we need to update
+            // the offset to reflect the new padding.
+            field_map[i] = fields.len() as u32;
+
+            fields.push(field.llvm_ty(ctx));
+            offset = target_offset + field_layout.size;
+            previous_effective_alignment = effective_field_align;
+        });
+    }
+
+    let fields_padded = fields.len() > field_count;
+
+    if field_count > 0 {
+        if offset > layout.size {
+            panic!("computed struct fields for LLVM type are larger than the struct itself");
+        }
+
+        let padding = layout.size - offset;
+        if padding != Size::ZERO {
+            let padding_alignment = previous_effective_alignment;
+
+            // Verify that the padding will make the offset equivalent to
+            // the layout size.
+            debug_assert_eq!(offset.align_to(padding_alignment) + padding, layout.size);
+
+            fields.push(ctx.type_padding(padding, padding_alignment));
+        }
+    }
+
+    let field_remapping = if fields_padded { Some(field_map) } else { None };
+
+    (fields, packed, field_remapping)
 }

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -24,7 +24,8 @@ use llvm_sys::{
 };
 use smallvec::SmallVec;
 
-use super::{abi::ExtendedFnAbiMethods, context::CodeGenCtx, AddressSpaceWrapper};
+use super::abi::ExtendedFnAbiMethods;
+use crate::{context::CodeGenCtx, misc::AddressSpaceWrapper};
 
 /// Convert a [BasicTypeEnum] into a [AnyTypeEnum].
 ///

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -7,7 +7,7 @@ use hash_codegen::{
     abi::FnAbi,
     common::TypeKind,
     layout::{Layout, LayoutShape, TyInfo, Variants},
-    traits::{ctx::HasCtxMethods, layout::LayoutMethods, ty::BuildTypeMethods},
+    traits::{ctx::HasCtxMethods, layout::LayoutMethods, ty::TypeBuilderMethods},
 };
 use hash_ir::ty::{IrTy, IrTyId, RefKind};
 use hash_target::{
@@ -76,7 +76,7 @@ impl<'b> CodeGenCtx<'b> {
     }
 }
 
-impl<'b> BuildTypeMethods<'b> for CodeGenCtx<'b> {
+impl<'b> TypeBuilderMethods<'b> for CodeGenCtx<'b> {
     fn type_i1(&self) -> Self::Type {
         self.ll_ctx.bool_type().into()
     }

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -1,112 +1,182 @@
 //! Implements all of the type building methods for the LLVM
 //! backend.
 
+use core::panic;
+
 use hash_codegen::{abi::FnAbi, common::TypeKind, layout::TyInfo, traits::ty::BuildTypeMethods};
 use hash_ir::ty::IrTyId;
-use hash_target::{abi::Scalar, size::Size};
+use hash_target::{
+    abi::{AddressSpace, Scalar},
+    size::Size,
+};
 use inkwell as llvm;
+use llvm::types::{AnyTypeEnum, AsTypeRef, BasicType, BasicTypeEnum};
+use llvm_sys::{core::LLVMGetTypeKind, LLVMTypeKind};
 
-use super::context::CodeGenCtx;
+use super::{abi::ExtendedFnAbiMethods, context::CodeGenCtx, AddressSpaceWrapper};
+
+/// Convert a [BasicTypeEnum] into a [AnyTypeEnum].
+///
+/// @@PatchInkwell: maybe patch inkwell in order to support this conversion just
+/// using a `From` trait.
+pub fn convert_basic_ty_to_any<'b>(ty: BasicTypeEnum<'b>) -> AnyTypeEnum<'b> {
+    match ty {
+        BasicTypeEnum::ArrayType(ty) => AnyTypeEnum::ArrayType(ty),
+        BasicTypeEnum::FloatType(ty) => AnyTypeEnum::FloatType(ty),
+        BasicTypeEnum::IntType(ty) => AnyTypeEnum::IntType(ty),
+        BasicTypeEnum::PointerType(ty) => AnyTypeEnum::PointerType(ty),
+        BasicTypeEnum::StructType(ty) => AnyTypeEnum::StructType(ty),
+        BasicTypeEnum::VectorType(ty) => AnyTypeEnum::VectorType(ty),
+    }
+}
 
 impl<'b> BuildTypeMethods<'b> for CodeGenCtx<'b> {
     fn type_i1(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.bool_type().into()
     }
 
     fn type_i8(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i8_type().into()
     }
 
     fn type_i16(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i16_type().into()
     }
 
     fn type_i32(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i32_type().into()
     }
 
     fn type_i64(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i64_type().into()
     }
 
     fn type_i128(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i128_type().into()
     }
 
     fn type_isize(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.i64_type().into()
     }
 
     fn type_f32(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.f32_type().into()
     }
 
     fn type_f64(&self) -> Self::Type {
-        todo!()
+        self.ll_ctx.f64_type().into()
     }
 
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        ty.array_type(len as u32).into()
     }
 
     fn type_function(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type {
-        todo!()
+        let ret: BasicTypeEnum = ret.try_into().unwrap();
+        let args = args.iter().map(|ty| (*ty).try_into().unwrap()).collect::<Vec<_>>();
+        ret.fn_type(&args, false).into()
     }
 
-    fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type {
-        todo!()
+    fn type_struct(&self, fields: &[Self::Type], packed: bool) -> Self::Type {
+        let fields = fields.iter().map(|ty| (*ty).try_into().unwrap()).collect::<Vec<_>>();
+        self.ll_ctx.struct_type(&fields, packed).into()
     }
 
     fn type_ptr_to(&self, ty: Self::Type) -> Self::Type {
-        todo!()
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let AddressSpaceWrapper(addr) = AddressSpace::DATA.into();
+        ty.ptr_type(addr).into()
     }
 
-    fn type_ptr_to_ext(
-        &self,
-        ty: Self::Type,
-        address_space: hash_target::abi::AddressSpace,
-    ) -> Self::Type {
-        todo!()
+    fn type_ptr_to_ext(&self, ty: Self::Type, address_space: AddressSpace) -> Self::Type {
+        let ty: BasicTypeEnum = ty.try_into().unwrap();
+        let AddressSpaceWrapper(addr) = address_space.into();
+        ty.ptr_type(addr).into()
     }
 
     fn element_type(&self, ty: Self::Type) -> Self::Type {
-        todo!()
+        match ty {
+            llvm::types::AnyTypeEnum::ArrayType(array) => {
+                convert_basic_ty_to_any(array.get_element_type())
+            }
+            llvm::types::AnyTypeEnum::VectorType(vec) => {
+                convert_basic_ty_to_any(vec.get_element_type())
+            }
+            llvm::types::AnyTypeEnum::PointerType(_) => {
+                panic!("`element_type` not supported on opaque pointer type")
+            }
+            _ => panic!("`element_type` called on element-like type"),
+        }
     }
 
     fn vector_length(&self, ty: Self::Type) -> usize {
-        todo!()
+        let AnyTypeEnum::VectorType(vec) = ty else {
+            panic!("`vector_length` called on non-vector type")
+        };
+
+        vec.get_size() as usize
     }
 
     fn float_width(&self, ty: Self::Type) -> usize {
-        todo!()
+        let kind = self.ty_kind(ty);
+
+        match kind {
+            TypeKind::Float => 32,
+            TypeKind::Double => 64,
+            TypeKind::X86FP80 => 80,
+            TypeKind::FP128 | TypeKind::PPCFP128 => 128,
+            _ => panic!("`float_width` called on non-float type"),
+        }
     }
 
     fn int_width(&self, ty: Self::Type) -> u64 {
-        todo!()
+        ty.into_int_type().get_bit_width() as u64
     }
 
     fn ty_of_value(&self, value: Self::Value) -> Self::Type {
-        todo!()
+        value.get_type()
     }
 
-    fn kind_of_ty(&self, ty: Self::Type) -> TypeKind {
-        todo!()
+    /// Compute the [TypeKind] from the given [AnyTypeEnum] using
+    /// [`LLVMGetTypeKind`].
+    fn ty_kind(&self, ty: Self::Type) -> TypeKind {
+        let kind = unsafe { LLVMGetTypeKind(ty.as_type_ref()) };
+
+        match kind {
+            LLVMTypeKind::LLVMVoidTypeKind => TypeKind::Void,
+            LLVMTypeKind::LLVMHalfTypeKind => TypeKind::Half,
+            LLVMTypeKind::LLVMFloatTypeKind => TypeKind::Float,
+            LLVMTypeKind::LLVMDoubleTypeKind => TypeKind::Double,
+            LLVMTypeKind::LLVMX86_FP80TypeKind => TypeKind::X86FP80,
+            LLVMTypeKind::LLVMFP128TypeKind => TypeKind::FP128,
+            LLVMTypeKind::LLVMPPC_FP128TypeKind => TypeKind::PPCFP128,
+            LLVMTypeKind::LLVMLabelTypeKind => TypeKind::Label,
+            LLVMTypeKind::LLVMIntegerTypeKind => TypeKind::Integer,
+            LLVMTypeKind::LLVMFunctionTypeKind => TypeKind::Function,
+            LLVMTypeKind::LLVMStructTypeKind => TypeKind::Struct,
+            LLVMTypeKind::LLVMArrayTypeKind => TypeKind::Array,
+            LLVMTypeKind::LLVMPointerTypeKind => TypeKind::Pointer,
+            LLVMTypeKind::LLVMVectorTypeKind => TypeKind::FixedVector,
+            LLVMTypeKind::LLVMMetadataTypeKind => TypeKind::Metadata,
+            LLVMTypeKind::LLVMX86_MMXTypeKind => TypeKind::X86MMX,
+            LLVMTypeKind::LLVMTokenTypeKind => TypeKind::Token,
+            LLVMTypeKind::LLVMScalableVectorTypeKind => TypeKind::ScalableVector,
+            LLVMTypeKind::LLVMBFloatTypeKind => TypeKind::Float,
+            LLVMTypeKind::LLVMX86_AMXTypeKind => TypeKind::X86AMX,
+        }
     }
 
     fn immediate_backend_ty(&self, info: TyInfo) -> Self::Type {
-        todo!()
-    }
-
-    fn backend_ty_from_ir_ty(&self, ty: IrTyId) -> Self::Type {
-        todo!()
+        info.immediate_llvm_ty(self)
     }
 
     fn backend_ty_from_info(&self, info: TyInfo) -> Self::Type {
-        todo!()
+        info.llvm_ty(self)
     }
 
     fn backend_ty_from_abi(&self, abi: &FnAbi) -> Self::Type {
-        todo!()
+        abi.llvm_ty(self)
     }
 }
 

--- a/compiler/hash-codegen/src/common.rs
+++ b/compiler/hash-codegen/src/common.rs
@@ -24,67 +24,67 @@ pub enum CheckedOp {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TypeKind {
     /// 16-bit floating point type.
-    HalfTy,
+    Half,
 
     /// 16-bit floating point type (7-bit mantissa).
     BFloatTy,
 
     /// 32-bit floating point type.
-    FloatTy,
+    Float,
 
     /// 64-bit floating point type.
-    DoubleTy,
+    Double,
 
     /// 80-bit floating point type (X87).
-    X86FP80Ty,
+    X86FP80,
 
     /// 128-bit floating point type (112-bit mantissa).
-    FP128Ty,
+    FP128,
 
     /// 128-bit floating point type (two 64-bits, PowerPC).
-    PPCFP128Ty,
+    PPCFP128,
 
     /// Void type, no size.
-    VoidTy,
+    Void,
 
     /// Label type, only used as function return type.
-    LabelTy,
+    Label,
 
     /// Metadata type, only used in LLVM metadata.
     ///
     /// More information can be found here:
     /// <https://llvm.org/doxygen/classllvm_1_1Metadata.html>
-    MetadataTy,
+    Metadata,
 
     /// X86 MMX vector type (64 bits, X86 specific).
-    X86MMXTy,
+    X86MMX,
 
     /// X86 AMX vector type (8192 bits, X86 specific).
-    X86AMXTy,
+    X86AMX,
 
     /// Token type, only used in LLVM metadata.
-    TokenTy,
+    Token,
 
     /// Integer types
-    IntegerTy,
+    Integer,
 
     /// Function types
-    FunctionTy,
+    Function,
 
     /// Pointer types
-    PointerTy,
+    Pointer,
 
     /// Structure types
-    StructTy,
+    Struct,
 
     /// Array types
-    ArrayTy,
+    Array,
 
     /// Fixed vector types
-    FixedVectorTy,
+    FixedVector,
 
     /// Scalable vector types
-    ScalableVectorTy,
+    ScalableVector,
 
     /// Typed pointer types
     TypedPointerTy,

--- a/compiler/hash-codegen/src/lib.rs
+++ b/compiler/hash-codegen/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod common;
 pub mod lower;
+pub mod symbols;
 pub mod traits;
 
 // re-export `abi` and `layout` crates to make them available to the backend

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -99,7 +99,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
             let make_arg_abi = |ty: IrTyId, _index: Option<usize>| {
                 let lc = self.ctx.layout_computer();
-                let info = self.ctx.layout_of_id(ty);
+                let info = self.ctx.layout_of(ty);
                 let arg = ArgAbi::new(&lc, info, |scalar| {
                     let mut attributes = ArgAttributes::new();
                     adjust_arg_attributes(&lc, &mut attributes, ty, scalar);

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -60,7 +60,7 @@ pub fn compute_non_ssa_locals<'b, Builder: BlockBuilderMethods<'b>>(
         .iter()
         .map(|local| {
             let ty = local.ty();
-            let layout = fn_builder.ctx.layout_of_id(ty);
+            let layout = fn_builder.ctx.layout_of(ty);
 
             if layout.is_zst(fn_builder.ctx.layout_computer()) {
                 LocalMemoryKind::Zst
@@ -201,7 +201,7 @@ impl<'ir, 'b, Builder: BlockBuilderMethods<'b>> IrVisitorMut<'b>
         // If the place base type is a ZST then we can short-circuit
         // since they don't require any memory accesses.
         let base_ty = self.fn_builder.body.declarations[place.local].ty;
-        let base_layout = self.fn_builder.ctx.layout_of_id(base_ty);
+        let base_layout = self.fn_builder.ctx.layout_of(base_ty);
 
         if base_layout.is_zst(self.fn_builder.ctx.layout_computer()) {
             return;

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -166,7 +166,7 @@ pub fn codegen_ir_body<'b, Builder: BlockBuilderMethods<'b>>(
         for local in fn_builder.body.vars_iter() {
             // we need to get the type and layout from the local
             let decl = &fn_builder.body.declarations[local];
-            let info = fn_builder.ctx.layout_of_id(decl.ty);
+            let info = fn_builder.ctx.layout_of(decl.ty);
 
             fn_builder.locals[local] = allocate(local, info);
         }

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -10,7 +10,7 @@ use super::{locals::LocalRef, place::PlaceRef, utils, FnBuilder};
 use crate::{
     common::MemFlags,
     traits::{
-        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
         layout::LayoutMethods, ty::BuildTypeMethods, CodeGenObject, Codegen,
     },
 };

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -11,7 +11,7 @@ use crate::{
     common::MemFlags,
     traits::{
         builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
-        layout::LayoutMethods, ty::BuildTypeMethods, CodeGenObject, Codegen,
+        layout::LayoutMethods, ty::TypeBuilderMethods, CodeGenObject, Codegen,
     },
 };
 

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -283,7 +283,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                             OperandValue::Immediate(value)
                         }
                         ir::Const::Str(interned_str) => {
-                            let (ptr, size) = builder.const_interned_str(*interned_str);
+                            let (ptr, size) = builder.const_str(*interned_str);
                             OperandValue::Pair(ptr, size)
                         }
                     },

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -163,7 +163,7 @@ impl<'b, V: CodeGenObject> OperandRef<V> {
             OperandValue::Ref(..) => panic!("deref on a by-ref operand"),
         };
 
-        let info = builder.layout_of_id(projected_ty);
+        let info = builder.layout_of(projected_ty);
         let alignment = builder.map_layout(info.layout, |layout| layout.alignment.abi);
 
         PlaceRef { value: ptr_value, info, alignment }
@@ -261,7 +261,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             ir::Operand::Place(place) => self.codegen_consume_operand(builder, *place),
             ir::Operand::Const(ref constant) => {
                 let ty = constant.ty(builder.ir_ctx());
-                let info = builder.layout_of_id(ty);
+                let info = builder.layout_of(ty);
 
                 let value = match constant {
                     ir::ConstKind::Value(const_value) => match const_value {

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -17,7 +17,7 @@ use crate::{
     layout::TyInfo,
     traits::{
         builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
-        ty::BuildTypeMethods, CodeGenObject,
+        ty::TypeBuilderMethods, CodeGenObject,
     },
 };
 

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -130,7 +130,7 @@ impl<'b, V: CodeGenObject> PlaceRef<V> {
         builder: &mut Builder,
         cast_to: IrTyId,
     ) -> V {
-        let cast_info = builder.layout_of_id(cast_to);
+        let cast_info = builder.layout_of(cast_to);
         let cast_to_ty = builder.immediate_backend_ty(cast_info);
 
         let (variants, is_uninhabited) = builder.map_layout(self.info.layout, |layout| {
@@ -299,7 +299,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
     /// all projections that occur on the [Place].
     pub fn compute_place_ty_info(&self, builder: &mut Builder, place: ir::Place) -> TyInfo {
         let place_ty = PlaceTy::from_place(place, &self.body.declarations, self.ctx.ir_ctx());
-        builder.layout_of_id(place_ty.ty)
+        builder.layout_of(place_ty.ty)
     }
 
     /// Emit backend specific code for handling a [Place].
@@ -375,7 +375,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                     // @@Verify: if the size of the array is not known, do we
                     // have to do record the size of this slice using `extra_value`?
 
-                    sub_slice.info = builder.layout_of_id(projected_ty);
+                    sub_slice.info = builder.layout_of(projected_ty);
                     sub_slice.value = builder.pointer_cast(
                         sub_slice.value,
                         builder.type_ptr_to(builder.backend_ty_from_info(sub_slice.info)),

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -16,7 +16,7 @@ use super::{locals::LocalRef, FnBuilder};
 use crate::{
     layout::TyInfo,
     traits::{
-        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
         ty::BuildTypeMethods, CodeGenObject,
     },
 };

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -35,8 +35,8 @@ fn shift_mask_value<'b, Builder: BlockBuilderMethods<'b>>(
     mask_ty: Builder::Type,
     invert: bool,
 ) -> Builder::Value {
-    match builder.kind_of_ty(ty) {
-        TypeKind::IntegerTy => {
+    match builder.ty_kind(ty) {
+        TypeKind::Integer => {
             let bits = builder.int_width(ty) - 1;
 
             if invert {

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     common::{CheckedOp, IntComparisonKind, TypeKind},
     traits::{
-        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
         layout::LayoutMethods, ty::BuildTypeMethods,
     },
 };

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -16,7 +16,7 @@ use crate::{
     common::{CheckedOp, IntComparisonKind, TypeKind},
     traits::{
         builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
-        layout::LayoutMethods, ty::BuildTypeMethods,
+        layout::LayoutMethods, ty::TypeBuilderMethods,
     },
 };
 

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -199,7 +199,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 // compute the layout of the type, and then depending
                 // on the operation it then emits the size or the
                 // alignment.
-                let info = builder.layout_of_id(ty);
+                let info = builder.layout_of(ty);
                 let (size, alignment) = builder.map_layout(info.layout, |layout| {
                     (layout.size.bytes(), layout.alignment.abi.bytes())
                 });
@@ -212,7 +212,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(value),
-                    info: builder.layout_of_id(self.ctx.ir_ctx().tys().common_tys.usize),
+                    info: builder.layout_of(self.ctx.ir_ctx().tys().common_tys.usize),
                 }
             }
             ir::RValue::UnaryOp(operator, ref operand) => {
@@ -261,7 +261,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(result),
-                    info: builder.layout_of_id(operator.ty(
+                    info: builder.layout_of(operator.ty(
                         self.ctx.ir_ctx(),
                         lhs.info.ty,
                         rhs.info.ty,
@@ -283,13 +283,12 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                 // This yields the operand ty as `(<lhs_ty>, bool)`.
                 let operand_ty = rvalue.ty(&self.body.declarations, self.ctx.ir_ctx());
 
-                OperandRef { value: result, info: builder.layout_of_id(operand_ty) }
+                OperandRef { value: result, info: builder.layout_of(operand_ty) }
             }
             ir::RValue::Aggregate(_, _) => {
                 // This is only called if the aggregate value is a ZST, so we just
                 // create a new ZST operand...
-                let info =
-                    builder.layout_of_id(rvalue.ty(&self.body.declarations, self.ctx.ir_ctx()));
+                let info = builder.layout_of(rvalue.ty(&self.body.declarations, self.ctx.ir_ctx()));
                 OperandRef::new_zst(builder, info)
             }
             ir::RValue::Len(place) => {
@@ -297,7 +296,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(size),
-                    info: builder.layout_of_id(self.ctx.ir_ctx().tys().common_tys.usize),
+                    info: builder.layout_of(self.ctx.ir_ctx().tys().common_tys.usize),
                 }
             }
             ir::RValue::Ref(_, place, kind) => {
@@ -311,7 +310,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
                         // the length of the slice as an implicit value using `extra`)
                         OperandRef {
                             value: OperandValue::Immediate(place.value),
-                            info: builder.layout_of_id(ty),
+                            info: builder.layout_of(ty),
                         }
                     }
 
@@ -328,7 +327,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 OperandRef {
                     value: OperandValue::Immediate(discriminant),
-                    info: builder.layout_of_id(discriminant_ty),
+                    info: builder.layout_of(discriminant_ty),
                 }
             }
         }
@@ -499,7 +498,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 
                 // check if the type is a ZST, and if so this satisfies the
                 // case that the rvalue creates an operand...
-                self.ctx.layout_of_id(ty).is_zst(self.ctx.layout_computer())
+                self.ctx.layout_of(ty).is_zst(self.ctx.layout_computer())
             }
         }
     }

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -15,6 +15,7 @@ use hash_ir::{
     ty::IrTy,
 };
 use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
+use hash_source::constant::CONSTANT_MAP;
 use hash_target::abi::{AbiRepresentation, ValidScalarRange};
 
 use super::{
@@ -530,7 +531,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
         builder.switch_to_block(failure_block);
 
         // we need to convert the assert into a message.
-        let message = builder.const_str(assert_kind.message());
+        let message = builder.const_str(CONSTANT_MAP.create_string(assert_kind.message()));
         let args = &[message.0, message.1];
 
         // @@Todo: we need to create a call to `panic`, as in resolve the function

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::{
     common::{IntComparisonKind, MemFlags},
     traits::{
-        builder::BlockBuilderMethods, constants::BuildConstValueMethods, ctx::HasCtxMethods,
+        builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
         misc::MiscBuilderMethods, ty::BuildTypeMethods,
     },
 };

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -471,7 +471,7 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
             let target_block_1 = self.get_codegen_block_id(target_1);
             let target_block_2 = self.get_codegen_block_id(target_2);
 
-            let subject_ty = builder.immediate_backend_ty(builder.layout_of_id(ty));
+            let subject_ty = builder.immediate_backend_ty(builder.layout_of(ty));
             let target_value = builder.const_uint_big(subject_ty, value);
             let comparison =
                 builder.icmp(IntComparisonKind::Eq, subject.immediate_value(), target_value);

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -30,7 +30,7 @@ use crate::{
     common::{IntComparisonKind, MemFlags},
     traits::{
         builder::BlockBuilderMethods, constants::ConstValueBuilderMethods, ctx::HasCtxMethods,
-        misc::MiscBuilderMethods, ty::BuildTypeMethods,
+        misc::MiscBuilderMethods, ty::TypeBuilderMethods,
     },
 };
 

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -6,7 +6,7 @@ use hash_target::alignment::Alignment;
 
 use crate::{
     common::MemFlags,
-    traits::{builder::BlockBuilderMethods, constants::BuildConstValueMethods},
+    traits::{builder::BlockBuilderMethods, constants::ConstValueBuilderMethods},
 };
 
 /// Emit a `memcpy` instruction for a particular value with the provided

--- a/compiler/hash-codegen/src/symbols.rs
+++ b/compiler/hash-codegen/src/symbols.rs
@@ -1,0 +1,39 @@
+//! Common utilities to aid code generation backends when creating symbol
+//! names for items that are generated/emitted by the compiler.
+
+/// The maximum base that can be used for encoding numbers into strings.
+pub const MAX_BASE: usize = 64;
+
+/// The base used for alphanumeric symbols.
+pub const ALPHANUMERIC_BASE: usize = 62;
+
+/// The base used for case insensitive symbols.
+pub const CASE_INSENSITIVE_BASE: usize = 36;
+
+/// The alphabet used for encoding numbers into strings.
+const BASE: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
+
+/// A utility function that is used to push a string representation of a
+/// number into a string buffer. The number is encoded in the specified
+/// `base` and the result is pushed into the `output` string buffer.
+#[inline]
+pub fn push_string_encoded_count(mut count: u128, base: usize, output: &mut String) {
+    debug_assert!((2..=64).contains(&base));
+
+    let mut buf = [0; 128];
+    let mut i = buf.len();
+
+    let base = base as u128;
+
+    loop {
+        i -= 1;
+        buf[i] = BASE[(count % base) as usize];
+        count /= base;
+
+        if count == 0 {
+            break;
+        }
+    }
+
+    output.push_str(std::str::from_utf8(&buf[i..]).unwrap());
+}

--- a/compiler/hash-codegen/src/traits/constants.rs
+++ b/compiler/hash-codegen/src/traits/constants.rs
@@ -10,7 +10,7 @@ use super::BackendTypes;
 
 /// Trait that represents methods for emitting constants
 /// when building the IR.
-pub trait BuildConstValueMethods<'b>: BackendTypes {
+pub trait ConstValueBuilderMethods<'b>: BackendTypes {
     /// Emit a constant undefined value, this is use for generating
     /// zero-sized types.
     fn const_undef(&self, ty: Self::Type) -> Self::Value;
@@ -48,9 +48,6 @@ pub trait BuildConstValueMethods<'b>: BackendTypes {
 
     /// Emit a constant `u128` value.
     fn const_u128(&self, i: u128) -> Self::Value;
-
-    /// Emit a constant `i128` value.
-    fn const_i128(&self, i: i128) -> Self::Value;
 
     /// Emit a constant unsigned integer with a specified size.
     fn const_uint(&self, ty: Self::Type, value: u64) -> Self::Value;

--- a/compiler/hash-codegen/src/traits/constants.rs
+++ b/compiler/hash-codegen/src/traits/constants.rs
@@ -75,12 +75,7 @@ pub trait ConstValueBuilderMethods<'b>: BackendTypes {
     ///     len: usize, // <--- second value
     /// }
     /// ```
-    fn const_str(&self, s: &str) -> (Self::Value, Self::Value);
-
-    /// Emit a constant string value from an interned string. This returns
-    /// a value representing the pointer to the string characters, and a
-    /// second value representing the length of the string.
-    fn const_interned_str(&self, s: InternedStr) -> (Self::Value, Self::Value);
+    fn const_str(&self, s: InternedStr) -> (Self::Value, Self::Value);
 
     /// Emit a constant value from a `Const` value. This only deals with
     /// constant "scalar" values, for string values, there is specific code

--- a/compiler/hash-codegen/src/traits/debug.rs
+++ b/compiler/hash-codegen/src/traits/debug.rs
@@ -4,6 +4,7 @@
 //! backend via the [crate::traits::CodeGen] interface, and when it adds
 //! debug information to all of the generated IR.
 
+use hash_abi::FnAbi;
 use hash_ir::ty::IrTyId;
 use hash_source::{identifier::Identifier, location::SourceLocation};
 
@@ -27,7 +28,7 @@ pub trait BuildDebugInfoMethods: BackendTypes {
     /// particular scope in the source code. This is attached to a function.
     fn create_debug_info_scope_for_fn(
         &self,
-        fn_abi: (),
+        fn_abi: &FnAbi,
         value: Option<Self::Function>,
     ) -> Self::DebugInfoScope;
 

--- a/compiler/hash-codegen/src/traits/layout.rs
+++ b/compiler/hash-codegen/src/traits/layout.rs
@@ -1,7 +1,7 @@
 //! Trait methods to do with calculating and accessing the layout of types
 //! within a backend.
 
-use hash_ir::ty::{IrTy, IrTyId};
+use hash_ir::ty::IrTyId;
 use hash_layout::{Layout, LayoutId};
 use hash_utils::store::Store;
 
@@ -11,13 +11,11 @@ use crate::layout::TyInfo;
 /// Methods for calculating and querying the layout of types within a backend.
 pub trait LayoutMethods<'b>: BackendTypes + HasCtxMethods<'b> {
     /// Compute the layout of a interned type via [IrTyId].
-    fn layout_of_id(&self, _ty: IrTyId) -> TyInfo {
-        todo!()
-    }
-
-    /// Compute the layout of a [IrTy].
-    fn layout_of(&self, _ty: IrTy) -> TyInfo {
-        todo!()
+    fn layout_of(&self, ty: IrTyId) -> TyInfo {
+        // @@Todo: provide a mechanism for gracefully reporting the error rather
+        // than unwrapping
+        let layout = self.layout_computer().layout_of_ty(ty).unwrap();
+        TyInfo { ty, layout }
     }
 
     /// Perform a mapping on a [Layout]
@@ -32,7 +30,7 @@ pub trait LayoutMethods<'b>: BackendTypes + HasCtxMethods<'b> {
     /// immediate value.
     fn is_backend_immediate(&self, ty: TyInfo) -> bool;
 
-    /// Get the type of an element from a sclar pair, and assume
+    /// Get the type of an element from a scalar pair, and assume
     /// if it "immediate".
     fn scalar_pair_element_backend_type(
         &self,

--- a/compiler/hash-codegen/src/traits/mod.rs
+++ b/compiler/hash-codegen/src/traits/mod.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use self::{
-    constants::BuildConstValueMethods, ctx::HasCtxMethods, layout::LayoutMethods,
+    constants::ConstValueBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods,
     misc::MiscBuilderMethods, target::HasTargetSpec, ty::BuildTypeMethods,
 };
 
@@ -60,7 +60,7 @@ pub trait CodeGenMethods<'b>:
     + MiscBuilderMethods<'b>
     + HasCtxMethods<'b>
     + BuildTypeMethods<'b>
-    + BuildConstValueMethods<'b>
+    + ConstValueBuilderMethods<'b>
     + HasTargetSpec
 {
 }
@@ -72,7 +72,7 @@ impl<'b, T> CodeGenMethods<'b> for T where
         + MiscBuilderMethods<'b>
         + HasCtxMethods<'b>
         + BuildTypeMethods<'b>
-        + BuildConstValueMethods<'b>
+        + ConstValueBuilderMethods<'b>
         + HasTargetSpec
 {
 }

--- a/compiler/hash-codegen/src/traits/mod.rs
+++ b/compiler/hash-codegen/src/traits/mod.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use self::{
     constants::ConstValueBuilderMethods, ctx::HasCtxMethods, layout::LayoutMethods,
-    misc::MiscBuilderMethods, target::HasTargetSpec, ty::BuildTypeMethods,
+    misc::MiscBuilderMethods, target::HasTargetSpec, ty::TypeBuilderMethods,
 };
 
 pub mod abi;
@@ -59,7 +59,7 @@ pub trait CodeGenMethods<'b>:
     Backend<'b>
     + MiscBuilderMethods<'b>
     + HasCtxMethods<'b>
-    + BuildTypeMethods<'b>
+    + TypeBuilderMethods<'b>
     + ConstValueBuilderMethods<'b>
     + HasTargetSpec
 {
@@ -71,7 +71,7 @@ impl<'b, T> CodeGenMethods<'b> for T where
     Self: Backend<'b>
         + MiscBuilderMethods<'b>
         + HasCtxMethods<'b>
-        + BuildTypeMethods<'b>
+        + TypeBuilderMethods<'b>
         + ConstValueBuilderMethods<'b>
         + HasTargetSpec
 {

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -1,9 +1,9 @@
 //! Trait methods to do with emitting types for the backend.
 
 use hash_abi::FnAbi;
-use hash_ir::ty::IrTyId;
 use hash_layout::TyInfo;
-use hash_target::abi::AddressSpace;
+use hash_source::constant::FloatTy;
+use hash_target::abi::{AddressSpace, Integer};
 
 use super::Backend;
 use crate::common::TypeKind;
@@ -30,11 +30,30 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
     /// Create a `isize` type.
     fn type_isize(&self) -> Self::Type;
 
+    /// Create a integer type from the specified [abi::Integer].
+    fn type_from_integer(&self, int: Integer) -> Self::Type {
+        match int {
+            Integer::I8 => self.type_i8(),
+            Integer::I16 => self.type_i16(),
+            Integer::I32 => self.type_i32(),
+            Integer::I64 => self.type_i64(),
+            Integer::I128 => self.type_i128(),
+        }
+    }
+
     /// Create a float type.
     fn type_f32(&self) -> Self::Type;
 
     /// Create a double type.
     fn type_f64(&self) -> Self::Type;
+
+    /// Create a float type from the specified [FloatTy].
+    fn type_from_float(&self, ty: FloatTy) -> Self::Type {
+        match ty {
+            FloatTy::F32 => self.type_f32(),
+            FloatTy::F64 => self.type_f64(),
+        }
+    }
 
     /// Create an array type.
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -71,14 +71,11 @@ pub trait BuildTypeMethods<'b>: Backend<'b> {
     fn ty_of_value(&self, value: Self::Value) -> Self::Type;
 
     /// Get the [TypeKind] of a particular type.
-    fn kind_of_ty(&self, ty: Self::Type) -> TypeKind;
+    fn ty_kind(&self, ty: Self::Type) -> TypeKind;
 
     /// Create a new "immediate" backend type. This is mainly
     /// used for constants and ZSTs.
     fn immediate_backend_ty(&self, info: TyInfo) -> Self::Type;
-
-    /// Create a backend specific type from an [IrTyId].
-    fn backend_ty_from_ir_ty(&self, ty: IrTyId) -> Self::Type;
 
     /// Create a backend specific type from a [TyInfo].
     fn backend_ty_from_info(&self, info: TyInfo) -> Self::Type;

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -8,7 +8,7 @@ use hash_target::abi::{AddressSpace, Integer};
 use super::Backend;
 use crate::common::TypeKind;
 
-pub trait BuildTypeMethods<'b>: Backend<'b> {
+pub trait TypeBuilderMethods<'b>: Backend<'b> {
     /// Create a bit type.
     fn type_i1(&self) -> Self::Type;
 

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -15,13 +15,10 @@ pub mod ty;
 pub mod visitor;
 pub mod write;
 
-use std::{
-    cell::{Ref, RefCell},
-    collections::HashMap,
-};
+use std::cell::{Ref, RefCell};
 
 use hash_tir::{nominals::NominalDefId, terms::TermId};
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::{FxHashMap, SequenceStore, Store};
 use ir::{Body, Local, Place, PlaceProjection, ProjectionStore};
 use ty::{AdtData, AdtId, AdtStore, IrTy, IrTyId, TyListStore, TyStore};
 
@@ -88,7 +85,7 @@ pub struct IrCtx {
     ty_store: ty::TyStore,
 
     /// Storage for grouped types, ones that appear in a parent type, i.e. a
-    /// [`IrTy::Fn(...)`] type will use the `TyListStore` to store that
+    /// [`IrTy::Fn(...)`] type will use the [`TyListStore`] to store that
     /// parameter types.
     ty_list_store: ty::TyListStore,
 
@@ -97,28 +94,28 @@ pub struct IrCtx {
     adt_store: ty::AdtStore,
 
     /// Cache for the [IrTyId]s that are created from [TermId]s.
-    ty_cache: RefCell<HashMap<TyCacheEntry, IrTyId>>,
+    ty_cache: RefCell<FxHashMap<TyCacheEntry, IrTyId>>,
 }
 
 impl IrCtx {
-    /// Create a new [BodyDataStore].
+    /// Create a new [IrCtx].
     pub fn new() -> Self {
         Self {
             projection_store: ProjectionStore::default(),
             ty_store: TyStore::new(),
             ty_list_store: TyListStore::default(),
             adt_store: AdtStore::new(),
-            ty_cache: RefCell::new(HashMap::new()),
+            ty_cache: RefCell::new(FxHashMap::default()),
         }
     }
 
-    /// Get a reference to the [TyStore]
+    /// Get a reference to the [TyStore].
     pub fn tys(&self) -> &TyStore {
         &self.ty_store
     }
 
     /// Get a reference to the [IrTyId] cache.
-    pub fn ty_cache(&self) -> Ref<HashMap<TyCacheEntry, IrTyId>> {
+    pub fn ty_cache(&self) -> Ref<FxHashMap<TyCacheEntry, IrTyId>> {
         self.ty_cache.borrow()
     }
 

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -19,7 +19,7 @@ use hash_target::{
 };
 use hash_utils::{
     new_sequence_store_key, new_store_key,
-    store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, Store},
+    store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, Store, StoreKey},
 };
 use index_vec::{index_vec, IndexVec};
 
@@ -693,13 +693,23 @@ macro_rules! create_common_ty_table {
         /// using the associated [IrTyId]s of this map.
         pub struct CommonIrTys {
             $(pub $name: IrTyId, )*
+            pub byte_slice: IrTyId,
         }
 
         impl CommonIrTys {
             pub fn new(data: &DefaultStore<IrTyId, IrTy>) -> CommonIrTys {
-                CommonIrTys {
+                let mut table = CommonIrTys {
                     $($name: data.create($value), )*
-                }
+                    byte_slice: IrTyId::from_index_unchecked(0),
+                };
+
+                // @@Hack: find a way to nicely create this within the `create_common_ty_table!`,
+                // however this would require somehow referencing entries within the table before
+                // they are defined...
+                let byte_slice = data.create(IrTy::Slice(table.u8));
+
+                table.byte_slice = byte_slice;
+                table
             }
         }
     };

--- a/compiler/hash-layout/Cargo.toml
+++ b/compiler/hash-layout/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 
 [dependencies]
 index_vec = "0.1.3"
+fixedbitset = "0.4.2"
 
 hash-utils = { path = "../hash-utils" }
 hash-ir = { path = "../hash-ir" }
 hash-target = { path = "../hash-target" }
-fixedbitset = "0.4.2"

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -152,7 +152,7 @@ impl<'l> LayoutComputer<'l> {
     /// This is the entry point of the layout computation engine. From
     /// here, the [Layout] of a type will be computed all the way recursively
     /// until all of the leaves of the type are also turned into [Layout]s.
-    pub fn compute_layout_of_ty(&self, ty_id: IrTyId) -> Result<LayoutId, LayoutError> {
+    pub fn layout_of_ty(&self, ty_id: IrTyId) -> Result<LayoutId, LayoutError> {
         let dl = self.data_layout();
 
         let scalar_unit = |value: ScalarKind| {
@@ -217,7 +217,7 @@ impl<'l> LayoutComputer<'l> {
                         variant
                             .fields
                             .iter()
-                            .map(|field| self.compute_layout_of_ty(field.ty))
+                            .map(|field| self.layout_of_ty(field.ty))
                             .collect::<Result<Vec<_>, _>>()
                     })
                     .collect::<Result<IndexVec<VariantIdx, _>, _>>()?;
@@ -816,7 +816,7 @@ impl<'l> LayoutComputer<'l> {
     ) -> Result<LayoutId, LayoutError> {
         // first, we compute the layout of the element type
 
-        let element = self.compute_layout_of_ty(element_ty)?;
+        let element = self.layout_of_ty(element_ty)?;
         let (element_size, element_alignment) =
             self.layouts().map_fast(element, |element| (element.size, element.alignment));
 

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -197,7 +197,7 @@ impl TyInfo {
         if let Some(layout) = ctx.layouts().cache.borrow().get(&ty) {
             TyInfo { ty, layout: *layout }
         } else {
-            TyInfo { ty, layout: ctx.compute_layout_of_ty(ty).unwrap() }
+            TyInfo { ty, layout: ctx.layout_of_ty(ty).unwrap() }
         }
     }
 
@@ -349,10 +349,10 @@ impl Layout {
 /// etc), an array with a known size (which isn't supported in the language
 /// yet), or a `struct`-like type.
 ///
-/// For [`LayoutShape::Struct`], there are two maps stored, the first being all
-/// of the field **offset**s in "source" definition order, and a `memory_map`
-/// which specifies the actual order of fields in memory in relation to their
-/// offsets.
+/// For [`LayoutShape::Aggregate`], there are two maps stored, the first being
+/// all of the field **offset**s in "source" definition order, and a
+/// `memory_map` which specifies the actual order of fields in memory in
+/// relation to their offsets.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LayoutShape {
     /// Primitives, `!` and other scalar-like types have only one specific
@@ -413,7 +413,7 @@ impl FieldLayout {
 }
 
 impl LayoutShape {
-    /// Count the number of fields in the layout shape.
+    /// Count the number of fields in the [LayoutShape].
     #[inline]
     pub fn count(&self) -> usize {
         match *self {
@@ -424,7 +424,7 @@ impl LayoutShape {
         }
     }
 
-    /// Get a specific `offset` from the layout shape, and given an
+    /// Get a specific `offset` from the [LayoutShape], and given an
     /// index into the layout.
     #[inline]
     pub fn offset(&self, index: usize) -> Size {
@@ -443,11 +443,11 @@ impl LayoutShape {
     /// Get the memory index of a specific field in the layout shape, and given
     /// an a "source order" index into the layout. This is used to get the
     /// actual memory order of a field in the layout.
-    pub fn memory_index(&self, index: u32) -> u32 {
+    pub fn memory_index(&self, index: usize) -> usize {
         match self {
             LayoutShape::Primitive => unreachable!("primitive layout has no defined offsets"),
             LayoutShape::Union { .. } | LayoutShape::Array { .. } => index,
-            LayoutShape::Aggregate { memory_map, .. } => memory_map[index as usize],
+            LayoutShape::Aggregate { memory_map, .. } => memory_map[index] as usize,
         }
     }
 

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -13,7 +13,7 @@ mod temp;
 mod ty;
 mod utils;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use hash_ast::ast;
 use hash_ir::{
@@ -27,7 +27,7 @@ use hash_ir::{
 use hash_pipeline::settings::CompilerSettings;
 use hash_source::{identifier::Identifier, location::Span, SourceId, SourceMap};
 use hash_tir::{scope::ScopeId, storage::GlobalStorage, terms::TermId};
-use hash_utils::store::{SequenceStore, SequenceStoreKey};
+use hash_utils::store::{FxHashMap, SequenceStore, SequenceStoreKey};
 use index_vec::IndexVec;
 
 use self::ty::get_fn_ty_from_term;
@@ -190,7 +190,7 @@ pub(crate) struct Builder<'tcx> {
 
     /// A map that is used by the [Builder] to lookup which variables correspond
     /// to which locals.
-    declaration_map: HashMap<(ScopeId, Identifier), Local>,
+    declaration_map: FxHashMap<(ScopeId, Identifier), Local>,
 
     /// The current scope stack that builder is in.
     scope_stack: Vec<ScopeId>,
@@ -273,7 +273,7 @@ impl<'ctx> Builder<'ctx> {
             control_flow_graph: ControlFlowGraph::new(),
             declarations: IndexVec::new(),
             needed_constants: Vec::new(),
-            declaration_map: HashMap::new(),
+            declaration_map: FxHashMap::default(),
             reached_terminator: false,
             loop_block_info: None,
             scope_stack,

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -148,7 +148,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             let layout_computer = LayoutComputer::new(layout_storage, &ir_storage.ctx);
 
             // @@ErrorHandling: propagate this error if it occurs.
-            let layout = layout_computer.compute_layout_of_ty(ty).unwrap();
+            let layout = layout_computer.layout_of_ty(ty).unwrap();
 
             // Print the layout and add spacing between all of the specified layouts
             // that were requested.

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -220,7 +220,7 @@ pub struct CodeGenSettings {
     /// The specified target layout information for types. This defines
     /// the sizes of target-dependant types, and default alignments for
     /// primitive types.
-    pub layout: TargetDataLayout,
+    pub data_layout: TargetDataLayout,
 
     /// This is only the "backend" for the global instance of code generation.
     ///

--- a/compiler/hash-semantics/src/storage/cache.rs
+++ b/compiler/hash-semantics/src/storage/cache.rs
@@ -3,13 +3,12 @@
 
 use std::{
     cell::{Cell, RefCell},
-    collections::HashMap,
     fmt::Display,
     hash::Hash,
 };
 
 use hash_tir::terms::TermId;
-use hash_utils::store::{DefaultPartialStore, PartialCloneStore, PartialStore};
+use hash_utils::store::{DefaultPartialStore, FxHashMap, PartialCloneStore, PartialStore};
 use log::log_enabled;
 
 use crate::ops::validate::TermValidation;
@@ -58,7 +57,7 @@ impl<K, V> Default for CacheStore<K, V> {
 }
 
 impl<K: Copy + Hash + Eq, V: Clone> PartialStore<K, V> for CacheStore<K, V> {
-    fn internal_data(&self) -> &RefCell<HashMap<K, V>> {
+    fn internal_data(&self) -> &RefCell<FxHashMap<K, V>> {
         self.store.internal_data()
     }
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -91,7 +91,7 @@ impl CompilerSession {
         output_stream: impl Fn() -> CompilerOutputStream + 'static,
     ) -> Self {
         let target = settings.codegen_settings().target_info.target();
-        let layout_info = settings.codegen_settings().layout.clone();
+        let layout_info = settings.codegen_settings().data_layout.clone();
 
         let global = GlobalStorage::new(target);
         let local = LocalStorage::new(&global, SourceId::default());

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -59,6 +59,14 @@ impl FloatConstant {
 
         Self { value, ty: self.ty, suffix: self.suffix }
     }
+
+    /// Get the value of the float constant as a [f64].
+    pub fn as_f64(self) -> f64 {
+        match self.value {
+            FloatConstantValue::F64(inner) => inner,
+            FloatConstantValue::F32(inner) => inner as f64,
+        }
+    }
 }
 
 /// Provide implementations for converting primitive floating point types into
@@ -294,8 +302,16 @@ impl IntConstant {
         }
     }
 
+    /// Convert the constant into the "small" variant.
+    pub fn as_small(self) -> Option<u128> {
+        match self.value {
+            IntConstantValue::Small(inner) => Some(u128::from_be_bytes(inner)),
+            IntConstantValue::Big(_) => None,
+        }
+    }
+
     /// Convert the constant into a [BigInt].
-    pub fn to_big_int(self) -> BigInt {
+    pub fn as_big(self) -> BigInt {
         match self.value {
             IntConstantValue::Small(inner) => BigInt::from_signed_bytes_be(&inner),
             IntConstantValue::Big(inner) => *inner,

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -79,6 +79,22 @@ impl Integer {
             alignment == candidate.align(ctx).abi && alignment.bytes() >= candidate.size().bytes()
         })
     }
+
+    /// Create the largest [Integer] type with the given alignment or
+    /// less.
+    pub fn approximate_alignment<C: HasDataLayout>(ctx: &C, alignment: Alignment) -> Self {
+        use Integer::*;
+
+        for candidate in [I128, I64, I32, I16] {
+            if alignment >= candidate.align(ctx).abi
+                && alignment.bytes() >= candidate.size().bytes()
+            {
+                return candidate;
+            }
+        }
+
+        I8
+    }
 }
 
 /// Represents all of the primitive [AbiRepresentation::Scalar]s that are

--- a/compiler/hash-tir/src/nodes.rs
+++ b/compiler/hash-tir/src/nodes.rs
@@ -3,7 +3,7 @@
 use hash_ast::ast::AstNodeId;
 use hash_utils::{
     new_partial_store,
-    store::{PartialCloneStore, PartialStore},
+    store::{FxHashMap, PartialCloneStore, PartialStore},
 };
 
 use super::{pats::PatId, terms::TermId};

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -760,7 +760,7 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                         // same for max, what we want to do is write `MIN`
                         // and `MAX for these situations since it is easier for the
                         // user to understand the problem
-                        let value = CONSTANT_MAP.lookup_int_constant(*value).to_big_int();
+                        let value = CONSTANT_MAP.lookup_int_constant(*value).as_big();
 
                         if let Some(min) = kind.min(pointer_width) && min == value {
                             write!(f, "{kind}::MIN")

--- a/compiler/hash-utils/Cargo.toml
+++ b/compiler/hash-utils/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
+append-only-vec = "0.1"
 log = "0.4"
 stacker = "0.1.15"
 index_vec = "0.1.3"
 fixedbitset = "0.4.2"
-append-only-vec = "0.1"
+fxhash = "0.2.1"

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -28,6 +28,7 @@ macro_rules! new_store_key {
         }
 
         impl $crate::store::StoreKey for $name {
+
             fn to_index(self) -> usize {
                 self.index.try_into().unwrap()
             }


### PR DESCRIPTION
This patch implements functionality for dealing with constant values and types within the LLVM codegen backend.