### PR TITLE
Fix some normalisation bugs

### DIFF
--- a/compiler/hash-semantics/src/new/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/defs.rs
@@ -411,7 +411,6 @@ impl<'tc> DiscoveryPass<'tc> {
                             name: self.new_symbol(name.ident),
                             is_mutable: false,
                             ty: self.new_ty_hole(),
-                            value: None,
                         },
                     ))
                 }
@@ -426,7 +425,6 @@ impl<'tc> DiscoveryPass<'tc> {
                         is_mutable: binding.mutability.as_ref().map(|m| *m.body())
                             == Some(ast::Mutability::Mutable),
                         ty: self.new_ty_hole(),
-                        value: None,
                     },
                 ));
             }
@@ -482,7 +480,6 @@ impl<'tc> DiscoveryPass<'tc> {
                     name: self.new_fresh_symbol(),
                     is_mutable: false,
                     ty: self.new_ty_hole(),
-                    value: None,
                 },
             )),
             ast::Pat::Access(_) | ast::Pat::Lit(_) | ast::Pat::Range(_) => {}
@@ -500,7 +497,7 @@ impl<'tc> DiscoveryPass<'tc> {
         node: AstNodeRef<ast::Pat>,
         stack_id: StackId,
         declaration_name: Option<Symbol>,
-        rhs: Option<&ast::AstNode<ast::Expr>>,
+        _rhs: Option<&ast::AstNode<ast::Expr>>,
     ) {
         self.def_state().stack_members.modify_fast(stack_id, |members| {
             let members = match members {
@@ -527,7 +524,6 @@ impl<'tc> DiscoveryPass<'tc> {
                             is_mutable: binding_pat.mutability.as_ref().map(|m| *m.body())
                                 == Some(ast::Mutability::Mutable),
                             ty: self.new_ty_hole(),
-                            value: rhs.as_ref().map(|_| self.new_term_hole()),
                         },
                     ))
                 }

--- a/compiler/hash-semantics/src/new/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/paths.rs
@@ -295,7 +295,7 @@ impl<'tc> ResolutionPass<'tc> {
                     None => todo!(),
                 }
             }
-            BindingKind::Param(_, _) | BindingKind::StackMember(_) => {
+            BindingKind::Param(_, _) | BindingKind::StackMember(_, _) => {
                 // If the subject has no args, it is a variable, otherwise it is a
                 // function call.
                 match &component.args[..] {

--- a/compiler/hash-semantics/src/new/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/pats.rs
@@ -90,10 +90,7 @@ impl ResolutionPass<'_> {
                     )
                     .unwrap();
 
-                let stack_member_id = match self.context().get_binding(symbol).unwrap().kind {
-                    BindingKind::StackMember(member) => member,
-                    _ => panic!("Found non-stack-member binding for spread"),
-                };
+                let (stack_member_id, _) = self.context_utils().get_stack_binding(symbol);
 
                 (symbol, stack_member_id)
             });
@@ -223,7 +220,7 @@ impl ResolutionPass<'_> {
                         name: bound_var.name,
                         is_mutable: false,
                         stack_member: match bound_var.kind {
-                            BindingKind::StackMember(member) => Some(member),
+                            BindingKind::StackMember(member, _) => Some(member),
                             _ => panic!("Found non-stack member in pattern binding"),
                         },
                     })))

--- a/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
@@ -16,6 +16,7 @@ use hash_tir::{
         params::ParamId,
         scopes::{StackId, StackIndices, StackMemberId},
         symbols::Symbol,
+        terms::TermId,
         tuples::TupleTy,
         utils::{common::CommonUtils, AccessToUtils},
     },
@@ -197,12 +198,11 @@ impl<'tc> Scoping<'tc> {
 
     /// Add a stack member to the current scope, also adding it to the
     /// `bindings_by_name` map.
-    pub(super) fn add_stack_binding(&self, member_id: StackMemberId) {
+    pub(super) fn add_stack_binding(&self, member_id: StackMemberId, value: Option<TermId>) {
         // Get the data of the member.
-        let member_name =
-            self.stores().stack().map_fast(member_id.0, |stack| stack.members[member_id.1].name);
+        let member_name = self.get_stack_member_name(member_id);
         // Add the binding to the current scope.
-        self.context_utils().add_stack_binding(member_id);
+        self.context_utils().add_stack_binding(member_id, value);
         self.add_named_binding(member_name);
     }
 
@@ -369,7 +369,7 @@ impl<'tc> Scoping<'tc> {
             let mut start_end = StackIndices::Empty;
             self.for_each_stack_member_of_pat(node.pat.ast_ref(), &mut |member| {
                 start_end.extend_with_index(member.1);
-                self.add_stack_binding(member);
+                self.add_stack_binding(member, None);
             });
             start_end
         } else {
@@ -392,7 +392,7 @@ impl<'tc> Scoping<'tc> {
             let mut start_end = StackIndices::Empty;
             self.for_each_stack_member_of_pat(node.pat.ast_ref(), &mut |member| {
                 start_end.extend_with_index(member.1);
-                self.add_stack_binding(member);
+                self.add_stack_binding(member, None);
             });
             f(stack_id, start_end)
         })

--- a/compiler/hash-tir/src/new/scopes.rs
+++ b/compiler/hash-tir/src/new/scopes.rs
@@ -108,7 +108,6 @@ pub struct StackMember {
     pub name: Symbol,
     pub is_mutable: bool,
     pub ty: TyId,
-    pub value: Option<TermId>,
 }
 
 /// A stack, which is a list of stack members.
@@ -203,14 +202,10 @@ impl fmt::Display for WithEnv<'_, &StackMember> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}{}: {} = {}",
+            "{}{}: {}",
             if self.value.is_mutable { "mut " } else { "" },
             self.env().with(self.value.name),
             self.env().with(self.value.ty),
-            self.value
-                .value
-                .map(|val| self.env().with(val).to_string())
-                .unwrap_or_else(|| "{uninitialised}".to_string()),
         )
     }
 }

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -12,6 +12,7 @@ use crate::new::{
     locations::LocationTarget,
     params::{Param, ParamIndex, ParamsId},
     pats::{Pat, PatId, PatListId},
+    scopes::StackMemberId,
     symbols::{Symbol, SymbolData},
     terms::{Term, TermId, TermListId},
     tuples::{TupleTerm, TupleTy},
@@ -168,6 +169,13 @@ pub trait CommonUtils: AccessToEnv {
     /// Get symbol data.
     fn get_symbol(&self, symbol: Symbol) -> SymbolData {
         self.stores().symbol().get(symbol)
+    }
+
+    /// Get the name of a stack member
+    fn get_stack_member_name(&self, stack_member_id: StackMemberId) -> Symbol {
+        self.stores()
+            .stack()
+            .modify_fast(stack_member_id.0, |stack| stack.members[stack_member_id.1].name)
     }
 
     /// Duplicate a symbol by creating a new symbol with the same name.

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -65,7 +65,7 @@ impl<'env> ContextUtils<'env> {
     ///
     /// *Invariant*: It must be that the member's scope is the current stack
     /// scope.
-    pub fn add_stack_binding(&self, member_id: StackMemberId) {
+    pub fn add_stack_binding(&self, member_id: StackMemberId, value: Option<TermId>) {
         match self.context().get_current_scope().kind {
             ScopeKind::Stack(stack_id) => {
                 if stack_id != member_id.0 {
@@ -76,7 +76,7 @@ impl<'env> ContextUtils<'env> {
                     .stack()
                     .map_fast(stack_id, |stack| stack.members[member_id.1].name);
                 self.context()
-                    .add_binding(Binding { name, kind: BindingKind::StackMember(member_id) })
+                    .add_binding(Binding { name, kind: BindingKind::StackMember(member_id, value) })
             }
             _ => panic!("add_stack_binding called in non-stack scope"),
         }
@@ -93,7 +93,7 @@ impl<'env> ContextUtils<'env> {
         };
 
         for stack_index in decl.iter_stack_indices() {
-            self.add_stack_binding((current_stack_id, stack_index));
+            self.add_stack_binding((current_stack_id, stack_index), decl.value);
         }
     }
 
@@ -152,9 +152,9 @@ impl<'env> ContextUtils<'env> {
     }
 
     /// Get the given stack binding, or panic if it does not exist.
-    pub fn get_stack_binding(&self, name: Symbol) -> StackMemberId {
+    pub fn get_stack_binding(&self, name: Symbol) -> (StackMemberId, Option<TermId>) {
         match self.context().get_binding(name).unwrap().kind {
-            BindingKind::StackMember(member) => member,
+            BindingKind::StackMember(member, value) => (member, value),
             _ => panic!("get_stack_binding called on non-stack binding"),
         }
     }

--- a/compiler/hash-tir/src/new/utils/stack.rs
+++ b/compiler/hash-tir/src/new/utils/stack.rs
@@ -58,7 +58,6 @@ impl<'tc> StackUtils<'tc> {
             is_mutable: data.is_mutable,
             name: data.name,
             ty: data.ty,
-            value: data.value,
         })
     }
 }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -437,7 +437,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 unreachable!("mod members and ctors should have all been resolved by now")
             }
             BindingKind::Param(_, param_id) => Ok(self.stores().params().get_element(param_id).ty),
-            BindingKind::StackMember(stack_member_id) => Ok(self
+            BindingKind::StackMember(stack_member_id, _) => Ok(self
                 .stores()
                 .stack()
                 .map_fast(stack_member_id.0, |stack| stack.members[stack_member_id.1].ty)),


### PR DESCRIPTION
This PR addresses the following issues:
- Pattern binds in match cases were added to the scope but the scope was exited before the case was run
- Stack members stored their values, rather than the context, which doesn't work if the same stack appears in the context multiple times (recursion, loops, etc)

Closes #767.