### PR TITLE
Implement normalisation of TIR terms

### DIFF
--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -81,7 +81,11 @@ impl<'tc> AstPass for InferencePass<'tc> {
             |term_id| Ok(self.inference_ops().infer_term(term_id, None)?.0),
             |term_id| self.substitution_ops().atom_has_holes(term_id),
         )?;
-        stream_less_writeln!("{}", self.env().with(term));
+
+        // @@Temp:
+        let evaluated = self.normalisation_ops().normalise(term.into())?;
+        stream_less_writeln!("{}", self.env().with(evaluated));
+
         Ok(())
     }
 
@@ -95,7 +99,10 @@ impl<'tc> AstPass for InferencePass<'tc> {
             |mod_def_id| self.inference_ops().infer_mod_def(mod_def_id).map(|()| mod_def_id),
             |mod_def_id| self.substitution_ops().mod_def_has_holes(mod_def_id),
         )?;
+
+        // @@Temp:
         stream_less_writeln!("{}", self.env().with(mod_def_id));
+
         Ok(())
     }
 }

--- a/compiler/hash-semantics/src/new/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/exprs.rs
@@ -604,14 +604,14 @@ impl<'tc> ResolutionPass<'tc> {
         // Convert all the cases and their bodies
         let cases =
             self.stores().match_cases().create_from_iter(node.cases.iter().filter_map(|case| {
-                self.scoping().enter_match_case(case.ast_ref(), |_, stack_indices| {
+                self.scoping().enter_match_case(case.ast_ref(), |stack_id, stack_indices| {
                     let bind_pat =
                         self.try_or_add_error(self.make_pat_from_ast_pat(case.pat.ast_ref()));
                     let value =
                         self.try_or_add_error(self.make_term_from_ast_expr(case.expr.ast_ref()));
                     match (bind_pat, value) {
                         (Some(bind_pat), Some(value)) => {
-                            Some(MatchCase { bind_pat, value, stack_indices })
+                            Some(MatchCase { bind_pat, value, stack_indices, stack_id })
                         }
                         _ => None,
                     }

--- a/compiler/hash-tir/src/new/control.rs
+++ b/compiler/hash-tir/src/new/control.rs
@@ -11,7 +11,7 @@ use textwrap::indent;
 use super::{
     environment::env::{AccessToEnv, WithEnv},
     pats::{PatId, PatListId},
-    scopes::StackIndices,
+    scopes::{StackId, StackIndices},
     utils::common::CommonUtils,
 };
 use crate::new::{scopes::BlockTerm, terms::TermId};
@@ -45,6 +45,7 @@ pub struct MatchTerm {
 #[derive(Debug, Clone, Copy)]
 pub struct MatchCase {
     pub bind_pat: PatId,
+    pub stack_id: StackId,
     pub stack_indices: StackIndices,
     pub value: TermId,
 }

--- a/compiler/hash-tir/src/new/lits.rs
+++ b/compiler/hash-tir/src/new/lits.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display};
 use hash_ast::ast;
 use hash_source::constant::CONSTANT_MAP;
 use hash_utils::store::SequenceStore;
+use num_bigint::BigInt;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
@@ -19,12 +20,26 @@ pub struct IntLit {
     pub underlying: ast::IntLit,
 }
 
+impl IntLit {
+    /// Return the value of the integer literal.
+    pub fn value(&self) -> BigInt {
+        CONSTANT_MAP.lookup_int_constant(self.underlying.value).as_big()
+    }
+}
+
 /// A string literal.
 ///
 /// Uses the `ast` representation.
 #[derive(Copy, Clone, Debug)]
 pub struct StrLit {
     pub underlying: ast::StrLit,
+}
+
+impl StrLit {
+    /// Return the value of the string literal.
+    pub fn value(&self) -> &'static str {
+        CONSTANT_MAP.lookup_string(self.underlying.data)
+    }
 }
 
 /// A float literal.
@@ -35,12 +50,26 @@ pub struct FloatLit {
     pub underlying: ast::FloatLit,
 }
 
+impl FloatLit {
+    /// Return the value of the float literal.
+    pub fn value(&self) -> f64 {
+        CONSTANT_MAP.lookup_float_constant(self.underlying.value).as_f64()
+    }
+}
+
 /// A character literal.
 ///
 /// Uses the `ast` representation.
 #[derive(Copy, Clone, Debug)]
 pub struct CharLit {
     pub underlying: ast::CharLit,
+}
+
+impl CharLit {
+    /// Return the value of the character literal.
+    pub fn value(&self) -> char {
+        self.underlying.data
+    }
 }
 
 /// A list constructor

--- a/compiler/hash-tir/src/new/pats.rs
+++ b/compiler/hash-tir/src/new/pats.rs
@@ -15,7 +15,7 @@ use super::{
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
     lits::{ListPat, LitPat},
-    scopes::BindingPat,
+    scopes::{BindingPat, StackMemberId},
     symbols::Symbol,
     tuples::TuplePat,
 };
@@ -30,6 +30,8 @@ pub struct Spread {
     pub name: Symbol,
     /// The index in the sequence of target patterns, of this spread pattern.
     pub index: usize,
+    /// The stack member that this spread pattern binds to, if any.
+    pub stack_member: Option<StackMemberId>,
 }
 
 /// A range pattern containing two bounds `start` and `end`.

--- a/compiler/hash-tir/src/new/scopes.rs
+++ b/compiler/hash-tir/src/new/scopes.rs
@@ -34,6 +34,10 @@ pub struct BindingPat {
     pub name: Symbol,
     /// Whether the binding is declared as mutable.
     pub is_mutable: bool,
+    /// The stack member that this binding pattern binds to.
+    ///
+    /// If this is `None`, then the binding pattern is a wildcard `_`.
+    pub stack_member: Option<StackMemberId>,
 }
 
 /// Indices into a stack, that represent a contiguous range of stack members.

--- a/compiler/hash-tir/src/new/scopes.rs
+++ b/compiler/hash-tir/src/new/scopes.rs
@@ -14,6 +14,7 @@ use utility_types::omit;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
+    params::ParamIndex,
     pats::Pat,
     terms::Term,
 };
@@ -92,10 +93,10 @@ impl DeclTerm {
 }
 
 /// Term to assign a value to a subject.
-// @@Todo: figure out exact rules about what subject could be.
 #[derive(Debug, Clone, Copy)]
 pub struct AssignTerm {
     pub subject: TermId,
+    pub index: Option<ParamIndex>,
     pub value: TermId,
 }
 
@@ -183,7 +184,18 @@ impl fmt::Display for WithEnv<'_, &DeclTerm> {
 
 impl fmt::Display for WithEnv<'_, &AssignTerm> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} = {}", self.env().with(self.value.subject), self.env().with(self.value.value),)
+        write!(
+            f,
+            "{}{} = {}",
+            self.env().with(self.value.subject),
+            match self.value.index {
+                Some(index) => {
+                    format!(".{}", self.env().with(index))
+                }
+                None => "".to_string(),
+            },
+            self.env().with(self.value.value),
+        )
     }
 }
 

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -14,7 +14,8 @@ use crate::{
         },
         mods::ModDefId,
         params::{ParamId, ParamsId},
-        scopes::{DeclTerm, StackMemberId},
+        scopes::{DeclTerm, StackId, StackMemberId},
+        symbols::Symbol,
         terms::TermId,
     },
 };
@@ -140,5 +141,21 @@ impl<'env> ContextUtils<'env> {
                 }
             })
         })
+    }
+
+    /// Get the current stack, or panic we are not in a stack.
+    pub fn get_current_stack(&self) -> StackId {
+        match self.context().get_current_scope().kind {
+            ScopeKind::Stack(stack_id) => stack_id,
+            _ => panic!("get_current_stack called in non-stack scope"),
+        }
+    }
+
+    /// Get the given stack binding, or panic if it does not exist.
+    pub fn get_stack_binding(&self, name: Symbol) -> StackMemberId {
+        match self.context().get_binding(name).unwrap().kind {
+            BindingKind::StackMember(member) => member,
+            _ => panic!("get_stack_binding called on non-stack binding"),
+        }
     }
 }

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -173,7 +173,7 @@ impl<'env> TraversingUtils<'env> {
                 Term::Assign(assign_term) => {
                     let subject = self.fmap_term(assign_term.subject, f)?;
                     let value = self.fmap_term(assign_term.value, f)?;
-                    Ok(self.new_term(AssignTerm { subject, value }))
+                    Ok(self.new_term(AssignTerm { subject, value, index: assign_term.index }))
                 }
                 Term::Unsafe(unsafe_term) => {
                     let inner = self.fmap_term(unsafe_term.inner, f)?;

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -144,7 +144,12 @@ impl<'env> TraversingUtils<'env> {
                         self.stores().match_cases().try_create_from_iter(cases.iter().map(|case| {
                             let bind_pat = self.fmap_pat(case.bind_pat, f)?;
                             let value = self.fmap_term(case.value, f)?;
-                            Ok(MatchCase { bind_pat, stack_indices: case.stack_indices, value })
+                            Ok(MatchCase {
+                                bind_pat,
+                                stack_indices: case.stack_indices,
+                                value,
+                                stack_id: case.stack_id,
+                            })
                         }))
                     })?;
                     Ok(self.new_term(MatchTerm { cases, subject }))

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -643,10 +643,12 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// Infer a stack declaration term, and return its type.
     pub fn infer_decl_term(
         &self,
-        _decl_term: &DeclTerm,
-        _annotation_ty: Option<TyId>,
+        decl_term: &DeclTerm,
+        annotation_ty: Option<TyId>,
     ) -> TcResult<(DeclTerm, TyId)> {
-        todo!()
+        // @@Todo
+        self.context_utils().add_from_decl_term(decl_term);
+        Ok((*decl_term, annotation_ty.unwrap_or_else(|| self.new_ty_hole())))
     }
 
     pub fn generalise_term_inference(&self, inference: (impl Into<Term>, TyId)) -> (TermId, TyId) {
@@ -730,9 +732,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 .infer_decl_term(decl_term, annotation_ty)
                 .map(|i| self.generalise_term_inference(i)),
 
-            Term::Match(_) => todo!(),
-            Term::Assign(_) => todo!(),
-            Term::Access(_) => todo!(),
+            // @@Todo:
+            Term::Match(_) | Term::Assign(_) | Term::Access(_) => {
+                Ok((term_id, annotation_ty.unwrap_or_else(|| self.new_ty_hole())))
+            }
+
             Term::Hole(_) => Err(TcError::Blocked),
         })?;
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -28,10 +28,7 @@ use hash_tir::{
     },
     ty_as_variant,
 };
-use hash_utils::{
-    store::{CloneStore, SequenceStore, SequenceStoreKey, Store},
-    stream_less_writeln,
-};
+use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
 use super::unification::Uni;
 use crate::{

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -372,7 +372,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 // parameters of the function call.
                 let arg_sub = self
                     .substitution_ops()
-                    .create_sub_from_applying_args_to_params(fn_call_term.args, fn_ty.params)?;
+                    .create_sub_from_applying_args_to_params(fn_call_term.args, fn_ty.params);
 
                 // Apply the substitution to the return type of the function type.
                 Ok((
@@ -735,25 +735,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Access(_) => todo!(),
             Term::Hole(_) => Err(TcError::Blocked),
         })?;
-
-        stream_less_writeln!(
-            "Un-normalised: {}: {}",
-            self.env().with(result.0),
-            self.env().with(result.1)
-        );
-
-        // @@Temporary
-        let normalised_term = self.normalisation_ops().normalise(result.0.into()).unwrap();
-        let normalised_ty = self
-            .normalisation_ops()
-            .normalise_to_ty(result.1.into())
-            .unwrap()
-            .unwrap_or_else(|| self.new_ty_hole());
-        stream_less_writeln!(
-            "Normalised: {}: {}",
-            self.env().with(normalised_term),
-            self.env().with(normalised_ty)
-        );
 
         Ok(result)
     }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -572,7 +572,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 let stack = self.stores().stack().get(block_term.stack_id);
                 if let Some(local_mod_def) = stack.local_mod_def {
                     self.infer_mod_def(local_mod_def)?;
-                    self.context_utils().add_mod_members(local_mod_def, |_| {});
                 }
 
                 let mut error_state = self.new_error_state();
@@ -922,8 +921,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// Infer the given module definition.
     pub fn infer_mod_def(&self, mod_def_id: ModDefId) -> TcResult<()> {
         self.context().enter_scope(mod_def_id.into(), || {
-            self.context_utils().add_mod_members(mod_def_id, |_| {});
-
             let members = self.stores().mod_def().map_fast(mod_def_id, |def| def.members);
             let mut error_state = self.new_error_state();
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(unwrap_infallible, never_type, try_trait_v2, try_blocks, control_flow_enum)]
+#![feature(unwrap_infallible, never_type, try_trait_v2, try_blocks, control_flow_enum, let_chains)]
 
 use errors::{TcError, TcErrorState, TcResult};
 use hash_intrinsics::{intrinsics::AccessToIntrinsics, primitives::AccessToPrimitives};

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 
 use derive_more::{Constructor, Deref, From};
 use hash_ast::ast::RangeEnd;
+use hash_intrinsics::utils::PrimitiveUtils;
 use hash_tir::new::{
     access::AccessTerm,
     args::{ArgData, ArgsId, PatArgsId},
@@ -173,13 +174,6 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
 
     /// Evaluate an assignment term.
     fn eval_assign(&self, _assign_term: AssignTerm) -> Result<ControlFlow<Atom>, Signal> {
-        todo!()
-    }
-
-    /// Check if the given atom is the `true` constructor.
-    ///
-    /// Assumes that the atom is normalised.
-    fn is_true(&self, _atom: Atom) -> bool {
         todo!()
     }
 
@@ -446,6 +440,19 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             MatchResult::Successful
         } else {
             MatchResult::Failed
+        }
+    }
+
+    /// Check if the given atom is the `true` constructor.
+    ///
+    /// Assumes that the atom is normalised.
+    fn is_true(&self, atom: Atom) -> bool {
+        match atom {
+            Atom::Term(term) => self.stores().term().map_fast(term, |term| match term {
+                Term::Ctor(ctor_term) => ctor_term.ctor == self.get_bool_ctor(true),
+                _ => false,
+            }),
+            Atom::Ty(_) | Atom::FnDef(_) | Atom::Pat(_) => false,
         }
     }
 

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -3,13 +3,16 @@ use std::ops::ControlFlow;
 
 use derive_more::{Constructor, Deref, From};
 use hash_tir::new::{
-    control::LoopControlTerm,
+    access::AccessTerm,
+    casting::CastTerm,
+    control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     environment::context::{BindingKind, ScopeKind},
-    fns::FnBody,
-    scopes::BlockTerm,
+    fns::{FnBody, FnCallTerm},
+    refs::{DerefTerm, RefTerm},
+    scopes::{AssignTerm, BlockTerm, DeclTerm},
     symbols::Symbol,
-    terms::{Term, TermId},
-    tys::{Ty, TyId},
+    terms::{Term, TermId, UnsafeTerm},
+    tys::{Ty, TyId, TypeOfTerm},
     utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
 };
 use hash_utils::store::{PartialStore, SequenceStore, SequenceStoreKey, Store};
@@ -32,6 +35,7 @@ pub enum Signal {
 }
 
 impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
+    /// Normalise the given atom.
     pub fn normalise(&self, atom: Atom) -> TcResult<Atom> {
         match self.eval(atom) {
             Ok(t) => Ok(t),
@@ -44,10 +48,12 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
         }
     }
 
+    /// Normalise the given atom, and try to use it as a type.
     pub fn normalise_to_ty(&self, atom: Atom) -> TcResult<Option<TyId>> {
         match self.normalise(atom)? {
             Atom::Term(term) => match self.get_term(term) {
                 Term::Ty(ty) => Ok(Some(ty)),
+                Term::Var(var) => Ok(Some(self.new_ty(var))),
                 _ => Ok(None),
             },
             Atom::Ty(ty) => Ok(Some(ty)),
@@ -56,12 +62,12 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate an atom.
-    pub fn eval(&self, atom: Atom) -> Result<Atom, Signal> {
+    fn eval(&self, atom: Atom) -> Result<Atom, Signal> {
         self.traversing_utils().fmap_atom(atom, |atom| self.eval_once(atom))
     }
 
     /// Evaluate a block term.
-    pub fn eval_block(&self, block_term: BlockTerm) -> Result<Atom, Signal> {
+    fn eval_block(&self, block_term: BlockTerm) -> Result<Atom, Signal> {
         self.context().enter_scope(ScopeKind::Stack(block_term.stack_id), || {
             for statement in block_term
                 .statements
@@ -74,16 +80,17 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
         })
     }
 
-    pub fn eval_var(&self, var: Symbol) -> Result<ControlFlow<TermId>, Signal> {
+    /// Evaluate a variable.
+    fn eval_var(&self, var: Symbol) -> Result<Atom, Signal> {
         match self.context().get_binding(var).unwrap().kind {
-            BindingKind::Param(_, _) => Ok(ControlFlow::Continue(())),
-            BindingKind::Arg(_, arg_id) => Ok(ControlFlow::Break(
-                self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].value),
-            )),
+            BindingKind::Param(_, _) => Ok(self.new_term(var).into()),
+            BindingKind::Arg(_, arg_id) => {
+                Ok(self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].value).into())
+            }
             BindingKind::StackMember(stack_member) => {
                 self.stores().stack().map_fast(stack_member.0, |stack| {
                     match stack.members[stack_member.1].value {
-                        Some(value) => Ok(ControlFlow::Break(value)),
+                        Some(value) => Ok(value.into()),
                         None => {
                             // @@Todo: make this a user error
                             panic!("Tried to read uninitialised stack member")
@@ -100,156 +107,193 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
         }
     }
 
+    /// Evaluate a match term.
+    fn eval_match(&self, match_term: MatchTerm) -> Result<Atom, Signal> {
+        todo!()
+    }
+
+    /// Evaluate a cast term.
+    fn eval_cast(&self, cast_term: CastTerm) -> Result<Atom, Signal> {
+        todo!()
+    }
+
+    /// Evaluate a reference term.
+    fn eval_ref(&self, ref_term: RefTerm) -> Result<Atom, Signal> {
+        todo!()
+    }
+
+    /// Evaluate a dereference term.
+    fn eval_deref(&self, deref_term: DerefTerm) -> Result<ControlFlow<Atom>, Signal> {
+        let evaluated_inner = self.eval(deref_term.subject.into())?;
+        // Reduce:
+        if let Atom::Term(term) = evaluated_inner {
+            if let Term::Ref(ref_expr) = self.get_term(term) {
+                return Ok(ControlFlow::Break(ref_expr.subject.into()));
+            }
+        }
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// Evaluate an access term.
+    fn eval_access(&self, access_term: AccessTerm) -> Result<ControlFlow<Atom>, Signal> {
+        todo!()
+    }
+
+    /// Evaluate an unsafe term.
+    fn eval_unsafe(&self, unsafe_term: UnsafeTerm) -> Result<Atom, Signal> {
+        // @@Todo: handle unsafe safety
+        self.eval(unsafe_term.inner.into())
+    }
+
+    /// Evaluate a `typeof` term.
+    fn eval_type_of(&self, type_of_term: TypeOfTerm) -> Result<Atom, Signal> {
+        // Infer the type of the term:
+        let (_, ty) = self.inference_ops().infer_term(type_of_term.term, None)?;
+        Ok(ty.into())
+    }
+
+    /// Evaluate a loop control term.
+    fn eval_loop_control(&self, loop_control_term: LoopControlTerm) -> Signal {
+        match loop_control_term {
+            LoopControlTerm::Break => Signal::Break,
+            LoopControlTerm::Continue => Signal::Continue,
+        }
+    }
+
+    /// Evaluate an assignment term.
+    fn eval_assign(&self, assign_term: AssignTerm) -> Result<ControlFlow<Atom>, Signal> {
+        todo!()
+    }
+
+    /// Evaluate a declaration term.
+    fn eval_decl(&self, decl_term: DeclTerm) -> Result<ControlFlow<Atom>, Signal> {
+        todo!()
+    }
+
+    /// Evaluate a `return` term.
+    fn eval_return(&self, return_term: ReturnTerm) -> Result<!, Signal> {
+        let normalised = self.eval(return_term.expression.into())?;
+        Err(Signal::Return(normalised))
+    }
+
+    /// Evaluate a `loop` term.
+    fn eval_loop(&self, loop_term: LoopTerm) -> Result<Atom, Signal> {
+        loop {
+            match self.eval_block(loop_term.block) {
+                Ok(_) | Err(Signal::Continue) => continue,
+                Err(Signal::Break) => break,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(self.new_void_term().into())
+    }
+
+    /// Evaluate a term and use it as a type.
+    fn eval_ty_eval(&self, term: TermId) -> Result<Atom, Signal> {
+        let evaluated = self.eval(term.into())?;
+        match evaluated {
+            Atom::Ty(_) => Ok(evaluated),
+            Atom::Term(term) => match self.get_term(term) {
+                Term::Ty(ty) => Ok(ty.into()),
+                _ => Ok(evaluated),
+            },
+            Atom::FnDef(_) | Atom::Pat(_) => unreachable!(),
+        }
+    }
+
+    /// Evaluate a function call.
+    fn eval_fn_call(&self, mut fn_call: FnCallTerm) -> Result<Atom, Signal> {
+        let evaluated_inner = self.eval(fn_call.subject.into())?;
+
+        // Beta-reduce:
+        if let Atom::Term(term) = evaluated_inner {
+            fn_call.subject = term;
+
+            if let Term::FnRef(fn_def_id) = self.get_term(term) {
+                let fn_def = self.get_fn_def(fn_def_id);
+                // @@Todo: handle pure/impure
+
+                match fn_def.body {
+                    FnBody::Defined(defined_fn_def) => {
+                        // Make a substitution from the arguments to the parameters:
+                        let sub = self.substitution_ops().create_sub_from_applying_args_to_params(
+                            fn_call.args,
+                            fn_def.ty.params,
+                        );
+
+                        // Apply substitution to body:
+                        let result =
+                            self.substitution_ops().apply_sub_to_term(defined_fn_def, &sub);
+
+                        // Evaluate result:
+                        return match self.eval(result.into()) {
+                            Err(Signal::Return(result)) | Ok(result) => Ok(result),
+                            Err(e) => Err(e),
+                        };
+                    }
+
+                    FnBody::Intrinsic(intrinsic_id) => {
+                        let args_as_terms: Vec<TermId> =
+                            self.stores().args().map_fast(fn_call.args, |args| {
+                                args.iter().map(|arg| arg.value).collect()
+                            });
+
+                        // Run intrinsic:
+                        let result: TermId =
+                            self.intrinsics().by_id().map_fast(intrinsic_id, |intrinsic| {
+                                let intrinsic = intrinsic.unwrap();
+                                (intrinsic.implementation)(self.0, &args_as_terms)
+                            });
+
+                        return Ok(result.into());
+                    }
+
+                    FnBody::Axiom => {
+                        // Nothing further to do
+                    }
+                }
+            }
+        }
+
+        Ok(self.new_term(fn_call).into())
+    }
+
     /// Evaluate an atom once, for use with `fmap`.
     fn eval_once(&self, atom: Atom) -> Result<ControlFlow<Atom>, Signal> {
-        // @@Todo: enter scopes
         match atom {
             Atom::Term(term) => match self.get_term(term) {
-                // Forward to types:
+                // Types
                 Term::Ty(_) => Ok(ControlFlow::Continue(())),
-                // Infer type:
-                Term::TypeOf(term) => {
-                    let (_, ty) = self.inference_ops().infer_term(term.term, None)?;
-                    Ok(ControlFlow::Break(ty.into()))
-                }
-
-                // @@Todo: different reference kinds
-                Term::Ref(_) => Ok(ControlFlow::Continue(())),
-
-                // Modalities:
-                Term::Unsafe(unsafe_expr) => {
-                    // @@Todo: handle unsafe safety
-                    Ok(ControlFlow::Break(self.eval(unsafe_expr.inner.into())?))
-                }
 
                 // Introduction forms:
-                Term::Tuple(_) | Term::Hole(_) | Term::FnRef(_) | Term::Ctor(_) | Term::Prim(_) => {
-                    Ok(ControlFlow::Continue(()))
-                }
+                Term::Ref(_)
+                | Term::Tuple(_)
+                | Term::Hole(_)
+                | Term::FnRef(_)
+                | Term::Ctor(_)
+                | Term::Prim(_) => Ok(ControlFlow::Continue(())),
 
-                Term::Match(_) => todo!(),
-
-                Term::FnCall(mut fn_call) => {
-                    let evaluated_inner = self.eval(fn_call.subject.into())?;
-
-                    // Beta-reduce:
-                    if let Atom::Term(term) = evaluated_inner {
-                        fn_call.subject = term;
-
-                        if let Term::FnRef(fn_def_id) = self.get_term(term) {
-                            let fn_def = self.get_fn_def(fn_def_id);
-                            // @@Todo: handle pure/impure
-
-                            match fn_def.body {
-                                FnBody::Defined(defined_fn_def) => {
-                                    // Make a substitution from the arguments to the parameters:
-                                    let sub = self
-                                        .substitution_ops()
-                                        .create_sub_from_applying_args_to_params(
-                                            fn_call.args,
-                                            fn_def.ty.params,
-                                        );
-
-                                    // Apply substitution to body:
-                                    let result = self
-                                        .substitution_ops()
-                                        .apply_sub_to_term(defined_fn_def, &sub);
-
-                                    // Evaluate result:
-                                    return match self.eval(result.into()) {
-                                        Err(Signal::Return(result)) | Ok(result) => {
-                                            Ok(ControlFlow::Break(result))
-                                        }
-                                        Err(e) => Err(e),
-                                    };
-                                }
-
-                                FnBody::Intrinsic(intrinsic_id) => {
-                                    let args_as_terms: Vec<TermId> =
-                                        self.stores().args().map_fast(fn_call.args, |args| {
-                                            args.iter().map(|arg| arg.value).collect()
-                                        });
-
-                                    // Run intrinsic:
-                                    let result: TermId = self.intrinsics().by_id().map_fast(
-                                        intrinsic_id,
-                                        |intrinsic| {
-                                            let intrinsic = intrinsic.unwrap();
-                                            (intrinsic.implementation)(self.0, &args_as_terms)
-                                        },
-                                    );
-
-                                    return Ok(ControlFlow::Break(result.into()));
-                                }
-
-                                FnBody::Axiom => {
-                                    // Nothing further to do
-                                }
-                            }
-                        }
-                    }
-
-                    Ok(ControlFlow::Break(self.new_term(fn_call).into()))
-                }
-
-                Term::Cast(_) => todo!(),
-
-                Term::Deref(deref_expr) => {
-                    let evaluated_inner = self.eval(deref_expr.subject.into())?;
-                    // Reduce:
-                    if let Atom::Term(term) = evaluated_inner {
-                        if let Term::Ref(ref_expr) = self.get_term(term) {
-                            return Ok(ControlFlow::Break(ref_expr.subject.into()));
-                        }
-                    }
-                    Ok(ControlFlow::Break(evaluated_inner))
-                }
-
-                Term::Var(var) => Ok(self.eval_var(var)?.map_break(|x| x.into())),
-
-                Term::Access(_) => todo!(),
+                // Potentially reducible forms:
+                Term::TypeOf(term) => Ok(ControlFlow::Break(self.eval_type_of(term)?)),
+                Term::Unsafe(unsafe_expr) => Ok(ControlFlow::Break(self.eval_unsafe(unsafe_expr)?)),
+                Term::Match(match_term) => Ok(ControlFlow::Break(self.eval_match(match_term)?)),
+                Term::FnCall(fn_call) => Ok(ControlFlow::Break(self.eval_fn_call(fn_call)?)),
+                Term::Cast(cast_term) => Ok(ControlFlow::Break(self.eval_cast(cast_term)?)),
+                Term::Var(var) => Ok(ControlFlow::Break(self.eval_var(var)?)),
+                Term::Deref(deref_term) => self.eval_deref(deref_term),
+                Term::Access(access_term) => self.eval_access(access_term),
 
                 // Imperative:
-                Term::LoopControl(loop_control) => match loop_control {
-                    LoopControlTerm::Break => Err(Signal::Break),
-                    LoopControlTerm::Continue => Err(Signal::Continue),
-                },
-                Term::Assign(_) => todo!(),
-                Term::Decl(_) => {
-                    todo!()
-                }
-                Term::Return(return_expr) => {
-                    let normalised = self.eval(return_expr.expression.into())?;
-                    Err(Signal::Return(normalised))
-                }
+                Term::LoopControl(loop_control) => Err(self.eval_loop_control(loop_control)),
+                Term::Assign(assign_term) => self.eval_assign(assign_term),
+                Term::Decl(decl_term) => self.eval_decl(decl_term),
+                Term::Return(return_expr) => self.eval_return(return_expr)?,
                 Term::Block(block_term) => Ok(ControlFlow::Break(self.eval_block(block_term)?)),
-                Term::Loop(loop_term) => {
-                    loop {
-                        match self.eval_block(loop_term.block) {
-                            Ok(_) | Err(Signal::Continue) => continue,
-                            Err(Signal::Break) => break,
-                            Err(e) => return Err(e),
-                        }
-                    }
-
-                    Ok(ControlFlow::Break(self.new_void_term().into()))
-                }
+                Term::Loop(loop_term) => Ok(ControlFlow::Break(self.eval_loop(loop_term)?)),
             },
             Atom::Ty(ty) => match self.get_ty(ty) {
-                Ty::Eval(term) => {
-                    let evaluated = self.eval(term.into())?;
-                    match evaluated {
-                        Atom::Ty(_) => Ok(ControlFlow::Break(evaluated)),
-                        Atom::Term(term) => match self.get_term(term) {
-                            Term::Ty(ty) => Ok(ControlFlow::Break(ty.into())),
-                            _ => Ok(ControlFlow::Break(evaluated)),
-                        },
-                        Atom::FnDef(_) | Atom::Pat(_) => unreachable!(),
-                    }
-                }
-                Ty::Var(var) => Ok(self
-                    .eval_var(var)?
-                    .map_break(|eval_result| self.use_term_as_ty_or_eval(eval_result).into())),
+                Ty::Eval(term) => Ok(ControlFlow::Break(self.eval_ty_eval(term)?)),
+                Ty::Var(var) => Ok(ControlFlow::Break(self.eval_var(var)?)),
                 Ty::Data(_)
                 | Ty::Universe(_)
                 | Ty::Ref(_)
@@ -260,10 +304,5 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             Atom::FnDef(_) => Ok(ControlFlow::Break(atom)),
             Atom::Pat(_) => Ok(ControlFlow::Continue(())),
         }
-    }
-
-    /// Reduce a term to normal form.
-    pub fn potentially_normalise_term(&self, _term_id: TermId) -> TcResult<Option<TermId>> {
-        todo!()
     }
 }

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -15,7 +15,7 @@ use hash_tir::new::{
 };
 use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
 
-use crate::{errors::TcResult, AccessToTypechecking};
+use crate::AccessToTypechecking;
 
 #[derive(Constructor, Deref)]
 pub struct SubstitutionOps<'a, T: AccessToTypechecking>(&'a T);
@@ -195,15 +195,16 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
         &self,
         args_id: ArgsId,
         params_id: ParamsId,
-    ) -> TcResult<Sub> {
+    ) -> Sub {
+        // @@Todo: dependent?
         self.stores().args().map_fast(args_id, |args| {
             self.stores().params().map_fast(params_id, |params| {
                 assert!(args_id.len() == params_id.len(), "TODO: user error");
 
                 // @@Todo: ensure arg indices match?
-                Ok(Sub::from_pairs(
+                Sub::from_pairs(
                     params.iter().zip(args.iter()).map(|(param, arg)| (param.name, arg.value)),
-                ))
+                )
             })
         })
     }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -97,12 +97,18 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
 
         match (src, target) {
             // @@Todo: eval fully
-            (Ty::Eval(term), _) => match self.normalisation_ops().normalise_to_ty(term.into())? {
+            (Ty::Eval(term), _) => match self
+                .normalisation_ops()
+                .maybe_to_ty(self.normalisation_ops().normalise(term.into())?)
+            {
                 Some(ty_id) => self.unify_tys(ty_id, target_id),
                 // @@Todo: usage error
                 _ => Uni::mismatch_types(src_id, target_id),
             },
-            (_, Ty::Eval(term)) => match self.normalisation_ops().normalise_to_ty(term.into())? {
+            (_, Ty::Eval(term)) => match self
+                .normalisation_ops()
+                .maybe_to_ty(self.normalisation_ops().normalise(term.into())?)
+            {
                 Some(ty) => self.unify_tys(src_id, ty),
                 // @@Todo: usage error
                 _ => Uni::mismatch_types(src_id, target_id),


### PR DESCRIPTION
Closes #673. For now interactive normalises its output. There are still some bugs to fix (next PRs)

```rs
>>> (a, b) := ((foo: i32) => (foo, (foo, () -> i32 => foo)))(3); b
(3_i32, () -> i32 => 3_i32)
```