### PR TITLE
language: remove `map` and `set` syntax from the language for now

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -406,24 +406,6 @@ define_tree! {
         pub inner: Child!(Ty),
     }
 
-    /// The set type, , e.g. `{str}`.
-    #[derive(Debug, PartialEq, Clone)]
-    #[node]
-    pub struct SetTy {
-        /// Inner type of the set
-        pub inner: Child!(Ty),
-    }
-
-    /// The map type, e.g. `{str: u32}`.
-    #[derive(Debug, PartialEq, Clone)]
-    #[node]
-    pub struct MapTy {
-        /// The `key` type of the map type
-        pub key: Child!(Ty),
-        /// The `value` type of the map type
-        pub value: Child!(Ty),
-    }
-
     /// The function type.
     #[derive(Debug, PartialEq, Clone)]
     #[node]
@@ -506,10 +488,6 @@ define_tree! {
         Tuple(TupleTy),
         /// list type
         List(ListTy),
-        /// Set type
-        Set(SetTy),
-        /// Map type
-        Map(MapTy),
         /// Function type
         Fn(FnTy),
         /// Named type, similar to a binding

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -375,29 +375,6 @@ impl AstVisitor for AstTreeGenerator {
         Ok(TreeNode::branch("list", vec![inner]))
     }
 
-    type SetTyRet = TreeNode;
-    fn visit_set_ty(
-        &self,
-        node: ast::AstNodeRef<ast::SetTy>,
-    ) -> Result<Self::TupleTyRet, Self::Error> {
-        let walk::SetTy { inner } = walk::walk_set_ty(self, node)?;
-
-        Ok(TreeNode::branch("set", vec![inner]))
-    }
-
-    type MapTyRet = TreeNode;
-    fn visit_map_ty(
-        &self,
-        node: ast::AstNodeRef<ast::MapTy>,
-    ) -> Result<Self::TupleTyRet, Self::Error> {
-        let walk::MapTy { key, value } = walk::walk_map_ty(self, node)?;
-
-        Ok(TreeNode::branch(
-            "map",
-            vec![TreeNode::branch("key", vec![key]), TreeNode::branch("key", vec![value])],
-        ))
-    }
-
     type TyArgRet = TreeNode;
     fn visit_ty_arg(
         &self,

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -386,15 +386,6 @@ impl<'a> Lexer<'a> {
             "impl" => TokenKind::Keyword(Keyword::Impl),
             "type" => TokenKind::Keyword(Keyword::Type),
             "typeof" => TokenKind::Keyword(Keyword::TypeOf),
-            // @@TODO: in the future, we want to make these macros or some similar syntax
-            "map" if self.peek() == '!' => {
-                self.skip();
-                TokenKind::Keyword(Keyword::Map)
-            }
-            "set" if self.peek() == '!' => {
-                self.skip();
-                TokenKind::Keyword(Keyword::Set)
-            }
             "_" => TokenKind::Ident(IDENTS.underscore),
             _ => TokenKind::Ident(name.into()),
         }

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -139,14 +139,6 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 let ty = self.parse_ty()?;
                 self.node_with_joined_span(Expr::Ty(TyExpr { ty }), token.span)
             }
-            TokenKind::Keyword(Keyword::Set) => {
-                let lit = self.parse_set_lit()?;
-                self.node_with_joined_span(Expr::Lit(LitExpr { data: lit }), token.span)
-            }
-            TokenKind::Keyword(Keyword::Map) => {
-                let lit = self.parse_map_lit()?;
-                self.node_with_joined_span(Expr::Lit(LitExpr { data: lit }), token.span)
-            }
             TokenKind::Keyword(Keyword::Impl)
                 if self.peek().map_or(false, |tok| !tok.is_brace_tree()) =>
             {

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -90,28 +90,14 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 Ty::Named(NamedTy { name })
             }
 
-            // Map or set type
-            TokenKind::Tree(Delimiter::Brace, tree_index) => {
+            // Expression in the type.
+            TokenKind::Tree(Delimiter::Brace, _tree_index) => {
                 self.skip_token();
-                let tree = self.token_trees.get(*tree_index as usize).unwrap();
-                let mut gen = self.from_stream(tree, token.span);
 
-                let key_ty = gen.parse_ty()?;
-
-                match gen.peek() {
-                    // This must be a map
-                    Some(token) if token.has_kind(TokenKind::Colon) => {
-                        gen.skip_token();
-
-                        // @@ErrorRecovery: Investigate introducing `Err` variant into types...
-                        let value_ty = gen.parse_ty()?;
-                        self.consume_gen(gen);
-
-                        Ty::Map(MapTy { key: key_ty, value: value_ty })
-                    }
-                    None => Ty::Set(SetTy { inner: key_ty }),
-                    Some(_) => gen.expected_eof()?,
-                }
+                // @@Todo: add the "expression in a type" variant
+                // let tree = self.token_trees.get(*tree_index as usize).unwrap();
+                // let mutgen = self.from_stream(tree, token.span);
+                todo!()
             }
 
             // List type

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -353,14 +353,6 @@ impl<'tc> ResolutionPass<'tc> {
                     "Found merge type after discovery"
                 )
             }
-            ast::Ty::Set(_) | ast::Ty::Map(_) => {
-                // @@Todo
-                panic_on_span!(
-                    self.node_location(node),
-                    self.source_map(),
-                    "Sets and maps not implemented yet"
-                )
-            }
         };
 
         self.ast_info().tys().insert(node.id(), ty_id);

--- a/compiler/hash-semantics/src/traverse/visitor.rs
+++ b/compiler/hash-semantics/src/traverse/visitor.rs
@@ -405,22 +405,6 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
         self.validate_and_register_simplified_term(node, term)
     }
 
-    type SetTyRet = TermId;
-
-    fn visit_set_ty(&self, node: AstNodeRef<ast::SetTy>) -> Result<Self::SetTyRet, Self::Error> {
-        let walk::SetTy { inner } = walk::walk_set_ty(self, node)?;
-
-        let inner_ty = self.core_defs().set_ty_fn();
-        let builder = self.builder();
-
-        let term = builder.create_app_ty_fn_term(
-            inner_ty,
-            builder.create_args([builder.create_arg("T", inner)], ParamOrigin::TyFn),
-        );
-
-        self.validate_and_register_simplified_term(node, term)
-    }
-
     type NamedTyRet = TermId;
 
     fn visit_named_ty(
@@ -1848,26 +1832,6 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
         let walk::UnsafeExpr { data } = walk::walk_unsafe_expr(self, node)?;
         Ok(data)
     }
-
-    type MapTyRet = TermId;
-
-    fn visit_map_ty(&self, node: AstNodeRef<ast::MapTy>) -> Result<Self::MapTyRet, Self::Error> {
-        let walk::MapTy { key, value } = walk::walk_map_ty(self, node)?;
-
-        let inner_ty = self.core_defs().map_ty_fn();
-        let builder = self.builder();
-
-        let term = builder.create_app_ty_fn_term(
-            inner_ty,
-            builder.create_args(
-                [builder.create_arg("K", key), builder.create_arg("V", value)],
-                ParamOrigin::TyFn,
-            ),
-        );
-
-        self.validate_and_register_simplified_term(node, term)
-    }
-
     type MatchBlockRet = TermId;
 
     fn visit_match_block(

--- a/compiler/hash-token/src/keyword.rs
+++ b/compiler/hash-token/src/keyword.rs
@@ -32,8 +32,6 @@ pub enum Keyword {
     Impl,
     Type,
     TypeOf,
-    Map,
-    Set,
 }
 
 /// Enum Variants for keywords

--- a/tests/cases/parser/literals/map_literals.hash
+++ b/tests/cases/parser/literals/map_literals.hash
@@ -1,9 +1,0 @@
-// run=pass, stage=parse
-
-my_map := map!{};
-my_map := map!{ "a": 1 };
-my_map := map!{ "a": 1, };
-my_map := map!{ "a": 1 + 2, };
-my_map := map!{ "a": 1, "b": 2};
-my_map := map!{ "a": 1, "b": 2,};
-my_map := map!{ (a + b): 1, "b": 2,};

--- a/tests/cases/parser/literals/set_literals.hash
+++ b/tests/cases/parser/literals/set_literals.hash
@@ -1,4 +1,0 @@
-// run=pass, stage=parse
-
-s := set!{ 1, 2, 3, 4 };
-s := set!{ 1, 2, 3 };

--- a/tests/cases/parser/types/enum_with_ty_params.hash
+++ b/tests/cases/parser/types/enum_with_ty_params.hash
@@ -19,7 +19,7 @@ Foo := enum<T = i32, U, Mux: Hash ~ Eq> (
     ContaintorOf(U), 
     DetainorOf(T), 
     MapOf(
-        items: { Mux: T }
+        items: Map<Mux, T>
     )
 );
 

--- a/tests/cases/parser/types/struct_with_ty_params.hash
+++ b/tests/cases/parser/types/struct_with_ty_params.hash
@@ -13,11 +13,11 @@ T := struct<U,> (
 Foo := struct<T = i32, U, Mux: Hash ~ Eq> (
     U, 
     T, 
-    { Mux: T }
+    Map<Mux, T>
 );
 
 Foo := struct<T = i32, K := Mux ~ Universe, U: Type, Mux: Hash ~ Eq> (
     U, 
     T, 
-    { Mux: T }
+    Map<Mux, T>
 );


### PR DESCRIPTION
This patch removes the parser and typechecking logic that tries to explicitly deal with map and set literals, and map//set types. Since they weren't being implemented in the new typechecking or the AST lowering, it was decided that they should be removed (for now) for code housekeeping.