### PR TITLE
Allow definitions in runtime blocks, and partially implement normalisation

### DIFF
--- a/compiler/hash-semantics/src/new/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/new/diagnostics/error.rs
@@ -46,6 +46,8 @@ pub enum SemanticError {
     CannotUseFunctionInTypePosition { location: SourceLocation },
     /// Cannot use a function in a pattern position.
     CannotUseFunctionInPatternPosition { location: SourceLocation },
+    /// Cannot use a non-constant item in constant position.
+    CannotUseNonConstantItem { location: SourceLocation },
     /// Cannot use the subject as a namespace.
     InvalidNamespaceSubject { location: SourceLocation },
     /// Cannot use arguments here.
@@ -214,6 +216,16 @@ impl<'tc> WithTcEnv<'tc, &SemanticError> {
 
                 error.add_span(*location).add_info(
                     "cannot use this in pattern position as it refers to a function definition",
+                );
+            }
+            SemanticError::CannotUseNonConstantItem { location } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ValueCannotBeUsedAsType)
+                    .title("cannot use a non-constant value in constant position");
+
+                error.add_span(*location).add_info(
+                    "cannot use this in constant position as it refers to a runtime value",
                 );
             }
             SemanticError::InvalidNamespaceSubject { location } => {

--- a/compiler/hash-semantics/src/new/passes/resolution/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/mod.rs
@@ -58,7 +58,8 @@ impl<'tc> AstPass for ResolutionPass<'tc> {
         let (prim_mod, _) = self.bootstrap();
         self.scoping().add_scope(prim_mod.into(), ContextKind::Environment);
         self.scoping().add_mod_members(prim_mod);
-        let _ = self.make_term_from_ast_body_block(node)?;
+        let term_id = self.make_term_from_ast_body_block(node)?;
+        self.ast_info().terms().insert(node.id(), term_id);
         Ok(())
     }
 

--- a/compiler/hash-semantics/src/new/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/paths.rs
@@ -314,8 +314,10 @@ impl<'tc> ResolutionPass<'tc> {
                     }
                 }
             }
-            BindingKind::Equality(_) => {
-                unreachable!("No equality judgements should be present during resolution")
+            BindingKind::Arg(_, _) | BindingKind::Equality(_) => {
+                unreachable!(
+                    "No equality judgements or arg bindings should be present during resolution"
+                )
             }
         }
     }

--- a/compiler/hash-semantics/src/new/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/paths.rs
@@ -295,7 +295,7 @@ impl<'tc> ResolutionPass<'tc> {
                     None => todo!(),
                 }
             }
-            BindingKind::Param(_) | BindingKind::StackMember(_) => {
+            BindingKind::Param(_, _) | BindingKind::StackMember(_) => {
                 // If the subject has no args, it is a variable, otherwise it is a
                 // function call.
                 match &component.args[..] {

--- a/compiler/hash-semantics/src/new/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/pats.rs
@@ -83,7 +83,15 @@ impl ResolutionPass<'_> {
             name: node
                 .name
                 .as_ref()
-                .map(|name| self.scoping().lookup_symbol_by_name(name.ident).unwrap())
+                .map(|name| {
+                    self.scoping()
+                        .lookup_symbol_by_name_or_error(
+                            name.ident,
+                            name.span(),
+                            self.scoping().get_current_context_kind(),
+                        )
+                        .unwrap()
+                })
                 .unwrap_or_else(|| self.new_fresh_symbol()),
             index: node.position,
         }))

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -301,9 +301,14 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         node: AstNodeRef<ast::TyFn>,
     ) -> SemanticResult<TyId> {
-        // First, make the params
-        let params = self.try_or_add_error(self.resolve_params_from_ast_params(&node.params, true));
         self.scoping().enter_ty_fn_ty(node, |mut ty_fn| {
+            // First, make the params
+            let params = self.try_or_add_error(self.resolve_params_from_ast_params(
+                &node.params,
+                true,
+                ty_fn.into(),
+            ));
+
             // Add the params if they exist
             if let Some(params) = params {
                 ty_fn.params = params;

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -23,6 +23,31 @@ use crate::new::{
     tuples::TupleTy,
 };
 
+/// All the places a parameter can come from.
+#[derive(Debug, Clone, Copy, From)]
+pub enum ParamOrigin {
+    /// A parameter in a function definition.
+    Fn(FnDefId),
+    /// A parameter in a function type.
+    FnTy(FnTy),
+    /// A parameter in a tuple type.
+    TupleTy(TupleTy),
+    /// A parameter in a constructor.
+    Ctor(CtorDefId),
+    /// A parameter in a data definition.
+    Data(DataDefId),
+}
+
+impl ParamOrigin {
+    /// A constant parameter is one that cannot depend on non-constant bindings.
+    pub fn is_constant(&self) -> bool {
+        match self {
+            ParamOrigin::Fn(_) | ParamOrigin::FnTy(_) | ParamOrigin::TupleTy(_) => false,
+            ParamOrigin::Ctor(_) | ParamOrigin::Data(_) => true,
+        }
+    }
+}
+
 /// The kind of a binding.
 #[derive(Debug, Clone, Copy)]
 pub enum BindingKind {
@@ -37,7 +62,7 @@ pub enum BindingKind {
     /// A parameter variable
     ///
     /// For example, `(x: i32) => x` or `(T: Type, t: T)`
-    Param(ParamId),
+    Param(ParamOrigin, ParamId),
     /// Stack member.
     ///
     /// For example, `a` in `{ a := 3; a }`
@@ -50,6 +75,19 @@ pub enum BindingKind {
     ///
     /// This is a special binding because it cannot be referenced by name.
     Equality(EqualityJudgement),
+}
+
+impl BindingKind {
+    /// A constant binding is one that cannot depend on non-constant bindings.
+    pub fn is_constant(&self) -> bool {
+        match self {
+            BindingKind::ModMember(_, _) | BindingKind::Ctor(_, _) => true,
+            BindingKind::Param(origin, _) => origin.is_constant(),
+            BindingKind::StackMember(_) | BindingKind::Arg(_, _) | BindingKind::Equality(_) => {
+                false
+            }
+        }
+    }
 }
 
 /// A binding.
@@ -88,6 +126,20 @@ pub enum ScopeKind {
     FnTy(FnTy),
     /// A tuple type scope.
     TupleTy(TupleTy),
+}
+
+impl ScopeKind {
+    /// Whether this scope is constant.
+    ///
+    /// A constant scope is one that cannot depend on non-constant bindings.
+    pub fn is_constant(&self) -> bool {
+        match self {
+            ScopeKind::Mod(_) | ScopeKind::Data(_) | ScopeKind::Ctor(_) => true,
+            ScopeKind::Stack(_) | ScopeKind::Fn(_) | ScopeKind::FnTy(_) | ScopeKind::TupleTy(_) => {
+                false
+            }
+        }
+    }
 }
 
 /// Information about a scope in the context.
@@ -290,7 +342,7 @@ impl fmt::Display for WithEnv<'_, Binding> {
             BindingKind::Ctor(_, ctor_id) => {
                 write!(f, "{}", self.env().with(ctor_id))
             }
-            BindingKind::Param(param_id) => {
+            BindingKind::Param(_, param_id) => {
                 write!(f, "{}", self.env().with(param_id))
             }
             BindingKind::StackMember(stack_member) => {

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -12,6 +12,7 @@ use indexmap::IndexMap;
 
 use super::env::{AccessToEnv, WithEnv};
 use crate::new::{
+    args::ArgId,
     data::{CtorDefId, DataDefId},
     fns::{FnDefId, FnTy},
     mods::{ModDefId, ModMemberId},
@@ -41,6 +42,10 @@ pub enum BindingKind {
     ///
     /// For example, `a` in `{ a := 3; a }`
     StackMember(StackMemberId),
+    /// Parameter substitution (argument)
+    ///
+    /// For example, `a=3` in `((a: i32) => a + 3)(3)`
+    Arg(ParamId, ArgId),
     /// Equality judgement
     ///
     /// This is a special binding because it cannot be referenced by name.
@@ -293,6 +298,9 @@ impl fmt::Display for WithEnv<'_, Binding> {
             }
             BindingKind::Equality(equality) => {
                 write!(f, "{}", self.env().with(equality))
+            }
+            BindingKind::Arg(_, arg_id) => {
+                write!(f, "{}", self.env().with(arg_id))
             }
         }
     }

--- a/compiler/hash-tir/src/new/terms.rs
+++ b/compiler/hash-tir/src/new/terms.rs
@@ -12,7 +12,7 @@ use hash_utils::{
 use super::{
     casting::CastTerm,
     environment::env::{AccessToEnv, WithEnv},
-    holes::{Hole, HoleBinder},
+    holes::Hole,
     lits::PrimTerm,
     symbols::Symbol,
     tys::TypeOfTerm,
@@ -51,9 +51,6 @@ pub struct RuntimeTerm {
 /// them through some secondary map.
 #[derive(Debug, Clone, Copy, From)]
 pub enum Term {
-    // Runtime
-    Runtime(RuntimeTerm),
-
     // Primitives
     Tuple(TupleTerm),
     Prim(PrimTerm),
@@ -102,7 +99,6 @@ pub enum Term {
 
     /// Holes
     Hole(Hole),
-    HoleBinder(HoleBinder),
 }
 
 new_store_key!(pub TermId);
@@ -126,7 +122,6 @@ impl fmt::Display for WithEnv<'_, &RuntimeTerm> {
 impl fmt::Display for WithEnv<'_, &Term> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
-            Term::Runtime(runtime_term) => write!(f, "{}", self.env().with(runtime_term)),
             Term::Tuple(tuple_term) => write!(f, "{}", self.env().with(tuple_term)),
             Term::Prim(lit_term) => write!(f, "{}", self.env().with(lit_term)),
             Term::Ctor(ctor_term) => write!(f, "{}", self.env().with(ctor_term)),
@@ -162,7 +157,6 @@ impl fmt::Display for WithEnv<'_, &Term> {
             Term::Ref(ref_term) => write!(f, "{}", self.env().with(ref_term)),
             Term::Deref(deref_term) => write!(f, "{}", self.env().with(deref_term)),
             Term::Hole(hole) => write!(f, "{}", self.env().with(*hole)),
-            Term::HoleBinder(hole_binder) => write!(f, "{}", self.env().with(*hole_binder)),
         }
     }
 }

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -8,7 +8,7 @@ use crate::new::{
     data::{DataDef, DataDefId, DataTy},
     environment::env::AccessToEnv,
     fns::{FnDef, FnDefId},
-    holes::{Hole, HoleBinder, HoleBinderKind},
+    holes::Hole,
     locations::LocationTarget,
     params::{Param, ParamIndex, ParamsId},
     pats::{Pat, PatId, PatListId},
@@ -222,16 +222,6 @@ pub trait CommonUtils: AccessToEnv {
     /// Create a new type hole.
     fn new_ty_hole(&self) -> TyId {
         self.stores().ty().create_with(|_| Ty::Hole(self.new_hole()))
-    }
-
-    /// Create a new hole binder.
-    fn new_hole_binder(&self, hole: Hole, ty: TyId, inner: TermId) -> TermId {
-        self.new_term(HoleBinder { hole, kind: HoleBinderKind::Hole(ty), inner })
-    }
-
-    /// Create a new guess binder.
-    fn new_guess_binder(&self, hole: Hole, guess: TermId, ty: TyId, inner: TermId) -> TermId {
-        self.new_term(HoleBinder { hole, kind: HoleBinderKind::Guess(guess, ty), inner })
     }
 
     /// Create a new empty argument list.

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -9,7 +9,7 @@ use crate::{
         args::ArgsId,
         data::{DataDefCtors, DataDefId},
         environment::{
-            context::{Binding, BindingKind, EqualityJudgement, ScopeKind},
+            context::{Binding, BindingKind, EqualityJudgement, ParamOrigin, ScopeKind},
             env::{AccessToEnv, Env},
         },
         mods::ModDefId,
@@ -32,10 +32,10 @@ impl<'env> ContextUtils<'env> {
     ///
     /// This should be used when entering a scope that has parameters. Ensure
     /// that the given parameter belongs to the current scope.
-    pub fn add_param_binding(&self, param_id: ParamId) {
+    pub fn add_param_binding(&self, param_id: ParamId, origin: ParamOrigin) {
         // @@Safety: Maybe we should check that the param belongs to the current scope?
         let name = self.stores().params().map_fast(param_id.0, |params| params[param_id.1].name);
-        self.context().add_binding(Binding { name, kind: BindingKind::Param(param_id) });
+        self.context().add_binding(Binding { name, kind: BindingKind::Param(origin, param_id) });
     }
 
     /// Add argument bindings from the given parameters, using the

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -1,18 +1,19 @@
 //! Contains context-related utilities.
 use derive_more::Constructor;
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 
 use super::common::CommonUtils;
 use crate::{
     impl_access_to_env,
     new::{
+        args::ArgsId,
         data::{DataDefCtors, DataDefId},
         environment::{
             context::{Binding, BindingKind, EqualityJudgement, ScopeKind},
             env::{AccessToEnv, Env},
         },
         mods::ModDefId,
-        params::ParamId,
+        params::{ParamId, ParamsId},
         scopes::{DeclTerm, StackMemberId},
         terms::TermId,
     },
@@ -35,6 +36,20 @@ impl<'env> ContextUtils<'env> {
         // @@Safety: Maybe we should check that the param belongs to the current scope?
         let name = self.stores().params().map_fast(param_id.0, |params| params[param_id.1].name);
         self.context().add_binding(Binding { name, kind: BindingKind::Param(param_id) });
+    }
+
+    /// Add argument bindings from the given parameters, using the
+    /// given arguments.
+    ///
+    /// *Invariant*: the lengths of the arguments and parameters must match.
+    pub fn add_arg_bindings(&self, params_id: ParamsId, args_id: ArgsId) {
+        assert_eq!(params_id.len(), args_id.len());
+        for i in params_id.to_index_range() {
+            self.context().add_binding(Binding {
+                name: self.stores().params().map_fast(params_id, |params| params[i].name),
+                kind: BindingKind::Arg((params_id, i), (args_id, i)),
+            });
+        }
     }
 
     /// Add an equality judgement to the context.
@@ -75,6 +90,7 @@ impl<'env> ContextUtils<'env> {
             ScopeKind::Stack(stack_id) => stack_id,
             _ => unreachable!(), // decls are only allowed in stack scopes
         };
+
         for stack_index in decl.iter_stack_indices() {
             self.add_stack_binding((current_stack_id, stack_index));
         }

--- a/compiler/hash-tir/src/new/utils/stack.rs
+++ b/compiler/hash-tir/src/new/utils/stack.rs
@@ -6,6 +6,7 @@ use crate::{
     impl_access_to_env,
     new::{
         environment::env::{AccessToEnv, Env},
+        mods::ModDefId,
         scopes::{Stack, StackId, StackMember, StackMemberData},
     },
 };
@@ -21,7 +22,14 @@ impl_access_to_env!(StackUtils<'tc>);
 impl<'tc> StackUtils<'tc> {
     /// Create a new empty stack.
     pub fn create_stack(&self) -> StackId {
-        self.stores().stack().create_with(|id| Stack { id, members: vec![] })
+        self.stores().stack().create_with(|id| Stack { id, members: vec![], local_mod_def: None })
+    }
+
+    /// Set the local mod def of the given stack.
+    pub fn set_local_mod_def(&self, stack_id: StackId, local_mod_def_id: ModDefId) {
+        self.stores().stack().modify_fast(stack_id, |stack| {
+            stack.local_mod_def = Some(local_mod_def_id);
+        })
     }
 
     /// Set the members of the given stack.

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -71,6 +71,13 @@ pub trait Mapper<E> = Fn(Atom) -> Result<ControlFlow<Atom>, E> + Copy;
 /// Contains the implementation of `fmap` and `visit` for each atom, as well as
 /// secondary components such as arguments and parameters.
 impl<'env> TraversingUtils<'env> {
+    pub fn fmap_atom_non_preserving<E, F: Mapper<E>>(&self, atom: Atom, f: F) -> Result<Atom, E> {
+        match f(atom)? {
+            ControlFlow::Continue(()) => self.fmap_atom(atom, f),
+            ControlFlow::Break(atom) => Ok(atom),
+        }
+    }
+
     pub fn fmap_atom<E, F: Mapper<E>>(&self, atom: Atom, f: F) -> Result<Atom, E> {
         match atom {
             Atom::Term(term_id) => Ok(Atom::Term(self.fmap_term(term_id, f)?)),

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -16,14 +16,13 @@ use crate::{
         data::{CtorDefId, CtorPat, CtorTerm, DataDefCtors, DataDefId, DataTy, PrimitiveCtorInfo},
         environment::env::{AccessToEnv, Env, WithEnv},
         fns::{FnBody, FnCallTerm, FnDefData, FnDefId, FnTy},
-        holes::{HoleBinder, HoleBinderKind},
         lits::{ListCtor, ListPat, PrimTerm},
         mods::{ModDefId, ModMemberId, ModMemberValue},
         params::{ParamData, ParamsId},
         pats::{Pat, PatId, PatListId},
         refs::{DerefTerm, RefTerm, RefTy},
         scopes::{AssignTerm, BlockTerm, DeclTerm},
-        terms::{RuntimeTerm, Term, TermId, TermListId, UnsafeTerm},
+        terms::{Term, TermId, TermListId, UnsafeTerm},
         tuples::{TuplePat, TupleTerm, TupleTy},
         tys::{Ty, TyId, TypeOfTerm},
     },
@@ -85,10 +84,6 @@ impl<'env> TraversingUtils<'env> {
         match f(term_id.into())? {
             ControlFlow::Break(atom) => Ok(TermId::try_from(atom).unwrap()),
             ControlFlow::Continue(()) => match self.get_term(term_id) {
-                Term::Runtime(rt_term) => {
-                    let term_ty = self.fmap_ty(rt_term.term_ty, f)?;
-                    Ok(self.new_term(RuntimeTerm { term_ty }))
-                }
                 Term::Tuple(tuple_term) => {
                     let data = self.fmap_args(tuple_term.data, f)?;
                     Ok(self.new_term(Term::Tuple(TupleTerm { data })))
@@ -202,27 +197,6 @@ impl<'env> TraversingUtils<'env> {
                     Ok(self.new_term(DerefTerm { subject }))
                 }
                 Term::Hole(hole_term) => Ok(self.new_term(hole_term)),
-                Term::HoleBinder(hole_binder) => match hole_binder.kind {
-                    HoleBinderKind::Hole(ty) => {
-                        let ty = self.fmap_ty(ty, f)?;
-                        let inner = self.fmap_term(hole_binder.inner, f)?;
-                        Ok(self.new_term(HoleBinder {
-                            hole: hole_binder.hole,
-                            inner,
-                            kind: HoleBinderKind::Hole(ty),
-                        }))
-                    }
-                    HoleBinderKind::Guess(guess, ty) => {
-                        let guess = self.fmap_term(guess, f)?;
-                        let ty = self.fmap_ty(ty, f)?;
-                        let inner = self.fmap_term(hole_binder.inner, f)?;
-                        Ok(self.new_term(HoleBinder {
-                            hole: hole_binder.hole,
-                            inner,
-                            kind: HoleBinderKind::Guess(guess, ty),
-                        }))
-                    }
-                },
             },
         }
     }
@@ -398,7 +372,6 @@ impl<'env> TraversingUtils<'env> {
         match f(term_id.into())? {
             ControlFlow::Break(_) => Ok(()),
             ControlFlow::Continue(()) => match self.get_term(term_id) {
-                Term::Runtime(rt_term) => self.visit_ty(rt_term.term_ty, f),
                 Term::Tuple(tuple_term) => self.visit_args(tuple_term.data, f),
                 Term::Prim(prim_term) => match prim_term {
                     PrimTerm::Lit(_) => Ok(()),
@@ -457,17 +430,6 @@ impl<'env> TraversingUtils<'env> {
                 Term::Ref(ref_term) => self.visit_term(ref_term.subject, f),
                 Term::Deref(deref_term) => self.visit_term(deref_term.subject, f),
                 Term::Hole(_) => Ok(()),
-                Term::HoleBinder(hole_binder) => match hole_binder.kind {
-                    HoleBinderKind::Hole(ty) => {
-                        self.visit_ty(ty, f)?;
-                        self.visit_term(hole_binder.inner, f)
-                    }
-                    HoleBinderKind::Guess(guess, ty) => {
-                        self.visit_term(guess, f)?;
-                        self.visit_ty(ty, f)?;
-                        self.visit_term(hole_binder.inner, f)
-                    }
-                },
             },
         }
     }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -441,6 +441,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 .stores()
                 .stack()
                 .map_fast(stack_member_id.0, |stack| stack.members[stack_member_id.1].ty)),
+            BindingKind::Arg(param_id, _) => Ok(self.stores().params().get_element(param_id).ty),
         }
     }
 
@@ -636,28 +637,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         _decl_term: &DeclTerm,
         _annotation_ty: Option<TyId>,
     ) -> TcResult<(DeclTerm, TyId)> {
-        // let uni = self.check_pat(decl_term.bind_pat, decl_term.ty)?;
-
         todo!()
-        // match uni {
-        //     Uni::Successful(sub) => {
-        //         match decl_term.value {
-        //             Some(value) => {
-        //                 let new_ty = self.check_term(decl_term.value,
-        // ty_id)?;                 todo!()
-        //             }
-        //             None => {
-        //                 todo!()
-        //             }
-        //         }
-
-        //         self.context_utils().add_decl_term_to_context(&decl_term);
-        //     }
-        //     Uni::Blocked => {
-        //         self.context_utils().add_decl_term_to_context(&decl_term);
-        //         Ok(None)
-        //     }
-        // }
     }
 
     pub fn generalise_term_inference(&self, inference: (impl Into<Term>, TyId)) -> (TermId, TyId) {
@@ -686,7 +666,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         term_id: TermId,
         annotation_ty: Option<TyId>,
     ) -> TcResult<(TermId, TyId)> {
-        self.stores().term().map(term_id, |term| match term {
+        let result = self.stores().term().map(term_id, |term| match term {
             Term::Tuple(tuple_term) => self
                 .infer_tuple_term(tuple_term, annotation_ty)
                 .map(|i| self.generalise_term_and_ty_inference(i)),
@@ -745,7 +725,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Assign(_) => todo!(),
             Term::Access(_) => todo!(),
             Term::Hole(_) => Err(TcError::Blocked),
-        })
+        })?;
+
+        Ok(result)
     }
 
     /// Infer the type of a pattern, and return it.

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -727,6 +727,21 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Hole(_) => Err(TcError::Blocked),
         })?;
 
+        println!("Un-normalised: {}: {}", self.env().with(result.0), self.env().with(result.1));
+
+        // @@Temporary
+        let normalised_term = self.normalisation_ops().normalise(result.0.into()).unwrap();
+        let normalised_ty = self
+            .normalisation_ops()
+            .normalise_to_ty(result.1.into())
+            .unwrap()
+            .unwrap_or_else(|| self.new_ty_hole());
+        println!(
+            "Normalised: {}: {}",
+            self.env().with(normalised_term),
+            self.env().with(normalised_ty)
+        );
+
         Ok(result)
     }
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -687,9 +687,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         annotation_ty: Option<TyId>,
     ) -> TcResult<(TermId, TyId)> {
         self.stores().term().map(term_id, |term| match term {
-            Term::Runtime(rt_term) => self
-                .infer_runtime_term(rt_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
             Term::Tuple(tuple_term) => self
                 .infer_tuple_term(tuple_term, annotation_ty)
                 .map(|i| self.generalise_term_and_ty_inference(i)),
@@ -747,7 +744,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Match(_) => todo!(),
             Term::Assign(_) => todo!(),
             Term::Access(_) => todo!(),
-            Term::HoleBinder(_) => todo!(),
             Term::Hole(_) => Err(TcError::Blocked),
         })
     }

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(unwrap_infallible, never_type, try_trait_v2, try_blocks)]
+#![feature(unwrap_infallible, never_type, try_trait_v2, try_blocks, control_flow_enum)]
 
 use errors::{TcError, TcErrorState, TcResult};
 use hash_intrinsics::{intrinsics::AccessToIntrinsics, primitives::AccessToPrimitives};

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -102,6 +102,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
 
     /// Evaluate an atom once, for use with `fmap`.
     fn eval_once(&self, atom: Atom) -> Result<ControlFlow<Atom>, Signal> {
+        // @@Todo: enter scopes
         match atom {
             Atom::Term(term) => match self.get_term(term) {
                 // Forward to types:

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -1,20 +1,52 @@
 //! Operations for normalising terms and types.
 use derive_more::{Constructor, Deref};
-use hash_tir::new::terms::TermId;
+use hash_tir::new::{
+    terms::{Term, TermId},
+    utils::common::CommonUtils,
+};
 
 use crate::{errors::TcResult, AccessToTypechecking};
 
 #[derive(Constructor, Deref)]
 pub struct NormalisationOps<'a, T: AccessToTypechecking>(&'a T);
 
+/// Represents a normalised atom, with some additional information.
+pub struct Norm<T> {
+    /// The normalised term.
+    pub term: T,
+}
+
 impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     /// Turn a term to weak head normal form.
-    pub fn standardise_term(&self, _term_id: TermId) -> TcResult<TermId> {
-        todo!()
+    pub fn weak_head_normalise_term(&self, term_id: TermId) -> TcResult<Norm<TermId>> {
+        let term = self.get_term(term_id);
+        match term {
+            Term::Tuple(_) => todo!(),
+            Term::Prim(_) => todo!(),
+            Term::Ctor(_) => todo!(),
+            Term::FnCall(_) => todo!(),
+            Term::FnRef(_) => todo!(),
+            Term::Block(_) => todo!(),
+            Term::Var(_) => todo!(),
+            Term::Loop(_) => todo!(),
+            Term::LoopControl(_) => todo!(),
+            Term::Match(_) => todo!(),
+            Term::Return(_) => todo!(),
+            Term::Decl(_) => todo!(),
+            Term::Assign(_) => todo!(),
+            Term::Unsafe(_) => todo!(),
+            Term::Access(_) => todo!(),
+            Term::Cast(_) => todo!(),
+            Term::TypeOf(_) => todo!(),
+            Term::Ty(_) => todo!(),
+            Term::Ref(_) => todo!(),
+            Term::Deref(_) => todo!(),
+            Term::Hole(_) => todo!(),
+        }
     }
 
     /// Turn a term to weak head normal form, or return `None` .
-    pub fn potentially_standardise_term(&self, _term_id: TermId) -> TcResult<Option<TermId>> {
+    pub fn normalise_term(&self, _term_id: TermId) -> TcResult<Norm<T>> {
         todo!()
     }
 

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -1,53 +1,256 @@
 //! Operations for normalising terms and types.
-use derive_more::{Constructor, Deref};
-use hash_tir::new::{
-    terms::{Term, TermId},
-    utils::common::CommonUtils,
-};
+use std::ops::ControlFlow;
 
-use crate::{errors::TcResult, AccessToTypechecking};
+use derive_more::{Constructor, Deref, From};
+use hash_tir::new::{
+    control::LoopControlTerm,
+    environment::context::{BindingKind, ScopeKind},
+    fns::FnBody,
+    scopes::BlockTerm,
+    symbols::Symbol,
+    terms::{Term, TermId},
+    tys::{Ty, TyId},
+    utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
+};
+use hash_utils::store::{PartialStore, SequenceStore, SequenceStoreKey, Store};
+
+use crate::{
+    errors::{TcError, TcResult},
+    AccessToTypechecking,
+};
 
 #[derive(Constructor, Deref)]
 pub struct NormalisationOps<'a, T: AccessToTypechecking>(&'a T);
 
-/// Represents a normalised atom, with some additional information.
-pub struct Norm<T> {
-    /// The normalised term.
-    pub term: T,
+/// Represents a normalisation result.
+#[derive(Debug, Clone, From)]
+pub enum Signal {
+    Break,
+    Continue,
+    Return(Atom),
+    Err(TcError),
 }
 
 impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
-    /// Turn a term to weak head normal form.
-    pub fn weak_head_normalise_term(&self, term_id: TermId) -> TcResult<Norm<TermId>> {
-        let term = self.get_term(term_id);
-        match term {
-            Term::Tuple(_) => todo!(),
-            Term::Prim(_) => todo!(),
-            Term::Ctor(_) => todo!(),
-            Term::FnCall(_) => todo!(),
-            Term::FnRef(_) => todo!(),
-            Term::Block(_) => todo!(),
-            Term::Var(_) => todo!(),
-            Term::Loop(_) => todo!(),
-            Term::LoopControl(_) => todo!(),
-            Term::Match(_) => todo!(),
-            Term::Return(_) => todo!(),
-            Term::Decl(_) => todo!(),
-            Term::Assign(_) => todo!(),
-            Term::Unsafe(_) => todo!(),
-            Term::Access(_) => todo!(),
-            Term::Cast(_) => todo!(),
-            Term::TypeOf(_) => todo!(),
-            Term::Ty(_) => todo!(),
-            Term::Ref(_) => todo!(),
-            Term::Deref(_) => todo!(),
-            Term::Hole(_) => todo!(),
+    pub fn normalise(&self, atom: Atom) -> TcResult<Atom> {
+        match self.eval(atom) {
+            Ok(t) => Ok(t),
+            Err(e) => match e {
+                Signal::Break | Signal::Continue | Signal::Return(_) => {
+                    panic!("Got signal when normalising: {e:?}")
+                }
+                Signal::Err(e) => Err(e),
+            },
         }
     }
 
-    /// Turn a term to weak head normal form, or return `None` .
-    pub fn normalise_term(&self, _term_id: TermId) -> TcResult<Norm<T>> {
-        todo!()
+    pub fn normalise_to_ty(&self, atom: Atom) -> TcResult<Option<TyId>> {
+        match self.normalise(atom)? {
+            Atom::Term(term) => match self.get_term(term) {
+                Term::Ty(ty) => Ok(Some(ty)),
+                _ => Ok(None),
+            },
+            Atom::Ty(ty) => Ok(Some(ty)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Evaluate an atom.
+    pub fn eval(&self, atom: Atom) -> Result<Atom, Signal> {
+        self.traversing_utils().fmap_atom(atom, |atom| self.eval_once(atom))
+    }
+
+    /// Evaluate a block term.
+    pub fn eval_block(&self, block_term: BlockTerm) -> Result<Atom, Signal> {
+        self.context().enter_scope(ScopeKind::Stack(block_term.stack_id), || {
+            for statement in block_term
+                .statements
+                .to_index_range()
+                .map(|i| self.stores().term_list().get_at_index(block_term.statements, i))
+            {
+                let _ = self.eval(statement.into())?;
+            }
+            self.eval(block_term.return_value.into())
+        })
+    }
+
+    pub fn eval_var(&self, var: Symbol) -> Result<ControlFlow<TermId>, Signal> {
+        match self.context().get_binding(var).unwrap().kind {
+            BindingKind::Param(_) => Ok(ControlFlow::Continue(())),
+            BindingKind::Arg(_, arg_id) => Ok(ControlFlow::Break(
+                self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].value),
+            )),
+            BindingKind::StackMember(stack_member) => {
+                self.stores().stack().map_fast(stack_member.0, |stack| {
+                    match stack.members[stack_member.1].value {
+                        Some(value) => Ok(ControlFlow::Break(value)),
+                        None => {
+                            // @@Todo: make this a user error
+                            panic!("Tried to read uninitialised stack member")
+                        }
+                    }
+                })
+            }
+
+            // Variables are never bound to a module member, constructor or equality.
+            // @@Todo: make types better
+            BindingKind::ModMember(_, _) | BindingKind::Ctor(_, _) | BindingKind::Equality(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Evaluate an atom once, for use with `fmap`.
+    fn eval_once(&self, atom: Atom) -> Result<ControlFlow<Atom>, Signal> {
+        match atom {
+            Atom::Term(term) => match self.get_term(term) {
+                // Forward to types:
+                Term::Ty(_) => Ok(ControlFlow::Continue(())),
+                // Infer type:
+                Term::TypeOf(term) => {
+                    let (_, ty) = self.inference_ops().infer_term(term.term, None)?;
+                    Ok(ControlFlow::Break(ty.into()))
+                }
+
+                // @@Todo: different reference kinds
+                Term::Ref(_) => Ok(ControlFlow::Continue(())),
+
+                // Modalities:
+                Term::Unsafe(unsafe_expr) => {
+                    // @@Todo: handle unsafe safety
+                    Ok(ControlFlow::Break(self.eval(unsafe_expr.inner.into())?))
+                }
+
+                // Introduction forms:
+                Term::Tuple(_) | Term::Hole(_) | Term::FnRef(_) | Term::Ctor(_) | Term::Prim(_) => {
+                    Ok(ControlFlow::Continue(()))
+                }
+
+                Term::Match(_) => todo!(),
+
+                Term::FnCall(mut fn_call) => {
+                    let evaluated_inner = self.eval(fn_call.subject.into())?;
+
+                    // Beta-reduce:
+                    if let Atom::Term(term) = evaluated_inner {
+                        fn_call.subject = term;
+
+                        if let Term::FnRef(fn_def_id) = self.get_term(term) {
+                            let fn_def = self.get_fn_def(fn_def_id);
+                            // @@Todo: handle pure/impure
+
+                            match fn_def.body {
+                                FnBody::Defined(defined_fn_def) => {
+                                    return Ok(ControlFlow::Break(self.context().enter_scope(
+                                        fn_def_id.into(),
+                                        || {
+                                            // Add the parameter substitutions to the context:
+                                            self.context_utils()
+                                                .add_arg_bindings(fn_def.ty.params, fn_call.args);
+
+                                            // Normalise the body of the function.
+                                            match self.eval(defined_fn_def.into()) {
+                                                Err(Signal::Return(result)) | Ok(result) => {
+                                                    Ok(result)
+                                                }
+                                                err => err,
+                                            }
+                                        },
+                                    )?));
+                                }
+
+                                FnBody::Intrinsic(intrinsic_id) => {
+                                    let args_as_terms: Vec<TermId> =
+                                        self.stores().args().map_fast(fn_call.args, |args| {
+                                            args.iter().map(|arg| arg.value).collect()
+                                        });
+
+                                    // Run intrinsic:
+                                    let result: TermId = self.intrinsics().by_id().map_fast(
+                                        intrinsic_id,
+                                        |intrinsic| {
+                                            let intrinsic = intrinsic.unwrap();
+                                            (intrinsic.implementation)(self.0, &args_as_terms)
+                                        },
+                                    );
+
+                                    return Ok(ControlFlow::Break(result.into()));
+                                }
+
+                                FnBody::Axiom => {
+                                    // Nothing further to do
+                                }
+                            }
+                        }
+                    }
+
+                    Ok(ControlFlow::Break(self.new_term(fn_call).into()))
+                }
+
+                Term::Cast(_) => todo!(),
+
+                Term::Deref(deref_expr) => {
+                    let evaluated_inner = self.eval(deref_expr.subject.into())?;
+                    // Reduce:
+                    if let Atom::Term(term) = evaluated_inner {
+                        if let Term::Ref(ref_expr) = self.get_term(term) {
+                            return Ok(ControlFlow::Break(ref_expr.subject.into()));
+                        }
+                    }
+                    Ok(ControlFlow::Break(evaluated_inner))
+                }
+
+                Term::Var(var) => Ok(self.eval_var(var)?.map_break(|x| x.into())),
+
+                Term::Access(_) => todo!(),
+
+                // Imperative:
+                Term::LoopControl(loop_control) => match loop_control {
+                    LoopControlTerm::Break => Err(Signal::Break),
+                    LoopControlTerm::Continue => Err(Signal::Continue),
+                },
+                Term::Assign(_) => todo!(),
+                Term::Decl(_) => {
+                    todo!()
+                }
+                Term::Return(return_expr) => {
+                    let normalised = self.eval(return_expr.expression.into())?;
+                    Err(Signal::Return(normalised))
+                }
+                Term::Block(block_term) => Ok(ControlFlow::Break(self.eval_block(block_term)?)),
+                Term::Loop(loop_term) => {
+                    loop {
+                        match self.eval_block(loop_term.block) {
+                            Ok(_) | Err(Signal::Continue) => continue,
+                            Err(Signal::Break) => break,
+                            Err(e) => return Err(e),
+                        }
+                    }
+
+                    Ok(ControlFlow::Break(self.new_void_term().into()))
+                }
+            },
+            Atom::Ty(ty) => match self.get_ty(ty) {
+                Ty::Eval(term) => {
+                    let evaluated = self.eval(term.into())?;
+                    match evaluated {
+                        Atom::Ty(_) => Ok(ControlFlow::Break(evaluated)),
+                        Atom::Term(_) => Ok(ControlFlow::Continue(())),
+                        Atom::FnDef(_) | Atom::Pat(_) => unreachable!(),
+                    }
+                }
+                Ty::Var(var) => Ok(self
+                    .eval_var(var)?
+                    .map_break(|eval_result| self.use_term_as_ty_or_eval(eval_result).into())),
+                Ty::Data(_)
+                | Ty::Universe(_)
+                | Ty::Ref(_)
+                | Ty::Hole(_)
+                | Ty::Tuple(_)
+                | Ty::Fn(_) => Ok(ControlFlow::Continue(())),
+            },
+            Atom::FnDef(_) | Atom::Pat(_) => Ok(ControlFlow::Continue(())),
+        }
     }
 
     /// Reduce a term to normal form.

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -76,7 +76,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
 
     pub fn eval_var(&self, var: Symbol) -> Result<ControlFlow<TermId>, Signal> {
         match self.context().get_binding(var).unwrap().kind {
-            BindingKind::Param(_) => Ok(ControlFlow::Continue(())),
+            BindingKind::Param(_, _) => Ok(ControlFlow::Continue(())),
             BindingKind::Arg(_, arg_id) => Ok(ControlFlow::Break(
                 self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].value),
             )),

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -97,12 +97,14 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
 
         match (src, target) {
             // @@Todo: eval fully
-            (Ty::Eval(term), _) => match self.use_term_as_ty(term) {
-                Some(ty) => self.unify_tys(ty, target_id),
+            (Ty::Eval(term), _) => match self.normalisation_ops().normalise_to_ty(term.into())? {
+                Some(ty_id) => self.unify_tys(ty_id, target_id),
+                // @@Todo: usage error
                 _ => Uni::mismatch_types(src_id, target_id),
             },
-            (_, Ty::Eval(term)) => match self.use_term_as_ty(term) {
+            (_, Ty::Eval(term)) => match self.normalisation_ops().normalise_to_ty(term.into())? {
                 Some(ty) => self.unify_tys(src_id, ty),
+                // @@Todo: usage error
                 _ => Uni::mismatch_types(src_id, target_id),
             },
 

--- a/compiler/hash-utils/src/store.rs
+++ b/compiler/hash-utils/src/store.rs
@@ -3,7 +3,13 @@
 
 // @@Organisation: Move this module to the `hash_alloc` crate and split it into
 // smaller modules.
-use std::{cell::RefCell, hash::Hash, marker::PhantomData, ops::Range};
+use std::{
+    cell::RefCell,
+    hash::Hash,
+    iter::{repeat, Repeat, Zip},
+    marker::PhantomData,
+    ops::Range,
+};
 
 use append_only_vec::AppendOnlyVec;
 pub use fxhash::FxHashMap;
@@ -298,6 +304,11 @@ pub trait SequenceStoreKey: Copy + Eq + Hash {
     /// [`SequenceStore::get_at_index()`].
     fn to_index_range(self) -> Range<usize> {
         0..self.len()
+    }
+
+    /// Turn the key into a range `(key, 0)..(key, len)`.
+    fn iter(self) -> Zip<Repeat<Self>, Range<usize>> {
+        repeat(self).zip(self.to_index_range())
     }
 
     /// Get the length of the entry corresponding to the key.


### PR DESCRIPTION
This PR allows definitions to be present in blocks `{}`, which means that definitions can now exist in interactive mode as well. It is ensured that inside these definitions nothing is accessed that is declared in a runtime context.

This PR also adds some initial normalisation code, to be completed in subsequent PRs.

Closes #706 