### PR TITLE
Remove DefParams/DefArgs/DefPatArgs in favour of the simple versions

### DIFF
--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -3,7 +3,6 @@ use std::iter::once;
 
 use hash_tir::new::{
     data::{DataDefId, ListCtorInfo, NumericCtorBits, NumericCtorInfo, PrimitiveCtorInfo},
-    defs::DefParamGroupData,
     environment::env::{AccessToEnv, Env},
     mods::{ModMemberData, ModMemberValue},
     params::ParamData,
@@ -93,15 +92,14 @@ impl DefinedPrimitives {
 
         DefinedPrimitives {
             // Never
-            never: env.data_utils().new_empty_data_def(
-                env.new_symbol("never"),
-                env.param_utils().new_empty_def_params(),
-            ),
+            never: env
+                .data_utils()
+                .new_empty_data_def(env.new_symbol("never"), env.param_utils().new_empty_params()),
 
             // bool
             bool: env.data_utils().create_enum_def(
                 env.new_symbol("bool"),
-                env.new_empty_def_params(),
+                env.new_empty_params(),
                 |_| {
                     vec![
                         (env.new_symbol("true"), env.new_empty_params()),
@@ -146,10 +144,7 @@ impl DefinedPrimitives {
                     name: t_sym,
                     ty: env.new_small_universe_ty(),
                 }));
-                let def_params = env
-                    .param_utils()
-                    .create_def_params(once(DefParamGroupData { implicit: true, params }));
-                env.data_utils().create_primitive_data_def_with_params(list_sym, def_params, |_| {
+                env.data_utils().create_primitive_data_def_with_params(list_sym, params, |_| {
                     PrimitiveCtorInfo::List(ListCtorInfo { element_ty: env.new_var_ty(t_sym) })
                 })
             },
@@ -164,14 +159,11 @@ impl DefinedPrimitives {
                     name: t_sym,
                     ty: env.new_small_universe_ty(),
                 }));
-                let def_params = env
-                    .param_utils()
-                    .create_def_params(once(DefParamGroupData { implicit: true, params }));
                 let some_params = env.param_utils().create_params(once(ParamData {
                     name: env.new_symbol("value"),
                     ty: env.new_var_ty(t_sym),
                 }));
-                env.data_utils().create_enum_def(option_sym, def_params, |_| {
+                env.data_utils().create_enum_def(option_sym, params, |_| {
                     vec![(none_sym, env.new_empty_params()), (some_sym, some_params)]
                 })
             },
@@ -190,9 +182,6 @@ impl DefinedPrimitives {
                     ]
                     .into_iter(),
                 );
-                let def_params = env
-                    .param_utils()
-                    .create_def_params(once(DefParamGroupData { implicit: true, params }));
                 let ok_params = env.param_utils().create_params(once(ParamData {
                     name: env.new_symbol("value"),
                     ty: env.new_var_ty(t_sym),
@@ -201,7 +190,7 @@ impl DefinedPrimitives {
                     name: env.new_symbol("error"),
                     ty: env.new_var_ty(e_sym),
                 }));
-                env.data_utils().create_enum_def(result_sym, def_params, |_| {
+                env.data_utils().create_enum_def(result_sym, params, |_| {
                     vec![(ok_sym, ok_params), (err_sym, err_params)]
                 })
             },

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -34,8 +34,8 @@ pub trait PrimitiveUtils: AccessToPrimitives + Sized {
     fn new_bool_term(&self, value: bool) -> TermId {
         self.new_term(Term::Ctor(CtorTerm {
             ctor: self.get_bool_ctor(value),
-            ctor_args: self.new_empty_def_args(),
-            data_args: self.new_empty_def_args(),
+            ctor_args: self.new_empty_args(),
+            data_args: self.new_empty_args(),
         }))
     }
 
@@ -43,14 +43,15 @@ pub trait PrimitiveUtils: AccessToPrimitives + Sized {
     fn bool_pat(&self, value: bool) -> PatId {
         self.new_pat(Pat::Ctor(CtorPat {
             ctor: self.get_bool_ctor(value),
-            ctor_pat_args: self.new_empty_def_pat_args(),
-            data_args: self.new_empty_def_args(),
+            ctor_pat_args: self.new_empty_pat_args(),
+            data_args: self.new_empty_args(),
+            ctor_pat_args_spread: None,
         }))
     }
 
     /// Create a new `never` type.
     fn new_never_ty(&self) -> TyId {
-        self.new_ty(DataTy { args: self.new_empty_def_args(), data_def: self.primitives().never() })
+        self.new_ty(DataTy { args: self.new_empty_args(), data_def: self.primitives().never() })
     }
 }
 

--- a/compiler/hash-semantics/src/new/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/new/diagnostics/error.rs
@@ -74,6 +74,7 @@ impl<'tc> WithTcEnv<'tc, &SemanticError> {
     /// Format the error nicely and add it to the given reporter.
     fn add_to_reporter(&self, reporter: &mut Reporter) {
         let locations = self.tc_env().stores().location();
+        // @@ErrorReporting: improve error messages and locations
         match &self.value {
             SemanticError::Signal => {}
             SemanticError::NeedMoreTypeAnnotationsToInfer { term } => {

--- a/compiler/hash-semantics/src/new/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/new/diagnostics/error.rs
@@ -48,6 +48,8 @@ pub enum SemanticError {
     CannotUseFunctionInPatternPosition { location: SourceLocation },
     /// Cannot use the subject as a namespace.
     InvalidNamespaceSubject { location: SourceLocation },
+    /// Cannot use arguments here.
+    UnexpectedArguments { location: SourceLocation },
     /// Type error, forwarded from the typechecker.
     TypeError { error: TcError },
 }
@@ -225,6 +227,16 @@ impl<'tc> WithTcEnv<'tc, &SemanticError> {
             }
             SemanticError::TypeError { error } => {
                 TcErrorReporter::new(self.env()).add_to_reporter(error, reporter)
+            }
+            SemanticError::UnexpectedArguments { location } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ValueCannotBeUsedAsType)
+                    .title("unexpected arguments given to subject");
+
+                error
+                    .add_span(*location)
+                    .add_info("cannot use these arguments as the subject does not expect them");
             }
         }
     }

--- a/compiler/hash-semantics/src/new/passes/discovery/params.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/params.rs
@@ -1,41 +1,11 @@
 //! Utilities for creating parameters and arguments during discovery.
 use hash_ast::ast::{self};
-use hash_tir::new::{
-    defs::{DefParamGroupData, DefParamsId},
-    environment::env::AccessToEnv,
-    params::ParamsId,
-    utils::AccessToUtils,
-};
-use itertools::Itertools;
+use hash_tir::new::{environment::env::AccessToEnv, params::ParamsId, utils::AccessToUtils};
 
 use super::DiscoveryPass;
 use crate::new::{environment::tc_env::AccessToTcEnv, passes::ast_utils::AstUtils};
 
 impl<'tc> DiscoveryPass<'tc> {
-    /// Create definition params from the iterator of parameter groups.
-    ///
-    /// The iterator elements are `(is_implicit, params)`.
-    pub(super) fn create_hole_def_params<'a>(
-        &self,
-        groups: impl Iterator<Item = (bool, &'a ast::AstNodes<ast::Param>)>,
-    ) -> DefParamsId {
-        let groups = groups.collect_vec();
-        let params = groups
-            .iter()
-            .copied()
-            .map(|group| {
-                let (implicit, params) = group;
-                DefParamGroupData { params: self.create_hole_params(params), implicit }
-            })
-            .collect_vec();
-
-        let def_params = self.param_utils().create_def_params(params.into_iter());
-        self.stores().location().add_locations_to_targets(def_params, |i| {
-            Some(self.source_location(groups[i].1.span()?))
-        });
-        def_params
-    }
-
     /// Create a parameter list from the given AST generic parameter list, where
     /// the type of each parameter is a hole.
     pub(super) fn create_hole_params_from<T>(

--- a/compiler/hash-semantics/src/new/passes/discovery/visitor.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/visitor.rs
@@ -1,5 +1,4 @@
 //! AST visitor for the discovery pass.
-use std::iter::once;
 
 use hash_ast::{
     ast::{self, AstNodeRef},
@@ -167,7 +166,7 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         // Create a data definition for the struct
         let struct_def_id = self.data_utils().create_struct_def(
             struct_name,
-            self.create_hole_def_params(once((true, &node.ty_params))),
+            self.create_hole_params(&node.ty_params),
             self.create_hole_params(&node.fields),
         );
 
@@ -190,7 +189,7 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         // Create a data definition for the enum
         let enum_def_id = self.data_utils().create_enum_def(
             enum_name,
-            self.create_hole_def_params(once((true, &node.ty_params))),
+            self.create_hole_params(&node.ty_params),
             |_| {
                 node.entries
                     .iter()

--- a/compiler/hash-semantics/src/new/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/pats.rs
@@ -211,7 +211,8 @@ impl ResolutionPass<'_> {
                     // @@Hack: Constructor term without args is a valid pattern
                     Ok(self.new_pat(Pat::Ctor(CtorPat {
                         ctor: ctor_term.ctor,
-                        ctor_pat_args: self.param_utils().create_def_pat_args(empty()),
+                        ctor_pat_args: self.param_utils().create_pat_args(empty()),
+                        ctor_pat_args_spread: None,
                         data_args: ctor_term.data_args,
                     })))
                 }

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -272,7 +272,7 @@ impl<'tc> ResolutionPass<'tc> {
             data_def: list_def,
             args: self.param_utils().create_positional_args_for_data_def(
                 list_def,
-                once(once(self.new_term(Term::Ty(inner_ty)))),
+                once(self.new_term(Term::Ty(inner_ty))),
             ),
         })))
     }

--- a/compiler/hash-tir/src/new/defs.rs
+++ b/compiler/hash-tir/src/new/defs.rs
@@ -3,70 +3,16 @@
 use std::fmt::Display;
 
 use derive_more::From;
-use hash_utils::{
-    new_sequence_store_key,
-    store::{DefaultSequenceStore, SequenceStore},
-};
-use utility_types::omit;
 
 use super::{
-    args::PatArgsId,
     data::DataDefId,
     environment::env::{AccessToEnv, WithEnv},
     fns::FnDefId,
     locations::LocationTarget,
     mods::ModDefId,
-    pats::Spread,
     scopes::StackId,
 };
-use crate::new::{args::ArgsId, params::ParamsId, symbols::Symbol, terms::TermId, tys::TyId};
-
-/// A group of definition parameters
-///
-/// This is either a set of implicit parameters `<a_1: A_1,...,a_n: A_N>` or a
-/// set of explicit parameters `(a_1: A_1,...,a_n: A_N)`.
-#[omit(DefParamGroupData, [id], [Debug, Clone, Copy])]
-#[derive(Debug, Clone, Copy)]
-pub struct DefParamGroup {
-    pub id: DefParamGroupId,
-    pub implicit: bool,
-    pub params: ParamsId,
-}
-new_sequence_store_key!(pub DefParamsId);
-pub type DefParamsStore = DefaultSequenceStore<DefParamsId, DefParamGroup>;
-pub type DefParamGroupId = (DefParamsId, usize);
-
-/// A group of definition arguments
-///
-/// This contains the original parameter group of the definition, as well as
-/// set of arguments for it, ordered by the original parameters.
-#[omit(DefArgGroupData, [id], [Debug, Clone, Copy])]
-#[derive(Debug, Clone, Copy)]
-pub struct DefArgGroup {
-    pub id: DefArgGroupId,
-    pub implicit: bool,
-    pub args: ArgsId,
-}
-new_sequence_store_key!(pub DefArgsId);
-pub type DefArgsStore = DefaultSequenceStore<DefArgsId, DefArgGroup>;
-pub type DefArgGroupId = (DefArgsId, usize);
-
-/// A group of definition pattern arguments
-///
-/// This contains the original parameter group of the definition, as well as
-/// set of pattern arguments for it, ordered by the original parameters.
-#[omit(DefPatArgGroupData, [id], [Debug, Clone, Copy])]
-#[derive(Debug, Clone, Copy)]
-pub struct DefPatArgGroup {
-    pub id: DefPatArgGroupId,
-    pub implicit: bool,
-    pub pat_args: PatArgsId,
-    /// The spread in this group of patterns, if any.
-    pub spread: Option<Spread>,
-}
-new_sequence_store_key!(pub DefPatArgsId);
-pub type DefPatArgsStore = DefaultSequenceStore<DefPatArgsId, DefPatArgGroup>;
-pub type DefPatArgGroupId = (DefPatArgsId, usize);
+use crate::new::{symbols::Symbol, terms::TermId, tys::TyId};
 
 /// A member of a definition.
 ///
@@ -122,128 +68,6 @@ impl Display for WithEnv<'_, DefId> {
             DefId::Fn(fn_id) => write!(f, "{}", self.env().with(fn_id)),
             DefId::Stack(stack_id) => write!(f, "{}", self.env().with(stack_id)),
         }
-    }
-}
-
-impl Display for WithEnv<'_, &DefParamGroup> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.value.implicit {
-            write!(f, "<")?;
-        } else {
-            write!(f, "(")?;
-        }
-        write!(f, "{}", self.env().with(self.value.params))?;
-        if self.value.implicit {
-            write!(f, ">")?;
-        } else {
-            write!(f, ")")?;
-        }
-        Ok(())
-    }
-}
-
-impl Display for WithEnv<'_, DefParamGroupId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let param_group = self.stores().def_params().get_element(self.value);
-        write!(f, "{}", self.env().with(&param_group))
-    }
-}
-
-impl Display for WithEnv<'_, DefParamsId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.stores().def_params().map_fast(self.value, |params| {
-            for param in params.iter() {
-                write!(f, "{}", self.env().with(param))?;
-            }
-            Ok(())
-        })
-    }
-}
-
-impl Display for WithEnv<'_, &DefArgGroup> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.value.implicit {
-            write!(f, "<")?;
-        } else {
-            write!(f, "(")?;
-        }
-        write!(f, "{}", self.env().with(self.value.args))?;
-        if self.value.implicit {
-            write!(f, ">")?;
-        } else {
-            write!(f, ")")?;
-        }
-        Ok(())
-    }
-}
-
-impl Display for WithEnv<'_, DefArgGroupId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let arg_group = self.stores().def_args().get_element(self.value);
-        write!(f, "{}", self.env().with(&arg_group))
-    }
-}
-
-impl Display for WithEnv<'_, DefArgsId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.stores().def_args().map_fast(self.value, |args| {
-            for arg in args.iter() {
-                write!(f, "{}", self.env().with(arg))?;
-            }
-            Ok(())
-        })
-    }
-}
-
-impl Display for WithEnv<'_, &DefPatArgGroup> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.value.implicit {
-            write!(f, "<")?;
-        } else {
-            write!(f, "(")?;
-        }
-
-        self.stores().pat_args().map_fast(self.value.pat_args, |pat_args| {
-            let mut pat_args_formatted =
-                pat_args.iter().map(|arg| self.env().with(arg).to_string()).collect::<Vec<_>>();
-
-            if let Some(spread) = self.value.spread {
-                pat_args_formatted.insert(spread.index, self.env().with(spread).to_string());
-            }
-
-            for (i, pat_arg) in pat_args_formatted.iter().enumerate() {
-                if i > 0 {
-                    write!(f, ", ")?;
-                }
-                write!(f, "{pat_arg}")?;
-            }
-            Ok(())
-        })?;
-
-        if self.value.implicit {
-            write!(f, ">")?;
-        } else {
-            write!(f, ")")?;
-        }
-        Ok(())
-    }
-}
-
-impl Display for WithEnv<'_, DefPatArgGroupId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let pat_arg_group = self.stores().def_pat_args().get_element(self.value);
-        write!(f, "{}", self.env().with(&pat_arg_group))
-    }
-}
-
-impl Display for WithEnv<'_, DefPatArgsId> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.stores().def_pat_args().map_fast(self.value, |pat_args| {
-            for pat_arg in pat_args.iter() {
-                write!(f, "{}", self.env().with(pat_arg))?;
-            }
-            Ok(())
-        })
     }
 }
 

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -17,7 +17,7 @@ use crate::{
         fns::FnDefId,
         holes::{Hole, HoleBinderKind},
         mods::{ModDefId, ModMemberId},
-        params::{DefParamIndex, ParamIndex},
+        params::ParamIndex,
         scopes::{StackId, StackMemberId},
         symbols::Symbol,
         tys::TyId,
@@ -63,7 +63,7 @@ pub enum BoundVarOrigin {
     /// Data definition parameter.
     ///
     /// For example, `T` in `Foo := struct <T> (x: T)`
-    Data(DataDefId, DefParamIndex),
+    Data(DataDefId, ParamIndex),
     /// Stack member.
     ///
     /// For example, `a` in `{ a := 3; a }`
@@ -294,9 +294,9 @@ impl fmt::Display for WithEnv<'_, &BoundVarOrigin> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
             BoundVarOrigin::Data(data_def_id, param_index) => {
-                let def_params_id =
+                let params_id =
                     self.stores().data_def().map_fast(*data_def_id, |mod_def| mod_def.params);
-                let param = self.get_def_param_by_index(def_params_id, *param_index);
+                let param = self.get_param_by_index(params_id, *param_index);
                 write!(f, "{}", self.env().with(&param))
             }
             BoundVarOrigin::FnTy(fn_ty_id, param_index) => {

--- a/compiler/hash-tir/src/new/environment/stores.rs
+++ b/compiler/hash-tir/src/new/environment/stores.rs
@@ -2,7 +2,6 @@
 use super::super::{
     args::{ArgsStore, PatArgsStore},
     data::{CtorDefsStore, DataDefStore},
-    defs::{DefArgsStore, DefParamsStore, DefPatArgsStore},
     fns::FnDefStore,
     locations::LocationStore,
     mods::{ModDefStore, ModMembersStore},
@@ -54,9 +53,6 @@ stores! {
     args: ArgsStore,
     ctor_defs: CtorDefsStore,
     data_def: DataDefStore,
-    def_args: DefArgsStore,
-    def_params: DefParamsStore,
-    def_pat_args: DefPatArgsStore,
     fn_def: FnDefStore,
     location: LocationStore,
     mod_def: ModDefStore,

--- a/compiler/hash-tir/src/new/locations.rs
+++ b/compiler/hash-tir/src/new/locations.rs
@@ -7,9 +7,6 @@ use hash_utils::store::SequenceStoreKey;
 use super::{
     args::{ArgId, ArgsId, PatArgId, PatArgsId},
     data::{CtorDefId, CtorDefsId, DataDefId},
-    defs::{
-        DefArgGroupId, DefArgsId, DefParamGroupId, DefParamsId, DefPatArgGroupId, DefPatArgsId,
-    },
     fns::FnDefId,
     mods::{ModDefId, ModMemberId, ModMembersId},
     params::{ParamId, ParamsId},
@@ -122,9 +119,6 @@ location_targets! {
     Arg: ArgId = sequence Args: ArgsId,
     Param: ParamId = sequence Params: ParamsId,
     PatArg: PatArgId = sequence PatArgs: PatArgsId,
-    DefParamGroup: DefParamGroupId = sequence DefParams: DefParamsId,
-    DefArgGroup: DefArgGroupId = sequence DefArgs: DefArgsId,
-    DefPatArgGroup: DefPatArgGroupId = sequence DefPatArgs: DefPatArgsId,
 }
 
 /// Stores the source location of various targets in the term tree.

--- a/compiler/hash-tir/src/new/params.rs
+++ b/compiler/hash-tir/src/new/params.rs
@@ -12,7 +12,6 @@ use utility_types::omit;
 
 use super::{
     args::{ArgsId, PatArgsId},
-    defs::{DefArgsId, DefParamsId, DefPatArgsId},
     environment::env::{AccessToEnv, WithEnv},
     locations::IndexedLocationTarget,
 };
@@ -52,21 +51,6 @@ impl From<ParamId> for ParamIndex {
     fn from(value: ParamId) -> Self {
         ParamIndex::Position(value.1)
     }
-}
-
-/// An index of a parameter of a definition parameter list.
-///
-/// This is a combination of the group index and the parameter index.
-/// Group index is
-/// ```notrust
-/// (a, b)(c, d)(e, f)
-/// ^0    ^1    ^2
-/// ```
-/// and parameter index is [`ParamIndex`].
-#[derive(Debug, Clone, Hash, Copy, PartialEq, Eq)]
-pub struct DefParamIndex {
-    pub group_index: usize,
-    pub param_index: ParamIndex,
 }
 
 impl fmt::Display for WithEnv<'_, &Param> {
@@ -114,50 +98,6 @@ impl From<SomeArgsId> for IndexedLocationTarget {
             SomeArgsId::Params(id) => IndexedLocationTarget::Params(id),
             SomeArgsId::PatArgs(id) => IndexedLocationTarget::PatArgs(id),
             SomeArgsId::Args(id) => IndexedLocationTarget::Args(id),
-        }
-    }
-}
-
-/// Some kind of definition arguments, either [`DefParamsId`], [`DefPatArgsId`]
-/// or [`DefArgsId`].
-#[derive(Debug, Clone, Copy)]
-pub enum SomeDefArgsId {
-    Params(DefParamsId),
-    PatArgs(DefPatArgsId),
-    Args(DefArgsId),
-}
-
-impl SomeDefArgsId {
-    /// Get the length of the inner stored parameter group list.
-    pub fn len(&self) -> usize {
-        match self {
-            SomeDefArgsId::Params(id) => id.len(),
-            SomeDefArgsId::PatArgs(id) => id.len(),
-            SomeDefArgsId::Args(id) => id.len(),
-        }
-    }
-
-    /// Whether the inner stored parameter group list is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Get the English subject noun of the [SomeDefArgsId]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            SomeDefArgsId::Params(_) => "parameter groups",
-            SomeDefArgsId::PatArgs(_) => "pattern argument groups",
-            SomeDefArgsId::Args(_) => "argument groups",
-        }
-    }
-}
-
-impl From<SomeDefArgsId> for IndexedLocationTarget {
-    fn from(target: SomeDefArgsId) -> Self {
-        match target {
-            SomeDefArgsId::Params(id) => IndexedLocationTarget::DefParams(id),
-            SomeDefArgsId::PatArgs(id) => IndexedLocationTarget::DefPatArgs(id),
-            SomeDefArgsId::Args(id) => IndexedLocationTarget::DefArgs(id),
         }
     }
 }

--- a/compiler/hash-tir/src/new/tuples.rs
+++ b/compiler/hash-tir/src/new/tuples.rs
@@ -58,7 +58,7 @@ impl Display for WithEnv<'_, &TupleTerm> {
 impl Display for WithEnv<'_, &TuplePat> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "(")?;
-        write!(f, "{}", self.env().with(self.value.data))?;
+        write!(f, "{}", self.env().with((self.value.data, self.value.data_spread)))?;
         write!(f, ")")
     }
 }

--- a/compiler/hash-tir/src/new/utils/data.rs
+++ b/compiler/hash-tir/src/new/utils/data.rs
@@ -1,19 +1,18 @@
 //! Data definition-related utilities.
-use std::iter::{empty, once};
+use std::iter::once;
 
 use derive_more::Constructor;
-use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
+use hash_utils::store::{SequenceStore, Store};
 use itertools::Itertools;
 
 use super::{common::CommonUtils, AccessToUtils};
 use crate::{
     impl_access_to_env,
     new::{
-        args::ArgData,
+        args::{ArgData, ArgsId},
         data::{
             CtorDef, CtorDefData, CtorDefsId, DataDef, DataDefCtors, DataDefId, PrimitiveCtorInfo,
         },
-        defs::{DefArgGroupData, DefArgsId, DefParamGroupData, DefParamsId},
         environment::env::{AccessToEnv, Env},
         params::{ParamIndex, ParamsId},
         symbols::Symbol,
@@ -31,7 +30,7 @@ impl_access_to_env!(DataUtils<'tc>);
 
 impl<'tc> DataUtils<'tc> {
     /// Create an empty data definition.
-    pub fn new_empty_data_def(&self, name: Symbol, params: DefParamsId) -> DataDefId {
+    pub fn new_empty_data_def(&self, name: Symbol, params: ParamsId) -> DataDefId {
         self.stores().data_def().create_with(|id| DataDef {
             id,
             name,
@@ -53,7 +52,7 @@ impl<'tc> DataUtils<'tc> {
         self.stores().data_def().create_with(|id| DataDef {
             id,
             name,
-            params: self.new_empty_def_params(),
+            params: self.new_empty_params(),
             ctors: DataDefCtors::Primitive(info),
         })
     }
@@ -64,7 +63,7 @@ impl<'tc> DataUtils<'tc> {
     pub fn create_primitive_data_def_with_params(
         &self,
         name: Symbol,
-        params: DefParamsId,
+        params: ParamsId,
         info: impl FnOnce(DataDefId) -> PrimitiveCtorInfo,
     ) -> DataDefId {
         self.stores().data_def().create_with(|id| DataDef {
@@ -111,33 +110,20 @@ impl<'tc> DataUtils<'tc> {
     pub fn create_forwarded_data_args_from_params(
         &self,
         _data_def_id: DataDefId,
-        def_params_id: DefParamsId,
-    ) -> DefArgsId {
-        self.stores().def_params().map(def_params_id, |def_params| {
-            // For each parameter group, create an argument group
-            self.param_utils().create_def_args(def_params.iter().enumerate().map(
-                |(i, def_param_group)| {
-                    // For the parameter list inside the group, create an argument
-                    // list
-                    let args = self.param_utils().create_args(self.stores().params().map(
-                        def_param_group.params,
-                        |params| {
-                            // For each parameter, create an argument referring to it
-                            params
-                                .iter()
-                                .enumerate()
-                                .map(|(_j, param)| ArgData {
-                                    target: ParamIndex::Position(i),
-                                    value: self.new_term(Term::Var(param.name)),
-                                })
-                                .collect_vec()
-                                .into_iter()
-                        },
-                    ));
-                    DefArgGroupData { args, implicit: def_param_group.implicit }
-                },
-            ))
-        })
+        params_id: ParamsId,
+    ) -> ArgsId {
+        self.param_utils().create_args(self.stores().params().map(params_id, |params| {
+            // For each parameter, create an argument referring to it
+            params
+                .iter()
+                .enumerate()
+                .map(|(i, param)| ArgData {
+                    target: ParamIndex::Position(i),
+                    value: self.new_term(Term::Var(param.name)),
+                })
+                .collect_vec()
+                .into_iter()
+        }))
     }
 
     /// Create a struct data definition, with some parameters.
@@ -150,14 +136,9 @@ impl<'tc> DataUtils<'tc> {
     pub fn create_struct_def(
         &self,
         name: Symbol,
-        params: DefParamsId,
+        params: ParamsId,
         fields_params: ParamsId,
     ) -> DataDefId {
-        // The field parameters correspond to a single parameter group
-        let fields_def_params = self
-            .param_utils()
-            .create_def_params(once(DefParamGroupData { implicit: false, params: fields_params }));
-
         // Create the arguments for the constructor, which are the type
         // parameters given.
         let result_args =
@@ -178,7 +159,7 @@ impl<'tc> DataUtils<'tc> {
                         // The constructor is the only one
                         data_def_ctor_index: 0,
                         data_def_id: id,
-                        params: fields_def_params,
+                        params: fields_params,
                         result_args: result_args(id),
                     }
                 },
@@ -197,7 +178,7 @@ impl<'tc> DataUtils<'tc> {
     pub fn create_enum_def(
         &self,
         name: Symbol,
-        params: DefParamsId,
+        params: ParamsId,
         variants: impl Fn(DataDefId) -> Vec<(Symbol, ParamsId)>,
     ) -> DataDefId {
         // Create the arguments for the constructor, which are the type
@@ -215,23 +196,13 @@ impl<'tc> DataUtils<'tc> {
                     let variant_name = variant.0;
                     let fields_params = variant.1;
 
-                    // The field parameters correspond to a single parameter group
-                    let fields_def_params = if !fields_params.is_empty() {
-                        self.param_utils().create_def_params(once(DefParamGroupData {
-                            implicit: false,
-                            params: fields_params,
-                        }))
-                    } else {
-                        self.param_utils().create_def_params(empty())
-                    };
-
                     // Create a constructor for each variant
                     move |ctor_id| CtorDef {
                         id: ctor_id,
                         name: variant_name,
                         data_def_ctor_index: index,
                         data_def_id: id,
-                        params: fields_def_params,
+                        params: fields_params,
                         result_args: result_args(id),
                     }
                 }),

--- a/compiler/hash-tir/src/new/utils/defs.rs
+++ b/compiler/hash-tir/src/new/utils/defs.rs
@@ -1,17 +1,7 @@
 //! General definition-related utilities.
 use derive_more::Constructor;
-use hash_utils::store::{CloneStore, SequenceStore};
 
-use super::common::CommonUtils;
-use crate::{
-    impl_access_to_env,
-    new::{
-        data::DataDefId,
-        defs::DefParamsId,
-        environment::env::{AccessToEnv, Env},
-        tys::TyId,
-    },
-};
+use crate::{impl_access_to_env, new::environment::env::Env};
 
 /// Common definition-related operations.
 #[derive(Constructor)]
@@ -21,25 +11,4 @@ pub struct DefUtils<'env> {
 
 impl_access_to_env!(DefUtils<'tc>);
 
-impl<'env> DefUtils<'env> {
-    /// Compute the function type of some definition with final type `T`.
-    ///
-    /// If the definition has parameters `(A1: B1) ... (AN: BN)`, then the
-    /// function type will be `(A1:B1) -> ... -> (AN:BN) -> T`.
-    fn compute_fn_ty_of_some_def(&self, def_params_id: DefParamsId, final_ty: TyId) -> TyId {
-        self.stores().def_params().map_fast(def_params_id, |def_params| {
-            if !def_params.is_empty() {
-                todo!("def with params not implemented")
-            } else {
-                final_ty
-            }
-        })
-    }
-
-    /// Compute the function type of some data definition, which is
-    /// `compute_fn_ty_of_some_def` where `T = Type`.
-    pub fn compute_fn_ty_of_data_def(&self, data_def_id: DataDefId) -> TyId {
-        let data_def = self.stores().data_def().get(data_def_id);
-        self.compute_fn_ty_of_some_def(data_def.params, self.new_small_universe_ty())
-    }
-}
+impl<'env> DefUtils<'env> {}

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -10,9 +10,8 @@ use hash_source::location::SourceLocation;
 use hash_tir::{
     impl_access_to_env,
     new::{
-        defs::DefParamsId,
         environment::env::{AccessToEnv, Env},
-        params::{ParamsId, SomeArgsId, SomeDefArgsId},
+        params::{ParamsId, SomeArgsId},
         terms::TermId,
         tys::TyId,
         utils::common::CommonUtils,
@@ -91,9 +90,6 @@ pub enum TcError {
     NeedMoreTypeAnnotationsToInfer { term: TermId },
     /// The given arguments do not match the length of the target parameters.
     WrongArgLength { params_id: ParamsId, args_id: SomeArgsId },
-    /// The given definition arguments do not match the length of the target
-    /// definition parameters.
-    WrongDefArgLength { def_params_id: DefParamsId, def_args_id: SomeDefArgsId },
     /// Not a function.
     NotAFunction { fn_call: TermId, actual_subject_ty: TyId },
     /// Cannot deref the subject.
@@ -177,26 +173,6 @@ impl<'tc> TcErrorReporter<'tc> {
                     error
                         .add_span(location)
                         .add_info(format!("got {arg_length} {} here", args_id.as_str()));
-                }
-            }
-            TcError::WrongDefArgLength { def_params_id: params_id, def_args_id: args_id } => {
-                let param_length = params_id.len();
-                let arg_length = args_id.len();
-
-                let error = reporter.error().code(HashErrorCode::ParameterLengthMismatch).title(format!(
-                    "mismatch in parameter groups: expected {param_length} groups but got {arg_length}"
-                ));
-
-                if let Some(location) = locations.get_overall_location(*params_id) {
-                    error
-                        .add_span(location)
-                        .add_info(format!("expected {param_length} parameter groups here"));
-                }
-
-                if let Some(location) = locations.get_overall_location(*args_id) {
-                    error
-                        .add_span(location)
-                        .add_info(format!("got {arg_length} {} groups here", args_id.as_str()));
                 }
             }
             TcError::NotAFunction { fn_call, actual_subject_ty } => {

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -5,7 +5,6 @@ use std::ops::ControlFlow;
 use derive_more::{Constructor, Deref};
 use hash_tir::new::{
     args::ArgsId,
-    defs::DefArgsId,
     holes::Hole,
     mods::ModDefId,
     params::ParamsId,
@@ -126,14 +125,6 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
     pub fn apply_sub_to_params_in_place(&self, params_id: ParamsId, sub: &Sub) {
         self.traversing_utils()
             .visit_params::<!, _>(params_id, &mut |atom| {
-                Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
-            })
-            .into_ok()
-    }
-
-    pub fn apply_sub_to_def_args_in_place(&self, def_args_id: DefArgsId, sub: &Sub) {
-        self.traversing_utils()
-            .visit_def_args::<!, _>(def_args_id, &mut |atom| {
                 Ok(self.apply_sub_to_atom_in_place_once(atom, sub))
             })
             .into_ok()

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -3,7 +3,6 @@
 use derive_more::{Constructor, Deref};
 use hash_tir::new::{
     args::ArgsId,
-    defs::{DefArgsId, DefParamsId},
     params::ParamsId,
     sub::Sub,
     terms::{Term, TermId},
@@ -135,7 +134,7 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
 
             (Ty::Data(d1), Ty::Data(d2)) => {
                 if d1.data_def == d2.data_def {
-                    self.unify_def_args(d1.args, d2.args)
+                    self.unify_args(d1.args, d2.args)
                 } else {
                     Uni::mismatch_types(src_id, target_id)
                 }
@@ -190,34 +189,6 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                     src.iter()
                         .zip(target.iter())
                         .map(|(src, target)| self.unify_tys(src.ty, target.ty)),
-                )
-            })
-        })
-    }
-
-    /// Unify two definition parameter lists, creating a substitution of holes.
-    pub fn unify_def_params(&self, src: DefParamsId, target: DefParamsId) -> TcResult<Uni> {
-        // @@Todo: dependent
-        self.map_def_params(src, |src| {
-            self.map_def_params(target, |target| {
-                self.reduce_unifications(
-                    src.iter()
-                        .zip(target.iter())
-                        .map(|(src, target)| self.unify_params(src.params, target.params)),
-                )
-            })
-        })
-    }
-
-    /// Unify two definition argument lists, creating a substitution of holes.
-    pub fn unify_def_args(&self, src: DefArgsId, target: DefArgsId) -> TcResult<Uni> {
-        // @@Todo: dependent
-        self.map_def_args(src, |src| {
-            self.map_def_args(target, |target| {
-                self.reduce_unifications(
-                    src.iter()
-                        .zip(target.iter())
-                        .map(|(src, target)| self.unify_args(src.args, target.args)),
                 )
             })
         })


### PR DESCRIPTION
Before, data types could contain multiple groups of parameters like `<T: Type> (t: T) ...`. This has been removed to simplify the implementation, since even the simple `Params` etc will allow for dependent referencing (e.g. `(T: Type, t: T)`). Now data types are only annotated with a single`<...>` parameter list. This also should cut down on memory usage, and nicely shaves off almost 1k lines of boilerplate.

Closes #755 