### PR TITLE
Implement matching and reordering of arguments

### DIFF
--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -143,6 +143,7 @@ impl DefinedPrimitives {
                 let params = env.param_utils().create_params(once(ParamData {
                     name: t_sym,
                     ty: env.new_small_universe_ty(),
+                    default: None,
                 }));
                 env.data_utils().create_primitive_data_def_with_params(list_sym, params, |_| {
                     PrimitiveCtorInfo::List(ListCtorInfo { element_ty: env.new_var_ty(t_sym) })
@@ -158,10 +159,12 @@ impl DefinedPrimitives {
                 let params = env.param_utils().create_params(once(ParamData {
                     name: t_sym,
                     ty: env.new_small_universe_ty(),
+                    default: None,
                 }));
                 let some_params = env.param_utils().create_params(once(ParamData {
                     name: env.new_symbol("value"),
                     ty: env.new_var_ty(t_sym),
+                    default: None,
                 }));
                 env.data_utils().create_enum_def(option_sym, params, |_| {
                     vec![(none_sym, env.new_empty_params()), (some_sym, some_params)]
@@ -177,18 +180,20 @@ impl DefinedPrimitives {
                 let e_sym = env.new_symbol("E");
                 let params = env.param_utils().create_params(
                     [
-                        ParamData { name: t_sym, ty: env.new_small_universe_ty() },
-                        ParamData { name: e_sym, ty: env.new_small_universe_ty() },
+                        ParamData { name: t_sym, ty: env.new_small_universe_ty(), default: None },
+                        ParamData { name: e_sym, ty: env.new_small_universe_ty(), default: None },
                     ]
                     .into_iter(),
                 );
                 let ok_params = env.param_utils().create_params(once(ParamData {
                     name: env.new_symbol("value"),
                     ty: env.new_var_ty(t_sym),
+                    default: None,
                 }));
                 let err_params = env.param_utils().create_params(once(ParamData {
                     name: env.new_symbol("error"),
                     ty: env.new_var_ty(e_sym),
+                    default: None,
                 }));
                 env.data_utils().create_enum_def(result_sym, params, |_| {
                     vec![(ok_sym, ok_params), (err_sym, err_params)]

--- a/compiler/hash-semantics/src/new/passes/resolution/params.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/params.rs
@@ -6,7 +6,7 @@ use hash_tir::new::{
     args::{ArgsId, PatArgsId},
     environment::{context::ParamOrigin, env::AccessToEnv},
     fns::FnCallTerm,
-    params::{ParamId, ParamsId, SomeArgsId},
+    params::{ParamId, ParamsId, SomeParamsOrArgsId},
     pats::Spread,
     terms::{Term, TermId},
     utils::common::CommonUtils,
@@ -82,11 +82,11 @@ impl ResolvedArgs {
     }
 }
 
-impl From<ResolvedArgs> for SomeArgsId {
+impl From<ResolvedArgs> for SomeParamsOrArgsId {
     fn from(value: ResolvedArgs) -> Self {
         match value {
-            ResolvedArgs::Term(args) => SomeArgsId::Args(args),
-            ResolvedArgs::Pat(args, _) => SomeArgsId::PatArgs(args),
+            ResolvedArgs::Term(args) => SomeParamsOrArgsId::Args(args),
+            ResolvedArgs::Pat(args, _) => SomeParamsOrArgsId::PatArgs(args),
         }
     }
 }

--- a/compiler/hash-semantics/src/new/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/pats.rs
@@ -10,7 +10,7 @@ use hash_ast::ast::{self, AstNodeRef};
 use hash_reporting::macros::panic_on_span;
 use hash_source::location::Span;
 use hash_tir::new::{
-    args::{PatArgData, PatArgsId},
+    args::{PatArgData, PatArgsId, PatOrCapture},
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::{context::BindingKind, env::AccessToEnv},
@@ -52,7 +52,7 @@ impl ResolutionPass<'_> {
                         Some(name) => ParamIndex::Name(name.ident),
                         None => ParamIndex::Position(i),
                     },
-                    pat: self.make_pat_from_ast_pat(arg.pat.ast_ref())?,
+                    pat: PatOrCapture::Pat(self.make_pat_from_ast_pat(arg.pat.ast_ref())?),
                 })
             })
             .collect::<SemanticResult<Vec<_>>>()?;
@@ -66,7 +66,7 @@ impl ResolutionPass<'_> {
     ) -> SemanticResult<PatListId> {
         let pats = pats
             .iter()
-            .map(|pat| self.make_pat_from_ast_pat(pat.ast_ref()))
+            .map(|pat| Ok(PatOrCapture::Pat(self.make_pat_from_ast_pat(pat.ast_ref())?)))
             .collect::<SemanticResult<Vec<_>>>()?;
         Ok(self.stores().pat_list().create_from_iter_fast(pats.into_iter()))
     }

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -71,8 +71,13 @@ impl<'tc> ResolutionPass<'tc> {
         let params = ty_args
             .ast_ref_iter()
             .filter_map(|ty_arg| {
-                self.try_or_add_error(self.make_ty_from_ast_ty(ty_arg.ty.ast_ref()))
-                    .map(|ty| ParamData { name: self.new_symbol_from_ast_name(&ty_arg.name), ty })
+                self.try_or_add_error(self.make_ty_from_ast_ty(ty_arg.ty.ast_ref())).map(|ty| {
+                    ParamData {
+                        name: self.new_symbol_from_ast_name(&ty_arg.name),
+                        ty,
+                        default: None,
+                    }
+                })
             })
             .collect_vec();
 

--- a/compiler/hash-tir/src/new/args.rs
+++ b/compiler/hash-tir/src/new/args.rs
@@ -3,14 +3,16 @@
 use core::fmt;
 use std::fmt::Debug;
 
+use derive_more::From;
 use hash_utils::{
     new_sequence_store_key,
-    store::{DefaultSequenceStore, SequenceStore},
+    store::{DefaultSequenceStore, SequenceStore, SequenceStoreKey},
 };
 use utility_types::omit;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
+    locations::{IndexedLocationTarget, LocationTarget},
     params::ParamIndex,
     pats::PatId,
 };
@@ -35,6 +37,35 @@ new_sequence_store_key!(pub ArgsId);
 pub type ArgId = (ArgsId, usize);
 pub type ArgsStore = DefaultSequenceStore<ArgsId, Arg>;
 
+/// A pattern or a capture.
+///
+/// A capture exists in pattern lists and pattern arguments, and is used to
+/// indicate that this field is captured by a spread pattern in the aggregate.
+///
+/// Initially, no pattern arguments are captures, instead the `spread` member in
+/// pattern lists denotes where the spread is located. Then, the list is
+/// reordered to match the target parameter list, which involves making some
+/// slots into `PatOrCapture::Capture` to indicate that the corresponding
+/// parameter is captured by the spread. After that point the spread is no
+/// longer needed (other than for errors).
+#[derive(Debug, Clone, Copy, From)]
+pub enum PatOrCapture {
+    /// A pattern.
+    Pat(PatId),
+    /// A capture.
+    Capture,
+}
+
+impl PatOrCapture {
+    /// Used for or-patterns which use a `PatListId` but contain no captures.
+    pub fn assert_pat(self) -> PatId {
+        match self {
+            PatOrCapture::Pat(pat) => pat,
+            PatOrCapture::Capture => panic!("Expected a pattern, got a capture"),
+        }
+    }
+}
+
 /// A pattern argument to a parameter
 ///
 /// This might be used for constructor patterns like `C(true, x)`.
@@ -46,12 +77,75 @@ pub struct PatArg {
     /// Argument target (named or positional).
     pub target: ParamIndex,
     /// The pattern in place for this argument.
-    pub pat: PatId,
+    pub pat: PatOrCapture,
 }
 
 new_sequence_store_key!(pub PatArgsId);
 pub type PatArgId = (PatArgsId, usize);
 pub type PatArgsStore = DefaultSequenceStore<PatArgsId, PatArg>;
+
+/// Some kind of arguments, either [`PatArgsId`] or [`ArgsId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]
+pub enum SomeArgsId {
+    PatArgs(PatArgsId),
+    Args(ArgsId),
+}
+
+/// An index into a `SomeArgsId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]
+pub struct SomeArgId(pub SomeArgsId, pub usize);
+
+impl SequenceStoreKey for SomeArgsId {
+    fn to_index_and_len(self) -> (usize, usize) {
+        match self {
+            SomeArgsId::PatArgs(id) => id.to_index_and_len(),
+            SomeArgsId::Args(id) => id.to_index_and_len(),
+        }
+    }
+
+    fn from_index_and_len_unchecked(index: usize, len: usize) -> Self {
+        SomeArgsId::Args(ArgsId::from_index_and_len_unchecked(index, len))
+    }
+}
+
+impl From<ArgId> for SomeArgId {
+    fn from(val: ArgId) -> Self {
+        SomeArgId(SomeArgsId::Args(val.0), val.1)
+    }
+}
+
+impl From<PatArgId> for SomeArgId {
+    fn from(val: PatArgId) -> Self {
+        SomeArgId(SomeArgsId::PatArgs(val.0), val.1)
+    }
+}
+
+impl From<SomeArgsId> for IndexedLocationTarget {
+    fn from(val: SomeArgsId) -> Self {
+        match val {
+            SomeArgsId::PatArgs(id) => IndexedLocationTarget::PatArgs(id),
+            SomeArgsId::Args(id) => IndexedLocationTarget::Args(id),
+        }
+    }
+}
+
+impl From<SomeArgId> for LocationTarget {
+    fn from(val: SomeArgId) -> Self {
+        match val {
+            SomeArgId(SomeArgsId::PatArgs(id), index) => LocationTarget::PatArg((id, index)),
+            SomeArgId(SomeArgsId::Args(id), index) => LocationTarget::Arg((id, index)),
+        }
+    }
+}
+
+impl fmt::Display for WithEnv<'_, SomeArgsId> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
+            SomeArgsId::Args(id) => write!(f, "{}", self.env().with(id)),
+            SomeArgsId::PatArgs(id) => write!(f, "{}", self.env().with(id)),
+        }
+    }
+}
 
 impl fmt::Display for WithEnv<'_, &Arg> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -81,6 +175,19 @@ impl fmt::Display for WithEnv<'_, ArgsId> {
             }
             Ok(())
         })
+    }
+}
+
+impl fmt::Display for WithEnv<'_, PatOrCapture> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
+            PatOrCapture::Pat(pat) => {
+                write!(f, "{}", self.env().with(pat))
+            }
+            PatOrCapture::Capture => {
+                write!(f, "_")
+            }
+        }
     }
 }
 

--- a/compiler/hash-tir/src/new/params.rs
+++ b/compiler/hash-tir/src/new/params.rs
@@ -72,21 +72,22 @@ impl fmt::Display for WithEnv<'_, &Param> {
     }
 }
 
-/// Some kind of arguments, either [`ParamsId`], [`PatArgsId`] or [`ArgsId`].
-#[derive(Debug, Clone, Copy)]
-pub enum SomeArgsId {
+/// Some kind of parameters or arguments, either [`ParamsId`], [`PatArgsId`] or
+/// [`ArgsId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]
+pub enum SomeParamsOrArgsId {
     Params(ParamsId),
     PatArgs(PatArgsId),
     Args(ArgsId),
 }
 
-impl SomeArgsId {
+impl SomeParamsOrArgsId {
     /// Get the length of the inner stored parameters.
     pub fn len(&self) -> usize {
         match self {
-            SomeArgsId::Params(id) => id.len(),
-            SomeArgsId::PatArgs(id) => id.len(),
-            SomeArgsId::Args(id) => id.len(),
+            SomeParamsOrArgsId::Params(id) => id.len(),
+            SomeParamsOrArgsId::PatArgs(id) => id.len(),
+            SomeParamsOrArgsId::Args(id) => id.len(),
         }
     }
 
@@ -95,22 +96,22 @@ impl SomeArgsId {
         self.len() == 0
     }
 
-    /// Get the English subject noun of the [SomeArgsId]
+    /// Get the English subject noun of the [SomeParamsOrArgsId]
     pub fn as_str(&self) -> &'static str {
         match self {
-            SomeArgsId::Params(_) => "parameters",
-            SomeArgsId::PatArgs(_) => "pattern arguments",
-            SomeArgsId::Args(_) => "arguments",
+            SomeParamsOrArgsId::Params(_) => "parameters",
+            SomeParamsOrArgsId::PatArgs(_) => "pattern arguments",
+            SomeParamsOrArgsId::Args(_) => "arguments",
         }
     }
 }
 
-impl From<SomeArgsId> for IndexedLocationTarget {
-    fn from(target: SomeArgsId) -> Self {
+impl From<SomeParamsOrArgsId> for IndexedLocationTarget {
+    fn from(target: SomeParamsOrArgsId) -> Self {
         match target {
-            SomeArgsId::Params(id) => IndexedLocationTarget::Params(id),
-            SomeArgsId::PatArgs(id) => IndexedLocationTarget::PatArgs(id),
-            SomeArgsId::Args(id) => IndexedLocationTarget::Args(id),
+            SomeParamsOrArgsId::Params(id) => IndexedLocationTarget::Params(id),
+            SomeParamsOrArgsId::PatArgs(id) => IndexedLocationTarget::PatArgs(id),
+            SomeParamsOrArgsId::Args(id) => IndexedLocationTarget::Args(id),
         }
     }
 }
@@ -150,12 +151,12 @@ impl fmt::Display for WithEnv<'_, ParamIndex> {
     }
 }
 
-impl fmt::Display for WithEnv<'_, SomeArgsId> {
+impl fmt::Display for WithEnv<'_, SomeParamsOrArgsId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
-            SomeArgsId::Params(id) => write!(f, "{}", self.env().with(id)),
-            SomeArgsId::PatArgs(id) => write!(f, "{}", self.env().with(id)),
-            SomeArgsId::Args(id) => write!(f, "{}", self.env().with(id)),
+            SomeParamsOrArgsId::Params(id) => write!(f, "{}", self.env().with(id)),
+            SomeParamsOrArgsId::PatArgs(id) => write!(f, "{}", self.env().with(id)),
+            SomeParamsOrArgsId::Args(id) => write!(f, "{}", self.env().with(id)),
         }
     }
 }

--- a/compiler/hash-tir/src/new/params.rs
+++ b/compiler/hash-tir/src/new/params.rs
@@ -14,6 +14,7 @@ use super::{
     args::{ArgsId, PatArgsId},
     environment::env::{AccessToEnv, WithEnv},
     locations::IndexedLocationTarget,
+    terms::TermId,
 };
 use crate::new::{symbols::Symbol, tys::TyId};
 
@@ -30,6 +31,8 @@ pub struct Param {
     pub name: Symbol,
     /// The type of the parameter.
     pub ty: TyId,
+    /// The default value of the parameter.
+    pub default: Option<TermId>,
 }
 
 new_sequence_store_key!(pub ParamsId);
@@ -55,7 +58,17 @@ impl From<ParamId> for ParamIndex {
 
 impl fmt::Display for WithEnv<'_, &Param> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.env().with(self.value.name), self.env().with(self.value.ty),)
+        write!(
+            f,
+            "{}: {}{}",
+            self.env().with(self.value.name),
+            self.env().with(self.value.ty),
+            if let Some(default) = self.value.default {
+                format!(" = {}", self.env().with(default))
+            } else {
+                "".to_string()
+            }
+        )
     }
 }
 
@@ -122,12 +135,18 @@ impl fmt::Display for WithEnv<'_, ParamsId> {
     }
 }
 
-impl fmt::Display for WithEnv<'_, ParamIndex> {
+impl fmt::Display for ParamIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.value {
+        match self {
             ParamIndex::Name(name) => write!(f, "{name}"),
             ParamIndex::Position(pos) => write!(f, "{pos}"),
         }
+    }
+}
+
+impl fmt::Display for WithEnv<'_, ParamIndex> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
     }
 }
 

--- a/compiler/hash-tir/src/new/pats.rs
+++ b/compiler/hash-tir/src/new/pats.rs
@@ -10,7 +10,7 @@ use hash_utils::{
 };
 
 use super::{
-    args::PatArgsId,
+    args::{PatArgsId, PatOrCapture},
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
@@ -67,7 +67,7 @@ new_store_key!(pub PatId);
 new_store!(pub PatStore<PatId, Pat>);
 
 new_sequence_store_key!(pub PatListId);
-pub type PatListStore = DefaultSequenceStore<PatListId, PatId>;
+pub type PatListStore = DefaultSequenceStore<PatListId, PatOrCapture>;
 
 impl fmt::Display for WithEnv<'_, Spread> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -4,13 +4,13 @@ use hash_source::{identifier::Identifier, location::SourceLocation};
 use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
 use crate::new::{
-    args::{Arg, ArgsId, PatArgsId},
+    args::{Arg, ArgId, ArgsId, PatArgsId},
     data::{DataDef, DataDefId, DataTy},
     environment::env::AccessToEnv,
     fns::{FnDef, FnDefId},
     holes::Hole,
     locations::LocationTarget,
-    params::{Param, ParamIndex, ParamsId},
+    params::{Param, ParamId, ParamIndex, ParamsId},
     pats::{Pat, PatId, PatListId},
     scopes::StackMemberId,
     symbols::{Symbol, SymbolData},
@@ -178,6 +178,35 @@ pub trait CommonUtils: AccessToEnv {
             .modify_fast(stack_member_id.0, |stack| stack.members[stack_member_id.1].name)
     }
 
+    /// Get the index target of an argument
+    fn get_arg_index(&self, arg_id: ArgId) -> ParamIndex {
+        self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].target)
+    }
+
+    /// Get the identifier name of a parameter
+    fn get_param_name_ident(&self, param_id: ParamId) -> Option<Identifier> {
+        let sym = self.get_param_name(param_id);
+        self.stores().symbol().map_fast(sym, |s| s.name)
+    }
+
+    /// Get the index target of a parameter
+    fn get_param_index(&self, param_id: ParamId) -> ParamIndex {
+        let sym = self.get_param_name(param_id);
+        self.stores().symbol().map_fast(sym, |s| {
+            s.name.map(ParamIndex::Name).unwrap_or(ParamIndex::Position(param_id.1))
+        })
+    }
+
+    /// Get the name of a parameter
+    fn get_param_name(&self, param_id: ParamId) -> Symbol {
+        self.stores().params().map_fast(param_id.0, |params| params[param_id.1].name)
+    }
+
+    /// Get the default value of a parameter, if any
+    fn get_param_default(&self, param_id: ParamId) -> Option<TermId> {
+        self.stores().params().map_fast(param_id.0, |params| params[param_id.1].default)
+    }
+
     /// Duplicate a symbol by creating a new symbol with the same name.
     fn duplicate_symbol(&self, existing_symbol: Symbol) -> Symbol {
         let existing_symbol_name = self.stores().symbol().map_fast(existing_symbol, |s| s.name);
@@ -243,7 +272,7 @@ pub trait CommonUtils: AccessToEnv {
             types
                 .iter()
                 .copied()
-                .map(|ty| move |id| Param { id, name: self.new_fresh_symbol(), ty }),
+                .map(|ty| move |id| Param { id, name: self.new_fresh_symbol(), ty, default: None }),
         )
     }
 

--- a/compiler/hash-tir/src/new/utils/params.rs
+++ b/compiler/hash-tir/src/new/utils/params.rs
@@ -31,7 +31,8 @@ impl<'env> ParamUtils<'env> {
         param_names: impl Iterator<Item = Symbol> + ExactSizeIterator,
     ) -> ParamsId {
         self.stores().params().create_from_iter_with(
-            param_names.map(|name| move |id| Param { id, name, ty: self.new_ty_hole() }),
+            param_names
+                .map(|name| move |id| Param { id, name, ty: self.new_ty_hole(), default: None }),
         )
     }
 
@@ -40,9 +41,9 @@ impl<'env> ParamUtils<'env> {
         &self,
         params: impl Iterator<Item = ParamData> + ExactSizeIterator,
     ) -> ParamsId {
-        self.stores().params().create_from_iter_with(
-            params.map(|data| move |id| Param { id, name: data.name, ty: data.ty }),
-        )
+        self.stores().params().create_from_iter_with(params.map(|data| {
+            move |id| Param { id, name: data.name, ty: data.ty, default: data.default }
+        }))
     }
 
     /// Create arguments from the given iterator of argument data.

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -321,7 +321,11 @@ impl<'env> TraversingUtils<'env> {
         self.map_params(params_id, |params| {
             let mut new_params = Vec::with_capacity(params.len());
             for param in params {
-                new_params.push(ParamData { name: param.name, ty: self.fmap_ty(param.ty, f)? });
+                new_params.push(ParamData {
+                    name: param.name,
+                    ty: self.fmap_ty(param.ty, f)?,
+                    default: param.default.map(|default| self.fmap_term(default, f)).transpose()?,
+                });
             }
             Ok(self.param_utils().create_params(new_params.into_iter()))
         })
@@ -536,6 +540,9 @@ impl<'env> TraversingUtils<'env> {
         self.map_params(params_id, |params| {
             for &param in params {
                 self.visit_ty(param.ty, f)?;
+                if let Some(default) = param.default {
+                    self.visit_term(default, f)?;
+                }
             }
             Ok(())
         })

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -64,7 +64,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             };
 
             // Add the parameter
-            params.push(ParamData { name: get_arg_name(arg), ty })
+            params.push(ParamData { name: get_arg_name(arg), ty, default: None })
         };
 
         match annotation_params {
@@ -400,7 +400,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
         match fn_def.body {
             FnBody::Defined(fn_body) => {
-                self.context().enter_scope(fn_def_id.into(), || {
+                self.context().enter_scope(fn_def_id.into(), || -> TcResult<_> {
                     // @@Todo: `return` statement type inference
                     let inferred_return_ty = self.infer_term(fn_body, None)?.1;
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -6,7 +6,7 @@ use hash_intrinsics::utils::PrimitiveUtils;
 use hash_source::constant::{FloatTy, IntTy, SIntTy, UIntTy};
 use hash_tir::{
     new::{
-        args::{ArgsId, PatArgsId},
+        args::{ArgsId, PatArgsId, PatOrCapture},
         casting::CastTerm,
         control::{LoopControlTerm, LoopTerm, ReturnTerm},
         data::{
@@ -17,7 +17,7 @@ use hash_tir::{
         lits::{Lit, PrimTerm},
         mods::{ModDefId, ModMemberId, ModMemberValue},
         params::{Param, ParamData, ParamsId},
-        pats::{Pat, PatId},
+        pats::{Pat, PatId, PatListId},
         refs::{DerefTerm, RefTerm, RefTy},
         scopes::{BlockTerm, DeclTerm},
         symbols::Symbol,
@@ -91,6 +91,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         args: ArgsId,
         annotation_params: Option<ParamsId>,
     ) -> TcResult<(ArgsId, ParamsId)> {
+        match annotation_params {
+            Some(params) => {
+                self.param_ops().validate_and_reorder_args_against_params(args, params)?;
+            }
+            None => todo!(),
+        }
+
         Ok((
             args,
             self.stores().args().map(args, |args| {
@@ -116,8 +123,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 self.infer_some_args(
                     pat_args,
                     annotation_params,
-                    |pat_arg, param| {
-                        Ok(self.infer_pat(pat_arg.pat, param.map(|param| param.ty))?.1)
+                    |pat_arg, param| match pat_arg.pat {
+                        PatOrCapture::Pat(pat) => {
+                            Ok(self.infer_pat(pat, param.map(|param| param.ty))?.1)
+                        }
+                        PatOrCapture::Capture => Ok(self.new_ty_hole()),
                     },
                     |pat_arg| self.new_symbol_from_param_index(pat_arg.target),
                 )
@@ -629,7 +639,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         cast_term: CastTerm,
         annotation_ty: Option<TyId>,
     ) -> TcResult<(CastTerm, TyId)> {
-        let inferred_term_ty = self.infer_term(cast_term.subject_term, None)?.1;
+        let inferred_term_ty = self.infer_term(cast_term.subject_term, annotation_ty)?.1;
         let Uni { sub, .. } =
             self.unification_ops().unify_tys(inferred_term_ty, cast_term.target_ty)?;
         let subbed_target = self.substitution_ops().apply_sub_to_ty(cast_term.target_ty, &sub);
@@ -740,6 +750,19 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         Ok(result)
     }
 
+    pub fn infer_pat_list(
+        &self,
+        pat_list_id: PatListId,
+        _annotation_ty: Option<&[TyId]>,
+    ) -> TcResult<TyId> {
+        self.stores().pat_list().map_fast(pat_list_id, |elements| {
+            self.infer_unified_list(elements, |pat| match pat {
+                PatOrCapture::Pat(pat) => Ok(self.infer_pat(pat, None)?.1),
+                PatOrCapture::Capture => Ok(self.new_ty_hole()),
+            })
+        })
+    }
+
     /// Infer the type of a pattern, and return it.
     pub fn infer_pat(&self, pat_id: PatId, annotation_ty: Option<TyId>) -> TcResult<(PatId, TyId)> {
         let pat = self.get_pat(pat_id);
@@ -761,10 +784,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
             Pat::List(list_term) => {
                 // @@Todo: checking annotations
-                let list_inner_type =
-                    self.stores().pat_list().map_fast(list_term.pats, |elements| {
-                        self.infer_unified_list(elements, |pat| Ok(self.infer_pat(pat, None)?.1))
-                    })?;
+                let list_inner_type = self.infer_pat_list(list_term.pats, None)?;
 
                 self.new_ty(DataTy {
                     data_def: self.primitives().list(),
@@ -787,13 +807,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 // @@todo: sub args
                 self.new_ty(DataTy { data_def, args: ctor_pat.data_args })
             }
-            Pat::Or(or_pat) => {
-                self.stores().pat_list().map_fast(or_pat.alternatives, |alternatives| {
-                    self.infer_unified_list(alternatives, |pat| {
-                        Ok(self.infer_pat(pat, annotation_ty)?.1)
-                    })
-                })?
-            }
+            Pat::Or(or_pat) => self.infer_pat_list(or_pat.alternatives, None)?,
             Pat::If(if_pat) => {
                 let _ = self.infer_term(
                     if_pat.condition,

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -11,6 +11,7 @@ use unification::UnificationOps;
 pub mod errors;
 pub mod inference;
 pub mod normalisation;
+pub mod params;
 pub mod substitution;
 pub mod unification;
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -68,4 +68,8 @@ pub trait AccessToTypechecking:
     fn normalisation_ops(&self) -> normalisation::NormalisationOps<Self> {
         normalisation::NormalisationOps::new(self)
     }
+
+    fn param_ops(&self) -> params::ParamOps<Self> {
+        params::ParamOps::new(self)
+    }
 }

--- a/compiler/hash-typecheck/src/params.rs
+++ b/compiler/hash-typecheck/src/params.rs
@@ -1,0 +1,252 @@
+use std::collections::HashSet;
+
+use derive_more::{Constructor, Deref};
+use hash_tir::new::{
+    args::{ArgData, ArgId, ArgsId},
+    params::{ParamId, ParamIndex, ParamsId},
+    utils::{common::CommonUtils, AccessToUtils},
+};
+use hash_utils::store::{SequenceStore, SequenceStoreKey};
+
+use crate::{errors::TcResult, AccessToTypechecking};
+
+#[derive(Constructor, Deref)]
+pub struct ParamOps<'a, T: AccessToTypechecking>(&'a T);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamError {
+    TooManyArgs { expected: ParamsId, got: ArgsId },
+    DuplicateArg { first: ArgId, second: ArgId },
+    DuplicateParam { first: ParamId, second: ParamId },
+    PositionalArgAfterNamedArg { first_named: ArgId, next_positional: ArgId },
+    RequiredParamAfterDefaultParam { first_default: ParamId, next_required: ParamId },
+    ArgNameNotFoundInParams { arg: ArgId, params: ParamsId },
+    RequiredParamNotFoundInArgs { param: ParamId, args: ArgsId },
+}
+
+impl<T: AccessToTypechecking> ParamOps<'_, T> {
+    /// Validate the given parameters, returning an error if they are invalid.
+    ///
+    /// Conditions for valid parameters are:
+    /// 1. No duplicate parameter names
+    /// 2. All parameters with defaults are at the end
+    pub fn validate_params(&self, params_id: ParamsId) -> TcResult<()> {
+        // @@Todo: ensure captures are closed
+
+        let mut error_state = self.new_error_state();
+
+        let mut seen = HashSet::new();
+        let mut found_default = None;
+
+        for param in params_id.iter() {
+            // Check for duplicate parameters
+            if let Some(param_name) = self.get_param_name_ident(param) {
+                if seen.contains(&param_name) {
+                    error_state
+                        .add_error(ParamError::DuplicateParam { first: param, second: param });
+                }
+                seen.insert(param_name);
+            }
+
+            // Ensure that parameters with defaults follow parameters without
+            // defaults
+            if let Some(default_param) = found_default {
+                if self.get_param_default(param).is_none() {
+                    // Required parameter after named parameter,
+                    // error
+                    error_state.add_error(ParamError::RequiredParamAfterDefaultParam {
+                        first_default: default_param,
+                        next_required: param,
+                    });
+                }
+            } else if self.get_param_default(param).is_some() {
+                // Found the first default parameter
+                found_default = Some(param);
+            }
+        }
+
+        self.return_or_register_errors(|| Ok(()), error_state)
+    }
+
+    /// Validate the given arguments against the given parameters, returning an
+    /// error if they are invalid.
+    ///
+    /// Conditions for valid arguments are:
+    /// 1. No duplicate argument names
+    /// 2. All named arguments follow positional arguments
+    /// 3. No more arguments than parameters
+    ///
+    /// The specific unification of the argument and parameter types is not
+    /// checked at this stage. The function
+    /// `validate_and_reorder_args_against_params` performs additional
+    /// validation of the argument names, and reorders the arguments to match
+    /// the parameters.
+    pub fn validate_args_against_params(
+        &self,
+        args_id: ArgsId,
+        params_id: ParamsId,
+    ) -> TcResult<()> {
+        let mut error_state = self.new_error_state();
+
+        // Check for too many arguments
+        if args_id.len() > params_id.len() {
+            error_state.add_error(ParamError::TooManyArgs { expected: params_id, got: args_id });
+        }
+
+        let mut seen = HashSet::new();
+        let mut found_named = None;
+
+        for arg in args_id.iter() {
+            // Check for duplicate arguments
+            match self.get_arg_index(arg) {
+                ParamIndex::Name(arg_name) => {
+                    if seen.contains(&arg_name) {
+                        error_state.add_error(ParamError::DuplicateArg { first: arg, second: arg });
+                    }
+                    seen.insert(arg_name);
+                }
+                ParamIndex::Position(_) => {
+                    // no-op, we assume that there are no duplicate positional
+                    // arguments..
+                }
+            }
+
+            // Ensure that named arguments follow positional arguments
+            match found_named {
+                Some(named_arg) => {
+                    match self.get_arg_index(arg) {
+                        ParamIndex::Name(_) => {
+                            // Named arguments, ok
+                        }
+                        ParamIndex::Position(_) => {
+                            // Positional arguments after named arguments, error
+                            error_state.add_error(ParamError::PositionalArgAfterNamedArg {
+                                first_named: named_arg,
+                                next_positional: arg,
+                            });
+                        }
+                    }
+                }
+                None => match self.get_arg_index(arg) {
+                    ParamIndex::Name(_) => {
+                        // Found the first named argument
+                        found_named = Some(arg);
+                    }
+                    ParamIndex::Position(_) => {
+                        // Still positional arguments, ok
+                    }
+                },
+            }
+        }
+
+        self.return_or_register_errors(|| Ok(()), error_state)
+    }
+
+    /// Validate the given arguments against the given parameters and reorder
+    /// the arguments to match the parameters.
+    ///
+    /// This assumes that the parameters have already been validated through
+    /// `validate_params`.
+    pub fn validate_and_reorder_args_against_params(
+        &self,
+        args_id: ArgsId,
+        params_id: ParamsId,
+    ) -> TcResult<ArgsId> {
+        // First validate the arguments
+        self.validate_args_against_params(args_id, params_id)?;
+
+        let mut error_state = self.new_error_state();
+        let mut result: Vec<Option<ArgData>> = vec![None; params_id.len()];
+
+        // Note: We have already validated that the number of arguments is less than
+        // or equal to the number of parameters
+
+        for (j, arg_id) in args_id.iter().enumerate() {
+            let arg = self.stores().args().get_element(arg_id);
+
+            match arg.target {
+                // Invariant: all positional arguments are before named
+                ParamIndex::Position(j_received) => {
+                    assert!(j_received == j);
+
+                    result[j] = Some(ArgData {
+                        // Add the name if present
+                        target: self.get_param_index((params_id, j)),
+                        value: arg.value,
+                    });
+                }
+                ParamIndex::Name(arg_name) => {
+                    // Find the position in the parameter list of the parameter with the
+                    // same name as the argument
+                    let maybe_param_index = params_id.iter().position(|param_id| {
+                        match self.get_param_name_ident(param_id) {
+                            Some(name) => name == arg_name,
+                            None => false,
+                        }
+                    });
+
+                    match maybe_param_index {
+                        Some(i) => {
+                            if result[i].is_some() {
+                                // Duplicate argument name, must be from positional
+                                assert!(j != i);
+                                error_state.add_error(ParamError::DuplicateArg {
+                                    first: (args_id, i),
+                                    second: (args_id, j),
+                                });
+                            } else {
+                                // Found an uncrossed parameter, add it to the result
+                                result[i] = Some(ArgData { target: arg.target, value: arg.value });
+                            }
+                        }
+                        None => {
+                            // No parameter with the same name as the argument
+                            error_state.add_error(ParamError::ArgNameNotFoundInParams {
+                                arg: arg_id,
+                                params: params_id,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // If there were any errors, return them
+        if error_state.has_errors() {
+            return self.return_or_register_errors(|| unreachable!(), error_state);
+        }
+
+        // Populate default values and catch missing arguments
+        for i in params_id.to_index_range() {
+            if result[i].is_none() {
+                let param_id = (params_id, i);
+                let default = self.get_param_default(param_id);
+
+                if let Some(default) = default {
+                    // If there is a default value, add it to the result
+                    result[i] =
+                        Some(ArgData { target: self.get_param_index(param_id), value: default });
+                } else {
+                    // No default value, and not present in the arguments, so
+                    // this is an error
+                    error_state.add_error(ParamError::RequiredParamNotFoundInArgs {
+                        param: param_id,
+                        args: args_id,
+                    });
+                }
+            }
+        }
+
+        // If there were any errors, return them
+        if error_state.has_errors() {
+            return self.return_or_register_errors(|| unreachable!(), error_state);
+        }
+
+        // Now, create the new argument list
+        // There should be no `None` elements at this point
+        let new_args_id =
+            self.param_utils().create_args(result.into_iter().map(|arg| arg.unwrap()));
+
+        Ok(new_args_id)
+    }
+}

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -239,7 +239,7 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                         Ok(self
                             .unify_tys(src.ty, target.ty)?
                             // @@Correctness: which name to use here?
-                            .map_result(|ty| ParamData { name: target.name, ty }))
+                            .map_result(|ty| ParamData { name: target.name, ty, default: None }))
                     }),
                     |param_data| self.param_utils().create_params(param_data.into_iter()),
                 )


### PR DESCRIPTION
This PR deals with reordering arguments and pattern arguments to match their parameter order.

The arguments are validated to all exist (if they have names), to have the right length, and then they are rearranged to the order of the parameters. For term arguments, default values are populated if not provided. For pattern arguments, if there is a spread, remaining arguments are captured by it, or otherwise all arguments are validated to exist.

In order to denote arguments that have been captured by a spread, the `Capture` variant is introduced for patterns and pattern lists.

This strategy will be used for function parameters, tuples, constructors.

Closes #698 