### PR TITLE
Implement implicit argument inference for function calls and constructors

### DIFF
--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -69,6 +69,7 @@ defined_primitives! {
     option,
     result,
     list,
+    equal,
 }
 
 impl DefinedPrimitives {
@@ -197,6 +198,38 @@ impl DefinedPrimitives {
                 }));
                 env.data_utils().create_enum_def(result_sym, params, |_| {
                     vec![(ok_sym, ok_params), (err_sym, err_params)]
+                })
+            },
+            equal: {
+                let eq_sym = env.new_symbol("Equal");
+                let refl_sym = env.new_symbol("Refl");
+
+                let t_sym = env.new_symbol("T");
+                let a_sym = env.new_symbol("a");
+                let b_sym = env.new_symbol("b");
+
+                let x_sym = env.new_symbol("x");
+
+                let params = env.param_utils().create_params(
+                    [
+                        ParamData { name: t_sym, ty: env.new_small_universe_ty(), default: None },
+                        ParamData { name: a_sym, ty: env.new_var_ty(t_sym), default: None },
+                        ParamData { name: b_sym, ty: env.new_var_ty(t_sym), default: None },
+                    ]
+                    .into_iter(),
+                );
+                let refl_params = env.param_utils().create_params(once(ParamData {
+                    name: x_sym,
+                    ty: env.new_var_ty(t_sym),
+                    default: None,
+                }));
+
+                let refl_result_args = env.param_utils().create_positional_args(
+                    [env.new_term(t_sym), env.new_term(x_sym), env.new_term(x_sym)].into_iter(),
+                );
+
+                env.data_utils().create_data_def(eq_sym, params, |_| {
+                    vec![(refl_sym, refl_params, refl_result_args)]
                 })
             },
         }

--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -4,8 +4,10 @@
 //! Typing errors are reported during this pass.
 
 use derive_more::Constructor;
-use hash_ast::ast::{self};
-use hash_tir::new::{environment::env::AccessToEnv, utils::common::CommonUtils};
+use hash_ast::ast;
+use hash_tir::new::{
+    environment::env::AccessToEnv, locations::LocationTarget, utils::common::CommonUtils,
+};
 use hash_typecheck::{
     errors::{TcError, TcResult},
     AccessToTypechecking,
@@ -27,47 +29,23 @@ pub struct InferencePass<'tc> {
 
 impl_access_to_tc_env!(InferencePass<'_>);
 
-/// The maximum number of hole-filling iterations to perform when inferring a
-/// term, before giving up and reporting an error.
-///
-/// @@Todo: remove this in favour of `infer_until_no_holes` in typechecker.
-const MAX_INFER_ITERATIONS: usize = 2;
-
 impl InferencePass<'_> {
-    /// Infer the given subject by the provided closure, until it contains no
-    /// more holes.
-    ///
-    /// If `MAX_INFER_ITERATIONS` is reached, then an error is returned.
-    fn infer_loop<T: Copy>(
+    /// Infer the given subject by the provided closure, or error if it contains
+    /// holes.
+    fn infer_fully<T: Copy>(
         &self,
         subject: T,
         infer_subject: impl Fn(T) -> TcResult<T>,
         subject_has_holes: impl Fn(T) -> bool,
+        location: impl Fn(T) -> LocationTarget,
     ) -> TcResult<T> {
-        let mut subject = subject;
-        for i in 0..MAX_INFER_ITERATIONS {
-            match infer_subject(subject) {
-                Ok(new_subject) => {
-                    subject = new_subject;
+        let subject = infer_subject(subject)?;
 
-                    // If we still have holes, then we need to infer again
-                    if subject_has_holes(subject) {
-                        continue;
-                    }
-
-                    // No holes, so we're done
-                    break;
-                }
-                Err(TcError::Blocked) if i < MAX_INFER_ITERATIONS - 1 => {
-                    // We're blocked on a hole, so try infer again as long as
-                    // we haven't reached the maximum number of iterations
-                    continue;
-                }
-                Err(err) => {
-                    return Err(err);
-                }
-            }
+        // If we have holes, error
+        if subject_has_holes(subject) {
+            return Err(TcError::NeedMoreTypeAnnotationsToInfer { term: location(subject) });
         }
+
         Ok(subject)
     }
 }
@@ -78,13 +56,14 @@ impl<'tc> AstPass for InferencePass<'tc> {
         node: ast::AstNodeRef<ast::BodyBlock>,
     ) -> crate::new::diagnostics::error::SemanticResult<()> {
         // Infer the expression
-        let (term, ty) = self.infer_loop(
+        let (term, ty) = self.infer_fully(
             (self.ast_info().terms().get_data_by_node(node.id()).unwrap(), self.new_ty_hole()),
             |(term_id, ty_id)| self.inference_ops().infer_term(term_id, ty_id),
             |(term_id, ty_id)| {
                 self.substitution_ops().atom_has_holes(term_id)
                     || self.substitution_ops().atom_has_holes(ty_id)
             },
+            |(term_id, _)| term_id.into(),
         )?;
 
         // @@Temp:
@@ -100,10 +79,11 @@ impl<'tc> AstPass for InferencePass<'tc> {
         node: ast::AstNodeRef<ast::Module>,
     ) -> crate::new::diagnostics::error::SemanticResult<()> {
         // Infer the whole module
-        let mod_def_id = self.infer_loop(
+        let mod_def_id = self.infer_fully(
             self.ast_info().mod_defs().get_data_by_node(node.id()).unwrap(),
             |mod_def_id| self.inference_ops().infer_mod_def(mod_def_id).map(|()| mod_def_id),
             |mod_def_id| self.substitution_ops().mod_def_has_holes(mod_def_id),
+            |mod_def_id| mod_def_id.into(),
         )?;
 
         // @@Temp:

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -239,9 +239,7 @@ impl<'tc> ResolutionPass<'tc> {
         let list_def = self.primitives().list();
         Ok(self.new_ty(Ty::Data(DataTy {
             data_def: list_def,
-            args: self
-                .param_utils()
-                .create_positional_args_for_data_def(list_def, once(self.use_ty_as_term(inner_ty))),
+            args: self.param_utils().create_positional_args(once(self.use_ty_as_term(inner_ty))),
         })))
     }
 

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -54,34 +54,37 @@ pub trait CommonUtils: AccessToEnv {
         }
     }
 
+    /// Try to get the parameter of the given parameters ID and index which is
+    /// either symbolic or positional.
+    fn try_get_param_by_index(&self, params_id: ParamsId, index: ParamIndex) -> Option<Param> {
+        match index {
+            ParamIndex::Name(name) => self.stores().params().map_fast(params_id, |params| {
+                params.iter().find_map(|x| {
+                    if self.stores().symbol().get(x.name).name? == name {
+                        Some(*x)
+                    } else {
+                        None
+                    }
+                })
+            }),
+            ParamIndex::Position(i) => {
+                self.stores().params().map_fast(params_id, |params| params.get(i).copied())
+            }
+        }
+    }
+
     /// Get the parameter of the given parameters ID and index which is
     /// either symbolic or positional.
     ///
     /// This will panic if the index does not exist.
     fn get_param_by_index(&self, params_id: ParamsId, index: ParamIndex) -> Param {
-        match index {
-            ParamIndex::Name(name) => self.stores().params().map_fast(params_id, |params| {
-                params
-                    .iter()
-                    .find_map(|x| {
-                        if self.stores().symbol().get(x.name).name? == name {
-                            Some(*x)
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Parameter with name `{}` does not exist in `{}`",
-                            name,
-                            self.env().with(params_id)
-                        )
-                    })
-            }),
-            ParamIndex::Position(i) => {
-                self.stores().params().map_fast(params_id, |params| params[i])
-            }
-        }
+        self.try_get_param_by_index(params_id, index).unwrap_or_else(|| {
+            panic!(
+                "Parameter with name `{}` does not exist in `{}`",
+                index,
+                self.env().with(params_id)
+            )
+        })
     }
 
     /// Create a new symbol with the given name.

--- a/compiler/hash-tir/src/new/utils/common.rs
+++ b/compiler/hash-tir/src/new/utils/common.rs
@@ -365,7 +365,10 @@ pub trait CommonUtils: AccessToEnv {
         match self.get_ty(ty) {
             Ty::Var(var) => self.new_term(var),
             Ty::Hole(hole) => self.new_term(hole),
-            Ty::Eval(term) => term,
+            Ty::Eval(term) => match self.try_use_term_as_ty(term) {
+                Some(ty) => self.use_ty_as_term(ty),
+                None => term,
+            },
             _ => self.new_term(ty),
         }
     }

--- a/compiler/hash-tir/src/new/utils/params.rs
+++ b/compiler/hash-tir/src/new/utils/params.rs
@@ -88,4 +88,19 @@ impl<'env> ParamUtils<'env> {
                 .into_iter(),
         )
     }
+
+    /// Instantiate the given parameters with holes for each argument.
+    pub fn instantiate_params_as_holes(&self, params: ParamsId) -> ArgsId {
+        self.create_args(
+            params
+                .iter()
+                .enumerate()
+                .map(|(i, _)| ArgData {
+                    target: ParamIndex::Position(i),
+                    value: self.new_term_hole(),
+                })
+                .collect_vec()
+                .into_iter(),
+        )
+    }
 }

--- a/compiler/hash-tir/src/new/utils/params.rs
+++ b/compiler/hash-tir/src/new/utils/params.rs
@@ -1,6 +1,6 @@
 //! Utilities for parameters and arguments.
 use derive_more::Constructor;
-use hash_utils::store::{SequenceStore, SequenceStoreKey, Store};
+use hash_utils::store::{SequenceStore, SequenceStoreKey};
 use itertools::Itertools;
 
 use super::common::CommonUtils;
@@ -8,7 +8,6 @@ use crate::{
     impl_access_to_env,
     new::{
         args::{Arg, ArgData, ArgsId, PatArg, PatArgData, PatArgsId, SomeArgsId},
-        data::DataDefId,
         environment::env::{AccessToEnv, Env},
         params::{Param, ParamData, ParamIndex, ParamsId},
         symbols::Symbol,
@@ -80,12 +79,7 @@ impl<'env> ParamUtils<'env> {
     /// Each argument will be a positional argument. Note that the outer
     /// iterator is for the argument groups, and the inner iterator is for
     /// the arguments in each group.
-    pub fn create_positional_args_for_data_def(
-        &self,
-        def: DataDefId,
-        args: impl IntoIterator<Item = TermId>,
-    ) -> ArgsId {
-        let _params = self.stores().data_def().map_fast(def, |def| def.params);
+    pub fn create_positional_args(&self, args: impl IntoIterator<Item = TermId>) -> ArgsId {
         self.create_args(
             args.into_iter()
                 .enumerate()

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -26,6 +26,7 @@ use crate::params::ParamError;
 ///
 /// This is used for error recovery, so that multiple errors can be reported
 /// at once.
+#[derive(Debug)]
 pub struct TcErrorState {
     pub errors: Vec<TcError>,
     pub has_blocked: bool,

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -40,14 +40,7 @@ pub trait AccessToTypechecking:
         mut error_state: TcErrorState,
     ) -> TcResult<T> {
         if error_state.has_errors() {
-            error_state.take_errors().into_iter().for_each(|error| {
-                self.diagnostics().add_error(self.convert_tc_error(error));
-            });
-            if error_state.has_blocked {
-                Err(TcError::Blocked)
-            } else {
-                Err(TcError::Signal)
-            }
+            Err(TcError::Compound { errors: error_state.take_errors() })
         } else {
             t()
         }

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -71,11 +71,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     /// Try to use the given atom as a type.
     pub fn maybe_to_ty(&self, atom: Atom) -> Option<TyId> {
         match atom {
-            Atom::Term(term) => match self.get_term(term) {
-                Term::Ty(ty) => Some(ty),
-                Term::Var(var) => Some(self.new_ty(var)),
-                _ => None,
-            },
+            Atom::Term(term) => self.try_use_term_as_ty(term),
             Atom::Ty(ty) => Some(ty),
             _ => None,
         }
@@ -91,7 +87,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     pub fn to_term(&self, atom: Atom) -> TermId {
         match atom {
             Atom::Term(term) => term,
-            Atom::Ty(ty) => self.new_term(ty),
+            Atom::Ty(ty) => self.use_ty_as_term(ty),
             Atom::FnDef(fn_def_id) => self.new_term(fn_def_id),
             _ => panic!("Cannot convert {} to a term", self.env().with(atom)),
         }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -220,6 +220,14 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                 (Term::Hole(a), Term::Hole(b)) => {
                     Uni::ok_iff_terms_match(a == b, src_id, target_id)
                 }
+                (Term::Hole(a), _) => {
+                    let sub = Sub::from_pairs([(a.0, target_id)]);
+                    Uni::ok_with(sub, target_id)
+                }
+                (_, Term::Hole(b)) => {
+                    let sub = Sub::from_pairs([(b.0, src_id)]);
+                    Uni::ok_with(sub, src_id)
+                }
                 _ => Uni::mismatch_terms(src_id, target_id),
             },
         }


### PR DESCRIPTION
Inference now works fully for implicit arguments:

```
foo := <T> => (t: T) => Option::Some(t); 

bar := foo(3) // bar : Option<i32>
```

Closes #737, closes #778