### PR TITLE
Add an equality judgement

### DIFF
--- a/compiler/hash-semantics/src/new/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/paths.rs
@@ -287,7 +287,10 @@ impl<'tc> ResolutionPass<'tc> {
                                 }
                             }
                         }
-                        NonTerminalResolvedPathComponent::Mod(_) => unreachable!(), /* Can never have a constructor starting from a module */
+
+                        NonTerminalResolvedPathComponent::Mod(_) => {
+                            unreachable!("Can never have a constructor starting from a module")
+                        }
                     },
                     None => todo!(),
                 }
@@ -310,6 +313,9 @@ impl<'tc> ResolutionPass<'tc> {
                         ))
                     }
                 }
+            }
+            BindingKind::Equality(_) => {
+                unreachable!("No equality judgements should be present during resolution")
             }
         }
     }

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -2,17 +2,19 @@
 use derive_more::Constructor;
 use hash_utils::store::{SequenceStore, Store};
 
+use super::common::CommonUtils;
 use crate::{
     impl_access_to_env,
     new::{
         data::{DataDefCtors, DataDefId},
         environment::{
-            context::{Binding, BindingKind, ScopeKind},
+            context::{Binding, BindingKind, EqualityJudgement, ScopeKind},
             env::{AccessToEnv, Env},
         },
         mods::ModDefId,
         params::ParamId,
         scopes::{DeclTerm, StackMemberId},
+        terms::TermId,
     },
 };
 
@@ -33,6 +35,14 @@ impl<'env> ContextUtils<'env> {
         // @@Safety: Maybe we should check that the param belongs to the current scope?
         let name = self.stores().params().map_fast(param_id.0, |params| params[param_id.1].name);
         self.context().add_binding(Binding { name, kind: BindingKind::Param(param_id) });
+    }
+
+    /// Add an equality judgement to the context.
+    pub fn add_equality_judgement(&self, lhs: TermId, rhs: TermId) {
+        self.context().add_binding(Binding {
+            name: self.new_fresh_symbol(),
+            kind: BindingKind::Equality(EqualityJudgement { lhs, rhs }),
+        });
     }
 
     /// Add a new stack binding to the current scope context.

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -430,6 +430,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// Infer the type of a variable, and return it.
     pub fn infer_var(&self, term: Symbol) -> TcResult<TyId> {
         match self.context().get_binding(term).unwrap().kind {
+            BindingKind::Equality(_) => {
+                unreachable!("equality judgements cannot be referenced")
+            }
             BindingKind::ModMember(_, _) | BindingKind::Ctor(_, _) => {
                 unreachable!("mod members and ctors should have all been resolved by now")
             }


### PR DESCRIPTION
As a prerequisite to dependent type checking, this PR adds an equality judgement to the context, so that the typechecker can keep track of terms which are equal.

Closes #757 

Merge #759 first.