### PR TITLE
codegen: several fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "hash-codegen",
  "hash-ir",
  "hash-pipeline",
+ "hash-reporting",
  "hash-source",
  "hash-target",
  "hash-utils",

--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1699,8 +1699,8 @@ define_tree! {
     #[derive(PartialEq, Debug, Clone)]
     #[node]
     pub struct DirectiveExpr {
-        /// The name of the directive (without the "#").
-        pub directives: SmallVec<[(Name, Span); 2]>,
+        /// The directives that apply on the subject expression.
+        pub directives: SmallVec<[AstNode<Name>; 2]>,
         /// An expression which is referenced in the directive
         pub subject: Child!(Expr),
     }
@@ -1969,4 +1969,15 @@ define_tree! {
         /// semi-colon.
         pub contents: Children!(Expr),
     }
+}
+
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+mod size_asserts {
+    use hash_utils::assert::static_assert_size;
+
+    use super::*;
+
+    static_assert_size!(Expr, 96);
+    static_assert_size!(Pat, 88);
+    static_assert_size!(Ty, 80);
 }

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -177,12 +177,12 @@ impl AstVisitor for AstTreeGenerator {
 
         let mut directives_iter = node.directives.iter().rev();
         let mut node = TreeNode::branch(
-            labelled("directive", directives_iter.next().unwrap().0, "\""),
+            labelled("directive", directives_iter.next().unwrap().ident, "\""),
             vec![subject],
         );
 
-        for (directive, _) in directives_iter {
-            node = TreeNode::branch(labelled("directive", directive, "\""), vec![node])
+        for directive in directives_iter {
+            node = TreeNode::branch(labelled("directive", directive.ident, "\""), vec![node])
         }
 
         Ok(node)

--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -38,8 +38,16 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
 
         // Create a new instance of a backend, and then run it...
         let mut backend = match settings.codegen_settings.backend {
-            CodeGenBackend::LLVM => create_llvm_backend(ctx.data()),
+            CodeGenBackend::LLVM if settings.entry_point().is_some() => {
+                create_llvm_backend(ctx.data())
+            }
             CodeGenBackend::VM => unimplemented!(),
+
+            // If the backend is specified to be LLVM, but there is no entry
+            // then we can't do anything so we just skip this...
+            _ => {
+                return Ok(());
+            }
         };
 
         backend.run()

--- a/compiler/hash-codegen-llvm/Cargo.toml
+++ b/compiler/hash-codegen-llvm/Cargo.toml
@@ -17,3 +17,4 @@ hash-source = {path = "../hash-source" }
 hash-target = { path = "../hash-target" }
 hash-utils = {path = "../hash-utils" }
 hash-pipeline = { path = "../hash-pipeline" }
+hash-reporting = { path = "../hash-reporting" }

--- a/compiler/hash-codegen-llvm/src/context.rs
+++ b/compiler/hash-codegen-llvm/src/context.rs
@@ -83,9 +83,10 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
         ir_ctx: &'b IrCtx,
         layouts: &'b LayoutCtx,
     ) -> Self {
-        let ptr_size = settings.codegen_settings.target_info.target().pointer_width;
+        let ptr_size = settings.codegen_settings.data_layout.pointer_size;
         let ll_ctx = module.get_context();
-        let size_ty = ll_ctx.custom_width_int_type(ptr_size as u32);
+
+        let size_ty = ll_ctx.custom_width_int_type(ptr_size.bits() as u32);
 
         Self {
             settings,

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -887,7 +887,6 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
                         offset,
                     );
 
-                    println!("loading scalar pair element");
                     self.to_immediate_scalar(load_value, scalar)
                 };
 

--- a/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
+++ b/compiler/hash-codegen-llvm/src/translation/intrinsics.rs
@@ -344,6 +344,8 @@ impl<'b, 'm> IntrinsicBuilderMethods<'b> for Builder<'_, 'b, 'm> {
     }
 
     fn codegen_expect_intrinsic(&mut self, value: Self::Value, expected: bool) -> Self::Value {
+        debug_assert!(value.is_int_value(), "expected `i1` value, got: `{value:?}`");
+
         let expected = self.const_bool(expected);
         self.call_intrinsic("llvm.expect.i1", &[value, expected])
     }

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -430,13 +430,10 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
     }
 
     fn immediate_llvm_ty(&self, ctx: &CodeGenCtx<'_, 'm>) -> llvm::types::AnyTypeEnum<'m> {
-        let is_bool = ctx.map_layout(self.layout, |layout| {
-            if let AbiRepresentation::Scalar(scalar) = layout.abi && scalar.is_bool() {
-                true
-            } else {
-                false
-            }
-        });
+        let is_bool = ctx.map_layout(
+            self.layout,
+            |layout| matches!(layout.abi, AbiRepresentation::Scalar(scalar) if scalar.is_bool()),
+        );
 
         if is_bool {
             ctx.type_i1()
@@ -449,10 +446,6 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
         &self,
         ctx: &CodeGenCtx<'_, 'm>,
         scalar: Scalar,
-
-        // @@Todo: implement pointee_info_at(offset) for this offset to
-        // work... since we're then indexing into a reference type
-        // layout
         offset: Size,
     ) -> llvm::types::AnyTypeEnum<'m> {
         match scalar.kind() {

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -24,7 +24,8 @@ use crate::traits::{
 /// Defines what kind of reference a local has. A [LocalRef::Place]
 /// is a reference to a stack allocation, and a [LocalRef::Operand]
 /// is a reference to an immediate value.
-pub enum LocalRef<V> {
+#[derive(Debug)]
+pub enum LocalRef<V: std::fmt::Debug> {
     /// A reference to a stack allocation.
     Place(PlaceRef<V>),
 

--- a/compiler/hash-codegen/src/lower/operands.rs
+++ b/compiler/hash-codegen/src/lower/operands.rs
@@ -17,8 +17,8 @@ use crate::{
 
 /// Represents an operand value for the IR. The `V` is a backend
 /// specific value type.
-#[derive(Clone, Copy)]
-pub enum OperandValue<V> {
+#[derive(Clone, Copy, Debug)]
+pub enum OperandValue<V: std::fmt::Debug> {
     /// A reference to an actual operand value.
     Ref(V, Alignment),
 
@@ -116,8 +116,8 @@ impl<'a, 'b, V: CodeGenObject> OperandValue<V> {
 
 /// Represents an operand within the IR. The `V` is a backend specific
 /// value type.
-#[derive(Clone, Copy)]
-pub struct OperandRef<V> {
+#[derive(Clone, Copy, Debug)]
+pub struct OperandRef<V: std::fmt::Debug> {
     /// The value of the operand.
     pub value: OperandValue<V>,
 
@@ -293,7 +293,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                             let abi = builder.map_layout(info.layout, |layout| layout.abi);
 
                             let AbiRepresentation::Scalar(scalar) = abi else {
-                                panic!("scalar constant doesn't have a scalar ABI rerpresentation")
+                                panic!("scalar constant doesn't have a scalar ABI representation")
                             };
 
                             // We convert the constant to a backend equivalent scalar
@@ -380,7 +380,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                 })
             }
             LocalRef::Operand(None) => {
-                panic!("use of operand before defiition")
+                panic!("use of operand before definition")
             }
 
             // We don't deal with locals that refer to a place, and

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -503,20 +503,20 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         target: ir::BasicBlock,
         can_merge: bool,
     ) -> bool {
-        let condition = self.codegen_operand(builder, condition).immediate_value();
+        let condition_operand = self.codegen_operand(builder, condition).immediate_value();
 
         // try and evaluate the condition at compile time to determine
         // if we can avoid generating the panic block if the condition
         // is always true or false.
         let const_condition =
-            builder.const_to_optional_u128(condition, false).map(|value| value == 1);
+            builder.const_to_optional_u128(condition_operand, false).map(|value| value == 1);
 
         if const_condition == Some(expected) {
             return self.codegen_goto_terminator(builder, target, can_merge);
         }
 
         // Add a hint for the condition as "expecting" the provided value
-        let condition = builder.codegen_expect_intrinsic(condition, expected);
+        let condition = builder.codegen_expect_intrinsic(condition_operand, expected);
 
         // Create a failure block and a conditional branch to it.
         let failure_block = builder.append_sibling_block("assert_failure");

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -532,8 +532,8 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         builder.switch_to_block(failure_block);
 
         // we need to convert the assert into a message.
-        let message = builder.const_str(CONSTANT_MAP.create_string(assert_kind.message()));
-        let args = &[message.0, message.1];
+        let (bytes, len) = builder.const_str(CONSTANT_MAP.create_string(assert_kind.message()));
+        let args = &[bytes, len];
 
         // @@Todo: we need to create a call to `panic`, as in resolve the function
         // abi to `panic` and the relative function pointer.

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -763,7 +763,12 @@ macro_rules! create_common_ty_table {
         /// using the associated [IrTyId]s of this map.
         pub struct CommonIrTys {
             $(pub $name: IrTyId, )*
+
+            /// A slice of bytes, i.e. `[u8]`.
             pub byte_slice: IrTyId,
+
+            /// A general pointer to bytes, i.e. `&[u8]`.
+            pub ptr: IrTyId,
         }
 
         impl CommonIrTys {
@@ -771,14 +776,17 @@ macro_rules! create_common_ty_table {
                 let mut table = CommonIrTys {
                     $($name: data.create($value), )*
                     byte_slice: IrTyId::from_index_unchecked(0),
+                    ptr: IrTyId::from_index_unchecked(0),
                 };
 
                 // @@Hack: find a way to nicely create this within the `create_common_ty_table!`,
                 // however this would require somehow referencing entries within the table before
                 // they are defined...
                 let byte_slice = data.create(IrTy::Slice(table.u8));
+                let ptr = data.create(IrTy::Ref(table.u8, Mutability::Immutable, RefKind::Normal));
 
                 table.byte_slice = byte_slice;
+                table.ptr = ptr;
                 table
             }
         }

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -230,7 +230,7 @@ impl TyInfo {
             | IrTy::Ref(_, _, _)
             | IrTy::Fn { .. } => panic!("TyInfo::field on a type that does not contain fields"),
 
-            IrTy::Str if field_index == 0 => ctx.ir_ctx().tys().common_tys.unit,
+            IrTy::Str if field_index == 0 => ctx.ir_ctx().tys().common_tys.ptr,
             IrTy::Str => ctx.ir_ctx().tys().common_tys.usize,
             IrTy::Slice(element) | IrTy::Array { ty: element, .. } => *element,
             IrTy::Adt(id) => match layout.variants {

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -382,7 +382,7 @@ impl<'a> AstVisitorMutSelf for LoweringVisitor<'a> {
 
         let mut new_applied_directives = self.applied_directives;
 
-        for (directive, _) in &node.directives {
+        for directive in &node.directives {
             if directive.is(IDENTS.dump_ir) {
                 new_applied_directives.insert(AppliedDirectives::IN_DUMP_IR);
             }

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -647,7 +647,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                             self.skip_token();
 
                             directive_span = directive_span.join(*span);
-                            directives.push((Name { ident: *ident }, directive_span));
+                            directives.push(AstNode::new(Name { ident: *ident }, directive_span));
                             prefixed = false;
                         }
                         Some(Token { kind: TokenKind::Hash, .. }) if !prefixed => {

--- a/compiler/hash-semantics/src/traverse/visitor.rs
+++ b/compiler/hash-semantics/src/traverse/visitor.rs
@@ -2072,7 +2072,7 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
         // the flag `within_intrinsics_directive` which changes the way that `mod`
         // blocks are validated and changes the parsing of the declarations inside the
         // mod block.
-        for (directive, _) in &node.directives {
+        for directive in &node.directives {
             if directive.is(IDENTS.intrinsics) {
                 self.state.within_intrinsics_directive.set(true);
             }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -28,7 +28,10 @@ use hash_tir::{
     },
     ty_as_variant,
 };
-use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
+use hash_utils::{
+    store::{CloneStore, SequenceStore, SequenceStoreKey, Store},
+    stream_less_writeln,
+};
 
 use super::unification::Uni;
 use crate::{
@@ -727,7 +730,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Hole(_) => Err(TcError::Blocked),
         })?;
 
-        println!("Un-normalised: {}: {}", self.env().with(result.0), self.env().with(result.1));
+        stream_less_writeln!(
+            "Un-normalised: {}: {}",
+            self.env().with(result.0),
+            self.env().with(result.1)
+        );
 
         // @@Temporary
         let normalised_term = self.normalisation_ops().normalise(result.0.into()).unwrap();
@@ -736,7 +743,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             .normalise_to_ty(result.1.into())
             .unwrap()
             .unwrap_or_else(|| self.new_ty_hole());
-        println!(
+        stream_less_writeln!(
             "Normalised: {}: {}",
             self.env().with(normalised_term),
             self.env().with(normalised_ty)

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -7,9 +7,8 @@ use std::{collections::HashSet, convert::Infallible, mem};
 
 use hash_ast::{
     ast::{
-        walk_mut_self, AstNode, AstNodeRef, AstVisitorMutSelf, BindingPat, Block, BlockExpr,
-        Declaration, DirectiveExpr, EnumDef, Expr, LitExpr, Mutability, Name, ParamOrigin,
-        StructDef,
+        walk_mut_self, AstNodeRef, AstVisitorMutSelf, BindingPat, Block, BlockExpr, Declaration,
+        DirectiveExpr, EnumDef, Expr, LitExpr, Mutability, Name, ParamOrigin, StructDef,
     },
     ast_visitor_mut_self_default_impl,
     origin::BlockOrigin,
@@ -225,9 +224,8 @@ impl AstVisitorMutSelf for SemanticAnalyser<'_> {
         let DirectiveExpr { directives, .. } = node.body();
         let _ = walk_mut_self::walk_directive_expr(self, node);
 
-        for (directive, span) in directives.iter().copied() {
-            let name = AstNode::new(directive, span);
-            self.validate_directive(name.ast_ref(), node.subject.ast_ref())?;
+        for directive in directives.iter() {
+            self.validate_directive(directive.ast_ref(), node.subject.ast_ref())?;
         }
         Ok(())
     }

--- a/tests/cases/semantics/directives/unknown_directive.stderr
+++ b/tests/cases/semantics/directives/unknown_directive.stderr
@@ -1,15 +1,15 @@
-warn: `memoise` is not a known directive
- --> $DIR/unknown_directive.hash:8:8
-7 |   
-8 |   Bar := #memoise () -> u32 => {
-  |          ^^^^^^^^ 
-9 |       into_bar: (T) -> Self
-  = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.
-
 warn: `erase` is not a known directive
  --> $DIR/unknown_directive.hash:3:8
 2 |   
 3 |   Bar := #erase trait<T> {
   |          ^^^^^^ 
 4 |       into_bar: (T) -> Self
+  = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.
+
+warn: `memoise` is not a known directive
+ --> $DIR/unknown_directive.hash:8:8
+7 |   
+8 |   Bar := #memoise () -> u32 => {
+  |          ^^^^^^^^ 
+9 |       into_bar: (T) -> Self
   = note: unknown directives are currently 'invisible' to the compiler and are treated as if they were just the inner expression. However, in the future this will become a hard error.


### PR DESCRIPTION
This patch fixes the following issues:
- `load_operand` wasn't dealing with loading immediates (i.e. `bool`) correctly, and converting them into `i8`s where an `i1` was expected.
- `size_ty` wasn't being correctly initialised with the correct integer width.
- fix interactive start-up crash with the LLVM backend.
- fix directive errors being reported in a non-deterministic order.