### PR TITLE
codegen+layout: fix issue with string literals not being dealt with properly.

### DIFF
--- a/compiler/hash-codegen/src/traits/builder.rs
+++ b/compiler/hash-codegen/src/traits/builder.rs
@@ -332,9 +332,9 @@ pub trait BlockBuilderMethods<'a, 'b>:
 
     // --- Intrinsic & Memory operations ---
 
-    /// Take an immediate `i1` value and zero extend it to a boolean
-    /// value.
-    fn bool_from_immediate(&mut self, v: Self::Value) -> Self::Value;
+    /// Useful wrapper for immediate value conversions. If the immediate `i1`
+    /// value and zero extend it to a boolean value.
+    fn value_from_immediate(&mut self, v: Self::Value) -> Self::Value;
 
     /// Convert a value to an immediate value of the given layout.
     fn to_immediate(&mut self, v: Self::Value, layout: LayoutId) -> Self::Value {
@@ -505,7 +505,20 @@ pub trait BlockBuilderMethods<'a, 'b>:
     ) -> Self::Value;
 
     ///  Emit an instruction to extract a value from a aggregate value.
-    fn extract_field(&mut self, value: Self::Value, field_index: usize) -> Self::Value;
+    ///
+    /// N.B. Aggregate values are considered to be either ADTs or  arrays.
+    fn extract_field_value(&mut self, value: Self::Value, field_index: usize) -> Self::Value;
+
+    /// Emit an instruction to insert a value into a aggregate value at a given
+    /// index position.
+    ///
+    /// N.B. Aggregate values are considered to be either ADTs or  arrays.
+    fn insert_field_value(
+        &mut self,
+        value: Self::Value,
+        element: Self::Value,
+        index: usize,
+    ) -> Self::Value;
 
     // --- Metadata ---
 

--- a/compiler/hash-ir/src/mod.rs
+++ b/compiler/hash-ir/src/mod.rs
@@ -44,6 +44,7 @@ pub trait WriteIr: Sized {
     }
 }
 
+impl WriteIr for &IrTy {}
 impl WriteIr for IrTyId {}
 impl WriteIr for IrTyListId {}
 impl WriteIr for AdtId {}

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -900,9 +900,13 @@ impl fmt::Debug for ForFormatting<'_, IrTyId> {
 
 impl fmt::Display for ForFormatting<'_, IrTyId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ty = self.ctx.tys().get(self.item);
+        self.ctx.tys().map_fast(self.item, |ty| write!(f, "{}", ty.for_fmt(self.ctx)))
+    }
+}
 
-        match ty {
+impl fmt::Display for ForFormatting<'_, &IrTy> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.item {
             IrTy::Int(variant) => write!(f, "{variant}"),
             IrTy::UInt(variant) => write!(f, "{variant}"),
             IrTy::Float(variant) => write!(f, "{variant}"),
@@ -927,11 +931,11 @@ impl fmt::Display for ForFormatting<'_, IrTyId> {
             IrTy::Adt(adt) => write!(f, "{}", adt.for_fmt(self.ctx)),
 
             IrTy::Fn { instance, params, return_ty, .. } if self.verbose => {
-                let name = self.ctx.instances.map_fast(instance, |instance| instance.name);
+                let name = self.ctx.instances.map_fast(*instance, |instance| instance.name);
                 write!(f, "{name}({}) -> {}", params.for_fmt(self.ctx), return_ty.for_fmt(self.ctx))
             }
             IrTy::Fn { instance, .. } => {
-                let name = self.ctx.instances.map_fast(instance, |instance| instance.name);
+                let name = self.ctx.instances.map_fast(*instance, |instance| instance.name);
                 write!(f, "{name}")
             }
             IrTy::Slice(ty) => write!(f, "[{}]", ty.for_fmt(self.ctx)),

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -14,7 +14,7 @@ use hash_utils::store::{SequenceStore, Store};
 
 use super::ir::*;
 use crate::{
-    ty::{AdtId, IrTyId, IrTyListId},
+    ty::{AdtId, IrTy, IrTyId, IrTyListId},
     IrCtx,
 };
 
@@ -44,6 +44,7 @@ pub trait WriteIr: Sized {
     }
 }
 
+impl WriteIr for &IrTy {}
 impl WriteIr for IrTyId {}
 impl WriteIr for IrTyListId {}
 impl WriteIr for AdtId {}

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -635,7 +635,10 @@ impl<'l> LayoutWriter<'l> {
         // If the layout is a `ZST`, then we just return a single box
         // with the layout, and a `<ZST>` label
         if layout.is_zst() {
-            boxes.push(BoxContent::new("<ZST>".to_string(), singular_box_content()));
+            boxes.push(BoxContent::new(
+                format!("<ZST>: {}", ty.for_fmt(self.ctx.ir_ctx())),
+                singular_box_content(),
+            ));
             return boxes;
         }
 


### PR DESCRIPTION
This patch fixes two issues in layout and codegen logic:
- arguments that should be passed as scalar pairs not being properly handled. 
- layout label of "ZST" for visualization is unclear - fixed by adding the type that is the ZST