### PR TITLE
Fix some inference bugs and implement constructor type argument inference

### DIFF
--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -29,7 +29,7 @@ impl_access_to_tc_env!(InferencePass<'_>);
 
 /// The maximum number of hole-filling iterations to perform when inferring a
 /// term, before giving up and reporting an error.
-const MAX_INFER_ITERATIONS: usize = 20;
+const MAX_INFER_ITERATIONS: usize = 2;
 
 impl InferencePass<'_> {
     /// Infer the given subject by the provided closure, until it contains no
@@ -76,15 +76,19 @@ impl<'tc> AstPass for InferencePass<'tc> {
         node: ast::AstNodeRef<ast::BodyBlock>,
     ) -> crate::new::diagnostics::error::SemanticResult<()> {
         // Infer the expression
-        let term = self.infer_loop(
-            self.ast_info().terms().get_data_by_node(node.id()).unwrap(),
-            |term_id| Ok(self.inference_ops().infer_term(term_id, self.new_ty_hole())?.0),
-            |term_id| self.substitution_ops().atom_has_holes(term_id),
+        let (term, ty) = self.infer_loop(
+            (self.ast_info().terms().get_data_by_node(node.id()).unwrap(), self.new_ty_hole()),
+            |(term_id, ty_id)| self.inference_ops().infer_term(term_id, ty_id),
+            |(term_id, ty_id)| {
+                self.substitution_ops().atom_has_holes(term_id)
+                    || self.substitution_ops().atom_has_holes(ty_id)
+            },
         )?;
 
         // @@Temp:
         let evaluated = self.normalisation_ops().normalise(term.into())?;
-        stream_less_writeln!("{}", self.env().with(evaluated));
+        let evaluated_ty = self.normalisation_ops().normalise(ty.into())?;
+        stream_less_writeln!("{}: {}", self.env().with(evaluated), self.env().with(evaluated_ty));
 
         Ok(())
     }

--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -29,6 +29,8 @@ impl_access_to_tc_env!(InferencePass<'_>);
 
 /// The maximum number of hole-filling iterations to perform when inferring a
 /// term, before giving up and reporting an error.
+///
+/// @@Todo: remove this in favour of `infer_until_no_holes` in typechecker.
 const MAX_INFER_ITERATIONS: usize = 2;
 
 impl InferencePass<'_> {

--- a/compiler/hash-semantics/src/new/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/paths.rs
@@ -180,7 +180,7 @@ impl<'tc> ResolutionPass<'tc> {
                     name_span,
                     self.scoping().get_current_context_kind(),
                 )?;
-                Ok(self.context().get_binding(binding_symbol).unwrap())
+                Ok(self.context().get_binding(binding_symbol))
             }
         }
     }

--- a/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
@@ -145,7 +145,7 @@ impl<'tc> Scoping<'tc> {
         if self.context().get_current_scope().kind.is_constant() {
             // If we are in a constant scope, we need to check that the binding
             // is also in a constant scope.
-            if !self.context().get_binding(symbol).unwrap().kind.is_constant() {
+            if !self.context().get_binding(symbol).kind.is_constant() {
                 return Err(SemanticError::CannotUseNonConstantItem {
                     location: self.source_location(span),
                 });

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -56,7 +56,7 @@ impl<'tc> ResolutionPass<'tc> {
                         .as_ref()
                         .map(|name| ParamIndex::Name(name.ident))
                         .unwrap_or_else(|| ParamIndex::Position(i)),
-                    value: self.new_term(Term::Ty(self.make_ty_from_ast_ty(arg.ty.ast_ref())?)),
+                    value: self.use_ty_as_term(self.make_ty_from_ast_ty(arg.ty.ast_ref())?),
                 })
             })
             .collect::<SemanticResult<Vec<_>>>()?;
@@ -178,7 +178,7 @@ impl<'tc> ResolutionPass<'tc> {
                 }
                 TerminalResolvedPathComponent::FnCall(fn_call_term) => {
                     // Function call
-                    Ok(self.new_ty(Ty::Eval(self.new_term(Term::FnCall(*fn_call_term)))))
+                    Ok(self.use_term_as_ty(self.new_term(Term::FnCall(*fn_call_term))))
                 }
                 TerminalResolvedPathComponent::Var(bound_var) => {
                     // Bound variable
@@ -248,11 +248,11 @@ impl<'tc> ResolutionPass<'tc> {
 
                 match (subject, args) {
                     (Some(subject), Some(args)) => {
-                        Ok(self.new_ty(Ty::Eval(self.new_term(Term::FnCall(FnCallTerm {
+                        Ok(self.use_term_as_ty(self.new_term(Term::FnCall(FnCallTerm {
                             subject,
                             args,
                             implicit: true,
-                        })))))
+                        }))))
                     }
                     _ => Err(SemanticError::Signal),
                 }
@@ -274,10 +274,9 @@ impl<'tc> ResolutionPass<'tc> {
         let list_def = self.primitives().list();
         Ok(self.new_ty(Ty::Data(DataTy {
             data_def: list_def,
-            args: self.param_utils().create_positional_args_for_data_def(
-                list_def,
-                once(self.new_term(Term::Ty(inner_ty))),
-            ),
+            args: self
+                .param_utils()
+                .create_positional_args_for_data_def(list_def, once(self.use_ty_as_term(inner_ty))),
         })))
     }
 

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -130,11 +130,8 @@ impl<'tc> ResolutionPass<'tc> {
                 }
             },
             ResolvedAstPathComponent::Terminal(terminal) => match terminal {
-                TerminalResolvedPathComponent::FnDef(_) => {
-                    // Functions are not allowed in type positions
-                    Err(SemanticError::CannotUseFunctionInTypePosition {
-                        location: self.source_location(original_node_span),
-                    })
+                TerminalResolvedPathComponent::FnDef(fn_def_id) => {
+                    Ok(self.use_term_as_ty(self.new_term(Term::FnRef(*fn_def_id))))
                 }
                 TerminalResolvedPathComponent::CtorPat(_) => {
                     panic_on_span!(
@@ -143,18 +140,13 @@ impl<'tc> ResolutionPass<'tc> {
                         "found CtorPat in type ast path"
                     )
                 }
-                TerminalResolvedPathComponent::CtorTerm(_) => {
-                    // Constructors are not allowed in type positions
-                    Err(SemanticError::CannotUseConstructorInTypePosition {
-                        location: self.source_location(original_node_span),
-                    })
+                TerminalResolvedPathComponent::CtorTerm(ctor_term) => {
+                    Ok(self.use_term_as_ty(self.new_term(Term::Ctor(*ctor_term))))
                 }
                 TerminalResolvedPathComponent::FnCall(fn_call_term) => {
-                    // Function call
                     Ok(self.use_term_as_ty(self.new_term(Term::FnCall(*fn_call_term))))
                 }
                 TerminalResolvedPathComponent::Var(bound_var) => {
-                    // Bound variable
                     Ok(self.new_ty(Ty::Var(bound_var.name)))
                 }
             },

--- a/compiler/hash-tir/src/new/environment/context.rs
+++ b/compiler/hash-tir/src/new/environment/context.rs
@@ -258,8 +258,16 @@ impl Context {
     }
 
     /// Get a binding from the context, reading all accessible scopes.
-    pub fn get_binding(&self, name: Symbol) -> Option<Binding> {
-        Some(Binding { name, kind: self.members.borrow().get(&name).copied()? })
+    pub fn get_binding(&self, name: Symbol) -> Binding {
+        Binding {
+            name,
+            kind: self
+                .members
+                .borrow()
+                .get(&name)
+                .copied()
+                .unwrap_or_else(|| panic!("tried to get a binding that doesn't exist")),
+        }
     }
 
     /// Modify a binding in the context.

--- a/compiler/hash-tir/src/new/sub.rs
+++ b/compiler/hash-tir/src/new/sub.rs
@@ -125,6 +125,8 @@ impl Sub {
     }
 
     /// Add variable substitutions from the given [`Sub`].
+    ///
+    /// @@Todo: apply to current substitution first
     pub fn extend(&mut self, other: &Sub) {
         self.data.extend(other.data.iter().copied())
     }

--- a/compiler/hash-tir/src/new/sub.rs
+++ b/compiler/hash-tir/src/new/sub.rs
@@ -118,6 +118,7 @@ impl Display for WithEnv<'_, &Sub> {
             if i > 0 {
                 write!(f, ", ")?;
             }
+
             write!(f, "{} ~> {}", self.env().with(from), self.env().with(to))?;
         }
         write!(f, "}}")

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -340,7 +340,7 @@ pub trait CommonUtils: AccessToEnv {
     }
 
     /// Try to use the given term as a type.
-    fn use_term_as_ty(&self, term: TermId) -> Option<TyId> {
+    fn try_use_term_as_ty(&self, term: TermId) -> Option<TyId> {
         match self.get_term(term) {
             Term::Var(var) => Some(self.new_ty(var)),
             Term::Ty(ty) => Some(ty),
@@ -350,8 +350,8 @@ pub trait CommonUtils: AccessToEnv {
     }
 
     /// Try to use the given term as a type, or defer to a `Ty::Eval`.
-    fn use_term_as_ty_or_eval(&self, term: TermId) -> TyId {
-        match self.use_term_as_ty(term) {
+    fn use_term_as_ty(&self, term: TermId) -> TyId {
+        match self.try_use_term_as_ty(term) {
             Some(ty) => ty,
             None => self.new_ty(Ty::Eval(term)),
         }

--- a/compiler/hash-tir/src/new/utils/context.rs
+++ b/compiler/hash-tir/src/new/utils/context.rs
@@ -175,7 +175,7 @@ impl<'env> ContextUtils<'env> {
 
     /// Get the given stack binding, or panic if it does not exist.
     pub fn get_stack_binding(&self, name: Symbol) -> (StackMemberId, Option<TermId>) {
-        match self.context().get_binding(name).unwrap().kind {
+        match self.context().get_binding(name).kind {
             BindingKind::StackMember(member, value) => (member, value),
             _ => panic!("get_stack_binding called on non-stack binding"),
         }

--- a/compiler/hash-tir/src/new/utils/traversing.rs
+++ b/compiler/hash-tir/src/new/utils/traversing.rs
@@ -222,7 +222,7 @@ impl<'env> TraversingUtils<'env> {
         match f(ty_id.into())? {
             ControlFlow::Break(ty) => match ty {
                 Atom::Ty(ty) => Ok(ty),
-                Atom::Term(term) => Ok(self.use_term_as_ty_or_eval(term)),
+                Atom::Term(term) => Ok(self.use_term_as_ty(term)),
                 _ => unreachable!("got non-type in fmap_ty"),
             },
             ControlFlow::Continue(()) => match self.get_ty(ty_id) {

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -106,7 +106,7 @@ pub enum TcError {
     Compound { errors: Vec<TcError> },
 
     /// More type annotations are needed to infer the type of the given term.
-    NeedMoreTypeAnnotationsToInfer { term: TermId },
+    NeedMoreTypeAnnotationsToInfer { term: LocationTarget },
 
     /// The given arguments do not match the length of the target parameters.
     WrongArgLength { params_id: ParamsId, args_id: SomeParamsOrArgsId },

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -122,7 +122,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
 
     /// Evaluate a variable.
     fn eval_var(&self, var: Symbol) -> Result<Atom, Signal> {
-        match self.context().get_binding(var).unwrap().kind {
+        match self.context().get_binding(var).kind {
             BindingKind::Param(_, _) => Ok(self.new_term(var).into()),
             BindingKind::Arg(_, arg_id) => {
                 Ok(self.stores().args().map_fast(arg_id.0, |args| args[arg_id.1].value).into())

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -112,7 +112,11 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             {
                 let _ = self.eval(statement.into())?;
             }
-            self.eval(block_term.return_value.into())
+
+            let sub = self.substitution_ops().create_sub_from_current_stack_members();
+            let result_term = self.eval(block_term.return_value.into())?;
+            let subbed_result_term = self.substitution_ops().apply_sub_to_atom(result_term, &sub);
+            Ok(subbed_result_term)
         })
     }
 
@@ -426,10 +430,9 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 match fn_def.body {
                     FnBody::Defined(defined_fn_def) => {
                         // Make a substitution from the arguments to the parameters:
-                        let sub = self.substitution_ops().create_sub_from_applying_args_to_params(
-                            fn_call.args,
-                            fn_def.ty.params,
-                        );
+                        let sub = self
+                            .substitution_ops()
+                            .create_sub_from_args_of_params(fn_call.args, fn_def.ty.params);
 
                         // Apply substitution to body:
                         let result =

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -251,4 +251,22 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
         }
         sub
     }
+
+    /// Create a substitution from the given source parameter names to the
+    /// target parameter names.
+    ///
+    /// Invariant: the parameters unify.
+    pub fn create_sub_from_param_names(
+        &self,
+        src_params: ParamsId,
+        target_params: ParamsId,
+    ) -> Sub {
+        let mut sub = Sub::identity();
+        for (src, target) in (src_params.iter()).zip(target_params.iter()) {
+            let src = self.stores().params().get_element(src);
+            let target = self.stores().params().get_element(target);
+            sub.insert(src.name, self.new_term(target.name));
+        }
+        sub
+    }
 }

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -200,6 +200,16 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
         has_holes
     }
 
+    /// Determines whether the given set of arguments contains one or more
+    /// holes.
+    pub fn args_have_holes(&self, args_id: ArgsId) -> bool {
+        let mut has_holes = false;
+        self.traversing_utils()
+            .visit_args::<!, _>(args_id, &mut |atom| Ok(self.has_holes_once(atom, &mut has_holes)))
+            .into_ok();
+        has_holes
+    }
+
     /// Determines whether the given set of parameters contains one or more
     /// holes.
     pub fn params_have_holes(&self, params_id: ParamsId) -> bool {


### PR DESCRIPTION
This PR follows from #731 by fixing a few bugs and implements inference of constructor type arguments. Now, `Option<_>::Some(3)` is typed as `Option<i32>`. This is currently not implemented for arbitrary functions, just constructors.

There are still a few bugs to fix but now the type-checker is able to check and run a lot of programs! (mod the unimplemented stuff)