### PR TITLE
pipeline+codegen= ❤️ | integrate LLVM backend with the pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,6 @@ dependencies = [
  "hash-source",
  "hash-target",
  "hash-utils",
- "index_vec",
 ]
 
 [[package]]
@@ -440,7 +439,6 @@ dependencies = [
  "hash-source",
  "hash-target",
  "hash-utils",
- "index_vec",
  "rayon",
 ]
 
@@ -458,7 +456,6 @@ dependencies = [
  "hash-source",
  "hash-target",
  "hash-utils",
- "index_vec",
  "rayon",
 ]
 
@@ -533,7 +530,6 @@ dependencies = [
  "hash-tir",
  "hash-utils",
  "html-escape",
- "index_vec",
  "smallvec",
 ]
 
@@ -545,7 +541,6 @@ dependencies = [
  "hash-ir",
  "hash-target",
  "hash-utils",
- "index_vec",
 ]
 
 [[package]]
@@ -575,7 +570,6 @@ dependencies = [
  "hash-tir",
  "hash-tree-def",
  "hash-utils",
- "index_vec",
  "indexmap",
  "num-traits",
  "rayon",
@@ -695,7 +689,6 @@ dependencies = [
  "hash-alloc",
  "hash-target",
  "hash-utils",
- "index_vec",
  "lazy_static",
  "num-bigint",
 ]

--- a/compiler/hash-abi/Cargo.toml
+++ b/compiler/hash-abi/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 bitflags = "2.0.0-rc.1"
-index_vec = "0.1.3"
 
 hash-ir = {path = "../hash-ir" }
 hash-layout = {path = "../hash-layout" }

--- a/compiler/hash-backend/Cargo.toml
+++ b/compiler/hash-backend/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 rayon = "1.5.0"
-index_vec = "0.1.3"
 
 hash-codegen = { path = "../hash-codegen" }
 hash-codegen-bytecode = { path = "../hash-codegen-bytecode" }

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -15,13 +15,6 @@ use hash_source::SourceId;
 #[derive(Default)]
 pub struct CodeGenPass;
 
-impl CodeGenPass {
-    /// Creates a new instance of the Hash backend.
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 pub trait BackendCtxQuery: CompilerInterface {
     fn data(&mut self) -> BackendCtx<'_>;
 }
@@ -43,11 +36,9 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
     fn run(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
         let BackendCtx { settings, .. } = ctx.data();
 
-        let llvm_ctx = llvm::context::Context::create();
-
         // Create a new instance of a backend, and then add each bo
         let mut backend = match settings.codegen_settings.backend {
-            CodeGenBackend::LLVM => create_llvm_backend(&llvm_ctx, ctx.data()),
+            CodeGenBackend::LLVM => create_llvm_backend(ctx.data()),
             CodeGenBackend::VM => unimplemented!(),
         };
 
@@ -55,9 +46,7 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
     }
 }
 
-pub fn create_llvm_backend<'b>(
-    ll_ctx: &LLVMContext,
-    ctx: BackendCtx<'b>,
-) -> Box<dyn Backend<'b> + 'b> {
-    Box::new(hash_codegen_llvm::LLVMBackend::new(ll_ctx, ctx))
+/// Create a new instance of the [hash_codegen_llvm::LLVMBackend].
+pub fn create_llvm_backend<'b>(ctx: BackendCtx<'b>) -> Box<dyn Backend<'b> + 'b> {
+    Box::new(hash_codegen_llvm::LLVMBackend::new(ctx))
 }

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -36,13 +36,16 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
     fn run(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
         let BackendCtx { settings, .. } = ctx.data();
 
-        // Create a new instance of a backend, and then add each bo
+        // Create a new instance of a backend, and then run it...
         let mut backend = match settings.codegen_settings.backend {
             CodeGenBackend::LLVM => create_llvm_backend(ctx.data()),
             CodeGenBackend::VM => unimplemented!(),
         };
 
         backend.run()
+
+        // @@Todo: we take all of the produced object files, and then pass
+        // them on to the linking stage.
     }
 }
 

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -43,9 +43,11 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
     fn run(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
         let BackendCtx { settings, .. } = ctx.data();
 
+        let llvm_ctx = llvm::context::Context::create();
+
         // Create a new instance of a backend, and then add each bo
         let mut backend = match settings.codegen_settings.backend {
-            CodeGenBackend::LLVM => create_llvm_backend(ctx.data()),
+            CodeGenBackend::LLVM => create_llvm_backend(&llvm_ctx, ctx.data()),
             CodeGenBackend::VM => unimplemented!(),
         };
 
@@ -53,6 +55,9 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
     }
 }
 
-pub fn create_llvm_backend<'b>(ctx: BackendCtx<'b>) -> Box<dyn Backend<'b> + 'b> {
-    Box::new(hash_codegen_llvm::LLVMBackend::new(ctx))
+pub fn create_llvm_backend<'b>(
+    ll_ctx: &LLVMContext,
+    ctx: BackendCtx<'b>,
+) -> Box<dyn Backend<'b> + 'b> {
+    Box::new(hash_codegen_llvm::LLVMBackend::new(ll_ctx, ctx))
 }

--- a/compiler/hash-codegen-llvm/src/context.rs
+++ b/compiler/hash-codegen-llvm/src/context.rs
@@ -11,17 +11,13 @@ use hash_codegen::{
 };
 use hash_ir::{
     ty::{InstanceId, IrTyId, VariantIdx},
-    IrCtx, IrStorage,
+    IrCtx,
 };
 use hash_pipeline::settings::CompilerSettings;
 use hash_source::constant::InternedStr;
 use hash_target::Target;
 use inkwell as llvm;
-use llvm::{
-    context::ContextRef,
-    types::{AnyTypeEnum, IntType},
-    values::FunctionValue,
-};
+use llvm::values::FunctionValue;
 
 use crate::translation::ty::TyMemoryRemap;
 
@@ -41,7 +37,7 @@ pub struct CodeGenCtx<'b, 'm> {
     pub layouts: &'b LayoutCtx,
 
     /// The LLVM module that we are putting items into.
-    pub module: &'m llvm::module::Module<'m>,
+    pub module: &'b llvm::module::Module<'m>,
 
     /// The LLVM "context" that is used for building and
     /// translating into LLVM IR.
@@ -82,7 +78,7 @@ pub struct CodeGenCtx<'b, 'm> {
 impl<'b, 'm> CodeGenCtx<'b, 'm> {
     /// Create a new [CodeGenCtx].
     pub fn new(
-        module: &'m llvm::module::Module<'m>,
+        module: &'b llvm::module::Module<'m>,
         settings: &'b CompilerSettings,
         ir_ctx: &'b IrCtx,
         layouts: &'b LayoutCtx,

--- a/compiler/hash-codegen-llvm/src/context.rs
+++ b/compiler/hash-codegen-llvm/src/context.rs
@@ -41,7 +41,7 @@ pub struct CodeGenCtx<'b, 'm> {
     pub layouts: &'b LayoutCtx,
 
     /// The LLVM module that we are putting items into.
-    pub module: llvm::module::Module<'m>,
+    pub module: &'m llvm::module::Module<'m>,
 
     /// The LLVM "context" that is used for building and
     /// translating into LLVM IR.
@@ -82,7 +82,7 @@ pub struct CodeGenCtx<'b, 'm> {
 impl<'b, 'm> CodeGenCtx<'b, 'm> {
     /// Create a new [CodeGenCtx].
     pub fn new(
-        module: llvm::module::Module<'m>,
+        module: &'m llvm::module::Module<'m>,
         settings: &'b CompilerSettings,
         ir_ctx: &'b IrCtx,
         layouts: &'b LayoutCtx,

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -1,6 +1,98 @@
-//! The LLVM code generation backend for Hash.
+//! The LLVM code generation backend for Hash. This implements the [Backend]
+//! trait that provides an interface between a code generation backend and the
+//! actual compiler pipeline, the [BackendCtx] trait which provides an interface
+//! between the backend and the compiler context, and the [LLVMBackend] struct
+//! which is the actual implementation of the LLVM backend. It is expected that
+//! the backend performs it's work in the [LLVMBackend::run] method, and saves
+//! the results of each module in the [Workspace].
 #![feature(let_chains, hash_raw_entry)]
+#![allow(unused)]
+
+use std::path::PathBuf;
+
+use hash_codegen::{
+    backend::{Backend, BackendCtx},
+    layout::LayoutCtx,
+};
+use hash_ir::IrStorage;
+use hash_pipeline::{workspace::Workspace, CompilerResult};
+use hash_source::ModuleId;
+use hash_utils::index_vec::IndexVec;
+use inkwell as llvm;
+use llvm::targets::TargetTriple;
+use misc::{CodeModelWrapper, OptimisationLevelWrapper, RelocationModeWrapper};
 
 pub mod context;
 pub mod misc;
 pub mod translation;
+
+pub struct ModuleData<'b> {
+    /// The LLVM module.
+    module: llvm::module::Module<'b>,
+
+    /// The path to the file which contains the module.
+    path: PathBuf,
+}
+
+pub struct LLVMBackend<'b> {
+    /// The current compiler workspace, which is where the results of the
+    /// linking and bytecode emission will be stored.
+    workspace: &'b mut Workspace,
+
+    /// A map which maps a [ModuleId] to it's corresponding [llvm::Module] and
+    /// file paths.
+    modules: IndexVec<ModuleId, ModuleData<'b>>,
+
+    /// The IR storage that is used to store the lowered IR, and all metadata
+    /// about the IR.
+    ir_storage: &'b IrStorage,
+
+    /// All of the information about the layouts of types
+    /// in the current session.
+    layouts: &'b LayoutCtx,
+
+    /// The LLVM context.
+    context: llvm::context::Context,
+
+    /// The target machine that we use to write all of the
+    /// generated code into the object files.
+    target_machine: llvm::targets::TargetMachine,
+}
+
+impl<'b> LLVMBackend<'b> {
+    /// Create a new LLVM Backend from the given [BackendCtx].
+    pub fn new(ctx: BackendCtx<'b>) -> Self {
+        let BackendCtx { workspace, ir_storage, layout_storage: layouts, settings, .. } = ctx;
+
+        // We have to create a target machine from the provided target
+        // data.
+        let target = settings.codegen_settings.target_info.target();
+
+        let llvm_target = llvm::targets::Target::from_name(target.arch.as_str()).unwrap();
+
+        let target_triple = TargetTriple::create(target.name.as_ref());
+        let target_machine = llvm_target
+            .create_target_machine(
+                &target_triple,
+                target.cpu.as_ref(),
+                target.cpu_features.as_ref(),
+                OptimisationLevelWrapper::from(settings.optimisation_level).0,
+                RelocationModeWrapper::from(target.relocation_mode).0,
+                CodeModelWrapper::from(target.code_model).0,
+            )
+            .unwrap();
+
+        let context = llvm::context::Context::create();
+
+        Self { modules: IndexVec::new(), workspace, context, target_machine, ir_storage, layouts }
+    }
+}
+
+impl<'b> Backend<'b> for LLVMBackend<'b> {
+    /// This is the entry point for the LLVM backend, this is where each module
+    /// is translated into an LLVM IR module and is then emitted as a bytecode
+    /// module to the disk.
+    fn run(&mut self) -> CompilerResult<()> {
+        Ok(())
+    }
+}

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -17,6 +17,7 @@ use hash_codegen::{
 use hash_ir::IrStorage;
 use hash_pipeline::{workspace::Workspace, CompilerResult};
 use hash_source::ModuleId;
+use hash_target::TargetArch;
 use hash_utils::index_vec::IndexVec;
 use inkwell as llvm;
 use llvm::targets::TargetTriple;
@@ -67,6 +68,23 @@ impl<'b> LLVMBackend<'b> {
         // We have to create a target machine from the provided target
         // data.
         let target = settings.codegen_settings.target_info.target();
+
+        // we have to initialise the target with the default configuration based
+        // on which architecture we are compiling for.
+        let config = llvm::targets::InitializationConfig::default();
+
+        match target.arch {
+            TargetArch::X86 | TargetArch::X86_64 => {
+                llvm::targets::Target::initialize_x86(&config);
+            }
+            TargetArch::Arm => {
+                llvm::targets::Target::initialize_arm(&config);
+            }
+            TargetArch::Aarch64 => {
+                llvm::targets::Target::initialize_aarch64(&config);
+            }
+            TargetArch::Unknown => unreachable!(),
+        }
 
         let llvm_target = llvm::targets::Target::from_name(target.arch.as_str()).unwrap();
 

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -301,7 +301,9 @@ impl From<OptimisationLevel> for OptimisationLevelWrapper {
 
             // @@Todo: there seems to be no way to specify that we want to optimise for
             // minimal size, i.e. `-Oz` in clang.
-            OptimisationLevel::Size => OptimisationLevelWrapper(Default),
+            OptimisationLevel::Size | OptimisationLevel::MinSize => {
+                OptimisationLevelWrapper(Default)
+            }
         }
     }
 }

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -238,7 +238,7 @@ impl AttributeKind {
     }
 
     /// Create an [Attribute] from an [AttributeKind].
-    pub fn create_attribute(&self, ctx: &CodeGenCtx<'_>) -> Attribute {
+    pub fn create_attribute(&self, ctx: &CodeGenCtx<'_, '_>) -> Attribute {
         // @@Naming: the `create_enum_attribute` will create an attribute
         // with just an integer value, furthermore the value "0" denotes that
         // the attribute is just a flag. This is a really bad design

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -2,7 +2,8 @@
 //! generation types and the LLVM backend specific data types.
 
 use hash_codegen::common::{AtomicOrdering, IntComparisonKind, RealComparisonKind};
-use hash_target::abi::AddressSpace;
+use hash_pipeline::settings::OptimisationLevel;
+use hash_target::{abi::AddressSpace, CodeModel, RelocationMode};
 use inkwell::attributes::Attribute;
 
 use crate::context::CodeGenCtx;
@@ -13,17 +14,19 @@ pub struct IntPredicateWrapper(pub inkwell::IntPredicate);
 
 impl From<IntComparisonKind> for IntPredicateWrapper {
     fn from(value: IntComparisonKind) -> Self {
+        use inkwell::IntPredicate::*;
+
         match value {
-            IntComparisonKind::Eq => Self(inkwell::IntPredicate::EQ),
-            IntComparisonKind::Ne => Self(inkwell::IntPredicate::NE),
-            IntComparisonKind::Ugt => Self(inkwell::IntPredicate::UGT),
-            IntComparisonKind::Uge => Self(inkwell::IntPredicate::UGE),
-            IntComparisonKind::Ult => Self(inkwell::IntPredicate::ULT),
-            IntComparisonKind::Ule => Self(inkwell::IntPredicate::ULE),
-            IntComparisonKind::Sgt => Self(inkwell::IntPredicate::SGT),
-            IntComparisonKind::Sge => Self(inkwell::IntPredicate::SGE),
-            IntComparisonKind::Slt => Self(inkwell::IntPredicate::SLT),
-            IntComparisonKind::Sle => Self(inkwell::IntPredicate::SLE),
+            IntComparisonKind::Eq => Self(EQ),
+            IntComparisonKind::Ne => Self(NE),
+            IntComparisonKind::Ugt => Self(UGT),
+            IntComparisonKind::Uge => Self(UGE),
+            IntComparisonKind::Ult => Self(ULT),
+            IntComparisonKind::Ule => Self(ULE),
+            IntComparisonKind::Sgt => Self(SGT),
+            IntComparisonKind::Sge => Self(SGE),
+            IntComparisonKind::Slt => Self(SLT),
+            IntComparisonKind::Sle => Self(SLE),
         }
     }
 }
@@ -34,23 +37,25 @@ pub struct FloatPredicateWrapper(pub inkwell::FloatPredicate);
 
 impl From<RealComparisonKind> for FloatPredicateWrapper {
     fn from(value: RealComparisonKind) -> Self {
+        use inkwell::FloatPredicate::*;
+
         match value {
-            RealComparisonKind::False => Self(inkwell::FloatPredicate::PredicateFalse),
-            RealComparisonKind::Oeq => Self(inkwell::FloatPredicate::OEQ),
-            RealComparisonKind::Ogt => Self(inkwell::FloatPredicate::OGT),
-            RealComparisonKind::Oge => Self(inkwell::FloatPredicate::OGE),
-            RealComparisonKind::Olt => Self(inkwell::FloatPredicate::OLT),
-            RealComparisonKind::Ole => Self(inkwell::FloatPredicate::OLE),
-            RealComparisonKind::One => Self(inkwell::FloatPredicate::ONE),
-            RealComparisonKind::Ord => Self(inkwell::FloatPredicate::ORD),
-            RealComparisonKind::Uno => Self(inkwell::FloatPredicate::UNO),
-            RealComparisonKind::Ueq => Self(inkwell::FloatPredicate::UEQ),
-            RealComparisonKind::Ugt => Self(inkwell::FloatPredicate::UGT),
-            RealComparisonKind::Uge => Self(inkwell::FloatPredicate::UGE),
-            RealComparisonKind::Ult => Self(inkwell::FloatPredicate::ULT),
-            RealComparisonKind::Ule => Self(inkwell::FloatPredicate::ULE),
-            RealComparisonKind::Une => Self(inkwell::FloatPredicate::UNE),
-            RealComparisonKind::True => Self(inkwell::FloatPredicate::PredicateTrue),
+            RealComparisonKind::False => Self(PredicateFalse),
+            RealComparisonKind::Oeq => Self(OEQ),
+            RealComparisonKind::Ogt => Self(OGT),
+            RealComparisonKind::Oge => Self(OGE),
+            RealComparisonKind::Olt => Self(OLT),
+            RealComparisonKind::Ole => Self(OLE),
+            RealComparisonKind::One => Self(ONE),
+            RealComparisonKind::Ord => Self(ORD),
+            RealComparisonKind::Uno => Self(UNO),
+            RealComparisonKind::Ueq => Self(UEQ),
+            RealComparisonKind::Ugt => Self(UGT),
+            RealComparisonKind::Uge => Self(UGE),
+            RealComparisonKind::Ult => Self(ULT),
+            RealComparisonKind::Ule => Self(ULE),
+            RealComparisonKind::Une => Self(UNE),
+            RealComparisonKind::True => Self(PredicateTrue),
         }
     }
 }
@@ -61,16 +66,16 @@ pub struct AtomicOrderingWrapper(pub inkwell::AtomicOrdering);
 
 impl From<AtomicOrdering> for AtomicOrderingWrapper {
     fn from(value: AtomicOrdering) -> Self {
+        use inkwell::AtomicOrdering::*;
+
         match value {
-            AtomicOrdering::NotAtomic => Self(inkwell::AtomicOrdering::NotAtomic),
-            AtomicOrdering::Unordered => Self(inkwell::AtomicOrdering::Unordered),
-            AtomicOrdering::Monotonic => Self(inkwell::AtomicOrdering::Monotonic),
-            AtomicOrdering::Acquire => Self(inkwell::AtomicOrdering::Acquire),
-            AtomicOrdering::Release => Self(inkwell::AtomicOrdering::Release),
-            AtomicOrdering::AcquireRelease => Self(inkwell::AtomicOrdering::AcquireRelease),
-            AtomicOrdering::SequentiallyConsistent => {
-                Self(inkwell::AtomicOrdering::SequentiallyConsistent)
-            }
+            AtomicOrdering::NotAtomic => Self(NotAtomic),
+            AtomicOrdering::Unordered => Self(Unordered),
+            AtomicOrdering::Monotonic => Self(Monotonic),
+            AtomicOrdering::Acquire => Self(Acquire),
+            AtomicOrdering::Release => Self(Release),
+            AtomicOrdering::AcquireRelease => Self(AcquireRelease),
+            AtomicOrdering::SequentiallyConsistent => Self(SequentiallyConsistent),
         }
     }
 }
@@ -245,7 +250,62 @@ impl AttributeKind {
     }
 }
 
-// get_named_enum_kind_id
+/// A wrapper type to convert the generic [CodeModel] into the
+/// [inkwell::targets::CodeModel] equivalent type.
+
+pub struct CodeModelWrapper(pub inkwell::targets::CodeModel);
+
+impl From<CodeModel> for CodeModelWrapper {
+    fn from(value: CodeModel) -> Self {
+        use inkwell::targets::CodeModel::*;
+
+        match value {
+            CodeModel::Default => CodeModelWrapper(Default),
+            CodeModel::JITDefault => CodeModelWrapper(JITDefault),
+            CodeModel::Small => CodeModelWrapper(Small),
+            CodeModel::Kernel => CodeModelWrapper(Kernel),
+            CodeModel::Medium => CodeModelWrapper(Medium),
+            CodeModel::Large => CodeModelWrapper(Large),
+        }
+    }
+}
+
+/// A wrapper type to convert the generic [RelocationMode] into the
+/// [inkwell::targets::RelocMode] equivalent type.
+pub struct RelocationModeWrapper(pub inkwell::targets::RelocMode);
+
+impl From<RelocationMode> for RelocationModeWrapper {
+    fn from(value: RelocationMode) -> Self {
+        use inkwell::targets::RelocMode::*;
+
+        match value {
+            RelocationMode::Default => RelocationModeWrapper(Default),
+            RelocationMode::Static => RelocationModeWrapper(Static),
+            RelocationMode::PIC => RelocationModeWrapper(PIC),
+            RelocationMode::DynamicNoPIC => RelocationModeWrapper(DynamicNoPic),
+        }
+    }
+}
+
+/// A wrapper type to convert the generic [OptimisationLevel] into the
+/// [inkwell::OptimizationLevel] equivalent type.
+pub struct OptimisationLevelWrapper(pub inkwell::OptimizationLevel);
+
+impl From<OptimisationLevel> for OptimisationLevelWrapper {
+    fn from(value: OptimisationLevel) -> Self {
+        use inkwell::OptimizationLevel::*;
+
+        match value {
+            OptimisationLevel::Debug => OptimisationLevelWrapper(None),
+            OptimisationLevel::Release => OptimisationLevelWrapper(Aggressive),
+
+            // @@Todo: there seems to be no way to specify that we want to optimise for
+            // minimal size, i.e. `-Oz` in clang.
+            OptimisationLevel::Size => OptimisationLevelWrapper(Default),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use inkwell::attributes::Attribute;

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -41,14 +41,14 @@ use crate::misc::{
     AtomicOrderingWrapper, FloatPredicateWrapper, IntPredicateWrapper, MetadataTypeKind,
 };
 
-impl<'b> Builder<'b> {
+impl<'a, 'b, 'm> Builder<'a, 'b, 'm> {
     /// Create a PHI node in the current block.
     fn phi(
         &mut self,
-        ty: AnyTypeEnum<'b>,
-        values: &[&dyn BasicValue<'b>],
-        blocks: &[BasicBlock<'b>],
-    ) -> PhiValue<'b> {
+        ty: AnyTypeEnum<'m>,
+        values: &[&dyn BasicValue<'m>],
+        blocks: &[BasicBlock<'m>],
+    ) -> PhiValue<'m> {
         debug_assert_eq!(values.len(), blocks.len());
 
         // Create the PHI value, and then add all of the incoming values.
@@ -72,12 +72,12 @@ impl<'b> Builder<'b> {
     }
 }
 
-impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
+impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
     fn ctx(&self) -> &Self::CodegenCtx {
         self.ctx
     }
 
-    fn build(ctx: &'b Self::CodegenCtx, block: Self::BasicBlock) -> Self {
+    fn build(ctx: &'a Self::CodegenCtx, block: Self::BasicBlock) -> Self {
         let builder = ctx.ll_ctx.create_builder();
 
         // We need to set the insertion point to the end of the block
@@ -88,7 +88,7 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
     }
 
     fn append_block(
-        ctx: &'b Self::CodegenCtx,
+        ctx: &'a Self::CodegenCtx,
         func: Self::Function,
         name: &str,
     ) -> Self::BasicBlock {
@@ -1092,9 +1092,9 @@ impl<'b> BlockBuilderMethods<'b> for Builder<'b> {
 /// This will apply all of the stored metadata on the [Scalar] to
 /// the value within the LLVM IR. Here, we emit information about the
 /// [ValidScalarRange], alignment metadata and `non-null`ness.
-fn load_scalar_value_metadata<'ll>(
-    builder: &mut Builder<'ll>,
-    load: AnyValueEnum<'ll>,
+fn load_scalar_value_metadata<'m>(
+    builder: &mut Builder<'_, '_, 'm>,
+    load: AnyValueEnum<'m>,
     scalar: Scalar,
     info: TyInfo,
 

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -11,7 +11,7 @@ use inkwell::{module::Linkage, types::BasicTypeEnum, values::AnyValueEnum};
 use super::ty::ExtendedTyBuilderMethods;
 use crate::context::CodeGenCtx;
 
-impl<'b> ConstValueBuilderMethods<'b> for CodeGenCtx<'b> {
+impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
     fn const_undef(&self, ty: Self::Type) -> Self::Value {
         let ty: BasicTypeEnum = ty.try_into().unwrap();
         match ty {
@@ -93,7 +93,7 @@ impl<'b> ConstValueBuilderMethods<'b> for CodeGenCtx<'b> {
             debug_assert!(value < (1 << bit_size));
         }
 
-        self.const_uint(self.size_ty, value)
+        self.const_uint(self.size_ty.into(), value)
     }
 
     fn const_float(&self, ty: Self::Type, val: f64) -> Self::Value {

--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -9,7 +9,7 @@ use hash_source::{identifier::Identifier, location::SourceLocation};
 
 use super::Builder;
 
-impl<'b> BuildDebugInfoMethods for Builder<'b> {
+impl<'b, 'm> BuildDebugInfoMethods for Builder<'_, 'b, 'm> {
     fn create_debug_info_scope_for_fn(
         &self,
         _fn_abi: &FnAbi,

--- a/compiler/hash-codegen-llvm/src/translation/declare.rs
+++ b/compiler/hash-codegen-llvm/src/translation/declare.rs
@@ -10,7 +10,7 @@ use inkwell::{
 use super::abi::ExtendedFnAbiMethods;
 use crate::context::CodeGenCtx;
 
-impl<'b> CodeGenCtx<'b> {
+impl<'b, 'm> CodeGenCtx<'b, 'm> {
     /// Standard function to declare a C-like function. This should only be used
     /// for declaring FFI functions or various LLVM intrinsics.
     ///
@@ -32,8 +32,8 @@ impl<'b> CodeGenCtx<'b> {
         &self,
         name: &str,
         addr: UnnamedAddress,
-        ty: AnyTypeEnum<'b>,
-    ) -> FunctionValue<'b> {
+        ty: AnyTypeEnum<'m>,
+    ) -> FunctionValue<'m> {
         self.declare_fn(
             name,
             ty,
@@ -50,11 +50,11 @@ impl<'b> CodeGenCtx<'b> {
     pub(crate) fn declare_fn(
         &self,
         name: &str,
-        ty: AnyTypeEnum<'b>,
+        ty: AnyTypeEnum<'m>,
         calling_convention: CallingConvention,
         addr: UnnamedAddress,
         visibility: GlobalVisibility,
-    ) -> FunctionValue<'b> {
+    ) -> FunctionValue<'m> {
         let func = if let Some(func) = self.module.get_function(name) {
             func
         } else {
@@ -73,7 +73,7 @@ impl<'b> CodeGenCtx<'b> {
     ///
     /// This will set some sane defaults when declaring the function, and apply
     /// all of the attributes onto the created [FunctionValue].
-    pub(crate) fn declare_hash_fn(&self, name: &str, abi: &FnAbi) -> FunctionValue<'b> {
+    pub(crate) fn declare_hash_fn(&self, name: &str, abi: &FnAbi) -> FunctionValue<'m> {
         let func = self.declare_fn(
             name,
             abi.llvm_ty(self),
@@ -94,8 +94,8 @@ impl<'b> CodeGenCtx<'b> {
     pub(crate) fn declare_global(
         &self,
         name: &str,
-        ty: BasicTypeEnum<'b>,
-    ) -> Option<GlobalValue<'b>> {
+        ty: BasicTypeEnum<'m>,
+    ) -> Option<GlobalValue<'m>> {
         if self.module.get_global(name).is_some() {
             None
         } else {

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -15,12 +15,12 @@ use inkwell::values::{AnyValueEnum, UnnamedAddress};
 
 use super::Builder;
 
-impl<'b> Builder<'b> {
+impl<'b, 'm> Builder<'_, 'b, 'm> {
     /// Call an intrinsic function with the specified arguments.
     pub(crate) fn call_intrinsic(
         &mut self,
         name: &str,
-        args: &[AnyValueEnum<'b>],
+        args: &[AnyValueEnum<'m>],
     ) -> <Self as BackendTypes>::Value {
         let func = self.get_intrinsic_function(name);
         self.call(func, args, None)
@@ -299,7 +299,7 @@ impl<'b> Builder<'b> {
     }
 }
 
-impl<'b> IntrinsicBuilderMethods<'b> for Builder<'b> {
+impl<'b, 'm> IntrinsicBuilderMethods<'b> for Builder<'_, 'b, 'm> {
     fn codegen_intrinsic_call(
         &mut self,
         ty: IrTyId,

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -11,9 +11,9 @@ use llvm::values::{AnyValueEnum, BasicMetadataValueEnum};
 use super::Builder;
 use crate::misc::MetadataTypeKind;
 
-impl<'b> Builder<'b> {
+impl<'m> Builder<'_, '_, 'm> {
     /// Emit a `no-undef` metadata attribute on a specific value.
-    pub fn set_no_undef(&mut self, value: AnyValueEnum<'b>) {
+    pub fn set_no_undef(&mut self, value: AnyValueEnum<'m>) {
         let value = value.into_instruction_value();
 
         let metadata = self.ctx.ll_ctx.metadata_node(&[]);
@@ -21,7 +21,7 @@ impl<'b> Builder<'b> {
     }
 
     /// Emit a `nonnull` metadata attribute on a specific value.
-    pub fn set_non_null(&mut self, value: AnyValueEnum<'b>) {
+    pub fn set_non_null(&mut self, value: AnyValueEnum<'m>) {
         let value = value.into_instruction_value();
 
         let metadata = self.ctx.ll_ctx.metadata_node(&[]);
@@ -29,7 +29,7 @@ impl<'b> Builder<'b> {
     }
 
     /// Specify the alignment for a particular value.
-    pub fn set_alignment(&mut self, value: AnyValueEnum<'b>, alignment: Alignment) {
+    pub fn set_alignment(&mut self, value: AnyValueEnum<'m>, alignment: Alignment) {
         let value = value.into_instruction_value();
 
         let alignment_metadata: BasicMetadataValueEnum =
@@ -42,7 +42,7 @@ impl<'b> Builder<'b> {
 
     /// Emit lifetime marker information to LLVM via a `llvm.lifetime.start`
     /// or `llvm.lifetime.end` intrinsic.
-    pub fn emit_lifetime_marker(&mut self, intrinsic: &str, ptr: AnyValueEnum<'b>, size: Size) {
+    pub fn emit_lifetime_marker(&mut self, intrinsic: &str, ptr: AnyValueEnum<'m>, size: Size) {
         let size = size.bytes();
 
         // We don't do anything if this is a unit.

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -13,13 +13,13 @@ use inkwell::{
 use super::abi::ExtendedFnAbiMethods;
 use crate::context::CodeGenCtx;
 
-impl<'b> CodeGenCtx<'b> {
+impl<'b, 'm> CodeGenCtx<'b, 'm> {
     /// Generate code for a reference to a function or method item. The
     /// [Instance] specifies the function reference to generate, and any
     /// attributes that need to be applied to the function. If the function
     /// has already been generated, a reference will be returned from the
     /// cache.
-    pub fn get_fn_or_create_ref(&self, instance: InstanceId) -> FunctionValue<'b> {
+    pub fn get_fn_or_create_ref(&self, instance: InstanceId) -> FunctionValue<'m> {
         // First check if we have already created the function reference...
         if let Some(fn_val) = self.instances.borrow().get(&instance) {
             return *fn_val;
@@ -57,7 +57,7 @@ impl<'b> CodeGenCtx<'b> {
     }
 }
 
-impl<'b> MiscBuilderMethods<'b> for CodeGenCtx<'b> {
+impl<'b, 'm> MiscBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
     fn get_fn(&self, instance: InstanceId) -> Self::Function {
         self.get_fn_or_create_ref(instance)
     }

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -27,10 +27,10 @@ pub(crate) mod ty;
 /// all of the specified builder methods.
 pub struct Builder<'a, 'b, 'm> {
     /// The actual InkWell builder
-    builder: inkwell::builder::Builder<'m>,
+    pub(crate) builder: inkwell::builder::Builder<'m>,
 
     /// The context for the builder.
-    ctx: &'a CodeGenCtx<'b, 'm>,
+    pub(crate) ctx: &'a CodeGenCtx<'b, 'm>,
 }
 
 /// This specifies that the [Builder] context is [CodeGenCtx].

--- a/compiler/hash-codegen-llvm/src/translation/mod.rs
+++ b/compiler/hash-codegen-llvm/src/translation/mod.rs
@@ -25,42 +25,42 @@ pub(crate) mod ty;
 
 /// A [Builder] is defined as being a context that is used to implement
 /// all of the specified builder methods.
-pub struct Builder<'b> {
+pub struct Builder<'a, 'b, 'm> {
     /// The actual InkWell builder
-    builder: inkwell::builder::Builder<'b>,
+    builder: inkwell::builder::Builder<'m>,
 
     /// The context for the builder.
-    ctx: &'b CodeGenCtx<'b>,
+    ctx: &'a CodeGenCtx<'b, 'm>,
 }
 
 /// This specifies that the [Builder] context is [CodeGenCtx].
-impl<'b> Codegen<'b> for Builder<'b> {
-    type CodegenCtx = CodeGenCtx<'b>;
+impl<'b, 'm> Codegen<'b> for Builder<'_, 'b, 'm> {
+    type CodegenCtx = CodeGenCtx<'b, 'm>;
 }
 
 /// This specifies all of the common IR type kinds for [Builder].
-impl<'b> BackendTypes for Builder<'b> {
-    type Value = <CodeGenCtx<'b> as BackendTypes>::Value;
-    type Function = <CodeGenCtx<'b> as BackendTypes>::Function;
-    type Type = <CodeGenCtx<'b> as BackendTypes>::Type;
-    type BasicBlock = <CodeGenCtx<'b> as BackendTypes>::BasicBlock;
+impl<'b, 'm> BackendTypes for Builder<'_, 'b, 'm> {
+    type Value = <CodeGenCtx<'b, 'm> as BackendTypes>::Value;
+    type Function = <CodeGenCtx<'b, 'm> as BackendTypes>::Function;
+    type Type = <CodeGenCtx<'b, 'm> as BackendTypes>::Type;
+    type BasicBlock = <CodeGenCtx<'b, 'm> as BackendTypes>::BasicBlock;
 
-    type DebugInfoScope = <CodeGenCtx<'b> as BackendTypes>::DebugInfoScope;
-    type DebugInfoLocation = <CodeGenCtx<'b> as BackendTypes>::DebugInfoLocation;
-    type DebugInfoVariable = <CodeGenCtx<'b> as BackendTypes>::DebugInfoVariable;
+    type DebugInfoScope = <CodeGenCtx<'b, 'm> as BackendTypes>::DebugInfoScope;
+    type DebugInfoLocation = <CodeGenCtx<'b, 'm> as BackendTypes>::DebugInfoLocation;
+    type DebugInfoVariable = <CodeGenCtx<'b, 'm> as BackendTypes>::DebugInfoVariable;
 }
 
-impl<'b> Backend<'b> for Builder<'b> {}
+impl<'b, 'm> Backend<'b> for Builder<'_, 'b, 'm> {}
 
-impl<'b> std::ops::Deref for Builder<'b> {
-    type Target = CodeGenCtx<'b>;
+impl<'b, 'm> std::ops::Deref for Builder<'_, 'b, 'm> {
+    type Target = CodeGenCtx<'b, 'm>;
 
     fn deref(&self) -> &Self::Target {
         self.ctx
     }
 }
 
-impl<'b> HasCtxMethods<'b> for Builder<'b> {
+impl<'b> HasCtxMethods<'b> for Builder<'_, 'b, '_> {
     fn settings(&self) -> &CompilerSettings {
         self.ctx.settings()
     }
@@ -78,7 +78,7 @@ impl<'b> HasCtxMethods<'b> for Builder<'b> {
     }
 }
 
-impl HasTargetSpec for Builder<'_> {
+impl HasTargetSpec for Builder<'_, '_, '_> {
     fn target_spec(&self) -> &Target {
         self.ctx.target_spec()
     }

--- a/compiler/hash-codegen/Cargo.toml
+++ b/compiler/hash-codegen/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 bitflags = "2.0.0-rc.1"
 fixedbitset = "0.4.2"
 rayon = "1.5.0"
-index_vec = "0.1.3"
 
 hash-abi = {path = "../hash-abi" }
 hash-layout = {path = "../hash-layout" }

--- a/compiler/hash-codegen/src/backend/mod.rs
+++ b/compiler/hash-codegen/src/backend/mod.rs
@@ -1,0 +1,52 @@
+//! This module defines all of the useful traits and data types that
+//! are used by the code generation backend to interface with
+//! the compiler pipeline.
+
+use hash_ir::IrStorage;
+use hash_layout::LayoutCtx;
+use hash_pipeline::{
+    interface::CompilerOutputStream, settings::CompilerSettings, workspace::Workspace,
+    CompilerResult,
+};
+
+/// The [BackendCtx] is the context that is needed for any
+/// [Backend] to generate code for the target backend.
+pub struct BackendCtx<'b> {
+    /// Reference to the current compiler workspace.
+    pub workspace: &'b mut Workspace,
+
+    /// Reference to the IR storage that is used to store
+    /// the lowered IR, and all metadata about the IR.
+    pub ir_storage: &'b IrStorage,
+
+    /// All of the layout information about the types in the
+    /// current session.
+    pub layout_storage: &'b LayoutCtx,
+
+    /// A reference to the backend settings in the current session.
+    pub settings: &'b CompilerSettings,
+
+    /// Reference to the output stream
+    pub stdout: CompilerOutputStream,
+
+    /// Reference to the rayon thread pool.
+    ///
+    /// @@Future: hopefully use this so that we can maximise the number of code
+    /// gen units for each module?
+    pub _pool: &'b rayon::ThreadPool,
+}
+
+/// The [Backend] trait specifies the required interface that needs
+/// to be implemented by a backend in order to interface with the
+/// pipeline.
+pub trait Backend<'b> {
+    /// The [Backend::run] method is called by the pipeline to
+    /// generate code for the specified source file. This method
+    /// may return a potential error which implies that something
+    /// went wrong during the code generation process, and it should
+    /// be treated as a fatal error.
+    ///
+    /// When the run is complete, all of the "bit-code" modules that
+    /// will have been generated will be applied to the [Workspace].
+    fn run(&mut self) -> CompilerResult<()>;
+}

--- a/compiler/hash-codegen/src/lib.rs
+++ b/compiler/hash-codegen/src/lib.rs
@@ -20,6 +20,7 @@
 //! generated.
 #![feature(let_chains, box_patterns, variant_count)]
 
+pub mod backend;
 pub mod common;
 pub mod lower;
 pub mod symbols;
@@ -28,25 +29,4 @@ pub mod traits;
 // re-export `abi` and `layout` crates to make them available to the backend
 // implementations.
 pub use hash_abi as abi;
-use hash_ir::IrStorage;
 pub use hash_layout as layout;
-use hash_pipeline::{settings::CompilerSettings, workspace::Workspace};
-
-/// The [BackendCtx] is the context that is needed for any [CodeGen]
-/// backend to generate code for the target backend.
-///
-/// @@Todo: determine how we deal with "code store".
-pub struct BackendCtx<'b> {
-    /// Reference to the current compiler workspace.
-    pub workspace: &'b mut Workspace,
-
-    /// Reference to the IR storage that is used to store
-    /// the lowered IR, and all metadata about the IR.
-    pub ir_storage: &'b IrStorage,
-
-    /// A reference to the backend settings in the current session.
-    pub settings: &'b CompilerSettings,
-
-    /// Reference to the rayon thread pool.
-    pub _pool: &'b rayon::ThreadPool,
-}

--- a/compiler/hash-codegen/src/lower/block.rs
+++ b/compiler/hash-codegen/src/lower/block.rs
@@ -6,7 +6,7 @@ use hash_ir::ir::BasicBlock;
 use super::{BlockStatus, FnBuilder};
 use crate::traits::builder::BlockBuilderMethods;
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Get a [Builder::BasicBlock] for a Hash IR block. This function tries
     /// to avoid creating new basic blocks via the builder if they have already
     /// been creating during the building process. The blocks are saved within

--- a/compiler/hash-codegen/src/lower/debug_info.rs
+++ b/compiler/hash-codegen/src/lower/debug_info.rs
@@ -8,4 +8,4 @@
 use super::FnBuilder;
 use crate::traits::builder::BlockBuilderMethods;
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {}
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {}

--- a/compiler/hash-codegen/src/lower/intrinsics.rs
+++ b/compiler/hash-codegen/src/lower/intrinsics.rs
@@ -7,7 +7,7 @@ use hash_ir::{intrinsics::Intrinsic, ty::IrTy};
 use super::{abi::compute_fn_abi_from_instance, FnBuilder};
 use crate::traits::{builder::BlockBuilderMethods, ctx::HasCtxMethods, misc::MiscBuilderMethods};
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Resolve a reference to an [Intrinsic].
     pub(super) fn resolve_intrinsic(
         &mut self,

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -12,9 +12,9 @@ use hash_ir::{
 use hash_layout::TyInfo;
 use hash_utils::{
     graph::dominators::Dominators,
+    index_vec::IndexVec,
     store::{SequenceStore, SequenceStoreKey},
 };
-use index_vec::IndexVec;
 
 use super::{operands::OperandRef, place::PlaceRef, FnBuilder};
 use crate::traits::{

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -47,8 +47,8 @@ impl<'b, V: CodeGenObject> LocalRef<V> {
     }
 }
 
-pub fn compute_non_ssa_locals<'b, Builder: BlockBuilderMethods<'b>>(
-    fn_builder: &FnBuilder<'b, Builder>,
+pub fn compute_non_ssa_locals<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
+    fn_builder: &FnBuilder<'a, 'b, Builder>,
 ) -> FixedBitSet {
     let body = fn_builder.body;
     let dominators = body.basic_blocks.dominators();
@@ -123,9 +123,9 @@ enum LocalMemoryKind {
     Ssa(ir::IrRef),
 }
 
-struct LocalKindAnalyser<'ir, 'b, Builder: BlockBuilderMethods<'b>> {
+struct LocalKindAnalyser<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> {
     /// The function lowering context.
-    fn_builder: &'ir FnBuilder<'b, Builder>,
+    fn_builder: &'ir FnBuilder<'a, 'b, Builder>,
 
     /// The [Dominator]s of the the function body.
     dominators: Dominators<ir::BasicBlock>,
@@ -136,7 +136,7 @@ struct LocalKindAnalyser<'ir, 'b, Builder: BlockBuilderMethods<'b>> {
     locals: IndexVec<Local, LocalMemoryKind>,
 }
 
-impl<'ir, 'b, Builder: BlockBuilderMethods<'b>> LocalKindAnalyser<'ir, 'b, Builder> {
+impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> LocalKindAnalyser<'ir, 'a, 'b, Builder> {
     /// Perform an "assignment" to a particular local. This will
     /// change the previous kind of memory with the following rules:
     ///
@@ -165,10 +165,10 @@ impl<'ir, 'b, Builder: BlockBuilderMethods<'b>> LocalKindAnalyser<'ir, 'b, Build
     }
 }
 
-impl<'ir, 'b, Builder: BlockBuilderMethods<'b>> IrVisitorMut<'b>
-    for LocalKindAnalyser<'ir, 'b, Builder>
+impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
+    for LocalKindAnalyser<'ir, 'a, 'b, Builder>
 {
-    fn ctx(&self) -> &'b hash_ir::IrCtx {
+    fn ctx(&self) -> &'ir hash_ir::IrCtx {
         self.fn_builder.ctx.ir_ctx()
     }
 

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -9,7 +9,7 @@ use hash_ir::{
     ir::{self, Local},
     traversal,
 };
-use index_vec::IndexVec;
+use hash_utils::index_vec::IndexVec;
 
 use self::{locals::LocalRef, operands::OperandRef, place::PlaceRef};
 use crate::traits::{builder::BlockBuilderMethods, layout::LayoutMethods};

--- a/compiler/hash-codegen/src/lower/mod.rs
+++ b/compiler/hash-codegen/src/lower/mod.rs
@@ -44,12 +44,12 @@ pub enum BlockStatus<BasicBlock> {
 
 /// This struct contains all the information required to convert Hash IR into
 /// the target code backend.
-pub struct FnBuilder<'b, Builder: BlockBuilderMethods<'b>> {
+pub struct FnBuilder<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> {
     /// The body that is being converted into the target backend.
     body: &'b ir::Body,
 
     /// The code generation context.
-    ctx: &'b Builder::CodegenCtx,
+    ctx: &'a Builder::CodegenCtx,
 
     /// The function that is being built.
     function: Builder::Function,
@@ -90,11 +90,11 @@ pub struct FnBuilder<'b, Builder: BlockBuilderMethods<'b>> {
     _unreachable_block: Option<Builder::BasicBlock>,
 }
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Create a new [FnBuilder] instance.
     pub fn new(
         body: &'b ir::Body,
-        ctx: &'b Builder::CodegenCtx,
+        ctx: &'a Builder::CodegenCtx,
         function: Builder::Function,
         fn_abi: &'b FnAbi,
     ) -> Self {
@@ -128,9 +128,9 @@ impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
 ///
 /// 3. Traverse the control flow graph in post-order and generate each
 /// block in the function.
-pub fn codegen_ir_body<'b, Builder: BlockBuilderMethods<'b>>(
+pub fn codegen_ir_body<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     body: &'b ir::Body,
-    ctx: &'b Builder::CodegenCtx,
+    ctx: &'a Builder::CodegenCtx,
     function: Builder::Function,
     fn_abi: &'b FnAbi,
 ) {
@@ -192,8 +192,8 @@ pub fn codegen_ir_body<'b, Builder: BlockBuilderMethods<'b>>(
 /// in it's own function due to the process being more complicated
 /// when dealing with ABI specifications, and possibly (in the future)
 /// variadic arguments that are passed to the function.
-fn allocate_argument_locals<'b, Builder: BlockBuilderMethods<'b>>(
-    fn_ctx: &mut FnBuilder<'b, Builder>,
+fn allocate_argument_locals<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
+    fn_ctx: &mut FnBuilder<'a, 'b, Builder>,
     builder: &mut Builder,
     memory_locals: &FixedBitSet,
 ) -> Vec<LocalRef<Builder::Value>> {

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -30,9 +30,9 @@ pub enum OperandValue<V> {
     Pair(V, V),
 }
 
-impl<'b, V: CodeGenObject> OperandValue<V> {
+impl<'a, 'b, V: CodeGenObject> OperandValue<V> {
     /// Store the [OperandValue] into the given [PlaceRef] destination.
-    pub fn store<Builder: BlockBuilderMethods<'b, Value = V>>(
+    pub fn store<Builder: BlockBuilderMethods<'a, 'b, Value = V>>(
         self,
         builder: &mut Builder,
         destination: PlaceRef<V>,
@@ -40,7 +40,7 @@ impl<'b, V: CodeGenObject> OperandValue<V> {
         self.store_with_flags(builder, destination, MemFlags::empty());
     }
 
-    fn store_with_flags<Builder: BlockBuilderMethods<'b, Value = V>>(
+    fn store_with_flags<Builder: BlockBuilderMethods<'a, 'b, Value = V>>(
         self,
         builder: &mut Builder,
         destination: PlaceRef<V>,
@@ -125,7 +125,7 @@ pub struct OperandRef<V> {
     pub info: TyInfo,
 }
 
-impl<'b, V: CodeGenObject> OperandRef<V> {
+impl<'a, 'b, V: CodeGenObject> OperandRef<V> {
     /// Create a new zero-sized type [OperandRef].
     pub fn new_zst<Builder: Codegen<'b, Value = V>>(builder: &Builder, info: TyInfo) -> Self {
         Self {
@@ -136,7 +136,7 @@ impl<'b, V: CodeGenObject> OperandRef<V> {
 
     /// Create a new [OperandRef] from an immediate value or a packed
     /// scalar pair value.
-    pub fn from_immediate_value_or_scalar_pair<Builder: BlockBuilderMethods<'b, Value = V>>(
+    pub fn from_immediate_value_or_scalar_pair<Builder: BlockBuilderMethods<'a, 'b, Value = V>>(
         builder: &mut Builder,
         value: V,
         info: TyInfo,
@@ -190,7 +190,7 @@ impl<'b, V: CodeGenObject> OperandRef<V> {
 
     /// Compute a new [OperandRef] from the current operand and a field
     /// projection.
-    pub fn extract_field<Builder: BlockBuilderMethods<'b, Value = V>>(
+    pub fn extract_field<Builder: BlockBuilderMethods<'a, 'b, Value = V>>(
         &self,
         builder: &mut Builder,
         index: usize,
@@ -269,7 +269,7 @@ impl<'b, V: CodeGenObject> OperandRef<V> {
     }
 }
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Generate code for a [Operand].
     pub(super) fn codegen_operand(
         &mut self,

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -29,7 +29,7 @@ use crate::{
 /// `bits - 1` places, e.g. shifting an `i8` by 7 places is valid, but shifting
 /// it by 8 places is not. So, the mask is computed, and then applied onto the
 /// shifting value in order to check whether a shift overflow has occurred.
-fn shift_mask_value<'b, Builder: BlockBuilderMethods<'b>>(
+fn shift_mask_value<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     ty: Builder::Type,
     mask_ty: Builder::Type,
@@ -56,7 +56,7 @@ fn shift_mask_value<'b, Builder: BlockBuilderMethods<'b>>(
 ///
 /// This is done by either truncating or zero extending the
 /// `shift_value` to the size of `lhs`.
-fn cast_shift_value<'b, Builder: BlockBuilderMethods<'b>>(
+fn cast_shift_value<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     lhs: Builder::Value,
     rhs: Builder::Value,
@@ -86,7 +86,7 @@ fn cast_shift_value<'b, Builder: BlockBuilderMethods<'b>>(
 ///
 /// This is equivalent of what x86 machine instructions like `sarl`
 /// perform. More information at <https://en.wikibooks.org/wiki/X86_Assembly/Shift_and_Rotate>.
-fn apply_shift_mask<'b, Builder: BlockBuilderMethods<'b>>(
+fn apply_shift_mask<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     shift_value: Builder::Value,
 ) -> Builder::Value {
@@ -101,7 +101,7 @@ fn apply_shift_mask<'b, Builder: BlockBuilderMethods<'b>>(
 /// to be truncated, and similarly in the case where the shifting value is
 /// smaller than the bit-width of the left-hand side operand, it needs to be
 /// zero extended.
-fn build_unchecked_rshift<'b, Builder: BlockBuilderMethods<'b>>(
+fn build_unchecked_rshift<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     ty: IrTyId,
     lhs: Builder::Value,
@@ -120,7 +120,7 @@ fn build_unchecked_rshift<'b, Builder: BlockBuilderMethods<'b>>(
     }
 }
 
-fn build_unchecked_lshift<'b, Builder: BlockBuilderMethods<'b>>(
+fn build_unchecked_lshift<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     lhs: Builder::Value,
     rhs: Builder::Value,
@@ -130,7 +130,7 @@ fn build_unchecked_lshift<'b, Builder: BlockBuilderMethods<'b>>(
     builder.shl(lhs, rhs)
 }
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Emit code for the given [ir::RValue] and store the result in the
     /// given [PlaceRef].
     pub fn codegen_rvalue(

--- a/compiler/hash-codegen/src/lower/statement.rs
+++ b/compiler/hash-codegen/src/lower/statement.rs
@@ -6,7 +6,7 @@ use hash_ir::ir::{Statement, StatementKind};
 use super::{locals::LocalRef, FnBuilder};
 use crate::traits::builder::BlockBuilderMethods;
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Lower a Hash IR [Statement] into a target backend code.
     pub fn codegen_statement(&mut self, builder: &mut Builder, statement: &Statement) {
         // @@DebugInfo: deal with debug information here for the location

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -53,7 +53,7 @@ pub enum ReturnDestinationKind<V> {
     DirectOperand(ir::Local),
 }
 
-impl<'b, Builder: BlockBuilderMethods<'b>> FnBuilder<'b, Builder> {
+impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Emit the target backend IR for a Hash IR [Terminator]. This
     /// function returns whether the block is a candidate for merging
     /// with the next block. The conditions for merging two blocks

--- a/compiler/hash-codegen/src/lower/utils.rs
+++ b/compiler/hash-codegen/src/lower/utils.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// N.B. If the type is a ZST, then this will not emit a `memcpy`
 /// instruction.
-pub fn mem_copy_ty<'b, Builder: BlockBuilderMethods<'b>>(
+pub fn mem_copy_ty<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>>(
     builder: &mut Builder,
     destination: (Builder::Value, Alignment),
     source: (Builder::Value, Alignment),

--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -23,7 +23,7 @@ use crate::{
 
 /// This trait defines all methods required to convert a Hash IR `BasicBlock`
 /// into the backend equivalent.
-pub trait BlockBuilderMethods<'b>:
+pub trait BlockBuilderMethods<'a, 'b>:
     Codegen<'b>
     + AbiBuilderMethods<'b>
     + IntrinsicBuilderMethods<'b>
@@ -34,11 +34,11 @@ pub trait BlockBuilderMethods<'b>:
     fn ctx(&self) -> &Self::CodegenCtx;
 
     /// Function to build the given `BasicBlock` into the backend equivalent.
-    fn build(ctx: &'b Self::CodegenCtx, block: Self::BasicBlock) -> Self;
+    fn build(ctx: &'a Self::CodegenCtx, block: Self::BasicBlock) -> Self;
 
     /// Add a block to the current function.
     fn append_block(
-        ctx: &'b Self::CodegenCtx,
+        ctx: &'a Self::CodegenCtx,
         func: Self::Function,
         name: &str,
     ) -> Self::BasicBlock;

--- a/compiler/hash-ir/Cargo.toml
+++ b/compiler/hash-ir/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 bitflags = "2.0.0-rc.1"
 fixedbitset = "0.4.2"
 html-escape = "0.2.12"
-index_vec = "0.1.3"
 smallvec = "1.9.0"
 
 hash-alloc = { path = "../hash-alloc" }

--- a/compiler/hash-ir/src/basic_blocks.rs
+++ b/compiler/hash-ir/src/basic_blocks.rs
@@ -6,8 +6,10 @@
 
 use std::{cell::OnceCell, fmt};
 
-use hash_utils::graph::{self, dominators::Dominators};
-use index_vec::IndexVec;
+use hash_utils::{
+    graph::{self, dominators::Dominators},
+    index_vec::IndexVec,
+};
 use smallvec::{smallvec, SmallVec};
 
 use crate::ir::{BasicBlock, BasicBlockData, Successors};

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -17,10 +17,10 @@ use hash_source::{
 use hash_tir::scope::ScopeId;
 use hash_utils::{
     graph::dominators::Dominators,
+    index_vec::{self, IndexVec},
     new_sequence_store_key,
     store::{DefaultSequenceStore, SequenceStore, SequenceStoreKey, Store},
 };
-use index_vec::IndexVec;
 use smallvec::{smallvec, SmallVec};
 
 use crate::{

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -18,10 +18,10 @@ use hash_target::{
     size::Size,
 };
 use hash_utils::{
+    index_vec::{self, index_vec, IndexVec},
     new_sequence_store_key, new_store_key,
     store::{CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, Store, StoreKey},
 };
-use index_vec::{index_vec, IndexVec};
 
 use crate::{
     ir::{LocalDecls, Place, PlaceProjection},

--- a/compiler/hash-layout/Cargo.toml
+++ b/compiler/hash-layout/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-index_vec = "0.1.3"
 fixedbitset = "0.4.2"
 
 hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -16,8 +16,7 @@ use hash_target::{
     primitives::{FloatTy, SIntTy, UIntTy},
     size::Size,
 };
-use hash_utils::store::Store;
-use index_vec::IndexVec;
+use hash_utils::{index_vec::IndexVec, store::Store};
 
 use crate::{CommonLayouts, FieldLayout, Layout, LayoutCtx, LayoutId, LayoutShape, Variants};
 

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -20,10 +20,10 @@ use hash_target::{
     size::Size,
 };
 use hash_utils::{
+    index_vec::IndexVec,
     new_store_key,
     store::{CloneStore, DefaultStore, FxHashMap, Store},
 };
-use index_vec::IndexVec;
 
 // Define a new key to represent a particular layout.
 new_store_key!(pub LayoutId);

--- a/compiler/hash-lower/Cargo.toml
+++ b/compiler/hash-lower/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 bitflags = "2.0.0-rc.1"
 fixedbitset = "0.4.2"
-index_vec = "0.1.3"
 indexmap = "1.9"
 num-traits = "0.2.15"
 rayon = "1.5.0"

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -27,8 +27,10 @@ use hash_ir::{
 use hash_pipeline::settings::CompilerSettings;
 use hash_source::{identifier::Identifier, location::Span, SourceId, SourceMap};
 use hash_tir::{scope::ScopeId, storage::GlobalStorage, terms::TermId};
-use hash_utils::store::{FxHashMap, SequenceStore, SequenceStoreKey};
-use index_vec::IndexVec;
+use hash_utils::{
+    index_vec::IndexVec,
+    store::{FxHashMap, SequenceStore, SequenceStoreKey},
+};
 
 use self::ty::get_fn_ty_from_term;
 use crate::cfg::ControlFlowGraph;

--- a/compiler/hash-lower/src/cfg.rs
+++ b/compiler/hash-lower/src/cfg.rs
@@ -7,7 +7,7 @@ use hash_ir::ir::{
     BasicBlock, BasicBlockData, Place, RValue, Statement, StatementKind, Terminator, TerminatorKind,
 };
 use hash_source::location::Span;
-use index_vec::IndexVec;
+use hash_utils::index_vec::IndexVec;
 
 pub struct ControlFlowGraph {
     /// The basic blocks that this control flow graph contains.

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -17,7 +17,7 @@ use hash_ir::{
     IrCtx,
 };
 use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
-use index_vec::{index_vec, IndexVec};
+use hash_utils::index_vec::{index_vec, IndexVec};
 
 use super::IrOptimisationPass;
 

--- a/compiler/hash-lower/src/optimise/simplify.rs
+++ b/compiler/hash-lower/src/optimise/simplify.rs
@@ -16,7 +16,7 @@ use hash_ir::{
     traversal, IrCtx,
 };
 use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
-use index_vec::{index_vec, Idx, IndexVec};
+use hash_utils::index_vec::{index_vec, Idx, IndexVec};
 use smallvec::{smallvec, SmallVec};
 
 use super::IrOptimisationPass;

--- a/compiler/hash-lower/src/ty/mod.rs
+++ b/compiler/hash-lower/src/ty/mod.rs
@@ -18,8 +18,10 @@ use hash_tir::{
         TupleTy,
     },
 };
-use hash_utils::store::{CloneStore, SequenceStore, Store};
-use index_vec::index_vec;
+use hash_utils::{
+    index_vec::index_vec,
+    store::{CloneStore, SequenceStore, Store},
+};
 
 /// A context that is used to lower types and terms into [IrTy]s.
 pub(crate) struct TyLoweringCtx<'ir> {

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -1,104 +1,22 @@
 //! Hash Compiler pipeline errors that can occur during the
 //! the pipeline initialisation.
-use std::{io, path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
-use hash_reporting::report::{Report, ReportKind};
 use hash_target::Target;
 
 use crate::{
-    fs::ImportError,
+    error::PipelineError,
     settings::{
         CodeGenBackend, CompilerSettings, CompilerStageKind, IrDumpMode, OptimisationLevel,
     },
 };
-
-/// Errors that might occur when attempting to compile and or interpret a
-/// program.
-#[derive(Debug)]
-pub enum ArgumentError {
-    /// Invalid target was passed to the compiler.
-    InvalidTarget(String),
-
-    /// Error that can occur when the pipeline tried to
-    /// create a resource on the operating system, but the resource
-    /// couldn't be created for some reason.
-    ResourceCreation {
-        /// The item that was being created.
-        path: PathBuf,
-
-        /// The specific [io::Error] that occurred.
-        error: io::Error,
-    },
-
-    /// Errors that can occur from importing module paths
-    /// when the compiler settings are still being processed.
-    ImportPath(ImportError),
-
-    /// When a specific "stage" of the compiler is specified.
-    /// but there exists no such stage.
-    UnknownStage(String),
-
-    /// When a stage is specified but the entry point is missing.
-    MissingEntryPoint,
-
-    /// When a configuration key is not recognised.
-    UnknownKey(String),
-
-    /// When a key-value pair doesn't follow the standard
-    /// `-C<key>=<value>` format.
-    MalformedKey(String),
-
-    /// A key was provided but was missing a key.
-    MissingValue(String),
-
-    /// When a configuration key value is not a valid option
-    /// for the specified key.
-    InvalidValue(String, String),
-}
-
-impl From<ArgumentError> for Report {
-    fn from(value: ArgumentError) -> Self {
-        let mut report = Report::new();
-        let message = match value {
-            ArgumentError::InvalidTarget(target) => format!(
-                "invalid target `{target}` specified, available targets are: `x86_64` and `x64`"
-            ),
-            ArgumentError::MissingEntryPoint => "missing entry point".to_string(),
-            ArgumentError::UnknownStage(stage) => format!("unknown stage `{stage}`, available stages are: `ast-gen`, `check`, `ir-gen`, `build`"),
-            ArgumentError::ResourceCreation { path, error } => {
-                let kind = error.kind();
-
-                error.raw_os_error().map_or_else(
-                    || format!("couldn't create `{}`, {}", path.to_string_lossy(), kind),
-                    |code| format!("couldn't create `{}`, {} (code: {})", path.to_string_lossy(), kind, code),
-                )
-            },
-            ArgumentError::ImportPath(err) => err.to_string(),
-            ArgumentError::UnknownKey(key) => {
-                format!("unknown configuration key `{key}`")
-            }
-            ArgumentError::MalformedKey(key) => {
-                format!("malformed configuration key `{key}`")
-            }
-            ArgumentError::MissingValue(key) => {
-                format!("missing value for configuration key `{key}`")
-            }
-            ArgumentError::InvalidValue(key, value) => {
-                format!("invalid value `{value}` for configuration key `{key}`")
-            }
-        };
-
-        report.kind(ReportKind::Error).title(message);
-        report
-    }
-}
 
 /// This function is used to parse the command line arguments that are
 /// passed to the compiler, it will return a [CompilerSettings] struct
 /// that contains all of the settings that the compiler should use. If
 /// there is an error, this will return an error that can be
 /// dealt with by the caller.
-pub fn parse_settings_from_args() -> Result<CompilerSettings, ArgumentError> {
+pub fn parse_settings_from_args() -> Result<CompilerSettings, PipelineError> {
     let mut settings = CompilerSettings::default();
     let mut args = std::env::args().skip(1);
 
@@ -125,7 +43,7 @@ pub fn parse_settings_from_args() -> Result<CompilerSettings, ArgumentError> {
                     settings.stage = CompilerStageKind::IrGen;
                 }
                 _ => {
-                    return Err(ArgumentError::UnknownStage(arg));
+                    return Err(PipelineError::UnknownStage(arg));
                 }
             };
 
@@ -134,7 +52,7 @@ pub fn parse_settings_from_args() -> Result<CompilerSettings, ArgumentError> {
                 let path = PathBuf::from(filename);
                 settings.entry_point = Some(path);
             } else {
-                return Err(ArgumentError::MissingEntryPoint);
+                return Err(PipelineError::MissingEntryPoint);
             }
         }
     }
@@ -151,7 +69,7 @@ pub fn parse_option(
     settings: &mut CompilerSettings,
     args: &mut impl Iterator<Item = String>,
     arg: &str,
-) -> Result<(), ArgumentError> {
+) -> Result<(), PipelineError> {
     // This is a configuration key that specifies the "key" and then
     // the value in the form of `-C<key>=<value>`
     if arg.starts_with("-C") {
@@ -162,7 +80,7 @@ pub fn parse_option(
             if let Some(arg) = args.next() {
                 parse_arg_configuration(settings, arg)?;
             } else {
-                return Err(ArgumentError::UnknownKey(arg.to_string()));
+                return Err(PipelineError::UnknownKey(arg.to_string()));
             }
         } else {
             parse_arg_configuration(settings, arg.trim_start_matches("-C").to_string())?;
@@ -183,11 +101,11 @@ pub fn parse_option(
                     let path = PathBuf::from(filename);
                     settings.output_directory = Some(path);
                 } else {
-                    return Err(ArgumentError::MissingValue(key));
+                    return Err(PipelineError::MissingValue(key));
                 }
             }
             _ => {
-                return Err(ArgumentError::UnknownKey(arg.to_string()));
+                return Err(PipelineError::UnknownKey(arg.to_string()));
             }
         }
     }
@@ -202,7 +120,7 @@ pub fn parse_option(
 fn parse_arg_configuration(
     settings: &mut CompilerSettings,
     arg: String,
-) -> Result<(), ArgumentError> {
+) -> Result<(), PipelineError> {
     // First try and see if we have been provided a key-value pair, if not
     // then we will assume that the key is the argument and the value is
     // `None`.
@@ -215,7 +133,7 @@ fn parse_arg_configuration(
 
     // When a value is expected from a key, but none is provided, this
     // closure will be used to return an error.
-    let expected_value = || ArgumentError::MissingValue(key.clone());
+    let expected_value = || PipelineError::MissingValue(key.clone());
 
     // @@Todo: it would be nice to have macro that can generate these
     // match statements, and perform the correct validation, and generate
@@ -225,7 +143,7 @@ fn parse_arg_configuration(
             let value = value.ok_or_else(expected_value)?;
 
             let target = Target::from_string(value.clone())
-                .ok_or_else(|| ArgumentError::InvalidTarget(value))?;
+                .ok_or_else(|| PipelineError::InvalidTarget(value))?;
 
             settings.codegen_settings.target_info.set_target(target)
         }
@@ -245,7 +163,7 @@ fn parse_arg_configuration(
                     settings.lowering_settings.dump = true;
                 }
                 _ => {
-                    return Err(ArgumentError::InvalidValue(key, value));
+                    return Err(PipelineError::InvalidValue(key, value));
                 }
             }
         }
@@ -260,7 +178,7 @@ fn parse_arg_configuration(
                     settings.lowering_settings.dump_mode = IrDumpMode::Graph;
                 }
                 _ => {
-                    return Err(ArgumentError::InvalidValue(key, value));
+                    return Err(PipelineError::InvalidValue(key, value));
                 }
             }
         }
@@ -275,12 +193,12 @@ fn parse_arg_configuration(
                     settings.codegen_settings.backend = CodeGenBackend::VM;
                 }
                 _ => {
-                    return Err(ArgumentError::InvalidValue(key, value));
+                    return Err(PipelineError::InvalidValue(key, value));
                 }
             }
         }
         _ => {
-            return Err(ArgumentError::UnknownKey(key));
+            return Err(PipelineError::UnknownKey(key));
         }
     };
 

--- a/compiler/hash-pipeline/src/error.rs
+++ b/compiler/hash-pipeline/src/error.rs
@@ -1,0 +1,90 @@
+//! Defines the error type for the hash pipeline. These errors
+//! can originate from the parsing of specified compiler arguments,
+//! resolving file paths, or when bootstrapping the compiler pipeline.
+
+use std::{io, path::PathBuf};
+
+use hash_reporting::report::{Report, ReportKind};
+
+use crate::fs::ImportError;
+
+// Errors that might occur when attempting to compile and or interpret a
+/// program.
+#[derive(Debug)]
+pub enum PipelineError {
+    /// Invalid target was passed to the compiler.
+    InvalidTarget(String),
+
+    /// Error that can occur when the pipeline tried to
+    /// create a resource on the operating system, but the resource
+    /// couldn't be created for some reason.
+    ResourceCreation {
+        /// The item that was being created.
+        path: PathBuf,
+
+        /// The specific [io::Error] that occurred.
+        error: io::Error,
+    },
+
+    /// Errors that can occur from importing module paths
+    /// when the compiler settings are still being processed.
+    ImportPath(ImportError),
+
+    /// When a specific "stage" of the compiler is specified.
+    /// but there exists no such stage.
+    UnknownStage(String),
+
+    /// When a stage is specified but the entry point is missing.
+    MissingEntryPoint,
+
+    /// When a configuration key is not recognised.
+    UnknownKey(String),
+
+    /// When a key-value pair doesn't follow the standard
+    /// `-C<key>=<value>` format.
+    MalformedKey(String),
+
+    /// A key was provided but was missing a key.
+    MissingValue(String),
+
+    /// When a configuration key value is not a valid option
+    /// for the specified key.
+    InvalidValue(String, String),
+}
+
+impl From<PipelineError> for Report {
+    fn from(value: PipelineError) -> Self {
+        let mut report = Report::new();
+        let message = match value {
+            PipelineError::InvalidTarget(target) => format!(
+                "invalid target `{target}` specified, available targets are: `x86_64` and `x64`"
+            ),
+            PipelineError::MissingEntryPoint => "missing entry point".to_string(),
+            PipelineError::UnknownStage(stage) => format!("unknown stage `{stage}`, available stages are: `ast-gen`, `check`, `ir-gen`, `build`"),
+            PipelineError::ResourceCreation { path, error } => {
+                let kind = error.kind();
+
+                error.raw_os_error().map_or_else(
+                    || format!("couldn't create `{}`, {}", path.to_string_lossy(), kind),
+                    |code| format!("couldn't create `{}`, {} (code: {})", path.to_string_lossy(), kind, code),
+                )
+            },
+            PipelineError::ImportPath(err) => err.to_string(),
+            PipelineError::UnknownKey(key) => {
+                format!("unknown configuration key `{key}`")
+            }
+            PipelineError::MalformedKey(key) => {
+                format!("malformed configuration key `{key}`")
+            }
+            PipelineError::MissingValue(key) => {
+                format!("missing value for configuration key `{key}`")
+            }
+            PipelineError::InvalidValue(key, value) => {
+                format!("invalid value `{value}` for configuration key `{key}`")
+            }
+        };
+
+        report.kind(ReportKind::Error).title(message);
+        report
+    }
+}

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -6,6 +6,7 @@
 //! used. This file also has definitions for how to access sources whether
 //! module or interactive.
 pub mod args;
+pub mod error;
 pub mod fs;
 pub mod interface;
 pub mod settings;

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -11,12 +11,12 @@ pub mod interface;
 pub mod settings;
 pub mod workspace;
 
-use std::{collections::HashMap, env, time::Duration};
+use std::{collections::HashMap, env::current_dir, path::Path, time::Duration};
 
 use fs::{read_in_path, resolve_path, PRELUDE};
 use hash_ast::node_map::ModuleEntry;
 use hash_reporting::{reporter::Reports, writer::ReportWriter};
-use hash_source::{constant::CONSTANT_MAP, ModuleKind, SourceId};
+use hash_source::{ModuleKind, SourceId};
 use hash_utils::{stream_writeln, timing::timed};
 use interface::{CompilerInterface, CompilerStage};
 use settings::CompilerStageKind;
@@ -162,9 +162,25 @@ impl<I: CompilerInterface> Compiler<I> {
             // for the prelude bootstrap to run
             let mut old_settings = std::mem::take(ctx.settings_mut());
 
-            // we need to load in the `prelude` module and have it ready for any other
-            // sources
-            ctx = self.run_on_filename(PRELUDE.to_string(), ModuleKind::Prelude, ctx);
+            // Resolve the current working directory so that we can
+            // resolve the prelude path...
+            let wd = match current_dir() {
+                Ok(wd) => wd,
+                Err(err) => {
+                    ctx.diagnostics_mut().push(err.into());
+                    return ctx;
+                }
+            };
+
+            let path = match resolve_path(PRELUDE, wd) {
+                Ok(path) => path,
+                Err(err) => {
+                    ctx.diagnostics_mut().push(err.into());
+                    return ctx;
+                }
+            };
+
+            ctx = self.run_on_filename(path, ModuleKind::Prelude, ctx);
 
             // Reset the settings
             std::mem::swap(ctx.settings_mut(), &mut old_settings);
@@ -181,6 +197,35 @@ impl<I: CompilerInterface> Compiler<I> {
         ctx
     }
 
+    /// Emit diagnostics to the error stream with the applied settings.
+    pub fn emit_diagnostics(&self, ctx: &I) {
+        let mut err_count = 0;
+        let mut warn_count = 0;
+        let mut stderr = ctx.error_stream();
+
+        // @@Copying: Ideally, we would not want to copy here!
+        for diagnostic in ctx.diagnostics().iter().cloned() {
+            if diagnostic.is_error() {
+                err_count += 1;
+            }
+
+            if diagnostic.is_warning() {
+                warn_count += 1;
+            }
+
+            stream_writeln!(stderr, "{}", ReportWriter::single(diagnostic, ctx.source_map()));
+        }
+
+        // @@Hack: to prevent the compiler from printing this message when the pipeline
+        // when it was instructed to terminate before all of the stages. For example, if
+        // the compiler is just checking the source, then it will terminate early.
+        if err_count != 0 || warn_count != 0 {
+            log::info!(
+                "compiler terminated with {err_count} error(s), and {warn_count} warning(s)."
+            );
+        }
+    }
+
     /// Run a job within the compiler pipeline with the provided state, entry
     /// point and the specified job parameters.
     pub fn run(&mut self, entry_point: SourceId, mut ctx: I) -> I {
@@ -188,31 +233,7 @@ impl<I: CompilerInterface> Compiler<I> {
 
         // we can print the diagnostics here
         if ctx.settings().emit_errors && (!ctx.diagnostics().is_empty() || result.is_err()) {
-            let mut err_count = 0;
-            let mut warn_count = 0;
-            let mut stderr = ctx.error_stream();
-
-            // @@Copying: Ideally, we would not want to copy here!
-            for diagnostic in ctx.diagnostics().iter().cloned() {
-                if diagnostic.is_error() {
-                    err_count += 1;
-                }
-
-                if diagnostic.is_warning() {
-                    warn_count += 1;
-                }
-
-                stream_writeln!(stderr, "{}", ReportWriter::single(diagnostic, ctx.source_map()));
-            }
-
-            // @@Hack: to prevent the compiler from printing this message when the pipeline
-            // when it was instructed to terminate before all of the stages. For example, if
-            // the compiler is just checking the source, then it will terminate early.
-            if err_count != 0 || warn_count != 0 {
-                log::info!(
-                    "compiler terminated with {err_count} error(s), and {warn_count} warning(s)."
-                );
-            }
+            self.emit_diagnostics(&ctx);
         }
 
         // Print compiler stage metrics if specified in the settings.
@@ -229,56 +250,30 @@ impl<I: CompilerInterface> Compiler<I> {
     /// [`Self::run`]
     pub fn run_on_filename(
         &mut self,
-        filename: impl Into<String>,
+        filename: impl AsRef<Path>,
         kind: ModuleKind,
         mut ctx: I,
     ) -> I {
-        // First we have to work out if we need to transform the path
-        let current_dir = env::current_dir().unwrap();
-
-        let path = CONSTANT_MAP.create_string(filename.into().as_str());
-        let filename = resolve_path(path, current_dir);
-
-        if let Err(err) = filename {
-            ctx.diagnostics_mut().push(err.create_report());
-
-            // Only print the error if specified within the settings
-            if ctx.settings().emit_errors {
-                let mut stderr = ctx.error_stream();
-                stream_writeln!(
-                    stderr,
-                    "{}",
-                    ReportWriter::single(err.create_report(), ctx.source_map())
-                );
-            }
-
-            return ctx;
-        };
-
-        let filename = filename.unwrap();
         let contents = read_in_path(&filename);
-        let mut stderr = ctx.error_stream();
 
         if let Err(err) = contents {
-            ctx.diagnostics_mut().push(err.create_report());
+            ctx.diagnostics_mut().push(err.into());
 
-            // Only print the error if specified within the settings
-
+            // Since this a fatal error because we couldn't read the file, we
+            // emit the diagnostics (if specified to emit) and terminate.
             if ctx.settings().emit_errors {
-                stream_writeln!(
-                    stderr,
-                    "{}",
-                    ReportWriter::single(err.create_report(), ctx.source_map())
-                );
+                self.emit_diagnostics(&ctx);
             }
 
             return ctx;
         };
 
         // Create the entry point and run!
-
-        let entry_point =
-            ctx.workspace_mut().add_module(contents.unwrap(), ModuleEntry::new(filename), kind);
+        let entry_point = ctx.workspace_mut().add_module(
+            contents.unwrap(),
+            ModuleEntry::new(filename.as_ref().to_path_buf()),
+            kind,
+        );
 
         self.run(entry_point, ctx)
     }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -139,6 +139,9 @@ pub enum OptimisationLevel {
     /// Optimise the given program as much as possible, essentially
     /// applying all optimisation.
     Release,
+
+    /// Optimise the given program for size rather than speed.
+    Size,
 }
 
 impl OptimisationLevel {
@@ -152,6 +155,7 @@ impl OptimisationLevel {
         match self {
             Self::Debug => "debug",
             Self::Release => "release",
+            Self::Size => "size",
         }
     }
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -219,8 +219,12 @@ pub enum OptimisationLevel {
     /// applying all optimisation.
     Release,
 
-    /// Optimise the given program for size rather than speed.
+    /// Optimise for size but not aggressively as
+    /// [`OptimisationLevel::MinSize`].
     Size,
+
+    /// Optimise the given program for size rather than speed.
+    MinSize,
 }
 
 impl OptimisationLevel {
@@ -229,12 +233,22 @@ impl OptimisationLevel {
         matches!(self, Self::Release)
     }
 
+    /// Get the level in optimisation of size.
+    pub fn size_level(&self) -> usize {
+        match self {
+            Self::Size => 1,
+            Self::MinSize => 2,
+            _ => 0,
+        }
+    }
+
     /// Get the optimisation level as a string.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Debug => "debug",
             Self::Release => "release",
             Self::Size => "size",
+            Self::MinSize => "min-size",
         }
     }
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -1,18 +1,36 @@
 //! Hash Compiler pipeline implementation. This file contains various structures
 //! and utilities representing settings and configurations that can be applied
 //! to the Compiler pipeline.
-use std::{fmt::Display, str::FromStr};
+use std::{
+    env::{self, temp_dir},
+    fmt::Display,
+    path::PathBuf,
+    str::FromStr,
+};
 
+use hash_source::constant::CONSTANT_MAP;
 use hash_target::{data_layout::TargetDataLayout, TargetInfo};
 
-use crate::args::ArgumentError;
+use crate::{args::ArgumentError, fs::resolve_path};
 
 /// Various settings that are present on the compiler pipeline when initially
 /// launching.
 #[derive(Debug, Clone)]
 pub struct CompilerSettings {
     /// An optionally specified entry point for the compiler.
-    pub entry_point: Option<String>,
+    ///
+    /// N.B. This path is the one that is specified via command-line arguments,
+    /// it is not resolved and it is not guaranteed to exist. The resolved
+    /// path can be accessed via [`CompilerSettings::entry_point`] API.
+    pub(crate) entry_point: Option<PathBuf>,
+
+    /// An optionally specified output directory for compiler generated
+    /// information and artifacts.
+    ///
+    /// N.B. This path is the one that is specified via command-line arguments,
+    /// it is not resolved and it is not guaranteed to exist. The resolved
+    /// path can be accessed via [`CompilerSettings::output_directory`] API.
+    pub(crate) output_directory: Option<PathBuf>,
 
     /// Whether debugging log statements are enabled.
     pub debug: bool,
@@ -64,10 +82,70 @@ impl CompilerSettings {
     }
 
     /// Get the entry point filename from the [CompilerSettings]. If
-    /// none was provided, it is assumed that this is then an interactive
+    /// [`None`] was provided, it is assumed that this is then an interactive
     /// session.
-    pub fn entry_point(&self) -> Option<String> {
-        self.entry_point.clone()
+    pub fn entry_point(&self) -> Option<Result<PathBuf, ArgumentError>> {
+        self.entry_point.as_ref().map(|path| {
+            let current_dir = env::current_dir().unwrap();
+            let path = CONSTANT_MAP.create_string(path.to_str().unwrap());
+            resolve_path(path, current_dir).map_err(ArgumentError::ImportPath)
+        })
+    }
+
+    /// Get the output directory from the [CompilerSettings]. The output path
+    /// is decided in the following way:
+    ///
+    /// 1. If the user has specified an output directory, use that.
+    ///
+    /// 2. If the user has specified an entry point, use the directory of the
+    ///    entry point with an appended `out` directory.
+    ///
+    /// 3. If the user has not specified an entry point, use the operating
+    /// system    temporary directory with an appended `hash-#session-id`
+    /// directory.
+    pub fn output_directory(&self) -> Result<PathBuf, ArgumentError> {
+        // For the `temp` directory case, we want to create a folder within the
+        // temporary directory that is unique to this session.
+        let temp_dir = {
+            let mut temp_dir = temp_dir();
+            temp_dir.push(format!("hash-{}", std::process::id()));
+            temp_dir
+        };
+
+        // We want to find the first suitable candidate for a valid output folder, these
+        // items are specified in order of priority.
+        let output_candidates = [&self.output_directory, &self.entry_point, &Some(temp_dir)];
+        let mut output_directory = None;
+
+        if let Some(candidate) = output_candidates.iter().copied().flatten().next() {
+            let mut candidate = candidate.clone();
+
+            // If the candidate is a file, then we want to get the parent directory
+            // of the file.
+            if candidate.is_file() {
+                candidate.pop();
+                candidate.push("target");
+            }
+
+            // We also push the "optimisation_level" as the final directory
+            // in order to separate the output of different optimisation levels.
+            candidate.push(self.optimisation_level.as_str());
+
+            // If the candidate doesn't exist or isn't a directory, then we want to
+            // create the full directory path so that the compiler can write to it
+            // later during compilation.
+            if !candidate.exists() || !candidate.is_dir() {
+                std::fs::create_dir_all(&candidate).map_err(|error| {
+                    ArgumentError::ResourceCreation { path: candidate.clone(), error }
+                })?;
+            }
+
+            output_directory = Some(candidate);
+        }
+
+        // It should not be possible to get here without at least one
+        // candidate for a valid output directory to be chosen.
+        Ok(output_directory.unwrap())
     }
 
     /// Specify whether the compiler pipeline should skip running
@@ -114,6 +192,7 @@ impl Default for CompilerSettings {
         Self {
             debug: false,
             entry_point: None,
+            output_directory: None,
             output_stage_results: false,
             output_metrics: false,
             skip_prelude: false,
@@ -248,6 +327,11 @@ pub struct CodeGenSettings {
     /// Hash VM which may mean that the code generation backend for that one
     /// might differ from the overall code generation backend.
     pub backend: CodeGenBackend,
+
+    /// An optionally specified path to a file that should be used to
+    /// write the executable to. If the path is [`None`], the executable
+    /// path will be derived from the workspace.
+    pub output_path: Option<PathBuf>,
 }
 
 /// All of the current possible code generation backends that

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -228,13 +228,13 @@ impl Workspace {
     /// imply that the function will return a path that already exists, or has
     /// been "acquired", it is intended to be used to generate a path for a
     /// module that is about to be emitted.
-    pub fn module_bitcode_path(&self, module: ModuleId) -> PathBuf {
+    pub fn module_bitcode_path(&self, module: ModuleId, extension: &'static str) -> PathBuf {
         let mut path = self.output_directory.clone();
         let module_path = self.source_map.module_path(module);
 
         path.push("build");
         path.push(format!(
-            "{}-{}.bc",
+            "{}-{}.{extension}",
             module_path.file_stem().unwrap().to_str().unwrap(),
             module.raw()
         ));

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -19,7 +19,7 @@ use hash_ast::{
 use hash_source::{ModuleId, ModuleKind, SourceId, SourceMap};
 use hash_utils::tree_writing::TreeWriter;
 
-use crate::{args::ArgumentError, settings::CompilerSettings};
+use crate::{error::PipelineError, settings::CompilerSettings};
 
 bitflags! {
     /// Defines the flags that can be used to control the compiler pipeline.
@@ -186,7 +186,7 @@ pub struct Workspace {
 
 impl Workspace {
     /// Create a new [Workspace], initialising all members to be empty.
-    pub fn new(settings: &CompilerSettings) -> Result<Self, ArgumentError> {
+    pub fn new(settings: &CompilerSettings) -> Result<Self, PipelineError> {
         let executable_path = settings.codegen_settings().output_path.clone();
         let output_directory = settings.output_directory()?;
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -38,7 +38,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
         Box::new(Typechecker::new()),
         Box::<IrGen>::default(),
         Box::new(IrOptimiser),
-        Box::new(CodeGenPass::new()),
+        Box::new(CodeGenPass),
     ]
 }
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -11,8 +11,8 @@
 use hash_ast::node_map::NodeMap;
 use hash_ast_desugaring::{AstDesugaringCtx, AstDesugaringCtxQuery, AstDesugaringPass};
 use hash_ast_expand::{AstExpansionCtx, AstExpansionCtxQuery, AstExpansionPass};
-use hash_backend::{Backend, BackendCtxQuery};
-use hash_codegen::BackendCtx;
+use hash_backend::{BackendCtxQuery, CodeGenPass};
+use hash_codegen::backend::BackendCtx;
 use hash_ir::IrStorage;
 use hash_layout::LayoutCtx;
 use hash_lower::{IrGen, IrOptimiser, LoweringCtx, LoweringCtxQuery};
@@ -38,7 +38,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
         Box::new(Typechecker::new()),
         Box::<IrGen>::default(),
         Box::new(IrOptimiser),
-        Box::new(Backend::new()),
+        Box::new(CodeGenPass::new()),
     ]
 }
 
@@ -210,10 +210,14 @@ impl LoweringCtxQuery for CompilerSession {
 
 impl BackendCtxQuery for CompilerSession {
     fn data(&mut self) -> BackendCtx {
+        let output_stream = self.output_stream();
+
         BackendCtx {
             workspace: &mut self.workspace,
             ir_storage: &self.ir_storage,
+            layout_storage: &self.layout_storage,
             settings: &self.settings,
+            stdout: output_stream,
             _pool: &self.pool,
         }
     }

--- a/compiler/hash-source/Cargo.toml
+++ b/compiler/hash-source/Cargo.toml
@@ -11,7 +11,6 @@ derive_more = "0.99"
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 num-bigint = "0.4"
-index_vec = "0.1.3"
 
 hash-alloc = { path = "../hash-alloc" }
 hash-target = { path = "../hash-target" }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -7,8 +7,7 @@ use std::{
 };
 
 use bimap::BiMap;
-use hash_utils::path::adjust_canonicalisation;
-use index_vec::define_index_type;
+use hash_utils::{index_vec::define_index_type, path::adjust_canonicalisation};
 use location::{compute_row_col_from_offset, RowColSpan, SourceLocation};
 
 pub mod constant;

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use bimap::BiMap;
-use hash_utils::{index_vec::define_index_type, path::adjust_canonicalisation};
+use hash_utils::{
+    index_vec::{define_index_type, index_vec, IndexVec},
+    path::adjust_canonicalisation,
+};
 use location::{compute_row_col_from_offset, RowColSpan, SourceLocation};
 
 pub mod constant;
@@ -134,14 +137,22 @@ impl From<SourceId> for InteractiveId {
 /// The [ModuleKind] enumeration describes what kind of module this is. If it is
 /// a [ModuleKind::Prelude], then certain things are allowed within this module
 /// in order to allow for `compiler` magic to interact with the prelude file.
+///
+/// @@TODO: maybe make this a `bitflags!`?
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ModuleKind {
     /// Any normal module that is within a workspace, including modules within
     /// the standard library.
     Normal,
+
     /// The `prelude` module, which allows for various features that are
     /// normally disallowed.
     Prelude,
+
+    /// Entry point, this module is considered to be the entry point of the
+    /// project, it has the same characteristics as a [`ModuleKind::Normal`]
+    /// module, but it is also the entry point of the project.
+    EntryPoint,
 }
 
 /// This data structure is used to store and organise the sources of the
@@ -154,13 +165,16 @@ pub struct SourceMap {
     /// A map between [ModuleId] and [PathBuf]. This is a bi-directional map
     /// and such value and key lookups are available.
     module_paths: BiMap<ModuleId, PathBuf>,
+
     ///  A map between [ModuleId] and the actual sources of the module.
-    module_content_map: Vec<String>,
+    module_content_map: IndexVec<InteractiveId, String>,
+
     /// A map between [ModuleId] and the kind of module
-    module_kind_map: Vec<ModuleKind>,
+    module_kind_map: IndexVec<ModuleId, ModuleKind>,
+
     /// A map between [InteractiveId] and the actual sources of the interactive
     /// block.
-    interactive_content_map: Vec<String>,
+    interactive_content_map: IndexVec<InteractiveId, String>,
 }
 
 impl SourceMap {
@@ -168,21 +182,25 @@ impl SourceMap {
     pub fn new() -> Self {
         Self {
             module_paths: BiMap::new(),
-            module_kind_map: vec![],
-            module_content_map: vec![],
-            interactive_content_map: vec![],
+            module_kind_map: index_vec![],
+            module_content_map: index_vec![],
+            interactive_content_map: index_vec![],
         }
     }
 
     /// Get a [Path] by a specific [SourceId]. If it is interactive, the path
     /// is always set as `<interactive>`.
-    pub fn path_by_id(&self, id: SourceId) -> &Path {
+    pub fn source_path(&self, id: SourceId) -> &Path {
         if id.is_interactive() {
             Path::new("<interactive>")
         } else {
-            let value = id.into();
-            self.module_paths.get_by_left(&value).unwrap().as_path()
+            self.module_path(id.into())
         }
+    }
+
+    /// Get a [Path] for a specific [ModuleId].
+    pub fn module_path(&self, id: ModuleId) -> &Path {
+        self.module_paths.get_by_left(&id).unwrap().as_path()
     }
 
     /// Get a canonicalised version of a [Path] for a [SourceId]. If it is
@@ -202,7 +220,7 @@ impl SourceMap {
     /// function adheres to the rules of module naming conventions which are
     /// specified within the documentation book.
     pub fn source_name(&self, id: SourceId) -> &str {
-        let path = self.path_by_id(id);
+        let path = self.source_path(id);
 
         // for interactive, there is no file and so we just default to using the whole
         // path
@@ -245,7 +263,7 @@ impl SourceMap {
     }
 
     /// Get the [ModuleKind] by [SourceId]. If the `id` is
-    /// [SourceId::Interactive], then the resultant [ModuleKind] is [None].
+    /// [InteractiveId], then the resultant [ModuleKind] is [None].
     pub fn module_kind_by_id(&self, source_id: SourceId) -> Option<ModuleKind> {
         if source_id.is_interactive() {
             return None;
@@ -255,7 +273,19 @@ impl SourceMap {
         self.module_kind_map.get(value as usize).copied()
     }
 
-    /// Add a module to the [SourceMap]
+    /// Get the entry point that has been registered with the [SourceMap].
+    ///
+    /// If no entry point has been registered, then the function will panic.
+    pub fn entry_point(&self) -> ModuleId {
+        self.module_kind_map
+            .iter()
+            .position(|kind| matches!(kind, ModuleKind::EntryPoint))
+            .unwrap()
+            .into()
+    }
+
+    /// Add a module to the [SourceMap] with the specified resolved file path,
+    /// contents and a kind of module.
     pub fn add_module(&mut self, path: PathBuf, contents: String, kind: ModuleKind) -> SourceId {
         let id = self.module_content_map.len() as u32;
         self.module_content_map.push(contents);

--- a/compiler/hash-target/build.rs
+++ b/compiler/hash-target/build.rs
@@ -1,0 +1,22 @@
+//! This build script is used to compute the name of the
+//! target in the form of a [target-triple][https://wiki.osdev.org/Target_Triplet]
+//! string. This is used to properly configure the compilation target
+//! for the code generation backends.
+
+use std::env;
+
+macro_rules! export_variable {
+    ($name:ident, $value:expr) => {
+        println!("cargo:rustc-env={}={}", stringify!($name), $value);
+    };
+}
+
+/// Expore the target triple as an environment variable.
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    export_variable!(TARGET_TRIPLE, target);
+
+    // By default Cargo only runs the build script when a file changes.
+    // This makes it re-run on target change
+    println!("cargo:rerun-if-changed-env=TARGET")
+}

--- a/compiler/hash-target/build.rs
+++ b/compiler/hash-target/build.rs
@@ -11,7 +11,7 @@ macro_rules! export_variable {
     };
 }
 
-/// Expore the target triple as an environment variable.
+/// Export the target triple as an environment variable.
 fn main() {
     let target = env::var("TARGET").unwrap();
     export_variable!(TARGET_TRIPLE, target);

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -120,7 +120,7 @@ impl TargetArch {
     pub fn from_host() -> Self {
         match ARCH {
             "x86" => Self::X86,
-            "x86_64" => Self::X86_64,
+            "x86_64" | "x86-64" | "x64" => Self::X86_64,
             "aarch64" => Self::Aarch64,
             "arm" => Self::Arm,
             _ => Self::Unknown,
@@ -131,7 +131,7 @@ impl TargetArch {
     pub fn as_str(&self) -> &'static str {
         match self {
             TargetArch::X86 => "x86",
-            TargetArch::X86_64 => "x86_64",
+            TargetArch::X86_64 => "x86-64",
             TargetArch::Aarch64 => "aarch64",
             TargetArch::Arm => "arm",
             TargetArch::Unknown => "unknown",

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -24,13 +24,30 @@ pub struct Target {
     /// supports a pointer size larger than 8 bytes.
     pub pointer_width: usize,
 
-    /// The name of the target.
-    pub name: TargetName,
+    /// The target-triple name of the [Target].
+    pub name: Cow<'static, str>,
+
+    /// The architecture of the target.
+    pub arch: TargetArch,
 
     /// The name of the entry point for the target.
     ///
     /// Default is `main`.
     pub entry_name: Cow<'static, str>,
+
+    /// Specifies the name of the cpu that the target has.
+    pub cpu: Cow<'static, str>,
+
+    /// This specifies the CPU features that are available on the
+    /// target that is being compiled for.
+    pub cpu_features: Cow<'static, str>,
+
+    /// Represents what kind of relocation model the target is
+    /// expecting.
+    pub relocation_mode: RelocationMode,
+
+    /// Represents what kind of code model the target is expecting.
+    pub code_model: CodeModel,
 
     /// The default visibility for symbols in this target should be "hidden"
     /// rather than "default"
@@ -41,9 +58,46 @@ pub struct Target {
     pub entry_abi: Abi,
 }
 
-/// Represents the available targets that the compiler can compiler for.
 #[derive(Debug, Clone, Copy)]
-pub enum TargetName {
+pub enum CodeModel {
+    /// The default code model.
+    Default,
+
+    /// The JIT code model.
+    JITDefault,
+
+    /// The small code model.
+    Small,
+
+    /// The kernel code model.
+    Kernel,
+
+    /// The medium code model.
+    Medium,
+
+    /// The large code model.
+    Large,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RelocationMode {
+    /// The default relocation mode.
+    Default,
+
+    /// The static relocation mode.
+    Static,
+
+    /// The PIC relocation mode.
+    PIC,
+
+    /// The dynamic no PIC relocation mode.
+    DynamicNoPIC,
+}
+
+/// Represents the available target architectures that the compiler can compiler
+/// for.
+#[derive(Debug, Clone, Copy)]
+pub enum TargetArch {
     /// x86 32-bit target architecture.
     X86,
 
@@ -61,8 +115,9 @@ pub enum TargetName {
     Unknown,
 }
 
-impl TargetName {
-    pub fn from_system() -> Self {
+impl TargetArch {
+    /// Get the [TargetArch] from the host system.
+    pub fn from_host() -> Self {
         match ARCH {
             "x86" => Self::X86,
             "x86_64" => Self::X86_64,
@@ -71,16 +126,27 @@ impl TargetName {
             _ => Self::Unknown,
         }
     }
+
+    /// Convert the [TargetName] to a static string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TargetArch::X86 => "x86",
+            TargetArch::X86_64 => "x86_64",
+            TargetArch::Aarch64 => "aarch64",
+            TargetArch::Arm => "arm",
+            TargetArch::Unknown => "unknown",
+        }
+    }
 }
 
-impl Display for TargetName {
+impl Display for TargetArch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TargetName::X86 => write!(f, "x86"),
-            TargetName::X86_64 => write!(f, "x86_64"),
-            TargetName::Aarch64 => write!(f, "aarch64"),
-            TargetName::Arm => write!(f, "arm"),
-            TargetName::Unknown => write!(f, "unknown"),
+            TargetArch::X86 => write!(f, "x86"),
+            TargetArch::X86_64 => write!(f, "x86_64"),
+            TargetArch::Aarch64 => write!(f, "aarch64"),
+            TargetArch::Arm => write!(f, "arm"),
+            TargetArch::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -88,15 +154,17 @@ impl Display for TargetName {
 impl Target {
     /// Create a new target from the given string.
     pub fn from_string(name: String) -> Option<Self> {
-        let (name, pointer_width) = match name.as_str() {
-            "x86" => (TargetName::X86, 4),
-            "x86_64" => (TargetName::X86_64, 8),
-            "arm" => (TargetName::Arm, 4),
-            "aarch64" => (TargetName::Aarch64, 8),
+        // @@Todo: move each branch into separate module in order
+        // to make it easier to add new targets.
+        let (cpu, arch, pointer_width) = match name.as_str() {
+            "x86" => ("x86-64", TargetArch::X86, 4),
+            "x86_64" => ("x86-64", TargetArch::X86_64, 8),
+            "arm" => ("arm", TargetArch::Arm, 4),
+            "aarch64" => ("aarch64", TargetArch::Aarch64, 8),
             _ => return None,
         };
 
-        Some(Self { name, pointer_width, ..Default::default() })
+        Some(Self { cpu: cpu.into(), arch, pointer_width, ..Default::default() })
     }
 }
 
@@ -104,11 +172,16 @@ impl Default for Target {
     fn default() -> Self {
         // get the size of the pointer for the current system
         let pointer_width = std::mem::size_of::<usize>();
-        let name = TargetName::from_system();
+        let arch = TargetArch::from_host();
 
         Self {
+            name: env!("TARGET_TRIPLE").into(),
+            cpu: "generic".into(),
+            cpu_features: "".into(),
+            relocation_mode: RelocationMode::PIC,
+            code_model: CodeModel::Default,
             pointer_width,
-            name,
+            arch,
             entry_name: "main".into(),
             entry_abi: Abi::C,
             default_hidden_visibility: false,

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -6,7 +6,7 @@
 use std::{cell::RefCell, hash::Hash, marker::PhantomData, ops::Range};
 
 use append_only_vec::AppendOnlyVec;
-pub use fxhash::FxHashMap;
+pub use fxhash::{FxHashMap, FxHashSet};
 
 /// Represents a key that can be used to index a [`Store`].
 pub trait StoreKey: Copy + Eq + Hash {

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -291,11 +291,16 @@ fn handle_pass_case(
 
 /// Generic test handler in the event whether a case should pass or fail.
 fn handle_test(test: TestingInput) {
-    let workspace = Workspace::new();
     let mut settings = CompilerSettings::new(WORKER_COUNT);
     settings.set_skip_prelude(true);
     settings.set_emit_errors(false);
     settings.set_stage(test.metadata.stage);
+
+    // We also have to specify the output directory for compiler artifacts to
+    // be `tests/target` in order to avoid producing artifacts within the test
+    // runner tree.
+
+    let workspace = Workspace::new(&settings).unwrap();
 
     // We also need to potentially apply any additional configuration options
     // that are specified by the test onto the compiler settings
@@ -343,8 +348,7 @@ fn handle_test(test: TestingInput) {
     let mut compiler_state = compiler.bootstrap(session);
 
     // // Now parse the module and store the result
-    compiler_state =
-        compiler.run_on_filename(test.path.to_str().unwrap(), ModuleKind::Normal, compiler_state);
+    compiler_state = compiler.run_on_filename(&test.path, ModuleKind::Normal, compiler_state);
 
     let diagnostics = compiler_state.diagnostics;
 


### PR DESCRIPTION
This patch integrates the code generation backend with the pipeline. This means that the compiler should now be able
to output bit code for the compiled programs in the form of object files (`.o`) which will then need to be linked with anything else required, or if there are multiple object files, they need to be linked themselves.

Additionally, this patch expands the responsibility of the `Workspace` to keep track of the project "temporary" store in order so it can always write files to a temporary place. This is where the object files should be written, and where an executable is written (unless specified elsewhere by the user).

Finally, this does some cleanup of the argument and error handling code in `hash-pipeline`.

closes #654 
closes #669 
closes #652 

Next to go... linking!