### PR TITLE
codegen: some fixes with code generation and layout info

### DIFF
--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -121,9 +121,14 @@ impl<'b> LLVMBackend<'b> {
         module.verify().unwrap();
 
         // For now, we assume that the object file extension is always `.o`.
-        let path = self.workspace.module_bitcode_path(id, ".o");
-        self.target_machine.write_to_file(module, FileType::Object, &path).unwrap();
+        let path = self.workspace.module_bitcode_path(id, "o");
 
+        // Check if we need to create the "build" folder
+        if let Some(parent) = path.parent() && !parent.exists() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+
+        self.target_machine.write_to_file(module, FileType::Object, &path).unwrap();
         Ok(())
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -204,6 +204,7 @@ impl<'b, 'm> Builder<'_, 'b, 'm> {
         intrinsic_on!("llvm.fshr.i128", fn(i128, i128, i128) -> i128);
 
         // Overflow intrinsics
+        intrinsic_on!("llvm.expect.i1", fn(bool, bool) -> bool);
 
         intrinsic_on!("llvm.sadd.with.overflow.i8", fn(i8, i8) -> struct_ty! {i8, bool});
         intrinsic_on!("llvm.sadd.with.overflow.i16", fn(i16, i16) -> struct_ty! {i16, bool});

--- a/compiler/hash-codegen-llvm/src/translation/metadata.rs
+++ b/compiler/hash-codegen-llvm/src/translation/metadata.rs
@@ -6,32 +6,26 @@ use hash_codegen::traits::{
 };
 use hash_target::{alignment::Alignment, size::Size};
 use inkwell as llvm;
-use llvm::values::{AnyValueEnum, BasicMetadataValueEnum};
+use llvm::values::{AnyValueEnum, BasicMetadataValueEnum, InstructionValue};
 
 use super::Builder;
 use crate::misc::MetadataTypeKind;
 
 impl<'m> Builder<'_, '_, 'm> {
     /// Emit a `no-undef` metadata attribute on a specific value.
-    pub fn set_no_undef(&mut self, value: AnyValueEnum<'m>) {
-        let value = value.into_instruction_value();
-
+    pub fn set_no_undef(&mut self, value: InstructionValue<'m>) {
         let metadata = self.ctx.ll_ctx.metadata_node(&[]);
         value.set_metadata(metadata, MetadataTypeKind::NoUndef as u32).unwrap();
     }
 
     /// Emit a `nonnull` metadata attribute on a specific value.
-    pub fn set_non_null(&mut self, value: AnyValueEnum<'m>) {
-        let value = value.into_instruction_value();
-
+    pub fn set_non_null(&mut self, value: InstructionValue<'m>) {
         let metadata = self.ctx.ll_ctx.metadata_node(&[]);
         value.set_metadata(metadata, MetadataTypeKind::NonNull as u32).unwrap();
     }
 
     /// Specify the alignment for a particular value.
-    pub fn set_alignment(&mut self, value: AnyValueEnum<'m>, alignment: Alignment) {
-        let value = value.into_instruction_value();
-
+    pub fn set_alignment(&mut self, value: InstructionValue<'m>, alignment: Alignment) {
         let alignment_metadata: BasicMetadataValueEnum =
             self.ctx.const_u64(alignment.bytes()).try_into().unwrap();
 

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -22,7 +22,7 @@ use llvm_sys::{
     core::{LLVMGetTypeKind, LLVMVectorType},
     LLVMTypeKind,
 };
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 
 use super::abi::ExtendedFnAbiMethods;
 use crate::{context::CodeGenCtx, misc::AddressSpaceWrapper};
@@ -520,7 +520,7 @@ fn create_and_pad_struct_fields_from_layout<'m>(
     // Assume that all fields and the last field will need to all be
     // padded.
     let mut fields = Vec::with_capacity(1 + field_count * 2);
-    let mut field_map = SmallVec::with_capacity(field_count);
+    let mut field_map = smallvec![0; field_count];
 
     for i in layout.shape.iter_increasing_offsets() {
         let target_offset = layout.shape.offset(i);

--- a/compiler/hash-codegen/src/lower/block.rs
+++ b/compiler/hash-codegen/src/lower/block.rs
@@ -14,7 +14,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// and another.
     pub fn maybe_get_codegen_block_id(&mut self, block: BasicBlock) -> Option<Builder::BasicBlock> {
         match self.block_map[block] {
-            BlockStatus::Unlowered => {
+            BlockStatus::UnLowered => {
                 // We add a new block to the builder, and then update the block
                 // map for the future.
                 let block_id =
@@ -76,7 +76,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
             let successor = successors.next().unwrap();
 
             // verify that we have not yet emitted the successor block
-            debug_assert!(matches!(self.block_map[successor], BlockStatus::Unlowered));
+            debug_assert!(matches!(self.block_map[successor], BlockStatus::UnLowered));
 
             // mark the successor block as skipped
             self.block_map[successor] = BlockStatus::Skip;

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -90,7 +90,7 @@ impl<'a, 'b, V: CodeGenObject> OperandValue<V> {
             }
             OperandValue::Pair(value_a, value_b) => {
                 let AbiRepresentation::Pair(scalar_a, scalar_b) = abi else {
-                    panic!("invalid ABI representation for a pair operand value");
+                    panic!("invalid ABI representation for a pair operand value: `{abi:?}`");
                 };
 
                 let ty = builder.backend_ty_from_info(destination.info);

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -221,11 +221,11 @@ impl<'a, 'b, V: CodeGenObject> PlaceRef<V> {
         builder: &mut Builder,
         field: usize,
     ) -> Self {
-        let abi = builder.map_layout(self.info.layout, |layout| layout.abi);
+        let (abi, field_offset) =
+            builder.map_layout(self.info.layout, |layout| (layout.abi, layout.shape.offset(field)));
 
         let field_info = self.info.field(builder.layout_computer(), field);
-        let (field_offset, is_zst) = builder
-            .map_layout(field_info.layout, |layout| (layout.shape.offset(field), layout.is_zst()));
+        let is_zst = builder.map_layout(field_info.layout, |layout| layout.is_zst());
 
         let field_alignment = self.alignment.restrict_to(field_offset);
 

--- a/compiler/hash-ir/src/basic_blocks.rs
+++ b/compiler/hash-ir/src/basic_blocks.rs
@@ -7,7 +7,10 @@
 use std::{cell::OnceCell, fmt};
 
 use hash_utils::{
-    graph::{self, dominators::Dominators},
+    graph::{
+        self,
+        dominators::{dominators, Dominators},
+    },
     index_vec::IndexVec,
 };
 use smallvec::{smallvec, SmallVec};
@@ -87,7 +90,7 @@ impl BasicBlocks {
 
     /// Compute all of the dominators of the this [BasicBlocks] graph.
     pub fn dominators(&self) -> Dominators<BasicBlock> {
-        Dominators::new(self)
+        dominators(self)
     }
 
     /// Invalidate the cache for all [BasicBlock]s.

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -1154,7 +1154,7 @@ index_vec::define_index_type! {
     /// Index for [BasicBlockData] stores within generated [Body]s.
     pub struct BasicBlock = u32;
 
-    MAX_INDEX = i32::max_value() as usize;
+    MAX_INDEX = u32::max_value() as usize;
     DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
 
     DEBUG_FORMAT = "bb{}";
@@ -1174,7 +1174,7 @@ index_vec::define_index_type! {
     /// Index for [LocalDecl] stores within generated [Body]s.
     pub struct Local = u32;
 
-    MAX_INDEX = i32::max_value() as usize;
+    MAX_INDEX = u32::max_value() as usize;
     DISABLE_MAX_INDEX_CHECK = cfg!(not(debug_assertions));
 
     DEBUG_FORMAT = "_{}";

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -90,11 +90,6 @@ pub struct IrCtx {
     /// The storage for all of the used types that are within the IR.
     ty_store: ty::TyStore,
 
-    /// Storage for grouped types, ones that appear in a parent type, i.e. a
-    /// [`IrTy::Fn(...)`] type will use the [`TyListStore`] to store that
-    /// parameter types.
-    ty_list_store: ty::TyListStore,
-
     /// Storage that is used to store all of the created ADTs that
     /// are registered within the IR.
     adt_store: ty::AdtStore,
@@ -114,12 +109,15 @@ pub struct IrCtx {
 impl IrCtx {
     /// Create a new [IrCtx].
     pub fn new() -> Self {
+        let ty_store = TyStore::new();
+        let instances = InstanceStore::new();
+        let intrinsics = Intrinsics::new(&ty_store, &instances);
+
         Self {
             projection_store: ProjectionStore::default(),
-            intrinsics: Intrinsics::new(),
-            ty_store: TyStore::new(),
-            instances: InstanceStore::new(),
-            ty_list_store: TyListStore::default(),
+            intrinsics,
+            ty_store,
+            instances,
             adt_store: AdtStore::new(),
             ty_cache: RefCell::new(FxHashMap::default()),
         }
@@ -152,7 +150,7 @@ impl IrCtx {
 
     /// Get a reference to the [TyListStore]
     pub fn tls(&self) -> &TyListStore {
-        &self.ty_list_store
+        &self.ty_store.tls
     }
 
     /// Get a reference to the [AdtStore]

--- a/compiler/hash-ir/src/mod.rs
+++ b/compiler/hash-ir/src/mod.rs
@@ -47,7 +47,6 @@ pub trait WriteIr: Sized {
 impl WriteIr for IrTyId {}
 impl WriteIr for IrTyListId {}
 impl WriteIr for AdtId {}
-
 impl WriteIr for Place {}
 
 impl fmt::Display for ForFormatting<'_, Place> {

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -178,8 +178,7 @@ impl<'tcx> Builder<'tcx> {
                 return block.and(Operand::Const(Const::Zero(ty_id).into()));
             }
 
-            if let Some((scope, member, kind)) = self.lookup_item_scope(name) && kind != ScopeKind::Variable {
-                println!("{member:?}");
+            if let Some((scope, _, kind)) = self.lookup_item_scope(name) && kind != ScopeKind::Variable {
                 let unevaluated_const = UnevaluatedConst { scope, name };
 
                 // record that this constant is used in this function

--- a/compiler/hash-lower/src/ty/mod.rs
+++ b/compiler/hash-lower/src/ty/mod.rs
@@ -53,8 +53,21 @@ impl<'ir> TyLoweringCtx<'ir> {
         // @@Hack: avoid re-creating "commonly" used types in order
         // to allow for type_id equality to work
         let id = match ir_ty {
-            IrTy::Bool => self.lcx.tys().common_tys.bool,
+            IrTy::Char => self.lcx.tys().common_tys.char,
+            IrTy::UInt(UIntTy::U8) => self.lcx.tys().common_tys.u8,
+            IrTy::UInt(UIntTy::U16) => self.lcx.tys().common_tys.u16,
+            IrTy::UInt(UIntTy::U32) => self.lcx.tys().common_tys.u32,
+            IrTy::UInt(UIntTy::U64) => self.lcx.tys().common_tys.u64,
+            IrTy::UInt(UIntTy::U128) => self.lcx.tys().common_tys.u128,
             IrTy::UInt(UIntTy::USize) => self.lcx.tys().common_tys.usize,
+            IrTy::Int(SIntTy::I8) => self.lcx.tys().common_tys.i8,
+            IrTy::Int(SIntTy::I16) => self.lcx.tys().common_tys.i16,
+            IrTy::Int(SIntTy::I32) => self.lcx.tys().common_tys.i32,
+            IrTy::Int(SIntTy::I64) => self.lcx.tys().common_tys.i64,
+            IrTy::Int(SIntTy::I128) => self.lcx.tys().common_tys.i128,
+            IrTy::Int(SIntTy::ISize) => self.lcx.tys().common_tys.isize,
+            IrTy::Float(FloatTy::F32) => self.lcx.tys().common_tys.f32,
+            IrTy::Float(FloatTy::F64) => self.lcx.tys().common_tys.f64,
             _ => self.lcx.tys().create(ir_ty),
         };
 
@@ -272,6 +285,7 @@ impl<'ir> TyLoweringCtx<'ir> {
                         id if id == IDENTS.f64 => IrTy::Float(FloatTy::F64),
                         id if id == IDENTS.char => IrTy::Char,
                         id if id == IDENTS.str => IrTy::Str,
+                        id if id == IDENTS.never => IrTy::Never,
                         name => {
                             // if the fields of the struct are not opaque, then we
                             // can create an ADT from it, otherwise this case should

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -163,6 +163,10 @@ impl<I: CompilerInterface> Compiler<I> {
             // for the prelude bootstrap to run
             let mut old_settings = std::mem::take(ctx.settings_mut());
 
+            // We don't need to run the prelude in the full pipeline, just until
+            // IR-gen since that will be dealt by the actual pipeline.
+            ctx.settings_mut().stage = CompilerStageKind::IrGen;
+
             // Resolve the current working directory so that we can
             // resolve the prelude path...
             let wd = match current_dir() {

--- a/compiler/hash-utils/src/graph/dominators.rs
+++ b/compiler/hash-utils/src/graph/dominators.rs
@@ -209,7 +209,7 @@ pub fn dominators<G: ControlFlowGraph>(graph: &G) -> Dominators<G::Node> {
     //
     // 3. parents for each graph vertex - `parent`
     'recurse: while let Some(frame) = stack.last_mut() {
-        while let Some(successor) = frame.iter.next() {
+        for successor in frame.iter.by_ref() {
             if real_to_pre_order[successor].is_none() {
                 let pre_order_index = pre_order_to_real.push(successor);
                 real_to_pre_order[successor] = Some(pre_order_index);

--- a/compiler/hash-utils/src/graph/dominators.rs
+++ b/compiler/hash-utils/src/graph/dominators.rs
@@ -38,7 +38,10 @@ impl<Node: Idx> Dominators<Node> {
         debug_assert!(length > 0);
         debug_assert!(post_order.last() == Some(&graph.start_node()));
 
-        let empty_marker = G::Node::from_usize(usize::MAX);
+        // @@Todo: figure out how to deal with an `EMPTY` marker since the index
+        // type might now always be defined as a `u32`, sometimes smaller, sometimes
+        // larger...
+        let empty_marker = G::Node::from_usize(u32::MAX as usize);
         let mut dominators = index_vec![empty_marker; length];
 
         // set the dominator of the root node to be itself
@@ -60,7 +63,7 @@ impl<Node: Idx> Dominators<Node> {
                 let new_idom_idx = {
                     let mut predecessors = predecessor_sets[idx]
                         .iter()
-                        .filter(|&predecessor| dominators[*predecessor] != empty_marker);
+                        .filter(|&&predecessor| dominators[predecessor] != empty_marker);
 
                     // get the first index in the predecessors
                     let new_dom_idx = predecessors.next().unwrap();

--- a/compiler/hash-utils/src/graph/dominators.rs
+++ b/compiler/hash-utils/src/graph/dominators.rs
@@ -3,14 +3,16 @@
 //! is a vertex node that lies on all paths from the root vertex
 //! node (i.e. in a control flow graph, `bb0` block).
 //!
-//! This module implements the algorithm described in the paper
-//! "A Simple, Fast Dominance Algorithm" by Keith D. Cooper, Timothy J. Harvey.
+//! This module implements the algorithm described in the paper:
 //!
-//! Ref: https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+//! "A Fast Algorithm for Finding Dominators in a Flowgraph"
+//! Thomas Lengauer and Robert Endre Tarjan.
+//! <https://www.cs.princeton.edu/courses/archive/spr03/cs423/download/dominators.pdf>
 
-use std::{cmp::Ordering, collections::HashSet};
+use std::cmp::Ordering;
 
-use index_vec::{index_vec, Idx, IndexVec};
+use index_vec::{define_index_type, index_vec, Idx, IndexVec};
+use smallvec::{smallvec, SmallVec};
 
 use super::ControlFlowGraph;
 
@@ -18,81 +20,26 @@ use super::ControlFlowGraph;
 /// each node in the graph to its dominator, and has an associated `root`
 /// node which is the root of the graph.
 pub struct Dominators<Node: Idx> {
-    /// The root node of the graph.
-    root: Node,
+    post_order_rank: IndexVec<Node, usize>,
 
     /// The dominators of each node in the graph.
-    dominators: IndexVec<Node, Node>,
+    immediate_dominators: IndexVec<Node, Option<Node>>,
 }
 
 impl<Node: Idx> Dominators<Node> {
-    /// Compute the dominators of a given control flow graph. This implements
-    /// the algorithm described in the paper "A Simple, Fast Dominance
-    /// Algorithm" by Keith D. Cooper, Timothy J. Harvey. The reference
-    /// paper is available at: https://www.cs.rice.edu/~keith/EMBED/dom.pdf
-    pub fn new<G: ControlFlowGraph<Node = Node>>(graph: &G) -> Self {
-        let root = graph.start_node();
-        let (post_order, predecessor_sets) = post_order_with_predecessors(graph);
-        let length = post_order.len();
+    pub fn dummy() -> Self {
+        Self { post_order_rank: IndexVec::new(), immediate_dominators: IndexVec::new() }
+    }
 
-        debug_assert!(length > 0);
-        debug_assert!(post_order.last() == Some(&graph.start_node()));
-
-        // @@Todo: figure out how to deal with an `EMPTY` marker since the index
-        // type might now always be defined as a `u32`, sometimes smaller, sometimes
-        // larger...
-        let empty_marker = G::Node::from_usize(u32::MAX as usize);
-        let mut dominators = index_vec![empty_marker; length];
-
-        // set the dominator of the root node to be itself
-        dominators[root] = root;
-
-        let mut changed = true;
-
-        while changed {
-            changed = false;
-
-            // Iterate in reverse post-order
-            for idx in (0..length - 1).rev() {
-                debug_assert!(post_order[idx] != root);
-
-                // Take the intersection of every predecessor's dominator set; that
-                // is the current best guess at the immediate dominator for this
-                // node.
-
-                let new_idom_idx = {
-                    let mut predecessors = predecessor_sets[idx]
-                        .iter()
-                        .filter(|&&predecessor| dominators[predecessor] != empty_marker);
-
-                    // get the first index in the predecessors
-                    let new_dom_idx = predecessors.next().unwrap();
-
-                    predecessors.fold(*new_dom_idx, |mut new_dom_idx, mut predecessor_idx| loop {
-                        match new_dom_idx.cmp(predecessor_idx) {
-                            Ordering::Less => new_dom_idx = dominators[new_dom_idx],
-                            Ordering::Greater => predecessor_idx = &dominators[*predecessor_idx],
-                            Ordering::Equal => return new_dom_idx,
-                        }
-                    })
-                };
-
-                debug_assert!(new_idom_idx.index() < length);
-
-                if new_idom_idx != dominators[idx] {
-                    dominators[idx] = new_idom_idx;
-                    changed = true;
-                }
-            }
-        }
-
-        Self { root: graph.start_node(), dominators }
+    /// Check if a node is reachable from the root node.
+    pub fn is_reachable(&self, node: Node) -> bool {
+        self.immediate_dominators[node].is_some()
     }
 
     /// Get the immediate dominator of a particular node.
     pub fn immediate_dominator(&self, node: Node) -> Node {
-        debug_assert!(self.dominators[node] != self.root);
-        self.dominators[node]
+        debug_assert!(self.is_reachable(node), "node `{node:?}` is not reachable");
+        self.immediate_dominators[node].unwrap()
     }
 
     /// Get all of the dominators of a particular node.
@@ -103,6 +50,17 @@ impl<Node: Idx> Dominators<Node> {
     /// Check if a particular node is a dominator of another node.
     pub fn is_dominated_by(&self, node: Node, dominator: Node) -> bool {
         self.dominators(node).any(|node| node == dominator)
+    }
+
+    /// Provide deterministic ordering of nodes such that, if any two nodes have
+    /// a dominator relationship, the dominator will always precede the
+    /// dominated. (The relative ordering of two unrelated nodes will also
+    /// be consistent, but otherwise the order has no meaning.)
+    ///
+    /// N.B. This method cannot be used to determine if either `Node` dominates
+    /// the other.
+    pub fn rank_partial_cmp(&self, lhs: Node, rhs: Node) -> Option<Ordering> {
+        self.post_order_rank[lhs].partial_cmp(&self.post_order_rank[rhs])
     }
 }
 
@@ -135,22 +93,237 @@ impl<'dom, Node: Idx> Iterator for DominatorsIter<'dom, Node> {
     }
 }
 
-type PredecessorSets<Node> = IndexVec<Node, HashSet<Node>>;
+define_index_type! {
+    /// A pre-order index into a graph.
+    struct PreOrderIndex = u32;
+}
 
-/// Compute the post-order traversal of a graph, along with the
-/// predecessor sets for each node.
-fn post_order_with_predecessors<G: ControlFlowGraph>(
-    graph: &G,
-) -> (Vec<G::Node>, PredecessorSets<G::Node>) {
-    let mut post_order = vec![];
-    let mut predecessor_sets = index_vec![HashSet::new(); graph.num_nodes()];
+/// A frame in the pre-order traversal of a graph.
+struct PreOrderFrame<Iter> {
+    /// The pre-order index of the current node.
+    pre_order_index: PreOrderIndex,
 
-    for node in graph.depth_first_search(graph.start_node()) {
-        post_order.push(node);
-        for successor in graph.successors(node) {
-            predecessor_sets[successor].insert(node);
+    /// The iterator over the successors of the current node.
+    iter: Iter,
+}
+
+/// Create an `IndexVec` with `n` elements, where the value of each
+/// element is the result of `func(i)`. (The underlying vector will
+/// be allocated only once, with a capacity of at least `n`.)
+///
+/// @@Todo: move this into index vec extensions...
+#[inline]
+fn from_fn_n<I: Idx, T>(func: impl FnMut(I) -> T, n: usize) -> IndexVec<I, T> {
+    let indices = (0..n).map(I::from_usize);
+    IndexVec::from_vec(indices.map(func).collect())
+}
+
+fn is_processed(node: PreOrderIndex, last_linked: Option<PreOrderIndex>) -> bool {
+    last_linked.map_or(false, |last_linked| node >= last_linked)
+}
+
+fn compress(
+    ancestor: &mut IndexVec<PreOrderIndex, PreOrderIndex>,
+    last_linked: Option<PreOrderIndex>,
+    semi: &IndexVec<PreOrderIndex, PreOrderIndex>,
+    label: &mut IndexVec<PreOrderIndex, PreOrderIndex>,
+    node: PreOrderIndex,
+) {
+    debug_assert!(is_processed(node, last_linked));
+
+    let mut stack: SmallVec<[_; 8]> = smallvec![node];
+    let mut u = ancestor[node];
+
+    while is_processed(u, last_linked) {
+        stack.push(u);
+        u = ancestor[u];
+    }
+
+    // Then in reverse order, pop the stack
+    for &[v, u] in stack.array_windows().rev() {
+        if semi[label[u]] < semi[label[v]] {
+            label[v] = label[u];
+        }
+
+        ancestor[v] = ancestor[u];
+    }
+}
+
+/// Evaluate the link-eval virtual forest, providing the currently minimum semi
+/// value for the passed `node`, which could be itself.
+///
+/// This maintains that for every vertex `v`, `label[v]` is such that:
+/// ```text
+/// semi[eval(v)] = min { semi[w] | root_in_forest(v) +> u *v }
+/// ```
+/// where `+>` is a proper ancestor and `*>` is just an ancestor.
+fn eval(
+    ancestor: &mut IndexVec<PreOrderIndex, PreOrderIndex>,
+    last_linked: Option<PreOrderIndex>,
+    semi: &IndexVec<PreOrderIndex, PreOrderIndex>,
+    label: &mut IndexVec<PreOrderIndex, PreOrderIndex>,
+    node: PreOrderIndex,
+) -> PreOrderIndex {
+    if is_processed(node, last_linked) {
+        compress(ancestor, last_linked, semi, label, node);
+        label[node]
+    } else {
+        node
+    }
+}
+
+/// This function computes the dominators of a graph using the Lengauer-Tarjan
+/// [algorithm][<https://www.cs.princeton.edu/courses/archive/spr03/cs423/download/dominators.pdf>].
+///
+/// This implements the pseudo-code from this paper, and is based on the
+/// Rust compiler implementation of the algorithm.
+pub fn dominators<G: ControlFlowGraph>(graph: &G) -> Dominators<G::Node> {
+    let mut post_order_rank = index_vec![0; graph.num_nodes()];
+
+    let mut parent: IndexVec<PreOrderIndex, PreOrderIndex> =
+        IndexVec::with_capacity(graph.num_nodes());
+
+    let mut stack = vec![PreOrderFrame {
+        pre_order_index: PreOrderIndex::new(0),
+        iter: graph.successors(graph.start_node()),
+    }];
+
+    // We store a mapping of pre-order indexes to the actual graph indexes, and
+    // backwards
+    let mut pre_order_to_real: IndexVec<PreOrderIndex, G::Node> =
+        IndexVec::with_capacity(graph.num_nodes());
+    let mut real_to_pre_order: IndexVec<G::Node, Option<PreOrderIndex>> =
+        index_vec![None; graph.num_nodes()];
+
+    pre_order_to_real.push(graph.start_node());
+    parent.push(PreOrderIndex::new(0));
+    real_to_pre_order[graph.start_node()] = Some(PreOrderIndex::new(0));
+    let mut post_order_index = 0;
+
+    // Traverse the graph in pre-order, and build up the following information:
+    //
+    // 1. pre-order to real mapping - `pre_order_to_real`
+    //
+    // 2. post-ordering mapping, which will be used for `rank_partial_cmp` -
+    // `post_order_rank`
+    //
+    // 3. parents for each graph vertex - `parent`
+    'recurse: while let Some(frame) = stack.last_mut() {
+        while let Some(successor) = frame.iter.next() {
+            if real_to_pre_order[successor].is_none() {
+                let pre_order_index = pre_order_to_real.push(successor);
+                real_to_pre_order[successor] = Some(pre_order_index);
+
+                parent.push(frame.pre_order_index);
+                stack.push(PreOrderFrame { pre_order_index, iter: graph.successors(successor) });
+                continue 'recurse;
+            }
+        }
+
+        post_order_rank[pre_order_to_real[frame.pre_order_index]] = post_order_index;
+        post_order_index += 1;
+        stack.pop();
+    }
+
+    let reachable_vertices = pre_order_to_real.len();
+
+    let mut idom: IndexVec<PreOrderIndex, PreOrderIndex> =
+        index_vec![PreOrderIndex::new(0); reachable_vertices];
+
+    let mut semi = from_fn_n(std::convert::identity, reachable_vertices);
+    let mut label = semi.clone();
+
+    let mut bucket = index_vec![vec![]; reachable_vertices];
+    let mut last_linked = None;
+
+    for w in (1..reachable_vertices).rev() {
+        let w = PreOrderIndex::new(w);
+        let z = parent[w];
+
+        for &v in bucket[z].iter() {
+            let y = eval(&mut parent, last_linked, &semi, &mut label, v);
+            idom[v] = if semi[y] < z { y } else { z };
+        }
+
+        semi[w] = w;
+        for v in graph.predecessors(pre_order_to_real[w]) {
+            let Some(v) = real_to_pre_order[v] else {
+                continue;
+            };
+
+            let x = eval(&mut parent, last_linked, &semi, &mut label, v);
+            semi[w] = std::cmp::min(semi[w], semi[x]);
+        }
+
+        if parent[w] != semi[w] {
+            bucket[semi[w]].push(w);
+        } else {
+            idom[w] = parent[w];
+        }
+
+        // Optimization: We share the parent array between processed and not
+        // processed elements; last_linked represents the divider.
+        last_linked = Some(w);
+    }
+
+    // Finalise the immediate dominators for any that were not fully settled during
+    // the initial traversal.
+    //
+    // If `immediate_dominators[w] != semi[w]`, then we know that we've stored
+    // vertex `y` from above ino `immediate_dominators[w]`. It is known to be
+    // our "relative dominator", which means that it's one of `w`'s ancestors
+    // and has the same immediate dominator as `w`, so use that as the immediate
+    // dominator for `w`.
+    for w in 1..reachable_vertices {
+        let w = PreOrderIndex::new(w);
+
+        if idom[w] != semi[w] {
+            idom[w] = idom[idom[w]];
         }
     }
 
-    (post_order, predecessor_sets)
+    let mut immediate_dominators = index_vec![None; graph.num_nodes()];
+    for (index, node) in pre_order_to_real.iter_enumerated() {
+        immediate_dominators[*node] = Some(pre_order_to_real[idom[index]]);
+    }
+
+    Dominators { post_order_rank, immediate_dominators }
+}
+
+#[cfg(test)]
+mod test_super {
+    use crate::graph::{dominators::dominators, tests::TestGraph};
+
+    #[test]
+    fn test_dominators_for_diamond() {
+        let graph = TestGraph::new(0, &[(0, 1), (0, 2), (1, 3), (2, 3)]);
+        let dominators = dominators(&graph);
+
+        let immediate_dominators = &dominators.immediate_dominators;
+
+        assert_eq!(immediate_dominators[0].map(|i| i.index()), Some(0usize));
+        assert_eq!(immediate_dominators[1].map(|i| i.index()), Some(0usize));
+        assert_eq!(immediate_dominators[2].map(|i| i.index()), Some(0usize));
+        assert_eq!(immediate_dominators[3].map(|i| i.index()), Some(0usize));
+    }
+
+    /// This tests the example from the paper (p. 122), which is a bit more
+    /// complex.
+    #[test]
+    fn test_from_paper() {
+        let graph = TestGraph::new(
+            6,
+            &[(6, 5), (6, 4), (5, 1), (4, 2), (4, 3), (1, 2), (2, 3), (3, 2), (2, 1)],
+        );
+
+        let dominators = dominators(&graph);
+        let immediate_dominators = &dominators.immediate_dominators;
+        assert_eq!(immediate_dominators[0].map(|i| i.index()), None); // <-- note that 0 is not in graph
+        assert_eq!(immediate_dominators[1].map(|i| i.index()), Some(6));
+        assert_eq!(immediate_dominators[2].map(|i| i.index()), Some(6));
+        assert_eq!(immediate_dominators[3].map(|i| i.index()), Some(6));
+        assert_eq!(immediate_dominators[4].map(|i| i.index()), Some(6));
+        assert_eq!(immediate_dominators[5].map(|i| i.index()), Some(6));
+        assert_eq!(immediate_dominators[6].map(|i| i.index()), Some(6));
+    }
 }

--- a/compiler/hash-utils/src/graph/mod.rs
+++ b/compiler/hash-utils/src/graph/mod.rs
@@ -4,6 +4,7 @@
 //! Based on rustc: https://github.com/rust-lang/rust/blob/master/compiler/rustc_data_structures/src/graph/mod.rs
 
 pub mod dominators;
+pub(crate) mod tests;
 pub mod visit;
 
 use index_vec::Idx;
@@ -15,6 +16,14 @@ pub trait DirectedGraph {
 
     /// Compute the number of nodes in the whole graph.
     fn num_nodes(&self) -> usize;
+
+    /// Return the start node of the graph.
+    ///
+    /// N.B. The default implementation of this method assumes that the
+    /// start node is always `0`.
+    fn start_node(&self) -> Self::Node {
+        Self::Node::from_usize(0)
+    }
 }
 
 pub trait GraphPredecessors<'graph> {
@@ -47,23 +56,14 @@ where
 
     /// Create a [DepthFirstSearch] iterator that starts at the given
     /// node.
-    fn depth_first_search(&self, from: Self::Node) -> visit::DepthFirstSearch<'_, Self> {
-        visit::DepthFirstSearch::new(self, from)
+    fn depth_traverse(&self, from: Self::Node) -> visit::DepthFirstTraversal<'_, Self> {
+        visit::DepthFirstTraversal::new(self, from)
     }
 }
 
 /// A trait that describes all of the properties that a control flow
 /// graph should have. This is mostly a convenience trait that is used
 /// to denote that a graph has both predecessors and successors.
-pub trait ControlFlowGraph: DirectedGraph + WithPredecessors + WithSuccessors {
-    /// Return the start node of the graph which all [ControlFlowGraph]s
-    /// have.
-    ///
-    /// N.B. The default implementation of this method assumes that the
-    /// start node is always `0`.
-    fn start_node(&self) -> Self::Node {
-        Self::Node::from_usize(0)
-    }
-}
+pub trait ControlFlowGraph: DirectedGraph + WithPredecessors + WithSuccessors {}
 
 impl<T> ControlFlowGraph for T where T: DirectedGraph + WithPredecessors + WithSuccessors {}

--- a/compiler/hash-utils/src/graph/tests/mod.rs
+++ b/compiler/hash-utils/src/graph/tests/mod.rs
@@ -1,0 +1,108 @@
+//! This contains a definition for a test graph data structure. It
+//! is intended that all algorithms that are implemented for graph
+//! traversal and manipulation can be tested using a dummy [TestGraph].
+#![allow(dead_code)] // This is allowed since we are using this for testing purposes.
+
+use std::cmp::max;
+
+use fxhash::FxHashMap;
+use index_vec::define_index_type;
+
+use super::WithPredecessors;
+
+define_index_type! {
+    /// A node within the graph.
+    pub struct TestNode = usize;
+
+    DEBUG_FORMAT = "TestNode({})";
+    MAX_INDEX = usize::MAX;
+    DISABLE_MAX_INDEX_CHECK = true;
+}
+
+pub(crate) struct TestGraph {
+    /// The total number of nodes within the graph.
+    node_count: usize,
+
+    /// The starting index of the node.
+    start_node: usize,
+
+    /// The successors of each node in the graph.
+    successors: FxHashMap<usize, Vec<usize>>,
+
+    /// The predecessors of each node in the graph.
+    predecessors: FxHashMap<usize, Vec<usize>>,
+}
+
+impl TestGraph {
+    pub fn new(start_node: usize, nodes: &[(usize, usize)]) -> Self {
+        let mut graph = TestGraph {
+            node_count: start_node + 1,
+            start_node,
+            successors: FxHashMap::default(),
+            predecessors: FxHashMap::default(),
+        };
+
+        for &(source, target) in nodes {
+            graph.node_count = max(graph.node_count, source + 1);
+            graph.node_count = max(graph.node_count, target + 1);
+
+            // now insert entries for each target and source
+            graph.successors.entry(source).or_default().push(target);
+            graph.predecessors.entry(target).or_default().push(source);
+        }
+
+        // Ensure that we all nodes have successor and predecessor entries
+        for node in 0..graph.node_count {
+            graph.successors.entry(node).or_default();
+            graph.predecessors.entry(node).or_default();
+        }
+
+        graph
+    }
+}
+
+impl super::DirectedGraph for TestGraph {
+    type Node = TestNode;
+
+    fn num_nodes(&self) -> usize {
+        self.node_count
+    }
+
+    fn start_node(&self) -> TestNode {
+        TestNode::from_usize(self.start_node)
+    }
+}
+
+impl super::GraphPredecessors<'_> for TestGraph {
+    type Item = TestNode;
+    type Iter = std::vec::IntoIter<TestNode>;
+}
+
+impl WithPredecessors for TestGraph {
+    fn predecessors(&self, node: TestNode) -> <Self as super::GraphPredecessors>::Iter {
+        let nodes = self.predecessors[&node.index()]
+            .clone()
+            .into_iter()
+            .map(TestNode::from_usize)
+            .collect::<Vec<_>>();
+
+        nodes.into_iter()
+    }
+}
+
+impl super::GraphSuccessors<'_> for TestGraph {
+    type Item = TestNode;
+    type Iter = std::vec::IntoIter<TestNode>;
+}
+
+impl super::WithSuccessors for TestGraph {
+    fn successors(&self, node: TestNode) -> <Self as super::GraphSuccessors>::Iter {
+        let nodes = self.successors[&node.index()]
+            .clone()
+            .into_iter()
+            .map(TestNode::from_usize)
+            .collect::<Vec<_>>();
+
+        nodes.into_iter()
+    }
+}

--- a/compiler/hash-utils/src/lib.rs
+++ b/compiler/hash-utils/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash compiler general utilities
-#![feature(type_alias_impl_trait, decl_macro)]
+#![feature(type_alias_impl_trait, decl_macro, array_windows)]
 
 pub mod assert;
 pub mod counter;

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
 
     match entry_point {
         Some(path) => {
-            compiler.run_on_filename(path, ModuleKind::Normal, compiler_state);
+            compiler.run_on_filename(path, ModuleKind::EntryPoint, compiler_state);
         }
         None => {
             hash_interactive::init(compiler, compiler_state);


### PR DESCRIPTION
This patch is just a general bug fixing patch with emitted LLVM IR, layout information, and the entry point not being registered, amongst other things.

However, this is the first PR that enabled the Hash compiler to emit some machine code!