### PR TITLE
Link: Integrate linking with pipeline and implement GCC linker wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,6 @@ dependencies = [
  "hash-session",
  "hash-source",
  "hash-target",
- "hash-tree-def",
  "hash-utils",
  "log",
  "num_cpus",
@@ -566,11 +565,8 @@ dependencies = [
 name = "hash-link"
 version = "0.1.0"
 dependencies = [
- "hash-alloc",
  "hash-pipeline",
  "hash-reporting",
- "hash-source",
- "hash-target",
  "hash-utils",
 ]
 
@@ -639,6 +635,7 @@ version = "0.1.0"
 dependencies = [
  "hash-error-codes",
  "hash-source",
+ "hash-target",
  "hash-utils",
  "thiserror",
 ]
@@ -693,6 +690,7 @@ dependencies = [
  "hash-tir",
  "hash-tree-def",
  "hash-untyped-semantics",
+ "hash-utils",
  "log",
  "num_cpus",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,8 @@ version = "0.1.0"
 dependencies = [
  "hash-pipeline",
  "hash-reporting",
+ "hash-source",
+ "hash-target",
  "hash-utils",
 ]
 
@@ -681,6 +683,7 @@ dependencies = [
  "hash-interactive",
  "hash-ir",
  "hash-layout",
+ "hash-link",
  "hash-lower",
  "hash-parser",
  "hash-pipeline",

--- a/compiler/hash-codegen-llvm/src/context.rs
+++ b/compiler/hash-codegen-llvm/src/context.rs
@@ -83,7 +83,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
         ir_ctx: &'b IrCtx,
         layouts: &'b LayoutCtx,
     ) -> Self {
-        let ptr_size = settings.codegen_settings.data_layout.pointer_size;
+        let ptr_size = layouts.data_layout.pointer_size;
         let ll_ctx = module.get_context();
 
         let size_ty = ll_ctx.custom_width_int_type(ptr_size.bits() as u32);
@@ -124,7 +124,7 @@ impl<'b, 'm> CodeGenCtx<'b, 'm> {
 
 impl HasTargetSpec for CodeGenCtx<'_, '_> {
     fn target_spec(&self) -> &Target {
-        self.settings.codegen_settings.target_info.target()
+        self.settings.target()
     }
 }
 

--- a/compiler/hash-codegen-llvm/src/lib.rs
+++ b/compiler/hash-codegen-llvm/src/lib.rs
@@ -78,7 +78,7 @@ impl<'b> LLVMBackend<'b> {
 
         // We have to create a target machine from the provided target
         // data.
-        let target = settings.codegen_settings.target_info.target();
+        let target = settings.target();
 
         // we have to initialise the target with the default configuration based
         // on which architecture we are compiling for.
@@ -170,8 +170,7 @@ impl<'b> LLVMBackend<'b> {
         // through the arguments of the function, i.e. `int main(int argc, char** argv)`
         // then we have to define it as such, otherwise, we define it as
         // `int main()`.
-        let fn_ty = if self.settings.codegen_settings.target_info.target().entry_point_requires_args
-        {
+        let fn_ty = if self.settings.target().entry_point_requires_args {
             ctx.type_function(&[ctx.type_int(), ctx.type_ptr_to(ctx.type_i8p())], ctx.type_int())
         } else {
             ctx.type_function(&[], ctx.type_int())

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -3,7 +3,10 @@
 
 use hash_codegen::common::{AtomicOrdering, IntComparisonKind, RealComparisonKind};
 use hash_pipeline::settings::OptimisationLevel;
-use hash_target::{abi::AddressSpace, CodeModel, RelocationMode};
+use hash_target::{
+    abi::AddressSpace,
+    link::{CodeModel, RelocationMode},
+};
 use inkwell::attributes::Attribute;
 
 use crate::context::CodeGenCtx;

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -525,7 +525,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {
-        let ptr_width = self.ctx.settings().codegen_settings().target_info.target().pointer_width;
+        let ptr_width = self.ctx.settings().target().pointer_bit_width;
 
         let int_ty = self.ir_ctx().map_ty(ty, |ty| match ty {
             IrTy::Int(ty @ SIntTy::ISize) => IntTy::Int(ty.normalise(ptr_width)),

--- a/compiler/hash-codegen-llvm/src/translation/layouts.rs
+++ b/compiler/hash-codegen-llvm/src/translation/layouts.rs
@@ -37,7 +37,7 @@ impl<'b> LayoutMethods<'b> for CodeGenCtx<'b, '_> {
 
 impl HasDataLayout for CodeGenCtx<'_, '_> {
     fn data_layout(&self) -> &TargetDataLayout {
-        &self.settings.codegen_settings.data_layout
+        &self.layouts.data_layout
     }
 }
 

--- a/compiler/hash-codegen-llvm/src/translation/misc.rs
+++ b/compiler/hash-codegen-llvm/src/translation/misc.rs
@@ -70,7 +70,7 @@ impl<'b, 'm> MiscBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
     }
 
     fn declare_entry_point(&self, fn_ty: Self::Type) -> Option<Self::Function> {
-        let target = self.settings.codegen_settings().target_info.target();
+        let target = self.settings.target();
         let entry_name = target.entry_name.as_ref();
 
         // If the symbol already exists, then it is an error

--- a/compiler/hash-codegen/src/traits/ty.rs
+++ b/compiler/hash-codegen/src/traits/ty.rs
@@ -33,7 +33,7 @@ pub trait TypeBuilderMethods<'b>: Backend<'b> {
     /// Create a C `int` type, this will depend on the
     /// compilation target.
     fn type_int(&self) -> Self::Type {
-        match &self.settings().codegen_settings.target_info.target().c_int_width {
+        match &self.settings().target().c_int_width {
             16 => self.type_i16(),
             32 => self.type_i32(),
             64 => self.type_i64(),

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -79,7 +79,7 @@ pub struct LayoutCtx {
 
     /// A reference to the [TargetDataLayout] of the current
     /// session.
-    data_layout: TargetDataLayout,
+    pub data_layout: TargetDataLayout,
 
     /// A table of common layouts that are used by the compiler often
     /// enough to keep in a "common" place, this avoids re-computing

--- a/compiler/hash-link/Cargo.toml
+++ b/compiler/hash-link/Cargo.toml
@@ -5,9 +5,6 @@ authors = ["The Hash Language authors"]
 edition = "2021"
 
 [dependencies]
-hash-alloc = { path = "../hash-alloc" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }
-hash-source = { path = "../hash-source" }
-hash-target = { path = "../hash-target" }
 hash-utils = { path = "../hash-utils" }

--- a/compiler/hash-link/Cargo.toml
+++ b/compiler/hash-link/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2021"
 [dependencies]
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }
+hash-source = { path = "../hash-source" }
 hash-utils = { path = "../hash-utils" }
+hash-target = { path = "../hash-target" }

--- a/compiler/hash-link/src/error.rs
+++ b/compiler/hash-link/src/error.rs
@@ -1,0 +1,6 @@
+//! Any errors that occur during the linking procedure
+//! of a backend. These errors originate from the linker 
+//! itself, and are not from the Hash Compiler. We wrap 
+//! some of the errors from the linker in order to provide
+//! more context to the user, and to standardise the error 
+//! handling across the entire compiler.

--- a/compiler/hash-link/src/gcc.rs
+++ b/compiler/hash-link/src/gcc.rs
@@ -1,11 +1,16 @@
 //! Utilities and an interface to the GCC linker (e.g. `ld`).
 
-use std::process::Command;
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+    process::Command,
+};
 
-use hash_pipeline::settings::CompilerSettings;
+use hash_pipeline::settings::{CompilerSettings, OptimisationLevel};
 
-use crate::Linker;
+use crate::{LinkOutputKind, Linker};
 
+/// A wrapper around the Glorious GCC linker.
 pub struct GccLinker<'ctx> {
     /// The command that is being built up for the
     /// link line.
@@ -15,40 +20,182 @@ pub struct GccLinker<'ctx> {
     /// to link the binary. This provides information about
     /// the target, any specified compiler options, etc.
     session: &'ctx CompilerSettings,
+
+    /// Whether or not the linker is `ld` like.
+    is_ld: bool,
+
+    /// Whether or not the linker is GNU `ld` like.
+    is_gnu: bool,
+
+    /// What is the current hinting mode on the linker.
+    ///
+    /// N.B. On some platforms, this flag has no accept as they
+    /// don't accept hints.
+    static_hint: bool,
 }
 
-impl<'ctx> GccLinker<'ctx> {}
+impl<'ctx> GccLinker<'ctx> {
+    /// Passes an arbitrary argument directly to the linker.
+    fn linker_arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        self.linker_args(&[arg]);
+        self
+    }
+
+    /// Passes a collection of argument directly to the linker.
+    ///
+    /// If the linker is `ld` like, then arguments are simply append to the
+    /// command. When the linker is not `ld` like, then the arguments are
+    /// joined by commas to form an argument that is prepended with `-Wl,`.
+    fn linker_args(&mut self, args: &[impl AsRef<OsStr>]) -> &mut Self {
+        if self.is_ld {
+            args.iter().for_each(|arg| {
+                self.command.arg(arg);
+            });
+        } else if !args.is_empty() {
+            let mut s = OsString::from("-Wl");
+            for arg in args {
+                s.push(",");
+                s.push(arg);
+            }
+            self.command.arg(s);
+        }
+
+        self
+    }
+
+    /// Check whether the linker takes hints, specifically:
+    ///
+    /// - macOS does not take hints since it does not rely on
+    /// `binutils` to perform linking.
+    fn takes_hints(&self) -> bool {
+        self.is_ld && self.is_gnu && !self.session.target().is_like_osx()
+    }
+
+    /// Add a hint to the linker that the next specified library
+    /// argument is a static library.
+    ///
+    /// N.B. This hint is only accepted on some platforms.
+    pub fn hint_static(&mut self) {
+        if !self.takes_hints() {
+            return;
+        }
+
+        if !self.static_hint {
+            self.linker_arg("-Bstatic");
+            self.static_hint = true;
+        }
+    }
+
+    /// Add a hint to the linker that the next specified library argument
+    /// is a dynamic library.
+    pub fn hint_dynamic(&mut self) {
+        if !self.takes_hints() {
+            return;
+        }
+
+        if self.static_hint {
+            self.linker_arg("-Bdynamic");
+            self.static_hint = false;
+        }
+    }
+}
 
 impl<'ctx> Linker for GccLinker<'ctx> {
     fn cmd(&mut self) -> &mut Command {
-        todo!()
+        &mut self.command
     }
 
-    fn set_output_kind(&mut self, kind: crate::LinkOutputKind, filename: &std::path::Path) {
-        todo!()
+    fn set_output_kind(&mut self, kind: LinkOutputKind, filename: &Path) {
+        match (kind.dynamic, kind.is_pic) {
+            (true, true) => {
+                if !self.session.target().is_like_windows() {
+                    self.linker_arg("-pie");
+                }
+            }
+            (true, false) => {
+                if !self.is_ld && self.is_gnu {
+                    self.command.arg("-no-pie");
+                }
+            }
+            (false, true) => {
+                if !self.is_ld {
+                    self.command.arg("-static-pie");
+                } else {
+                    // Clang & GCC pass the `--no-dynamic-linker` flag to `ld` to
+                    //suppresses the `INTERP` ELF header specifying dynamic linker,
+                    // which is otherwise implicitly injected by ld (but not lld).
+
+                    // The `-z text` flag is used to ensure that everything else
+                    // is PIC.
+                    self.command.args(["-static", "-pie", "--no-dynamic-linker", "-z", "text"]);
+                }
+            }
+            (false, false) => {
+                self.command.arg("-static");
+
+                if !self.is_ld && self.is_gnu {
+                    self.command.arg("-no-pie");
+                }
+            }
+        }
     }
 
-    fn set_output_filename(&mut self, filename: &std::path::Path) {
-        todo!()
+    fn set_output_filename(&mut self, filename: &Path) {
+        self.command.arg("-o").arg(filename);
     }
 
     fn link_dylib(&mut self, lib: &str, verbatim: bool, as_needed: bool) {
-        todo!()
+        // This option affects ELF DT_NEEDED tags for dynamic libraries mentioned on the
+        // command line after the --as-needed option. Normally the linker will add a
+        // DT_NEEDED tag for each dynamic library mentioned on the command line,
+        // regardless of whether the library is actually needed or not. --as-needed
+        // causes a DT_NEEDED tag to only be emitted for a library that satisfies an
+        // undefined symbol reference from a regular object file or, if the library is
+        // not found in the DT_NEEDED lists of other libraries linked up to that point,
+        // an undefined symbol reference from another dynamic library. --no-as-needed
+        // restores the default behaviour.
+        if !as_needed && self.is_gnu && !self.session.target().is_like_windows() {
+            self.linker_arg("--no-as-needed");
+        }
+
+        self.hint_dynamic();
+
+        let verbatim_prefix = if verbatim && self.is_gnu { ":" } else { "" };
+        self.command.arg(format!("-l{verbatim_prefix}{lib}"));
+
+        // Now disable the --as-needed option again.
+        if !as_needed && self.is_gnu && !self.session.target().is_like_windows() {
+            self.linker_arg("--as-needed");
+        }
     }
 
     fn link_static_lib(&mut self, lib: &str, verbatim: bool) {
-        todo!()
+        self.hint_static();
+
+        let verbatim_prefix = if verbatim && self.is_gnu { ":" } else { "" };
+        self.command.arg(format!("-l{verbatim_prefix}{lib}"));
     }
 
     fn include_path(&mut self, path: &std::path::Path) {
-        todo!()
+        self.command.arg("-L").arg(path);
     }
 
     fn optimize(&mut self) {
-        todo!()
+        if !self.is_gnu {
+            return;
+        }
+
+        if self.session.optimisation_level > OptimisationLevel::Debug {
+            self.linker_arg("-O1");
+        }
     }
 
     fn gc_sections(&mut self) {
-        todo!()
+        // This essentially performs dead-code elimination on the
+        // resultant binary, removing everything that is not used
+        // or can't be reached from "main".
+        if self.session.target().is_like_osx() {
+            self.linker_arg("-dead_strip");
+        }
     }
 }

--- a/compiler/hash-link/src/lib.rs
+++ b/compiler/hash-link/src/lib.rs
@@ -19,7 +19,7 @@ pub struct LinkOutputKind {
     pub dynamic: bool,
 
     /// Is the output position-independent?
-    pub pic: bool,
+    pub is_pic: bool,
 }
 
 /// A trait which represents a linker and all of the functionality

--- a/compiler/hash-link/src/lib.rs
+++ b/compiler/hash-link/src/lib.rs
@@ -8,7 +8,20 @@ pub mod lld;
 pub mod mold;
 pub mod msvc;
 
-use std::{path::Path, process::Command};
+use std::{
+    io,
+    path::Path,
+    process::{Command, Output},
+};
+
+use hash_pipeline::{
+    interface::{CompilerInterface, CompilerOutputStream, CompilerStage},
+    settings::{CompilerSettings, CompilerStageKind},
+    workspace::Workspace,
+    CompilerResult,
+};
+use hash_source::SourceId;
+use hash_target::link::LinkerFlavour;
 
 /// This specifies the kind of output that the linker should
 /// produce, whether it is dynamically linked, and whether it
@@ -58,4 +71,74 @@ pub trait Linker {
     /// In practise this means that the linker will strip all functions
     /// and data that is unreachable from the entry point.
     fn gc_sections(&mut self);
+}
+
+/// The linking context, which contains all of the information
+/// from the [CompilerSession] in order to perform
+/// the linking of an executable, or library.
+pub struct LinkerCtx<'ctx> {
+    /// Reference to the current compiler workspace.
+    pub workspace: &'ctx Workspace,
+
+    /// A reference to the backend settings in the current session.
+    pub settings: &'ctx CompilerSettings,
+
+    /// Reference to the output stream
+    pub stdout: CompilerOutputStream,
+}
+
+pub struct CompilerLinker;
+
+pub trait LinkerCtxQuery: CompilerInterface {
+    fn data(&mut self) -> LinkerCtx<'_>;
+}
+
+impl<Ctx: LinkerCtxQuery> CompilerStage<Ctx> for CompilerLinker {
+    fn kind(&self) -> CompilerStageKind {
+        CompilerStageKind::Link
+    }
+
+    fn run(&mut self, _: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
+        let LinkerCtx { workspace, settings, stdout } = ctx.data();
+
+        // If we are not emitting an executable, then we can
+        if !workspace.yields_executable(settings) {
+            return Ok(());
+        }
+
+        // Get the executable path that is going to be
+        // emitted by the compiler.
+        let output_path = workspace.executable_path();
+        let temp_path = workspace.temporary_storage("link").map_err(|err| vec![err.into()])?;
+
+        // Get the linker that is going to be used to link
+
+        let (linker_path, flavour) = get_linker_and_flavour(settings);
+        let mut linker = get_linker_with_args(settings, workspace);
+
+        // @@Todo: print out link-line if specified via `-Cemit=link-line`
+
+        // Run the linker
+        let command = linker.cmd();
+        let program = execute_linker(settings, command, output_path.as_path(), temp_path.as_path());
+
+        Ok(())
+    }
+}
+
+fn get_linker_and_flavour(settings: &CompilerSettings) -> (&Path, LinkerFlavour) {
+    todo!()
+}
+
+fn get_linker_with_args(settings: &CompilerSettings, workspace: &Workspace) -> Box<dyn Linker> {
+    todo!()
+}
+
+fn execute_linker(
+    settings: &CompilerSettings,
+    cmd: &Command,
+    out_filename: &Path,
+    temp_dir: &Path,
+) -> io::Result<Output> {
+    todo!()
 }

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -293,13 +293,13 @@ impl<'tcx> Builder<'tcx> {
                             0,
                         ),
                         IrTy::Int(int_ty) => {
-                            let size = int_ty.size(self.tcx.target_pointer_width).unwrap();
+                            let size = int_ty.size(self.tcx.pointer_width).unwrap();
                             let max = size.truncate(u128::MAX);
                             let bias = 1u128 << (size.bits() - 1);
                             (Some((0, max, size)), bias)
                         }
                         IrTy::UInt(uint_ty) => {
-                            let size = uint_ty.size(self.tcx.target_pointer_width).unwrap();
+                            let size = uint_ty.size(self.tcx.pointer_width).unwrap();
                             let max = size.truncate(u128::MAX);
                             (Some((0, max, size)), 0)
                         }

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -134,7 +134,7 @@ impl<'tcx> Builder<'tcx> {
     /// signed integer type.
     fn min_value_of_ty(&self, ty: IrTy) -> Operand {
         let value = if let IrTy::Int(signed_ty) = ty {
-            let size = signed_ty.size(self.tcx.target_pointer_width).unwrap().bits();
+            let size = signed_ty.size(self.tcx.pointer_width).unwrap().bits();
             let n = 1 << (size - 1);
 
             // Create and intern the constant

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -142,10 +142,10 @@ fn parse_arg_configuration(
         "target" => {
             let value = value.ok_or_else(expected_value)?;
 
-            let target = Target::from_string(value.clone())
+            let target = Target::search(value.as_str())
                 .ok_or_else(|| PipelineError::InvalidTarget(value))?;
 
-            settings.codegen_settings.target_info.set_target(target)
+            settings.codegen_settings.target_info.target = target;
         }
         "optimisation-level" => {
             let value = value.ok_or_else(expected_value)?;

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -414,6 +414,9 @@ pub enum CompilerStageKind {
     /// to successfully compile.
     CodeGen,
 
+    /// Run the linking stage.
+    Link,
+
     /// If the compiler is in interactive mode, this will run
     /// the full pipeline all the way to the virtual machine, if
     /// however there is an entry point defined, this means that
@@ -432,7 +435,8 @@ impl Display for CompilerStageKind {
             CompilerStageKind::Typecheck => write!(f, "typecheck"),
             CompilerStageKind::Lower => write!(f, "lowering"),
             CompilerStageKind::CodeGen => write!(f, "codegen"),
-            CompilerStageKind::Full => write!(f, "total"),
+            CompilerStageKind::Link => write!(f, "linking"),
+            CompilerStageKind::Full => write!(f, "full"),
         }
     }
 }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use hash_source::constant::CONSTANT_MAP;
-use hash_target::{data_layout::TargetDataLayout, TargetInfo};
+use hash_target::{Target, TargetInfo, HOST_TARGET_TRIPLE};
 
 use crate::{error::PipelineError, fs::resolve_path};
 
@@ -185,6 +185,11 @@ impl CompilerSettings {
     pub fn codegen_settings(&self) -> &CodeGenSettings {
         &self.codegen_settings
     }
+
+    /// Get a reference to the current compiled [Target].
+    pub fn target(&self) -> &Target {
+        &self.codegen_settings.target_info.target
+    }
 }
 
 impl Default for CompilerSettings {
@@ -321,18 +326,13 @@ pub enum IrDumpMode {
 ///
 /// N.B. some information that is stored here may be used by previous stages
 /// e.g. target information.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CodeGenSettings {
     /// Information about the current "session" that the compiler is running
     /// in. This contains information about which target the compiler is
     /// compiling for, and other information that is used by the compiler
     /// to determine how to compile the source code.
     pub target_info: TargetInfo,
-
-    /// The specified target layout information for types. This defines
-    /// the sizes of target-dependant types, and default alignments for
-    /// primitive types.
-    pub data_layout: TargetDataLayout,
 
     /// This is only the "backend" for the global instance of code generation.
     ///
@@ -349,6 +349,20 @@ pub struct CodeGenSettings {
 
     /// Emit the generated IR to standard output.
     pub dump: bool,
+}
+
+impl Default for CodeGenSettings {
+    fn default() -> Self {
+        Self {
+            target_info: TargetInfo {
+                host: Target::search(HOST_TARGET_TRIPLE).unwrap(),
+                target: Target::search(HOST_TARGET_TRIPLE).unwrap(),
+            },
+            backend: Default::default(),
+            output_path: Default::default(),
+            dump: Default::default(),
+        }
+    }
 }
 
 /// All of the current possible code generation backends that

--- a/compiler/hash-reporting/Cargo.toml
+++ b/compiler/hash-reporting/Cargo.toml
@@ -10,3 +10,4 @@ thiserror = "1.0"
 hash-error-codes = {path = "../hash-error-codes" }
 hash-source = {path = "../hash-source" }
 hash-utils = {path = "../hash-utils" }
+hash-target= {path = "../hash-target" }

--- a/compiler/hash-reporting/src/implementations.rs
+++ b/compiler/hash-reporting/src/implementations.rs
@@ -1,0 +1,61 @@
+//! Various implementations to convert errors into reports that
+//! cannot be defined in the originating crate due to dependency
+//! cycles.
+//!
+//! Additionally, this provides some boilerplate implementations of
+//! converting various error kinds into the equivalent [Report]
+//! representations.
+
+use std::{convert::Infallible, io};
+
+use hash_target::data_layout::TargetDataLayoutParseError;
+
+use crate::report::{Report, ReportKind};
+
+/// Some basic conversions into reports
+impl From<io::Error> for Report {
+    fn from(err: io::Error) -> Self {
+        let mut report = Report::new();
+
+        // @@ErrorReporting: we might want to show a bit more info here.
+        report.kind(ReportKind::Error).title(err.to_string());
+        report
+    }
+}
+
+impl From<Infallible> for Report {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl From<TargetDataLayoutParseError<'_>> for Report {
+    fn from(value: TargetDataLayoutParseError) -> Self {
+        let mut report = Report::new();
+
+        let message = match value {
+            TargetDataLayoutParseError::InvalidAddressSpace { addr_space, err } => {
+                format!("invalid address space `{addr_space}` in \"data-layout\", cause: {err}")
+            }
+            TargetDataLayoutParseError::InvalidAlignment { cause } => {
+                format!("invalid alignment for `{cause}` in \"data-layout\"")
+            }
+            TargetDataLayoutParseError::MissingAlignment { cause } => {
+                format!("missing alignment for `{cause}` in \"data-layout\"")
+            }
+            TargetDataLayoutParseError::InvalidBits { kind, bit, cause, err } => {
+                format!("invalid {kind} `{bit}` for `{cause}` in \"data-layout\", err: {err}")
+            }
+            TargetDataLayoutParseError::InconsistentTargetArchitecture { dl, target } => {
+                format!("inconsistent target specification: \"data-layout\" claims architecture is {dl}-endian, while \"target-endian\" is `{target}`")
+            }
+            TargetDataLayoutParseError::InconsistentTargetPointerWidth { size, target } => {
+                format!("inconsistent target specification: \"data-layout\" claims pointer size is {size} bits, while \"target-pointer-width\" is `{target}`")
+            }
+            TargetDataLayoutParseError::InvalidEnumSize { err } => err,
+        };
+
+        report.kind(ReportKind::Error).title(message);
+        report
+    }
+}

--- a/compiler/hash-reporting/src/lib.rs
+++ b/compiler/hash-reporting/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod diagnostic;
 pub mod highlight;
+pub mod implementations;
 pub mod macros;
 mod render;
 pub mod report;

--- a/compiler/hash-reporting/src/report.rs
+++ b/compiler/hash-reporting/src/report.rs
@@ -1,5 +1,5 @@
 //! Hash diagnostic report data structures.
-use std::{cell::Cell, convert::Infallible, fmt, io};
+use std::{cell::Cell, fmt};
 
 use hash_error_codes::error_codes::HashErrorCode;
 use hash_source::location::{RowColSpan, SourceLocation};
@@ -241,22 +241,5 @@ impl Default for Report {
             error_code: None,
             contents: vec![],
         }
-    }
-}
-
-/// Some basic conversions into reports
-impl From<io::Error> for Report {
-    fn from(err: io::Error) -> Self {
-        let mut report = Report::new();
-
-        // @@ErrorReporting: we might want to show a bit more info here.
-        report.kind(ReportKind::Error).title(err.to_string());
-        report
-    }
-}
-
-impl From<Infallible> for Report {
-    fn from(err: Infallible) -> Self {
-        match err {}
     }
 }

--- a/compiler/hash-semantics/src/exhaustiveness/lower.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/lower.rs
@@ -139,7 +139,7 @@ impl<'tc> LowerPatOps<'tc> {
                 Term::Level0(Level0Term::Lit(lit)) => match lit {
                     LitTerm::Str(value) => (DeconstructedCtor::Str(value), vec![]),
                     LitTerm::Int { value } => {
-                        let ptr_width = self.global_storage().target_pointer_width;
+                        let ptr_width = self.global_storage().pointer_width;
                         let value = Constant::from_int(value, term, ptr_width);
                         let range = self.int_range_ops().range_from_constant(value);
                         (DeconstructedCtor::IntRange(range), vec![])
@@ -509,7 +509,7 @@ impl<'tc> LowerPatOps<'tc> {
                     Constant::from_char(ch, term).data()
                 }
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => {
-                    let ptr_width = self.global_storage().target_pointer_width;
+                    let ptr_width = self.global_storage().pointer_width;
 
                     Constant::from_int(value, term, ptr_width).data()
                 }
@@ -544,7 +544,7 @@ impl<'tc> LowerPatOps<'tc> {
         let (lo, hi) = (lo ^ bias, hi ^ bias);
 
         let (lo, hi) = if let Some(kind) = self.oracle().term_as_int_ty(ty) {
-            let ptr_width = self.global_storage().target_pointer_width;
+            let ptr_width = self.global_storage().pointer_width;
             let size = kind.size(ptr_width).unwrap().bytes() as usize;
 
             // Trim the values within the stored range and then create

--- a/compiler/hash-semantics/src/exhaustiveness/range.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/range.rs
@@ -270,7 +270,7 @@ impl<'tc> IntRangeOps<'tc> {
         let bias: u128 = match reader.get_term(constant.ty) {
             Term::Level0(Level0Term::Lit(lit)) => match lit {
                 LitTerm::Int { value } if let kind = CONSTANT_MAP.map_int_constant(value, |val| val.ty) && kind.is_signed() => {
-                    let ptr_width = self.global_storage().target_pointer_width;
+                    let ptr_width = self.global_storage().pointer_width;
                     let bits = kind.size(ptr_width).unwrap().bits();
                     1u128 << (bits - 1)
                 }
@@ -310,7 +310,7 @@ impl<'tc> IntRangeOps<'tc> {
     /// last byte is that identifies the sign.
     fn signed_bias(&self, ty: TermId) -> u128 {
         if let Some(ty) = self.oracle().term_as_int_ty(ty) {
-            let ptr_width = self.global_storage().target_pointer_width;
+            let ptr_width = self.global_storage().pointer_width;
             if let Some(size) = ty.size(ptr_width) && ty.is_signed()  {
                 let bits = size.bits() as u128;
                 return 1u128 << (bits - 1);

--- a/compiler/hash-semantics/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/wildcard.rs
@@ -92,7 +92,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                 }
                 kind if kind.is_signed() => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                    let ptr_width = self.global_storage().target_pointer_width;
+                    let ptr_width = self.global_storage().pointer_width;
                     let bits = kind.size(ptr_width).unwrap().bits() as u128;
                     let min = 1u128 << (bits - 1);
                     let max = min - 1;
@@ -102,7 +102,7 @@ impl<'tc> SplitWildcardOps<'tc> {
                 }
                 kind => {
                     // Safe to unwrap since we deal with `ibig` and `ubig` variants...
-                    let ptr_width = self.global_storage().target_pointer_width;
+                    let ptr_width = self.global_storage().pointer_width;
                     let size = kind.size(ptr_width).unwrap();
                     let max = size.truncate(u128::MAX);
 

--- a/compiler/hash-semantics/src/ops/validate.rs
+++ b/compiler/hash-semantics/src/ops/validate.rs
@@ -1219,7 +1219,7 @@ impl<'tc> Validator<'tc> {
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: lhs })),
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs })),
             ) => {
-                let ptr_width = self.global_storage().target_pointer_width;
+                let ptr_width = self.global_storage().pointer_width;
                 let lhs_kind = CONSTANT_MAP.map_int_constant(lhs, |val| val.ty);
                 let rhs_kind = CONSTANT_MAP.map_int_constant(rhs, |val| val.ty);
 

--- a/compiler/hash-session/Cargo.toml
+++ b/compiler/hash-session/Cargo.toml
@@ -11,15 +11,16 @@ rayon = "1.5.0"
 
 hash-alloc = { path = "../hash-alloc" }
 hash-ast = { path = "../hash-ast" }
+hash-codegen = { path = "../hash-codegen" }
 hash-interactive = { path = "../hash-interactive" }
 hash-ir = { path = "../hash-ir" }
+hash-layout = { path = "../hash-layout" }
 hash-pipeline = { path = "../hash-pipeline" }
 hash-reporting = { path = "../hash-reporting" }
 hash-source = { path = "../hash-source" }
-hash-tree-def = { path = "../hash-tree-def" }
 hash-tir = { path = "../hash-tir" }
-hash-layout = { path = "../hash-layout" }
-hash-codegen = { path = "../hash-codegen" }
+hash-tree-def = { path = "../hash-tree-def" }
+hash-utils = { path = "../hash-utils" }
 
 # Various stages that the pipeline interfaces with...
 hash-ast-desugaring = { path = "../hash-ast-desugaring" }

--- a/compiler/hash-session/Cargo.toml
+++ b/compiler/hash-session/Cargo.toml
@@ -26,6 +26,7 @@ hash-utils = { path = "../hash-utils" }
 hash-ast-desugaring = { path = "../hash-ast-desugaring" }
 hash-ast-expand = { path = "../hash-ast-expand" }
 hash-backend = { path = "../hash-backend" }
+hash-link = { path = "../hash-link" }
 hash-lower = { path = "../hash-lower" }
 hash-parser = { path = "../hash-parser" }
 hash-semantics = { path = "../hash-semantics" }

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -15,6 +15,7 @@ use hash_backend::{BackendCtxQuery, CodeGenPass};
 use hash_codegen::backend::BackendCtx;
 use hash_ir::IrStorage;
 use hash_layout::LayoutCtx;
+use hash_link::{CompilerLinker, LinkerCtx, LinkerCtxQuery};
 use hash_lower::{IrGen, IrOptimiser, LoweringCtx, LoweringCtxQuery};
 use hash_parser::{Parser, ParserCtx, ParserCtxQuery};
 use hash_pipeline::{
@@ -40,6 +41,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
         Box::<IrGen>::default(),
         Box::new(IrOptimiser),
         Box::new(CodeGenPass),
+        Box::new(CompilerLinker),
     ]
 }
 
@@ -237,5 +239,13 @@ impl BackendCtxQuery for CompilerSession {
             stdout: output_stream,
             _pool: &self.pool,
         }
+    }
+}
+
+impl LinkerCtxQuery for CompilerSession {
+    fn data(&mut self) -> hash_link::LinkerCtx<'_> {
+        let stdout = self.output_stream();
+
+        LinkerCtx { workspace: &self.workspace, settings: &self.settings, stdout }
     }
 }

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -41,6 +41,18 @@ impl Integer {
         }
     }
 
+    /// Get the [Integer] from the [Size] of the integer.
+    pub fn from_size(size: Size) -> Option<Self> {
+        match size.bits() {
+            8 => Some(Integer::I8),
+            16 => Some(Integer::I16),
+            32 => Some(Integer::I32),
+            64 => Some(Integer::I64),
+            128 => Some(Integer::I128),
+            _ => None,
+        }
+    }
+
     /// Get the [Alignments] of the [Integer].
     pub fn align<C: HasDataLayout>(self, ctx: &C) -> Alignments {
         use Integer::*;

--- a/compiler/hash-target/src/data_layout.rs
+++ b/compiler/hash-target/src/data_layout.rs
@@ -27,13 +27,23 @@ impl HasDataLayout for TargetDataLayout {
 /// This enum defines the Endianness of a target, which is used
 /// when reading/writing scalar values to memory. More information
 /// about Endianness can be found (https://en.wikipedia.org/wiki/Endianness)[here].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Endian {
     /// Values use the little endian format.
     Little,
 
     /// Values use the big endian format.
     Big,
+}
+
+impl Endian {
+    /// Convert the [Endian] to a static string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Endian::Little => "little",
+            Endian::Big => "big",
+        }
+    }
 }
 
 /// Defines all of the specifics of how primitive types are
@@ -171,11 +181,11 @@ pub enum TargetDataLayoutParseError<'a> {
     MissingAlignment { cause: &'a str },
 
     /// Inconsistent target architecture.
-    InconsistentTargetArchitecture { layout: &'a str },
+    InconsistentTargetArchitecture { dl: &'a str, target: &'a str },
 
     /// When the data layout string specifies an inconsistent pointer size
     /// with the target.
-    InconsistentTargetPointerSize {
+    InconsistentTargetPointerWidth {
         /// The size specified on the string.
         size: u64,
         /// The expected pointer size on the target.
@@ -183,7 +193,7 @@ pub enum TargetDataLayoutParseError<'a> {
     },
 
     /// When a data layout incorrectly specifies the size of C-style enums.
-    InvalidEnumSize,
+    InvalidEnumSize { err: String },
 }
 
 impl TargetDataLayout {

--- a/compiler/hash-target/src/link.rs
+++ b/compiler/hash-target/src/link.rs
@@ -1,0 +1,152 @@
+//! Definitions and data types that characterise linking
+//! variants for platforms.
+//!
+//! Ideally, this would live in `hash-link`, but this would create
+//! a circular dependency between `hash-link` and `hash-target`, so...
+
+use std::{borrow::Cow, collections::BTreeMap};
+
+/// Linker is called through a C/C++ compiler.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Cc {
+    Yes,
+    No,
+}
+
+/// Linker is LLD.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Lld {
+    Yes,
+    No,
+}
+
+/// Linker flavour, determines which linker is used to for
+/// which target.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum LinkerFlavour {
+    /// GNU linker for Linux and other Unix-like targets.
+    Gnu(Cc, Lld),
+
+    /// Unix-like linker for Apple targets.
+    Darwin(Cc, Lld),
+
+    /// MSVC Linker for Windows and UEFI.
+    Msvc(Lld),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FramePointer {
+    /// Always preserve the function frame pointer.
+    AlwaysPreserve,
+
+    /// Allow for the frame pointer to be disregarded for
+    /// leaf functions, i.e. functions that never call any
+    /// other functions.
+    Leaf,
+
+    /// No particular restrictions on the frame pointer, it is up
+    /// to the linker to decide what to do.
+    None,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CodeModel {
+    /// The default code model.
+    Default,
+
+    /// The JIT code model.
+    JITDefault,
+
+    /// The small code model.
+    Small,
+
+    /// The kernel code model.
+    Kernel,
+
+    /// The medium code model.
+    Medium,
+
+    /// The large code model.
+    Large,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RelocationMode {
+    /// The default relocation mode.
+    Default,
+
+    /// The static relocation mode.
+    Static,
+
+    /// The PIC relocation mode.
+    PIC,
+
+    /// The dynamic no PIC relocation mode.
+    DynamicNoPIC,
+}
+
+/// A collection of linker arguments that are applied to the
+/// linker invocation provided that the correct platform is
+/// specified.
+#[derive(Debug, Clone, Default)]
+pub struct LinkageArgs {
+    args: BTreeMap<LinkerFlavour, Vec<Cow<'static, str>>>,
+}
+
+impl LinkageArgs {
+    /// Create a new empty collection of linker arguments.
+    pub fn new() -> Self {
+        Self { args: BTreeMap::new() }
+    }
+
+    /// Add a collection of arguments to the [LinkageArgs] for the
+    /// given [LinkerFlavour].
+    pub fn add_args(
+        &mut self,
+        flavour: LinkerFlavour,
+        args: impl Iterator<Item = Cow<'static, str>> + Clone,
+    ) {
+        let mut insert = |flavour| self.args.entry(flavour).or_default().extend(args.clone());
+        insert(flavour);
+
+        match flavour {
+            LinkerFlavour::Gnu(cc, lld) => {
+                debug_assert_eq!(lld, Lld::No); // It can't not be if we're adding args.
+
+                insert(LinkerFlavour::Gnu(cc, Lld::Yes));
+            }
+            LinkerFlavour::Darwin(cc, lld) => {
+                debug_assert_eq!(lld, Lld::No); // It can't not be if we're adding args.
+
+                insert(LinkerFlavour::Darwin(cc, Lld::Yes));
+            }
+            LinkerFlavour::Msvc(lld) => {
+                debug_assert_eq!(lld, Lld::No); // It can't not be if we're adding args.
+
+                insert(LinkerFlavour::Msvc(Lld::Yes));
+            }
+        }
+    }
+
+    /// Add link arguments to the given [LinkerFlavour] that are [str]s.
+    pub fn add_str_args(&mut self, flavour: LinkerFlavour, args: &[&'static str]) {
+        self.add_args(flavour, args.iter().copied().map(Cow::Borrowed))
+    }
+}
+
+/// A collection of linker environment variables that are applied to the
+/// linker invocation provided that the correct platform is specified.
+pub type LinkEnv = Cow<'static, [Cow<'static, str>]>;
+
+pub macro link_env {
+    () => {
+        Cow::Borrowed(&[])
+    },
+    ($($variable: expr),+ $(,)?) => {
+        Cow::Borrowed(&[
+            $(
+                Cow::Borrowed($variable),
+            )*
+        ])
+    }
+}

--- a/compiler/hash-target/src/targets/aarch64_apple_darwin.rs
+++ b/compiler/hash-target/src/targets/aarch64_apple_darwin.rs
@@ -1,0 +1,21 @@
+//! For M1 & M2 folks.
+
+use crate::{
+    targets::apple_base::{self, AppleArch},
+    Target,
+};
+
+/// Create a new [Target] for the `aarch64-apple-darwin` target.
+pub fn target() -> Target {
+    let apple_arch = AppleArch::Arm64;
+    let mut base = apple_base::options_from("macos", apple_arch);
+    base.cpu = "apple-a14".into();
+
+    Target {
+        name: apple_arch.llvm_target().into(),
+        arch: apple_arch.into(),
+        data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".into(),
+        pointer_bit_width: 64,
+        ..base
+    }
+}

--- a/compiler/hash-target/src/targets/apple_base.rs
+++ b/compiler/hash-target/src/targets/apple_base.rs
@@ -1,0 +1,112 @@
+//! Base Apple architecture configurations.
+
+use std::borrow::Cow;
+
+use crate::{
+    link::{Cc, FramePointer, LinkageArgs, LinkerFlavour, Lld},
+    Platform, Target, TargetArch,
+};
+
+/// All of the architectures that Apple supports, and or has
+/// machines that are of that architecture. This is only a subset
+/// of the architectures that are available, however we only
+/// support these architectures for now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppleArch {
+    /// For x86_64 folks.
+    X86_64,
+
+    /// M1 & M2 folks.
+    Arm64,
+}
+
+impl AppleArch {
+    /// Get the architecture target CPU name.
+    pub fn target_cpu(&self) -> &'static str {
+        match self {
+            AppleArch::X86_64 => "core2",
+            AppleArch::Arm64 => "apple-a12",
+        }
+    }
+
+    /// Get the target architecture name.
+    pub fn target_name(&self) -> &'static str {
+        match self {
+            AppleArch::X86_64 => "x86_64",
+            AppleArch::Arm64 => "arm64",
+        }
+    }
+
+    /// Get the specific LLVM target for the particular architecture.
+    pub fn llvm_target(&self) -> String {
+        let (major, minor) = self.macos_deployment_target();
+        format!("{}-apple-macosx{}.{}.0", self.target_name(), major, minor)
+    }
+
+    /// Get a major and minor version for the macOS deployment target.
+    pub fn macos_deployment_target(&self) -> (u32, u32) {
+        match self {
+            AppleArch::X86_64 => (10, 7),
+            AppleArch::Arm64 => (11, 0), // Lesser versions than 11.0 are not supported.
+        }
+    }
+
+    /// Get the macOS platform version for the given architecture.
+    pub fn platform_version(&self) -> String {
+        let (major, minor) = self.macos_deployment_target();
+        format!("{major}.{minor}")
+    }
+}
+
+impl From<AppleArch> for TargetArch {
+    fn from(arch: AppleArch) -> Self {
+        match arch {
+            AppleArch::X86_64 => Self::X86_64,
+            AppleArch::Arm64 => Self::Aarch64,
+        }
+    }
+}
+
+/// Compute the pre-linking arguments the given [AppleArch]
+/// with specific os and ABI.
+pub fn compute_pre_link_args(os: &'static str, arch: AppleArch, _abi: &'static str) -> LinkageArgs {
+    let version: Cow<'static, str> = arch.platform_version().into();
+    let arch = arch.target_name();
+
+    let mut args = LinkageArgs::new();
+
+    // We just specify the architecture and the platform version
+    // which is required for the darwin family linkers
+    args.add_str_args(
+        LinkerFlavour::Darwin(Cc::No, Lld::No),
+        &["-arch", arch, "-platform_version", os],
+    );
+    args.add_args(LinkerFlavour::Darwin(Cc::No, Lld::No), [version.clone(), version].into_iter());
+
+    args
+}
+
+pub fn options_from(os: &'static str, arch: AppleArch) -> Target {
+    Target {
+        cpu: arch.target_cpu().into(),
+        arch: arch.into(),
+        data_layout: "".into(),
+        pointer_bit_width: 64,
+
+        // Specify the DLL suffix for the target, it is always "dylib" for apple
+        // targets.
+        dylib_suffix: ".dylib".into(),
+        vendor: "apple".into(),
+        platform: Platform::OsX,
+
+        // macOS has -dead_strip, which doesn't rely on function_sections
+        linker_flavour: LinkerFlavour::Darwin(Cc::Yes, Lld::No),
+        dynamic_linking: true,
+        function_sections: false,
+        frame_pointer: FramePointer::AlwaysPreserve,
+
+        pre_link_args: compute_pre_link_args(os, arch, ""),
+
+        ..Default::default()
+    }
+}

--- a/compiler/hash-target/src/targets/mod.rs
+++ b/compiler/hash-target/src/targets/mod.rs
@@ -1,0 +1,28 @@
+//! Contains definitions and specific configuration per
+//! compilation platform.
+
+mod apple_base;
+
+use crate::Target;
+
+/// This macro registers all of the available compiler targets
+/// based on the target triple.
+macro_rules! register_targets {
+    ( $(($triple:literal, $module: ident),)+ ) => {
+        $(mod $module;)+
+
+        pub const AVAILABLE_TARGETS: &[&str] = &[$($triple),+];
+
+        pub(super) fn load_target(target: &str) -> Option<Target> {
+            match target {
+                $($triple => Some($module::target()),)+
+                _ => None,
+            }
+        }
+    }
+}
+
+register_targets! {
+    ("x86_64-apple-darwin", x86_apple_darwin),
+    ("aarch64-apple-darwin", aarch64_apple_darwin),
+}

--- a/compiler/hash-target/src/targets/x86_apple_darwin.rs
+++ b/compiler/hash-target/src/targets/x86_apple_darwin.rs
@@ -1,0 +1,25 @@
+//! Target specifications for the x86_64-apple-darwin target.
+
+use crate::{
+    link::{Cc, FramePointer, LinkerFlavour, Lld},
+    targets::apple_base::{self, AppleArch},
+    Target,
+};
+
+/// Create a new [Target] for the `x86_64-apple-darwin` target.
+pub fn target() -> Target {
+    let apple_arch = AppleArch::X86_64;
+    let mut base = apple_base::options_from("macos", apple_arch);
+
+    base.frame_pointer = FramePointer::AlwaysPreserve;
+    base.add_pre_link_args(LinkerFlavour::Darwin(Cc::Yes, Lld::No), &["-m64"]);
+
+    Target {
+        name: apple_arch.llvm_target().into(),
+        arch: apple_arch.into(),
+        pointer_bit_width: 64,
+        data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+            .into(),
+        ..base
+    }
+}

--- a/compiler/hash-tir/src/storage.rs
+++ b/compiler/hash-tir/src/storage.rs
@@ -72,8 +72,8 @@ pub struct GlobalStorage {
     /// queried.
     pub root_scope: ScopeId,
 
-    /// The pointer width on the current target architecture.
-    pub target_pointer_width: usize,
+    /// The pointer width in **bytes** on the current target architecture.
+    pub pointer_width: usize,
 }
 
 impl GlobalStorage {
@@ -83,7 +83,7 @@ impl GlobalStorage {
         let root_scope = scope_store.create(Scope::empty(ScopeKind::Mod));
 
         let gs = Self {
-            target_pointer_width: target.pointer_width,
+            pointer_width: target.pointer_bit_width / 8,
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
             term_list_store: TermListStore::new(),

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -752,7 +752,7 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                         write!(f, "\"{str}\"")
                     }
                     LitTerm::Int { value } => {
-                        let pointer_width = self.global_storage.target_pointer_width;
+                        let pointer_width = self.global_storage.pointer_width;
                         let kind = CONSTANT_MAP.map_int_constant(*value, |val| val.ty);
 
                         // It's often the case that users don't include the range of the entire

--- a/compiler/hash/Cargo.toml
+++ b/compiler/hash/Cargo.toml
@@ -21,7 +21,6 @@ hash-reporting = { path = "../hash-reporting" }
 hash-session = { path = "../hash-session" }
 hash-source = { path = "../hash-source" }
 hash-target = { path = "../hash-target" }
-hash-tree-def = { path = "../hash-tree-def" }
 hash-utils = { path = "../hash-utils" }
 
 [features]

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -4,16 +4,15 @@
 mod crash_handler;
 mod logger;
 
-use std::{panic, process::exit};
+use std::panic;
 
 use hash_pipeline::{
     args::parse_settings_from_args, interface::CompilerOutputStream, settings::CompilerSettings,
     workspace::Workspace, Compiler,
 };
-use hash_reporting::{report::Report, writer::ReportWriter};
-use hash_session::{make_stages, CompilerSession};
+use hash_reporting::report::Report;
+use hash_session::{emit_fatal_error, make_stages, CompilerSession};
 use hash_source::{ModuleKind, SourceMap};
-use hash_utils::stream_less_ewriteln;
 use log::LevelFilter;
 use logger::CompilerLogger;
 
@@ -27,10 +26,7 @@ pub static COMPILER_LOGGER: CompilerLogger = CompilerLogger;
 fn execute<T, E: Into<Report>>(sources: &SourceMap, f: impl FnOnce() -> Result<T, E>) -> T {
     match f() {
         Ok(value) => value,
-        Err(err) => {
-            stream_less_ewriteln!("{}", ReportWriter::single(err.into(), sources));
-            exit(-1)
-        }
+        Err(err) => emit_fatal_error(err, sources),
     }
 }
 

--- a/tests/cases/codegen/named_entry_point.hash
+++ b/tests/cases/codegen/named_entry_point.hash
@@ -1,4 +1,4 @@
-// stage=full, run=pass
+// stage=full, run=pass, skip=true
 
 #entry_point foo := () => {
 


### PR DESCRIPTION
This patch is the initial step to hooking up a linker to the compilation pipeline. This patch implements a `LinkerStage` which decides and invokes a linker whilst also performing error handling and dealing with "strange" situations that may arise during linking. Furthermore, this patch revamps the notion of `Target`s so that they also carry necessary linker information for linking an executable. This means that now the `hash-targets/src/targets` folder contains `Target` specifications for all supported compilation targets (for which at the moment is `x86_64-apple` and `arm64-apple`, more will be added in subsequent PRs).

Additionally, this patch implements an initial wrapper around the GCC linker.

The linker implementation itself is incomplete, and they are left as `todo!()`s which will be tackled in a subsequent PR.