### PR TITLE
Resolve dependent tuple members

### DIFF
--- a/compiler/hash-semantics/src/new/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/defs.rs
@@ -25,7 +25,7 @@ use crate::new::environment::tc_env::AccessToTcEnv;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, From)]
 pub(super) enum ItemId {
     Def(DefId),
-    FnTy(TyId),
+    Ty(TyId),
 }
 
 /// Contains information about seen definitions, members of definitions, as well
@@ -129,7 +129,7 @@ impl<'tc> DiscoveryPass<'tc> {
                 DefId::Fn(id) => ast_info.fn_defs().insert(node.id(), id),
                 DefId::Stack(id) => ast_info.stacks().insert(node.id(), id),
             },
-            ItemId::FnTy(id) => ast_info.tys().insert(node.id(), id),
+            ItemId::Ty(id) => ast_info.tys().insert(node.id(), id),
         };
     }
 

--- a/compiler/hash-semantics/src/new/passes/resolution/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/mod.rs
@@ -57,6 +57,7 @@ impl<'tc> AstPass for ResolutionPass<'tc> {
         // @@Todo: add intrinsics to the environment
         let (prim_mod, _) = self.bootstrap();
         self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
+        self.scoping().add_mod_members(prim_mod);
         let _ = self.make_term_from_ast_body_block(node)?;
         Ok(())
     }
@@ -67,6 +68,7 @@ impl<'tc> AstPass for ResolutionPass<'tc> {
     ) -> crate::new::diagnostics::error::SemanticResult<()> {
         let (prim_mod, _) = self.bootstrap();
         self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
+        self.scoping().add_mod_members(prim_mod);
         let _ = self.resolve_ast_module_inner_terms(node)?;
         Ok(())
     }

--- a/compiler/hash-semantics/src/new/passes/resolution/params.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/params.rs
@@ -198,6 +198,7 @@ impl<'tc> ResolutionPass<'tc> {
             match param_id {
                 Some(param_id) => {
                     // Remember the params ID to return at the end
+                    self.scoping().add_param_binding(param_id);
                     params_id = Some(param_id.0);
                 }
                 None => {

--- a/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
@@ -3,23 +3,26 @@ use std::{collections::HashMap, fmt};
 
 use hash_ast::ast;
 use hash_source::{identifier::Identifier, location::Span};
-use hash_tir::new::{
-    data::DataDefId,
-    environment::{
-        context::ScopeKind,
-        env::{AccessToEnv, Env},
+use hash_tir::{
+    new::{
+        data::DataDefId,
+        environment::{
+            context::ScopeKind,
+            env::{AccessToEnv, Env},
+        },
+        fns::FnTy,
+        locations::LocationTarget,
+        mods::ModDefId,
+        params::ParamId,
+        scopes::{StackId, StackIndices, StackMemberId},
+        symbols::Symbol,
+        utils::{common::CommonUtils, AccessToUtils},
     },
-    fns::FnDefId,
-    locations::LocationTarget,
-    mods::ModDefId,
-    scopes::{StackId, StackIndices, StackMemberId},
-    symbols::Symbol,
-    tys::TyId,
-    utils::{common::CommonUtils, AccessToUtils},
+    ty_as_variant,
 };
 use hash_utils::{
     state::HeavyState,
-    store::{CloneStore, Store},
+    store::{CloneStore, SequenceStore, SequenceStoreKey, Store},
 };
 
 use super::paths::NonTerminalResolvedPathComponent;
@@ -136,32 +139,16 @@ impl<'tc> Scoping<'tc> {
     }
 
     /// Run a function in a new scope, and then exit the scope.
-    ///
-    /// In addition to adding the appropriate bindings, this also adds the
-    /// appropriate names to `bindings_by_name`.
     pub(super) fn enter_scope<T>(
         &self,
         kind: ScopeKind,
         context_kind: ContextKind,
         f: impl FnOnce() -> T,
     ) -> T {
-        self.context_utils().enter_scope(kind, || {
+        self.context().enter_scope(kind, || {
             self.bindings_by_name.enter(
                 |b| {
-                    // Populate the map with all the bindings in the current
-                    // scope. Any duplicate names will be shadowed by the last entry.
-                    let mut map = HashMap::new();
-                    self.context().for_bindings_of_scope(
-                        self.context().get_current_scope_index(),
-                        |binding| {
-                            let symbol_data = self.stores().symbol().get(binding.name);
-                            if let Some(name) = symbol_data.name {
-                                map.insert(name, binding.name);
-                            }
-                        },
-                    );
-
-                    b.push((context_kind, map));
+                    b.push((context_kind, HashMap::new()));
                 },
                 |b| {
                     // Exit the scope on the context exit.
@@ -174,21 +161,22 @@ impl<'tc> Scoping<'tc> {
 
     /// Add a new scope
     pub(super) fn add_scope(&self, kind: ScopeKind, context_kind: ContextKind) {
-        self.context_utils().add_scope(kind);
-
+        self.context().add_scope(kind);
         let mut b = self.bindings_by_name.get_mut();
+        // Initialise the name map. Any duplicate names will be shadowed by the last
+        // entry.
+        b.push((context_kind, HashMap::new()));
+    }
 
-        // Populate the map with all the bindings in the current
-        // scope. Any duplicate names will be shadowed by the last entry.
-        let mut map = HashMap::new();
-        self.context().for_bindings_of_scope(self.context().get_current_scope_index(), |binding| {
-            let symbol_data = self.stores().symbol().get(binding.name);
-            if let Some(name) = symbol_data.name {
-                map.insert(name, binding.name);
-            }
-        });
+    /// Add a parameter to the current scope, also adding it to the
+    /// `bindings_by_name` map.
+    pub(super) fn add_param_binding(&self, param_id: ParamId) {
+        // Get the data of the parameter.
+        let param_name = self.stores().params().get_element(param_id).name;
 
-        b.push((context_kind, map));
+        // Add the binding to the current scope.
+        self.context_utils().add_param_binding(param_id);
+        self.add_named_binding(param_name);
     }
 
     /// Add a stack member to the current scope, also adding it to the
@@ -197,16 +185,39 @@ impl<'tc> Scoping<'tc> {
         // Get the data of the member.
         let member_name =
             self.stores().stack().map_fast(member_id.0, |stack| stack.members[member_id.1].name);
-        let member_name_data = self.stores().symbol().get(member_name);
-
         // Add the binding to the current scope.
         self.context_utils().add_stack_binding(member_id);
+        self.add_named_binding(member_name);
+    }
+
+    /// Add the data parameters constructors of the definition to the current
+    /// scope, also adding them to the `bindings_by_name` map.
+    pub(super) fn add_data_params_and_ctors(&self, data_def_id: DataDefId) {
+        let params = self.stores().data_def().map_fast(data_def_id, |def| def.params);
+        for i in params.to_index_range() {
+            self.add_param_binding((params, i));
+        }
+        self.context_utils()
+            .add_data_ctors(data_def_id, |binding| self.add_named_binding(binding.name));
+    }
+
+    /// Add the module members of the definition to the current scope,
+    /// also adding them to the `bindings_by_name` map.
+    pub(super) fn add_mod_members(&self, mod_def_id: ModDefId) {
+        self.context_utils()
+            .add_mod_members(mod_def_id, |binding| self.add_named_binding(binding.name));
+    }
+
+    /// Add a named binding to the current scope, by recording its identifier
+    /// name.
+    fn add_named_binding(&self, name: Symbol) {
+        let name_data = self.stores().symbol().get(name);
 
         // Add the binding to the `bindings_by_name` map.
-        if let Some(name) = member_name_data.name {
+        if let Some(ident_name) = name_data.name {
             match self.bindings_by_name.get_mut().last_mut() {
                 Some(bindings) => {
-                    bindings.1.insert(name, member_name);
+                    bindings.1.insert(ident_name, name);
                 }
                 None => panic!("No bindings_by_name map for current scope!"),
             }
@@ -283,66 +294,6 @@ impl<'tc> Scoping<'tc> {
         }
     }
 
-    /// Enter the scope of a module.
-    pub(super) fn _enter_module<T>(
-        &self,
-        node: ast::AstNodeRef<ast::Module>,
-        f: impl FnOnce(ModDefId) -> T,
-    ) -> T {
-        let mod_def_id = self.ast_info().mod_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Mod(mod_def_id), ContextKind::Environment, || f(mod_def_id))
-    }
-
-    /// Enter the scope of a module block.
-    pub(super) fn _enter_mod_def<T>(
-        &self,
-        node: ast::AstNodeRef<ast::ModDef>,
-        f: impl FnOnce(ModDefId) -> T,
-    ) -> T {
-        let mod_def_id = self.ast_info().mod_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Mod(mod_def_id), ContextKind::Environment, || f(mod_def_id))
-    }
-
-    /// Enter the scope of a function definition.
-    pub(super) fn _enter_struct_def<T>(
-        &self,
-        node: ast::AstNodeRef<ast::StructDef>,
-        f: impl FnOnce(DataDefId) -> T,
-    ) -> T {
-        let data_def_id = self.ast_info().data_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Data(data_def_id), ContextKind::Environment, || f(data_def_id))
-    }
-
-    /// Enter the scope of an enum definition.
-    pub(super) fn _enter_enum_def<T>(
-        &self,
-        node: ast::AstNodeRef<ast::EnumDef>,
-        f: impl FnOnce(DataDefId) -> T,
-    ) -> T {
-        let data_def_id = self.ast_info().data_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Data(data_def_id), ContextKind::Environment, || f(data_def_id))
-    }
-
-    /// Enter the scope of a function definition.
-    pub(super) fn _enter_fn_def<T>(
-        &self,
-        node: ast::AstNodeRef<ast::FnDef>,
-        f: impl FnOnce(FnDefId) -> T,
-    ) -> T {
-        let fn_def_id = self.ast_info().fn_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Fn(fn_def_id), ContextKind::Environment, || f(fn_def_id))
-    }
-
-    /// Enter the scope of a type function definition.
-    pub(super) fn _enter_ty_fn_def<T>(
-        &self,
-        node: ast::AstNodeRef<ast::TyFnDef>,
-        f: impl FnOnce(FnDefId) -> T,
-    ) -> T {
-        let fn_def_id = self.ast_info().fn_defs().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::Fn(fn_def_id), ContextKind::Environment, || f(fn_def_id))
-    }
-
     /// Enter the scope of a body block.
     ///
     /// If called on a non-stack body block, it will return none.
@@ -360,20 +311,22 @@ impl<'tc> Scoping<'tc> {
     pub(super) fn enter_ty_fn_ty<T>(
         &self,
         node: ast::AstNodeRef<ast::TyFn>,
-        f: impl FnOnce(TyId) -> T,
+        f: impl FnOnce(FnTy) -> T,
     ) -> T {
         let fn_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::FnTy(fn_ty_id), ContextKind::Environment, || f(fn_ty_id))
+        let fn_ty = ty_as_variant!(self, self.get_ty(fn_ty_id), Fn);
+        self.enter_scope(ScopeKind::FnTy(fn_ty), ContextKind::Environment, || f(fn_ty))
     }
 
     /// Enter the scope of a function type
     pub(super) fn enter_fn_ty<T>(
         &self,
         node: ast::AstNodeRef<ast::FnTy>,
-        f: impl FnOnce(TyId) -> T,
+        f: impl FnOnce(FnTy) -> T,
     ) -> T {
         let fn_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
-        self.enter_scope(ScopeKind::FnTy(fn_ty_id), ContextKind::Environment, || f(fn_ty_id))
+        let fn_ty = ty_as_variant!(self, self.get_ty(fn_ty_id), Fn);
+        self.enter_scope(ScopeKind::FnTy(fn_ty), ContextKind::Environment, || f(fn_ty))
     }
 
     /// Register a declaration, which will add it to the current stack scope.

--- a/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
@@ -16,6 +16,7 @@ use hash_tir::{
         params::ParamId,
         scopes::{StackId, StackIndices, StackMemberId},
         symbols::Symbol,
+        tuples::TupleTy,
         utils::{common::CommonUtils, AccessToUtils},
     },
     ty_as_variant,
@@ -327,6 +328,17 @@ impl<'tc> Scoping<'tc> {
         let fn_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
         let fn_ty = ty_as_variant!(self, self.get_ty(fn_ty_id), Fn);
         self.enter_scope(ScopeKind::FnTy(fn_ty), ContextKind::Environment, || f(fn_ty))
+    }
+
+    /// Enter the scope of a tuple type
+    pub(super) fn enter_tuple_ty<T>(
+        &self,
+        node: ast::AstNodeRef<ast::TupleTy>,
+        f: impl FnOnce(TupleTy) -> T,
+    ) -> T {
+        let tuple_ty_id = self.ast_info().tys().get_data_by_node(node.id()).unwrap();
+        let tuple_ty = ty_as_variant!(self, self.get_ty(tuple_ty_id), Tuple);
+        self.enter_scope(ScopeKind::TupleTy(tuple_ty), ContextKind::Environment, || f(tuple_ty))
     }
 
     /// Register a declaration, which will add it to the current stack scope.

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -18,7 +18,6 @@ use hash_tir::new::{
     params::{ParamData, ParamIndex, ParamsId},
     refs::{RefKind, RefTy},
     terms::Term,
-    tuples::TupleTy,
     tys::{Ty, TyId},
     utils::{common::CommonUtils, AccessToUtils},
 };
@@ -256,9 +255,10 @@ impl<'tc> ResolutionPass<'tc> {
 
     /// Make a type from the given [`ast::TupleTy`].
     fn make_ty_from_ast_tuple_ty(&self, node: AstNodeRef<ast::TupleTy>) -> SemanticResult<TyId> {
-        // @@Todo: traverse parameters of tuple types in discovery
-        let data = self.make_params_from_ast_ty_args(&node.entries)?;
-        Ok(self.new_ty(Ty::Tuple(TupleTy { data })))
+        self.scoping().enter_tuple_ty(node, |mut tuple_ty| {
+            tuple_ty.data = self.make_params_from_ast_ty_args(&node.entries)?;
+            Ok(self.new_ty(tuple_ty))
+        })
     }
 
     /// Make a type from the given [`ast::ListTy`].

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -10,22 +10,18 @@ use hash_ast::ast::{self, AstNodeRef, AstNodes};
 use hash_intrinsics::primitives::AccessToPrimitives;
 use hash_reporting::macros::panic_on_span;
 use hash_source::{identifier::IDENTS, location::Span};
-use hash_tir::{
-    new::{
-        args::{ArgData, ArgsId},
-        data::DataTy,
-        environment::env::AccessToEnv,
-        fns::FnCallTerm,
-        params::{ParamData, ParamIndex, ParamsId},
-        refs::{RefKind, RefTy},
-        terms::Term,
-        tuples::TupleTy,
-        tys::{Ty, TyId},
-        utils::{common::CommonUtils, AccessToUtils},
-    },
-    ty_as_variant,
+use hash_tir::new::{
+    args::{ArgData, ArgsId},
+    data::DataTy,
+    environment::env::AccessToEnv,
+    fns::FnCallTerm,
+    params::{ParamData, ParamIndex, ParamsId},
+    refs::{RefKind, RefTy},
+    terms::Term,
+    tuples::TupleTy,
+    tys::{Ty, TyId},
+    utils::{common::CommonUtils, AccessToUtils},
 };
-use hash_utils::store::CloneStore;
 use itertools::Itertools;
 
 use super::{
@@ -54,6 +50,7 @@ impl<'tc> ResolutionPass<'tc> {
             .iter()
             .enumerate()
             .map(|(i, arg)| {
+                // @@Todo: add to ctx if named
                 Ok(ArgData {
                     target: arg
                         .name
@@ -306,26 +303,23 @@ impl<'tc> ResolutionPass<'tc> {
     ) -> SemanticResult<TyId> {
         // First, make the params
         let params = self.try_or_add_error(self.resolve_params_from_ast_params(&node.params, true));
-        self.scoping().enter_ty_fn_ty(node, |ty_fn_id| {
-            self.stores().ty().modify(ty_fn_id, |ty| {
-                let ty_fn = ty_as_variant!(self, ty, Fn);
-                // Add the params if they exist
-                if let Some(params) = params {
-                    ty_fn.params = params;
-                }
+        self.scoping().enter_ty_fn_ty(node, |mut ty_fn| {
+            // Add the params if they exist
+            if let Some(params) = params {
+                ty_fn.params = params;
+            }
 
-                // Make the return type if it exists
-                let return_ty =
-                    self.try_or_add_error(self.make_ty_from_ast_ty(node.return_ty.ast_ref()));
-                if let Some(return_ty) = return_ty {
-                    ty_fn.return_ty = return_ty;
-                }
+            // Make the return type if it exists
+            let return_ty =
+                self.try_or_add_error(self.make_ty_from_ast_ty(node.return_ty.ast_ref()));
+            if let Some(return_ty) = return_ty {
+                ty_fn.return_ty = return_ty;
+            }
 
-                match (params, return_ty) {
-                    (Some(_params), Some(_return_ty)) => Ok(ty_fn_id),
-                    _ => Err(SemanticError::Signal),
-                }
-            })
+            match (params, return_ty) {
+                (Some(_params), Some(_return_ty)) => Ok(self.new_ty(ty_fn)),
+                _ => Err(SemanticError::Signal),
+            }
         })
     }
 
@@ -336,26 +330,23 @@ impl<'tc> ResolutionPass<'tc> {
     ) -> SemanticResult<TyId> {
         // First, make the params
         let params = self.try_or_add_error(self.make_params_from_ast_ty_args(&node.params));
-        self.scoping().enter_fn_ty(node, |fn_ty_id| {
-            self.stores().ty().modify(fn_ty_id, |ty| {
-                let fn_ty = ty_as_variant!(self, ty, Fn);
-                // Add the params if they exist
-                if let Some(params) = params {
-                    fn_ty.params = params;
-                }
+        self.scoping().enter_fn_ty(node, |mut fn_ty| {
+            // Add the params if they exist
+            if let Some(params) = params {
+                fn_ty.params = params;
+            }
 
-                // Make the return type if it exists
-                let return_ty =
-                    self.try_or_add_error(self.make_ty_from_ast_ty(node.return_ty.ast_ref()));
-                if let Some(return_ty) = return_ty {
-                    fn_ty.return_ty = return_ty;
-                }
+            // Make the return type if it exists
+            let return_ty =
+                self.try_or_add_error(self.make_ty_from_ast_ty(node.return_ty.ast_ref()));
+            if let Some(return_ty) = return_ty {
+                fn_ty.return_ty = return_ty;
+            }
 
-                match (params, return_ty) {
-                    (Some(_params), Some(_return_ty)) => Ok(fn_ty_id),
-                    _ => Err(SemanticError::Signal),
-                }
-            })
+            match (params, return_ty) {
+                (Some(_params), Some(_return_ty)) => Ok(self.new_ty(fn_ty)),
+                _ => Err(SemanticError::Signal),
+            }
         })
     }
 

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -15,7 +15,6 @@ use crate::{
     new::{
         data::{CtorDefId, DataDefId},
         fns::FnDefId,
-        holes::{Hole, HoleBinderKind},
         mods::{ModDefId, ModMemberId},
         params::ParamIndex,
         scopes::{StackId, StackMemberId},
@@ -68,10 +67,6 @@ pub enum BoundVarOrigin {
     ///
     /// For example, `a` in `{ a := 3; a }`
     StackMember(StackMemberId),
-    /// Hole binder
-    ///
-    /// For example `?a:B.a`
-    Hole(Hole, HoleBinderKind),
 }
 
 /// A binding.
@@ -101,8 +96,6 @@ pub enum ScopeKind {
     ///
     /// The inner type points to an `FnTy` variant.
     FnTy(TyId),
-    /// A hole scope.
-    Hole(Hole, HoleBinderKind),
 }
 
 /// Information about a scope in the context.
@@ -322,9 +315,6 @@ impl fmt::Display for WithEnv<'_, &BoundVarOrigin> {
             BoundVarOrigin::StackMember(stack_member) => {
                 write!(f, "{}", self.env().with(*stack_member))
             }
-            BoundVarOrigin::Hole(hole, hole_kind) => {
-                write!(f, "{}", self.env().with((*hole, *hole_kind)))
-            }
         }
     }
 }
@@ -376,9 +366,6 @@ impl fmt::Display for WithEnv<'_, ScopeKind> {
                 .stores()
                 .ty()
                 .map_fast(fn_ty, |fn_ty| write!(f, "fn ty {}", self.env().with(fn_ty),)),
-            ScopeKind::Hole(hole, hole_kind) => {
-                write!(f, "hole {}", self.env().with((hole, hole_kind)))
-            }
         }
     }
 }

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -12,13 +12,13 @@ use indexmap::IndexMap;
 
 use super::env::{AccessToEnv, WithEnv};
 use crate::new::{
-    data::{CtorDefId, CtorTerm, DataDefId, DataTy},
+    data::{CtorDefId, DataDefId},
     fns::{FnDefId, FnTy},
     mods::{ModDefId, ModMemberId},
     params::ParamId,
     scopes::{StackId, StackMemberId},
     symbols::Symbol,
-    tuples::{TupleTerm, TupleTy},
+    tuples::TupleTy,
 };
 /// The kind of a binding.
 #[derive(Debug, Clone, Copy)]
@@ -66,19 +66,10 @@ pub enum ScopeKind {
     Data(DataDefId),
     /// A constructor definition.
     Ctor(CtorDefId),
-
     /// A function type scope.
-    ///
-    /// The inner type points to an `FnTy` variant.
     FnTy(FnTy),
     /// A tuple type scope.
     TupleTy(TupleTy),
-    /// A data type arguments scope.
-    DataTy(DataTy),
-    /// A constructor term scope
-    CtorTerm(CtorTerm),
-    /// A tuple term scope.
-    TupleTerm(TupleTerm),
 }
 
 /// Information about a scope in the context.
@@ -315,13 +306,6 @@ impl fmt::Display for WithEnv<'_, ScopeKind> {
             ),
             ScopeKind::FnTy(fn_ty) => write!(f, "fn ty {}", self.env().with(&fn_ty)),
             ScopeKind::TupleTy(tuple_ty) => write!(f, "tuple ty {}", self.env().with(&tuple_ty)),
-            ScopeKind::DataTy(data_ty) => write!(f, "data ty {}", self.env().with(&data_ty)),
-            ScopeKind::CtorTerm(ctor_term) => {
-                write!(f, "ctor term {}", self.env().with(&ctor_term))
-            }
-            ScopeKind::TupleTerm(tuple_term) => {
-                write!(f, "tuple term {}", self.env().with(&tuple_term))
-            }
         }
     }
 }

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -5,15 +5,15 @@ use hash_utils::store::{SequenceStore, Store};
 use crate::{
     impl_access_to_env,
     new::{
-        data::DataDefCtors,
+        data::{DataDefCtors, DataDefId},
         environment::{
-            context::{Binding, BindingKind, BoundVarOrigin, ScopeKind},
+            context::{Binding, BindingKind, ScopeKind},
             env::{AccessToEnv, Env},
         },
-        params::{ParamId, ParamsId},
+        mods::ModDefId,
+        params::ParamId,
         scopes::{DeclTerm, StackMemberId},
     },
-    ty_as_variant,
 };
 
 /// Context-related utilities.
@@ -25,31 +25,14 @@ pub struct ContextUtils<'env> {
 impl_access_to_env!(ContextUtils<'tc>);
 
 impl<'env> ContextUtils<'env> {
-    /// Enter a new scope, and add all the appropriate bindings to it depending
-    /// on the scope kind.
+    /// Add a parameter binding
     ///
-    /// This will add all the scope bindings to the context for the duration of
-    /// the closure, unless the scope is a stack scope, in which case the
-    /// bindings should be added to the context using
-    /// [`ContextOps::add_stack_binding()`].
-    pub fn enter_scope<T>(&self, kind: ScopeKind, f: impl FnOnce() -> T) -> T {
-        let result = self.context().enter_scope(kind, || {
-            self.add_bindings_from_scope_kind(kind);
-            f()
-        });
-        result
-    }
-
-    /// Add the given scope to the context.
-    ///
-    /// This will add all the scope bindings to the context, and the scope
-    /// should be manually exited using [`Context::remove_scope()`] if
-    /// necessary.
-    ///
-    /// Prefer `enter_scope` if possible.
-    pub fn add_scope(&self, kind: ScopeKind) {
-        self.context().add_scope(kind);
-        self.add_bindings_from_scope_kind(kind);
+    /// This should be used when entering a scope that has parameters. Ensure
+    /// that the given parameter belongs to the current scope.
+    pub fn add_param_binding(&self, param_id: ParamId) {
+        // @@Safety: Maybe we should check that the param belongs to the current scope?
+        let name = self.stores().params().map_fast(param_id.0, |params| params[param_id.1].name);
+        self.context().add_binding(Binding { name, kind: BindingKind::Param(param_id) });
     }
 
     /// Add a new stack binding to the current scope context.
@@ -66,10 +49,8 @@ impl<'env> ContextUtils<'env> {
                     .stores()
                     .stack()
                     .map_fast(stack_id, |stack| stack.members[member_id.1].name);
-                self.context().add_binding(Binding {
-                    name,
-                    kind: BindingKind::BoundVar(BoundVarOrigin::StackMember(member_id)),
-                })
+                self.context()
+                    .add_binding(Binding { name, kind: BindingKind::StackMember(member_id) })
             }
             _ => panic!("add_stack_binding called in non-stack scope"),
         }
@@ -79,7 +60,7 @@ impl<'env> ContextUtils<'env> {
     ///
     /// This will add all the stack bindings of the declaration to the context
     /// using `add_stack_binding`.
-    pub fn add_decl_term_to_context(&self, decl: &DeclTerm) {
+    pub fn add_from_decl_term(&self, decl: &DeclTerm) {
         let current_stack_id = match self.context().get_current_scope().kind {
             ScopeKind::Stack(stack_id) => stack_id,
             _ => unreachable!(), // decls are only allowed in stack scopes
@@ -89,89 +70,49 @@ impl<'env> ContextUtils<'env> {
         }
     }
 
-    /// Add the given set of parameters to the context as bound variables.
+    /// Add the data constructors of the given data definition to the context.
     ///
-    /// The `bound_var_origin_from_param` function is used to determine the
-    /// origin of the bound variable, based on the parameter.
-    fn add_params_to_context(
-        &self,
-        params_id: ParamsId,
-        bound_var_origin_from_param: impl Fn(ParamId) -> BoundVarOrigin,
-    ) {
-        self.stores().params().map_fast(params_id, |params| {
-            for param in params.iter() {
-                self.context().add_binding(Binding {
-                    name: param.name,
-                    kind: BindingKind::BoundVar(bound_var_origin_from_param(param.id)),
-                });
+    /// Must be in the scope of the given data definition.
+    /// Assumes that the data definition's parameters have already been added.
+    pub fn add_data_ctors(&self, data_def_id: DataDefId, f: impl Fn(Binding)) {
+        // @@Safety: Maybe we should check that we are in this data def?
+        self.stores().data_def().map_fast(data_def_id, |data_def| {
+            // Add all the constructors
+            match data_def.ctors {
+                DataDefCtors::Defined(ctors) => {
+                    self.stores().ctor_defs().map_fast(ctors, |ctors| {
+                        for ctor in ctors.iter() {
+                            let binding = Binding {
+                                name: ctor.name,
+                                kind: BindingKind::Ctor(data_def_id, ctor.id),
+                            };
+                            self.context().add_binding(binding);
+                            f(binding);
+                        }
+                    })
+                }
+                DataDefCtors::Primitive(_) => {
+                    // No-op
+                }
             }
         })
     }
 
-    /// Add all the scope bindings corresponding to the given scope kind to the
-    /// context, unless the scope is a stack scope.
-    fn add_bindings_from_scope_kind(&self, kind: ScopeKind) {
-        match kind {
-            ScopeKind::Stack(_) => {
-                // Here we don't add anything because the stack bindings are
-                // added manually.
-            }
-            ScopeKind::Mod(mod_def_id) => {
-                self.stores().mod_def().map_fast(mod_def_id, |mod_def| {
-                    // Add all the module bindings
-                    self.stores().mod_members().map_fast(mod_def.members, |members| {
-                        for member in members.iter() {
-                            self.context().add_binding(Binding {
-                                name: member.name,
-                                kind: BindingKind::ModMember(mod_def_id, member.id),
-                            });
-                        }
-                    })
-                })
-            }
-            ScopeKind::Fn(fn_def_id) => {
-                self.stores().fn_def().map_fast(fn_def_id, |fn_def| {
-                    // Add all the parameters
-                    self.add_params_to_context(fn_def.ty.params, |param_id| {
-                        BoundVarOrigin::Fn(fn_def_id, param_id.into())
-                    })
-                })
-            }
-            ScopeKind::Data(data_def_id) => {
-                self.stores().data_def().map_fast(data_def_id, |data_def| {
-                    // Add all the parameters
-                    self.add_params_to_context(data_def.params, |param_id| {
-                        BoundVarOrigin::Data(data_def_id, param_id.into())
-                    });
-
-                    // Add all the constructors
-                    match data_def.ctors {
-                        DataDefCtors::Defined(ctors) => {
-                            self.stores().ctor_defs().map_fast(ctors, |ctors| {
-                                for ctor in ctors.iter() {
-                                    self.context().add_binding(Binding {
-                                        name: ctor.name,
-                                        kind: BindingKind::Ctor(data_def_id, ctor.id),
-                                    });
-                                }
-                            })
-                        }
-                        DataDefCtors::Primitive(_) => {
-                            // No-op
-                        }
-                    }
-                })
-            }
-            ScopeKind::FnTy(fn_ty_id) => {
-                // Add all the parameters
-                let fn_ty = self
-                    .stores()
-                    .ty()
-                    .map_fast(fn_ty_id, |fn_ty_val| ty_as_variant!(self, { *fn_ty_val }, Fn));
-                self.add_params_to_context(fn_ty.params, |param_id| {
-                    BoundVarOrigin::FnTy(fn_ty_id, param_id.into())
-                })
-            }
-        }
+    /// Add the module's members to the context.
+    ///
+    /// Must be in the scope of the given module.
+    pub fn add_mod_members(&self, mod_def_id: ModDefId, f: impl Fn(Binding)) {
+        self.stores().mod_def().map_fast(mod_def_id, |mod_def| {
+            self.stores().mod_members().map_fast(mod_def.members, |members| {
+                for member in members.iter() {
+                    let binding = Binding {
+                        name: member.name,
+                        kind: BindingKind::ModMember(mod_def_id, member.id),
+                    };
+                    self.context().add_binding(binding);
+                    f(binding);
+                }
+            })
+        })
     }
 }

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -116,13 +116,6 @@ impl<'env> ContextUtils<'env> {
                 // Here we don't add anything because the stack bindings are
                 // added manually.
             }
-            ScopeKind::Hole(hole, hole_kind) => {
-                // Add the hole
-                self.context().add_binding(Binding {
-                    name: hole.0,
-                    kind: BindingKind::BoundVar(BoundVarOrigin::Hole(hole, hole_kind)),
-                })
-            }
             ScopeKind::Mod(mod_def_id) => {
                 self.stores().mod_def().map_fast(mod_def_id, |mod_def| {
                     // Add all the module bindings

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -139,7 +139,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             match infer_item(*term) {
                 Ok(ty) => {
                     match self.unification_ops().unify_tys(ty, current_ty) {
-                        Ok(Uni { sub }) => {
+                        Ok(Uni { sub, .. }) => {
                             // Unification succeeded
                             self.substitution_ops().apply_sub_to_ty_in_place(current_ty, &sub);
                         }
@@ -149,7 +149,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                         Err(err) => {
                             // Error in unification, try to unify the other way
                             match self.unification_ops().unify_tys(current_ty, ty) {
-                                Ok(Uni { sub }) => {
+                                Ok(Uni { sub, .. }) => {
                                     // Unification succeeded the other way, so use this
                                     // type as a target
                                     current_ty = ty;
@@ -204,7 +204,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     pub fn check_by_unify(&self, inferred_ty: TyId, annotation_ty: Option<TyId>) -> TcResult<TyId> {
         match annotation_ty {
             Some(annotation_ty) => {
-                let Uni { sub } = self.unification_ops().unify_tys(inferred_ty, annotation_ty)?;
+                let Uni { sub, .. } =
+                    self.unification_ops().unify_tys(inferred_ty, annotation_ty)?;
                 self.substitution_ops().apply_sub_to_ty_in_place(annotation_ty, &sub);
                 Ok(annotation_ty)
             }
@@ -359,7 +360,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
                 // Unify the parameters of the function call with the parameters of the
                 // function type.
-                let Uni { sub } =
+                let Uni { sub, .. } =
                     self.unification_ops().unify_params(inferred_fn_call_params, fn_ty.params)?;
                 // Apply the substitution to the arguments.
                 self.substitution_ops().apply_sub_to_args_in_place(fn_call_term.args, &sub);
@@ -404,7 +405,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     let inferred_return_ty = self.infer_term(fn_body, None)?.1;
 
                     // Unify the inferred return type with the declared return type.
-                    let Uni { sub } = self
+                    let Uni { sub, .. } = self
                         .unification_ops()
                         .unify_tys(inferred_return_ty, fn_def.ty.return_ty)?;
 
@@ -536,7 +537,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 // Unified the inferred parameters with the declared parameters.
                 let data_ty_params =
                     self.stores().data_def().map_fast(data_ty.data_def, |data_def| data_def.params);
-                let Uni { sub } =
+                let Uni { sub, .. } =
                     self.unification_ops().unify_params(inferred_def_params, data_ty_params)?;
 
                 // Apply the substitution to the arguments.
@@ -646,7 +647,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         annotation_ty: Option<TyId>,
     ) -> TcResult<(CastTerm, TyId)> {
         let inferred_term_ty = self.infer_term(cast_term.subject_term, None)?.1;
-        let Uni { sub } =
+        let Uni { sub, .. } =
             self.unification_ops().unify_tys(inferred_term_ty, cast_term.target_ty)?;
         let subbed_target = self.substitution_ops().apply_sub_to_ty(cast_term.target_ty, &sub);
 
@@ -784,7 +785,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Pat::Range(range_pat) => {
                 let start = self.infer_lit(&range_pat.start.into(), annotation_ty)?.1;
                 let end = self.infer_lit(&range_pat.end.into(), annotation_ty)?.1;
-                let Uni { sub } = self.unification_ops().unify_tys(start, end)?;
+                let Uni { sub, .. } = self.unification_ops().unify_tys(start, end)?;
                 assert!(sub.is_empty()); // @@Todo: specialised unification for no sub
                 self.substitution_ops().apply_sub_to_ty(start, &sub)
             }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -460,10 +460,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     .stores()
                     .stack()
                     .map_fast(stack_member_id.0, |stack| stack.members[stack_member_id.1].ty)),
-                BoundVarOrigin::Hole(_, hole_kind) => match hole_kind {
-                    HoleBinderKind::Hole(ty_id) => Ok(ty_id),
-                    HoleBinderKind::Guess(term_id, _) => Ok(self.infer_term(term_id, None)?.1), /* @@Todo: unify with guess type? */
-                },
             },
         }
     }


### PR DESCRIPTION
This PR adds the ability to resolve tuples like `(T: Type, t: T)`. This also works for constructor parameters, data parameters, and function parameters.

Closes #758 