### PR TITLE
codegen(llvm): implement code generating a program entry point

### DIFF
--- a/compiler/hash-abi/src/lib.rs
+++ b/compiler/hash-abi/src/lib.rs
@@ -5,7 +5,7 @@
 
 use hash_layout::{compute::LayoutComputer, LayoutId, TyInfo};
 use hash_target::{
-    abi::{AbiRepresentation, Scalar},
+    abi::{Abi, AbiRepresentation, Scalar},
     size::Size,
 };
 use hash_utils::store::Store;
@@ -29,15 +29,13 @@ pub enum CallingConvention {
     Cold = 9,
 }
 
-/// Defines what ABI to use when calling a function.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Abi {
-    /// The C ABI.
-    C,
-
-    /// The default ABI, which attempts to perform optimisations
-    /// that are not possible with the C ABI.
-    Hash,
+impl From<Abi> for CallingConvention {
+    fn from(abi: Abi) -> Self {
+        match abi {
+            Abi::C | Abi::Hash => CallingConvention::C,
+            Abi::Cold => CallingConvention::Cold,
+        }
+    }
 }
 
 /// Defines ABI specific information about a function.

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -1,12 +1,10 @@
 //! Contains logic for computing ABIs of function types and their
 //! arguments.
 
-use hash_abi::{
-    Abi, ArgAbi, ArgAttributeFlag, ArgAttributes, ArgExtension, CallingConvention, FnAbi,
-};
+use hash_abi::{ArgAbi, ArgAttributeFlag, ArgAttributes, ArgExtension, CallingConvention, FnAbi};
 use hash_ir::ty::{InstanceId, IrTy, IrTyId, Mutability, RefKind};
 use hash_layout::compute::{LayoutComputer, LayoutError};
-use hash_target::abi::{Scalar, ScalarKind};
+use hash_target::abi::{Abi, Scalar, ScalarKind};
 use hash_utils::store::SequenceStore;
 
 use crate::traits::{ctx::HasCtxMethods, layout::LayoutMethods};

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -405,3 +405,19 @@ impl AddressSpace {
     /// The default address space, corresponding to data space.
     pub const DATA: Self = AddressSpace(0);
 }
+
+/// Defines what ABI to use when calling a function.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Abi {
+    /// The C ABI.
+    C,
+
+    /// The `cold` calling convention, something that
+    /// isn't often called and thus should be optimised
+    /// for size rather than speed.
+    Cold,
+
+    /// The default ABI, which attempts to perform optimisations
+    /// that are not possible with the C ABI.
+    Hash,
+}


### PR DESCRIPTION
This patch implements the remaining functionality that is needed for fully completing the code generation side of the LLVM backend.