### PR TITLE
language: rename list language items to arrays and add sized array types

### DIFF
--- a/compiler/hash-ast/src/origin.rs
+++ b/compiler/hash-ast/src/origin.rs
@@ -68,7 +68,7 @@ pub enum PatOrigin {
     Constructor,
 
     /// The parent pattern is a list, i.e `[1, 2, 3, ...]`
-    List,
+    Array,
 
     /// The parent pattern is a namespace, i.e `{ alloc, core }`
     Namespace,
@@ -82,7 +82,7 @@ impl PatOrigin {
             PatOrigin::Tuple => "tuple",
             PatOrigin::NamedField => "named field",
             PatOrigin::Constructor => "constructor",
-            PatOrigin::List => "list",
+            PatOrigin::Array => "array",
             PatOrigin::Namespace => "namespace",
         }
     }

--- a/compiler/hash-codegen-llvm/src/misc.rs
+++ b/compiler/hash-codegen-llvm/src/misc.rs
@@ -273,7 +273,7 @@ impl From<CodeModel> for CodeModelWrapper {
     }
 }
 
-/// A wrapper type to convert the generic [RelocationMode] into the
+/// A wrapper type to convert the generic [RelocationModel] into the
 /// [inkwell::targets::RelocMode] equivalent type.
 pub struct RelocationModeWrapper(pub inkwell::targets::RelocMode);
 

--- a/compiler/hash-codegen/src/backend/mod.rs
+++ b/compiler/hash-codegen/src/backend/mod.rs
@@ -36,11 +36,11 @@ pub struct BackendCtx<'b> {
     pub _pool: &'b rayon::ThreadPool,
 }
 
-/// The [Backend] trait specifies the required interface that needs
+/// The [CompilerBackend] trait specifies the required interface that needs
 /// to be implemented by a backend in order to interface with the
 /// pipeline.
 pub trait CompilerBackend<'b> {
-    /// The [Backend::run] method is called by the pipeline to
+    /// The [`CompilerBackend::run`] method is called by the pipeline to
     /// generate code for the specified source file. This method
     /// may return a potential error which implies that something
     /// went wrong during the code generation process, and it should

--- a/compiler/hash-codegen/src/lower/block.rs
+++ b/compiler/hash-codegen/src/lower/block.rs
@@ -7,7 +7,7 @@ use super::{BlockStatus, FnBuilder};
 use crate::traits::builder::BlockBuilderMethods;
 
 impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
-    /// Get a [Builder::BasicBlock] for a Hash IR block. This function tries
+    /// Get a backend basic block for a [BasicBlock]. This function tries
     /// to avoid creating new basic blocks via the builder if they have already
     /// been creating during the building process. The blocks are saved within
     /// the builder `block_map` field as a mapping of indices between one

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-/// A [PlaceRef] is the equivalent of an IR [Place], but within the code
+/// A [PlaceRef] is the equivalent of an IR [ir::Place], but within the code
 /// generation context. The place holds a value that is backend dependent, type,
 /// layout, and alignment information
 #[derive(Debug, Clone, Copy)]
@@ -301,14 +301,14 @@ impl<'a, 'b, V: CodeGenObject> PlaceRef<V> {
 }
 
 impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
-    /// Compute the type and layout of a [Place]. This deals with
-    /// all projections that occur on the [Place].
+    /// Compute the type and layout of a [ir::Place]. This deals with
+    /// all projections that occur on the [ir::Place].
     pub fn compute_place_ty_info(&self, builder: &mut Builder, place: ir::Place) -> TyInfo {
         let place_ty = PlaceTy::from_place(place, &self.body.declarations, self.ctx.ir_ctx());
         builder.layout_of(place_ty.ty)
     }
 
-    /// Emit backend specific code for handling a [Place].
+    /// Emit backend specific code for handling a [ir::Place].
     ///
     /// This function will return a [PlaceRef] which can be used to
     /// store a value into the place which can be used by the called

--- a/compiler/hash-codegen/src/lower/rvalue.rs
+++ b/compiler/hash-codegen/src/lower/rvalue.rs
@@ -481,7 +481,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         OperandValue::Pair(value, overflow)
     }
 
-    /// Check whether the given [RValue] will create an
+    /// Check whether the given [ir::RValue] will create an
     /// operand or not.
     pub fn rvalue_creates_operand(&self, rvalue: &ir::RValue) -> bool {
         match *rvalue {

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -1,12 +1,12 @@
 //! This module hosts all of the logic for converting IR
-//! [Terminator]s into corresponding target backend IR.
+//! [ir::Terminator]s into corresponding target backend IR.
 //! Given that the Hash IR does not necessarily have a
 //! one-to-one mapping with the target IR, some terminators
 //! might not exist in the target IR. For example, the
-//! [TerminatorKind::Call] terminator might not exist in
-//! some target IRs. In this case, the [TerminatorKind::Call],
-//! is lowered as two [BasicBlock]s being "merged" together
-//! into a single [BasicBlock]. The builder API will denote
+//! [`ir::TerminatorKind::Call`] terminator might not exist in
+//! some target IRs. In this case, the [ir::TerminatorKind::Call],
+//! is lowered as two [ir::BasicBlock]s being "merged" together
+//! into a single [ir::BasicBlock]. The builder API will denote
 //! whether two blocks have been merged together.
 
 use hash_abi::{ArgAbi, FnAbi, PassMode};

--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -147,7 +147,7 @@ impl DefinedPrimitives {
                     default: None,
                 }));
                 env.data_utils().create_primitive_data_def_with_params(list_sym, params, |_| {
-                    PrimitiveCtorInfo::List(ListCtorInfo { element_ty: env.new_var_ty(t_sym) })
+                    PrimitiveCtorInfo::Array(ListCtorInfo { element_ty: env.new_var_ty(t_sym) })
                 })
             },
 

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -852,7 +852,7 @@ create_common_ty_table!(
 
 /// Stores all the used [IrTy]s.
 ///
-/// [Rvalue]s are accessed by an ID, of type [IrTyId].
+/// [RValue]s are accessed by an ID, of type [IrTyId].
 pub struct TyStore {
     /// The map that relates [IrTyId]s to the underlying
     /// [IrTy]s.

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -88,7 +88,7 @@ pub struct LayoutCtx {
 }
 
 impl LayoutCtx {
-    /// Create a new [LayoutStorage].
+    /// Create a new [LayoutCtx].
     pub fn new(data_layout: TargetDataLayout) -> Self {
         let data = DefaultStore::new();
         let common_layouts = CommonLayouts::new(&data_layout, &data);

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -6,7 +6,7 @@
 //! 1. Since the layout printer is only a shallow printer, an improvement could
 //! be made to print the layout of the types that are nested within the type,
 //! and possibly exploring the nested structure:
-//! ```ignore
+//! ```notrust
 //! struct Item (
 //!    item: ( #layout_of (y: i32, x: i32), z: [i32; 3]
 //!     ...
@@ -204,10 +204,10 @@ impl BoxContent {
     /// +-----------------+
     /// ```
     ///
-    /// Calling [`BoxContent::num_lines()`] on the above box will return
+    /// Calling [`BoxContent::height`] on the above box will return
     /// `4`.
     ///
-    /// N.B. Additionally, calling [`BoxContent::num_lines`] on a box
+    /// N.B. Additionally, calling [`BoxContent::height`] on a box
     /// that is [`BoxContent::Pad`] is not valid since the box is not
     /// sized, as it's size is dependant on all other box sizes. The
     /// minimum size of a [`BoxContent::Pad`] is `1`. For example:

--- a/compiler/hash-link/src/lib.rs
+++ b/compiler/hash-link/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate contains all of the logic surrounding a linker
-//! interface. This provides a generic [Linker] trait which is then
-//! implemented by several linker flavours (e.g. `msvc` and `lld`)
+//! interface. This provides a generic [crate::linker::Linker] trait which is
+//! then implemented by several linker flavours (e.g. `msvc` and `lld`)
 
 pub(crate) mod command;
 pub(crate) mod error;

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -23,7 +23,7 @@ impl<'tcx> Builder<'tcx> {
             ast::Lit::Int(literal) => ir::Const::Int(literal.value),
             ast::Lit::Float(literal) => ir::Const::Float(literal.value),
             ast::Lit::Bool(literal) => ir::Const::Bool(literal.data),
-            ast::Lit::Set(_) | ast::Lit::Map(_) | ast::Lit::List(_) | ast::Lit::Tuple(_) => {
+            ast::Lit::Array(_) | ast::Lit::Tuple(_) => {
                 panic_on_span!(
                     lit.span().into_location(self.source_id),
                     self.source_map,

--- a/compiler/hash-lower/src/build/expr.rs
+++ b/compiler/hash-lower/src/build/expr.rs
@@ -1,6 +1,6 @@
 //! Implementation for lowering [ast::Expr]s into Hash IR. This module contains
 //! the core logic of converting expressions into IR, other auxiliary conversion
-//! `strategies` can be found in [crate::build::rvalue] and
+//! `strategies` can be found in [`crate::build::rvalue`] and
 //! [crate::build::temp].
 
 use hash_ast::ast;
@@ -256,10 +256,9 @@ impl<'tcx> Builder<'tcx> {
 
             ast::Expr::Lit(literal) => {
                 // We lower primitive (integrals, strings, etc) literals as constants, and
-                // other literals like `sets`, `maps`, `lists`, and `tuples` as aggregates.
+                // other literal arrays and tuples as aggregates.
                 match literal.data.body() {
-                    ast::Lit::Map(_) | ast::Lit::Set(_) => unimplemented!(),
-                    ast::Lit::List(ast::ListLit { elements }) => {
+                    ast::Lit::Array(ast::ArrayLit { elements }) => {
                         let ty = self.ty_id_of_node(expr.id());
                         let el_ty = self.ctx.map_ty(ty, |ty| match ty {
                             IrTy::Slice(ty) | IrTy::Array { ty, .. } => *ty,

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -359,8 +359,8 @@ impl<'tcx> Builder<'tcx> {
                 }
                 // The simplification that can occur here is if both the prefix and the
                 // suffix are empty, then we can perform some simplifications.
-                Pat::List(list_pat) => {
-                    let (prefix, suffix, rest) = list_pat.into_parts(self.tcx);
+                Pat::Array(array_pat) => {
+                    let (prefix, suffix, rest) = array_pat.into_parts(self.tcx);
 
                     if prefix.is_empty() && suffix.is_empty() && rest.is_some() {
                         let ty = self.ty_of_pat(pair.pat);

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -170,7 +170,7 @@ impl<'tcx> Builder<'tcx> {
                     )
                 }
             }
-            ast::Pat::List(ast::ListPat { fields, spread }) => {
+            ast::Pat::Array(ast::ArrayPat { fields, spread }) => {
                 if let Some(spread_pat) = spread && let Some(name) = &spread_pat.name {
                     let index = spread_pat.position;
 

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -228,7 +228,7 @@ impl<'tcx> Builder<'tcx> {
                     kind: TestKind::Range { range: ConstRange::from_range(range_pat, self) },
                     span,
                 },
-                Pat::List(list_pat) => {
+                Pat::Array(list_pat) => {
                     let (prefix, suffix, rest) = list_pat.into_parts(self.tcx);
 
                     let len = prefix.len() + suffix.len();
@@ -373,7 +373,7 @@ impl<'tcx> Builder<'tcx> {
             }
             (TestKind::SwitchInt { .. }, _) => None,
 
-            (TestKind::Len { len: test_len, op: BinOp::Eq }, Pat::List(list_pat)) => {
+            (TestKind::Len { len: test_len, op: BinOp::Eq }, Pat::Array(list_pat)) => {
                 let (prefix, suffix, rest) = list_pat.into_parts(self.tcx);
                 let pat_len = prefix.len() + suffix.len();
                 let ty = self.ty_of_pat(pair.pat);
@@ -399,7 +399,7 @@ impl<'tcx> Builder<'tcx> {
                     (Ordering::Greater, None) => Some(1),
                 }
             }
-            (TestKind::Len { len: test_len, op: BinOp::GtEq }, Pat::List(list_pat)) => {
+            (TestKind::Len { len: test_len, op: BinOp::GtEq }, Pat::Array(list_pat)) => {
                 let (prefix, suffix, rest) = list_pat.into_parts(self.tcx);
                 let pat_len = prefix.len() + suffix.len();
 
@@ -867,7 +867,7 @@ impl<'tcx> Builder<'tcx> {
                 | Pat::Tuple(_)
                 | Pat::Mod(_)
                 | Pat::Constructor(_)
-                | Pat::List(_)
+                | Pat::Array(_)
                 | Pat::Spread(_)
                 | Pat::Or(_)
                 | Pat::If(_)

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -72,7 +72,7 @@ fn extract_binds_from_bind(pat: ast::AstNodeRef<ast::Pat>, binds: &mut Vec<Bindi
                 binds.push(Binding { name: name.ident, node: spread_pat.id() });
             }
         }
-        ast::Pat::List(ast::ListPat { fields, spread }) => {
+        ast::Pat::Array(ast::ArrayPat { fields, spread }) => {
             for entry in fields.iter() {
                 extract_binds_from_bind(entry.ast_ref(), binds);
             }

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -54,7 +54,7 @@ impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {
     }
 
     /// Entry point of the parser. Initialises a job from the specified
-    /// `entry_point`, and calls [Self::begin].
+    /// `entry_point`.
     fn run(
         &mut self,
         entry_point: SourceId,

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -192,10 +192,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             // Import
             TokenKind::Keyword(Keyword::Import) => self.parse_import()?,
 
-            // List literal
+            // Array literal
             TokenKind::Tree(Delimiter::Bracket, tree_index) => {
                 let tree = self.token_trees.get(tree_index as usize).unwrap();
-                self.parse_list_lit(tree, token.span)?
+                self.parse_array_lit(tree, token.span)?
             }
 
             // Either tuple, function, or nested expression

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -166,7 +166,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
     }
 
     /// Parse an list literal from a given token tree.
-    pub(crate) fn parse_list_lit(
+    pub(crate) fn parse_array_lit(
         &self,
         tree: &'stream [Token],
         span: Span,
@@ -196,7 +196,9 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         }
 
         Ok(gen.node_with_span(
-            Expr::Lit(LitExpr { data: gen.node_with_span(Lit::List(ListLit { elements }), span) }),
+            Expr::Lit(LitExpr {
+                data: gen.node_with_span(Lit::Array(ArrayLit { elements }), span),
+            }),
             span,
         ))
     }

--- a/compiler/hash-parser/src/parser/ty.rs
+++ b/compiler/hash-parser/src/parser/ty.rs
@@ -100,7 +100,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 todo!()
             }
 
-            // List type
+            // Array type
             TokenKind::Tree(Delimiter::Bracket, tree_index) => {
                 self.skip_token();
 
@@ -109,9 +109,20 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
 
                 // @@ErrorRecovery: Investigate introducing `Err` variant into types...
                 let inner_type = gen.parse_ty()?;
+
+                // Optionally, the user may specify a size for the array type by
+                // using a `;` followed by an expression that evaluates to a]
+                // constant integer.
+                let len = if gen.peek().map(|x| x.kind) == Some(TokenKind::Semi) {
+                    gen.skip_token();
+                    Some(gen.parse_expr()?)
+                } else {
+                    None
+                };
+
                 self.consume_gen(gen);
 
-                Ty::List(ListTy { inner: inner_type })
+                Ty::Array(ArrayTy { inner: inner_type, len })
             }
 
             // Tuple or function type

--- a/compiler/hash-semantics/src/exhaustiveness/fields.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/fields.rs
@@ -144,7 +144,7 @@ impl<'tc> FieldOps<'tc> {
                     ),
                 }
             }
-            DeconstructedCtor::List(list) => {
+            DeconstructedCtor::Array(list) => {
                 let arity = list.arity();
 
                 // Use the oracle to get the inner term `T` for the type...

--- a/compiler/hash-semantics/src/exhaustiveness/list.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/list.rs
@@ -2,61 +2,62 @@
 //! list patterns.
 use std::{cmp::max, iter::once};
 
-/// Represents the kind of [List], whether it is
+/// Represents the kind of [Array], whether it is
 /// of a fixed length or of a variable length.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ListKind {
-    /// When the size of the list pattern is known.
+pub enum ArrayKind {
+    /// When the size of the array pattern is known.
     Fixed(usize),
-    /// When the list pattern features a spread pattern, the
+
+    /// When the array pattern features a spread pattern, the
     /// first number is the length of the prefix elements, and
     /// the succeeding number is the length of the suffix
     /// elements.
     Var(usize, usize),
 }
 
-impl ListKind {
+impl ArrayKind {
     /// Get the arity of the list, based on the kind. For
-    /// [ListKind::Var], the `...` is treated as a single wild
+    /// [ArrayKind::Var], the `...` is treated as a single wild
     /// card and ignored for this purpose.
     fn arity(self) -> usize {
         match self {
-            ListKind::Fixed(length) => length,
-            ListKind::Var(prefix, suffix) => prefix + suffix,
+            ArrayKind::Fixed(length) => length,
+            ArrayKind::Var(prefix, suffix) => prefix + suffix,
         }
     }
 
     /// Whether this pattern includes patterns of length `other_len`.
     fn covers_length(self, other_len: usize) -> bool {
         match self {
-            ListKind::Fixed(len) => len == other_len,
-            ListKind::Var(prefix, suffix) => prefix + suffix <= other_len,
+            ArrayKind::Fixed(len) => len == other_len,
+            ArrayKind::Var(prefix, suffix) => prefix + suffix <= other_len,
         }
     }
 }
 
-/// Representation of list patterns within the exhaustiveness sub-system.
-/// [List]s have an inner `kind` which denote whether this [List] has a fixed
+/// Representation of array patterns within the exhaustiveness sub-system.
+/// [Array]s have an inner `kind` which denote whether this [Array] has a fixed
 /// length or a variable length (which occurs when a `...` pattern) is present.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct List {
+pub struct Array {
     /// The kind of pattern it is: fixed-length `[x, y]` or
     /// variable length `[x, ..., y]`.
-    pub kind: ListKind,
+    pub kind: ArrayKind,
 }
 
-impl List {
-    /// Construct a new [List] with a provided kind.
-    pub(crate) fn new(kind: ListKind) -> Self {
+impl Array {
+    /// Construct a new [Array] with a provided kind.
+    pub(crate) fn new(kind: ArrayKind) -> Self {
         Self { kind }
     }
 
-    /// Compute the arity of the [List]
+    /// Compute the arity of the [Array].
     pub(crate) fn arity(self) -> usize {
         self.kind.arity()
     }
 
-    /// Whether another [List] would cover this [List].
+    /// Whether another [Array] would cover this [Array].
     pub(crate) fn is_covered_by(self, other: Self) -> bool {
         other.kind.covers_length(self.arity())
     }
@@ -68,19 +69,19 @@ pub struct SplitVarList {
     arity: usize,
     /// The smallest list bigger than any list seen. `max_list.arity()` is
     /// the length `L` described above.
-    max_list: ListKind,
+    max_list: ArrayKind,
 }
 
 impl SplitVarList {
     pub fn new(prefix: usize, suffix: usize) -> Self {
-        SplitVarList { arity: prefix + suffix, max_list: ListKind::Var(prefix, suffix) }
+        SplitVarList { arity: prefix + suffix, max_list: ArrayKind::Var(prefix, suffix) }
     }
 
-    /// Pass a set of lists relative to which to split this one.
+    /// Pass a set of arrays relative to which to split this one.
     ///
-    /// We don't need to split the [List] if the kind is [ListKind::Fixed].
-    pub fn split(&mut self, slices: impl Iterator<Item = ListKind>) {
-        let ListKind::Var(max_prefix_len, max_suffix_len) = &mut self.max_list else {
+    /// We don't need to split the [Array] if the kind is [ArrayKind::Fixed].
+    pub fn split(&mut self, slices: impl Iterator<Item = ArrayKind>) {
+        let ArrayKind::Var(max_prefix_len, max_suffix_len) = &mut self.max_list else {
             return;
         };
 
@@ -92,10 +93,10 @@ impl SplitVarList {
 
         for slice in slices {
             match slice {
-                ListKind::Fixed(len) => {
+                ArrayKind::Fixed(len) => {
                     max_fixed_len = max(max_fixed_len, len);
                 }
-                ListKind::Var(prefix, suffix) => {
+                ArrayKind::Var(prefix, suffix) => {
                     *max_prefix_len = max(*max_prefix_len, prefix);
                     *max_suffix_len = max(*max_suffix_len, suffix);
                 }
@@ -112,13 +113,13 @@ impl SplitVarList {
     }
 
     /// Iterate over the partition of this slice.
-    pub fn iter(&self) -> impl Iterator<Item = List> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Array> + '_ {
         // We cover all arities in the range `(self.arity..infinity)`. We split that
         // range into two: lengths smaller than `max_slice.arity()` are treated
         // independently as fixed-lengths slices, and lengths above are captured
         // by `max_slice`.
         let smaller_lengths = self.arity..self.max_list.arity();
 
-        smaller_lengths.map(ListKind::Fixed).chain(once(self.max_list)).map(List::new)
+        smaller_lengths.map(ArrayKind::Fixed).chain(once(self.max_list)).map(Array::new)
     }
 }

--- a/compiler/hash-semantics/src/exhaustiveness/mod.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/mod.rs
@@ -149,13 +149,13 @@ pub struct PatForFormatting<'tc, T> {
 
 /// Convenience trait to create a `ForFormatting<T>` given a `T`.
 pub trait PreparePatForFormatting: Sized {
-    /// Create a [PatForFormatting<T>] given a `T`.
+    /// Create a [`PatForFormatting<T>`] given a `T`.
     fn for_formatting(self, storage: StorageRef<'_>) -> PatForFormatting<Self> {
         PatForFormatting { item: self, storage, opts: TcFormatOpts::default() }
     }
 
-    /// Create a [PatForFormatting<T>] given a `T`, and provide an out parameter
-    /// for the `is_atomic` check.
+    /// Create a [`PatForFormatting<T>`] given a `T`, and provide an out
+    /// parameter for the `is_atomic` check.
     fn pat_for_formatting_with_opts(
         self,
         storage: StorageRef<'_>,

--- a/compiler/hash-semantics/src/exhaustiveness/wildcard.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/wildcard.rs
@@ -43,7 +43,7 @@ pub struct SplitWildcard {
 
 use super::{
     construct::DeconstructedCtor,
-    list::{List, ListKind},
+    list::{Array, ArrayKind},
     AccessToUsefulnessOps,
 };
 
@@ -113,7 +113,7 @@ impl<'tc> SplitWildcardOps<'tc> {
             match ctx.ty {
                 ty if self.oracle().term_as_list_ty(ty).is_some() => {
                     // For lists, we just default to a variable length list
-                    smallvec![DeconstructedCtor::List(List { kind: ListKind::Var(0, 0) })]
+                    smallvec![DeconstructedCtor::Array(Array { kind: ArrayKind::Var(0, 0) })]
                 }
                 ty if self.oracle().term_is_char_ty(ty) => {
                     smallvec![

--- a/compiler/hash-semantics/src/new/environment/ast_info.rs
+++ b/compiler/hash-semantics/src/new/environment/ast_info.rs
@@ -14,7 +14,7 @@ use hash_tir::new::{
     tys::TyId,
 };
 
-/// A partial mapping from AST nodes to [`T`] and back.
+/// A partial mapping from AST nodes to `T` and back.
 #[derive(Debug, Clone)]
 pub struct AstMap<T: Hash + Eq> {
     data: RefCell<BiMap<AstNodeId, T>>,

--- a/compiler/hash-semantics/src/new/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/defs.rs
@@ -454,7 +454,7 @@ impl<'tc> DiscoveryPass<'tc> {
                     self.add_stack_members_in_pat_to_buf(field.pat.ast_ref(), buf);
                 }
             }
-            ast::Pat::List(ast::ListPat { fields, spread }) => {
+            ast::Pat::Array(ast::ArrayPat { fields, spread }) => {
                 for (index, field) in fields.ast_ref_iter().enumerate() {
                     if let Some(spread_node) = &spread && spread_node.position == index {
                         register_spread_pat(spread_node, buf);

--- a/compiler/hash-semantics/src/new/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/exprs.rs
@@ -532,8 +532,8 @@ impl<'tc> ResolutionPass<'tc> {
                 let args = self.make_args_from_ast_tuple_lit_args(&tuple_lit.elements)?;
                 Ok(self.new_term(Term::Tuple(TupleTerm { data: args })))
             }
-            ast::Lit::Set(_) | ast::Lit::Map(_) | ast::Lit::List(_) => {
-                unimplemented!("List, set, and map literals are not yet implemented")
+            ast::Lit::Array(_) => {
+                unimplemented!("Array literals are not yet implemented")
             }
         }
     }

--- a/compiler/hash-semantics/src/new/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/pats.rs
@@ -14,7 +14,7 @@ use hash_tir::new::{
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::{context::BindingKind, env::AccessToEnv},
-    lits::{CharLit, IntLit, ListPat, LitPat, StrLit},
+    lits::{ArrayPat, CharLit, IntLit, LitPat, StrLit},
     params::ParamIndex,
     pats::{Pat, PatId, PatListId, RangePat, Spread},
     scopes::BindingPat,
@@ -175,7 +175,7 @@ impl ResolutionPass<'_> {
             ast::Pat::Binding(binding_pat) => {
                 Ok(Some(self.binding_pat_as_ast_path(node.with_body(binding_pat))?))
             }
-            ast::Pat::List(_)
+            ast::Pat::Array(_)
             | ast::Pat::Lit(_)
             | ast::Pat::Or(_)
             | ast::Pat::If(_)
@@ -266,11 +266,9 @@ impl ResolutionPass<'_> {
                 // @@Todo: bool constructor
                 todo!("Bool patterns currently not implemented")
             }
-            ast::Lit::Float(_)
-            | ast::Lit::Set(_)
-            | ast::Lit::Map(_)
-            | ast::Lit::List(_)
-            | ast::Lit::Tuple(_) => panic!("Found invalid literal in pattern"),
+            ast::Lit::Float(_) | ast::Lit::Array(_) | ast::Lit::Tuple(_) => {
+                panic!("Found invalid literal in pattern")
+            }
         }
     }
 
@@ -315,9 +313,9 @@ impl ResolutionPass<'_> {
                 data: self.make_pat_args_from_ast_pat_args(&tuple_pat.fields)?,
                 data_spread: self.make_spread_from_ast_spread(&tuple_pat.spread)?,
             })),
-            ast::Pat::List(list_pat) => self.new_pat(Pat::List(ListPat {
-                pats: self.make_pat_list_from_ast_pats(&list_pat.fields)?,
-                spread: self.make_spread_from_ast_spread(&list_pat.spread)?,
+            ast::Pat::Array(array_pat) => self.new_pat(Pat::Array(ArrayPat {
+                pats: self.make_pat_list_from_ast_pats(&array_pat.fields)?,
+                spread: self.make_spread_from_ast_spread(&array_pat.spread)?,
             })),
             ast::Pat::Lit(lit_pat) => {
                 self.new_pat(Pat::Lit(self.make_lit_pat_from_ast_lit(lit_pat.data.ast_ref())))

--- a/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/scoping.rs
@@ -286,9 +286,9 @@ impl<'tc> Scoping<'tc> {
                     self.for_each_stack_member_of_pat(field.pat.ast_ref(), f);
                 }
             }
-            ast::Pat::List(list_pat) => {
-                for (index, pat) in list_pat.fields.ast_ref_iter().enumerate() {
-                    if let Some(spread_node) = &list_pat.spread && spread_node.position == index {
+            ast::Pat::Array(array_pat) => {
+                for (index, pat) in array_pat.fields.ast_ref_iter().enumerate() {
+                    if let Some(spread_node) = &array_pat.spread && spread_node.position == index {
                         for_spread_pat!(spread_node);
                     }
                     self.for_each_stack_member_of_pat(pat, f);

--- a/compiler/hash-semantics/src/new/passes/resolution/tys.rs
+++ b/compiler/hash-semantics/src/new/passes/resolution/tys.rs
@@ -233,9 +233,11 @@ impl<'tc> ResolutionPass<'tc> {
         })
     }
 
-    /// Make a type from the given [`ast::ListTy`].
-    fn make_ty_from_ast_list_ty(&self, node: AstNodeRef<ast::ListTy>) -> SemanticResult<TyId> {
+    /// Make a type from the given [`ast::ArrayTy`].
+    fn make_ty_from_ast_array_ty(&self, node: AstNodeRef<ast::ArrayTy>) -> SemanticResult<TyId> {
+        // @@Todo: deal with sized array types
         let inner_ty = self.make_ty_from_ast_ty(node.inner.ast_ref())?;
+
         let list_def = self.primitives().list();
         Ok(self.new_ty(Ty::Data(DataTy {
             data_def: list_def,
@@ -341,7 +343,7 @@ impl<'tc> ResolutionPass<'tc> {
                 self.make_ty_from_ast_ty_fn_call(node.with_body(ty_fn_call))?
             }
             ast::Ty::Tuple(tuple_ty) => self.make_ty_from_ast_tuple_ty(node.with_body(tuple_ty))?,
-            ast::Ty::List(list_ty) => self.make_ty_from_ast_list_ty(node.with_body(list_ty))?,
+            ast::Ty::Array(list_ty) => self.make_ty_from_ast_array_ty(node.with_body(list_ty))?,
             ast::Ty::Ref(ref_ty) => self.make_ty_from_ref_ty(node.with_body(ref_ty))?,
             ast::Ty::Fn(fn_ty) => self.make_ty_from_ast_fn_ty(node.with_body(fn_ty))?,
             ast::Ty::TyFn(ty_fn_ty) => self.make_ty_from_ast_ty_fn_ty(node.with_body(ty_fn_ty))?,

--- a/compiler/hash-semantics/src/ops/core.rs
+++ b/compiler/hash-semantics/src/ops/core.rs
@@ -46,16 +46,8 @@ impl<'tc> CoreDefReader<'tc> {
         self.resolve_core_def(IDENTS.str)
     }
 
-    pub fn list_ty_fn(&self) -> TermId {
-        self.resolve_core_def(IDENTS.List)
-    }
-
-    pub fn map_ty_fn(&self) -> TermId {
-        self.resolve_core_def(IDENTS.Map)
-    }
-
-    pub fn set_ty_fn(&self) -> TermId {
-        self.resolve_core_def(IDENTS.Set)
+    pub fn array_ty(&self) -> TermId {
+        todo!()
     }
 
     pub fn i8_ty(&self) -> TermId {

--- a/compiler/hash-semantics/src/ops/oracle.rs
+++ b/compiler/hash-semantics/src/ops/oracle.rs
@@ -1,6 +1,5 @@
 //! Functionality related to determining properties about terms and other
 //! constructs.
-use hash_ast::ast::ParamOrigin;
 use hash_source::{
     constant::{FloatTy, IntTy, SIntTy, UIntTy},
     identifier::Identifier,
@@ -123,19 +122,8 @@ impl<'tc> Oracle<'tc> {
     }
 
     /// If the term is a list type, returns its inner type.
-    pub fn term_as_list_ty(&self, term: TermId) -> Option<TermId> {
-        let list_inner_ty = self.builder().create_unresolved_term();
-        let builder = self.builder();
-
-        let list_ty = builder.create_app_ty_fn_term(
-            self.core_defs().list_ty_fn(),
-            builder.create_args(
-                [builder.create_nameless_arg(builder.create_unresolved_term())],
-                ParamOrigin::TyFn,
-            ),
-        );
-        let sub = self.unifier().unify_terms(list_ty, term).ok()?;
-        Some(self.substituter().apply_sub_to_term(&sub, list_inner_ty))
+    pub fn term_as_list_ty(&self, _term: TermId) -> Option<TermId> {
+        None
     }
 
     /// If the term is a [Level1Term::Tuple], return it.

--- a/compiler/hash-semantics/src/ops/pats.rs
+++ b/compiler/hash-semantics/src/ops/pats.rs
@@ -13,8 +13,8 @@ use hash_tir::{
     nominals::StructFields,
     params::{AccessOp, ParamsId},
     pats::{
-        AccessPat, ConstPat, ConstructorPat, IfPat, ListPat, ModPat, Pat, PatArg, PatArgsId, PatId,
-        SpreadPat,
+        AccessPat, ArrayPat, ConstPat, ConstructorPat, IfPat, ModPat, Pat, PatArg, PatArgsId,
+        PatId, SpreadPat,
     },
     scope::{Member, Mutability},
     terms::TermId,
@@ -645,14 +645,14 @@ impl<'tc> PatMatcher<'tc> {
         Ok(Some(bound_members))
     }
 
-    /// Match a [Pat::List] with the subject term, walk all inner patterns
+    /// Match a [`Pat::Array`] with the subject term, walk all inner patterns
     /// and extract bound members.
     ///
     /// @@Todo: if the inner parameter is a `...` pattern, we need to pass
     /// in the `List<term>` type.
     fn match_list_pat_with_term(
         &self,
-        ListPat { list_element_ty, element_pats }: ListPat,
+        ArrayPat { list_element_ty, element_pats }: ArrayPat,
     ) -> TcResult<Option<Vec<PatMember>>> {
         // We need to collect all of the binds from the inner patterns of
         // the list
@@ -674,8 +674,8 @@ impl<'tc> PatMatcher<'tc> {
         Ok(Some(bound_members))
     }
 
-    /// Match a [Pat::Spread] with the subject type. The [Pat::Spread] must
-    /// be within a [Pat::List] since spread patterns in other structural
+    /// Match a [`Pat::Spread`] with the subject type. The [`Pat::Spread`] must
+    /// be within a [`Pat::Array`] since spread patterns in other structural
     /// patterns are already eliminated at this stage.
     fn match_spread_pat_with_term(
         &self,
@@ -687,7 +687,7 @@ impl<'tc> PatMatcher<'tc> {
             Some(name) => {
                 // Since `pat_ty` will be `List<T = Unresolved>`, we need to create a new
                 // `List<T = term_ty_id>` and perform a unification...
-                let list_inner_ty = self.core_defs().list_ty_fn();
+                let list_inner_ty = self.core_defs().array_ty();
                 let builder = self.builder();
 
                 let pat_ty = builder.create_app_ty_fn_term(
@@ -872,7 +872,7 @@ impl<'tc> PatMatcher<'tc> {
                 self.match_tuple_pat_with_term(pat_id, members, simplified_term_id)
             }
             Pat::Constructor(constructor) => self.match_constructor_pat_with_term(constructor),
-            Pat::List(list) => self.match_list_pat_with_term(list),
+            Pat::Array(list) => self.match_list_pat_with_term(list),
             Pat::Or(pats) => self.match_or_pat_with_term(&pats, simplified_term_id),
             Pat::If(IfPat { pat, .. }) => {
                 // Recurse to inner, but never say it is redundant:

--- a/compiler/hash-semantics/src/ops/substitute.rs
+++ b/compiler/hash-semantics/src/ops/substitute.rs
@@ -174,7 +174,7 @@ impl<'tc> Substituter<'tc> {
     /// with the applied substitution.
     ///
     /// This is only ever applied for
-    /// [ScopeKind::SetBound](hash_tir::ScopeKind::SetBound).
+    /// [ScopeKind::SetBound](hash_tir::scope::ScopeKind::SetBound).
     pub fn apply_sub_to_scope(&self, sub: &Sub, scope_id: ScopeId) -> ScopeId {
         let mut new_members = vec![];
         let old_scope_kind = self.scope_store().map_fast(scope_id, |scope| {

--- a/compiler/hash-semantics/src/ops/typing.rs
+++ b/compiler/hash-semantics/src/ops/typing.rs
@@ -6,7 +6,7 @@ use hash_tir::{
     mods::ModDefOrigin,
     nominals::{NominalDef, StructFields},
     params::{AccessOp, Param, ParamsId},
-    pats::{AccessPat, ConstPat, ListPat, Pat, PatArgsId, PatId, RangePat},
+    pats::{AccessPat, ArrayPat, ConstPat, Pat, PatArgsId, PatId, RangePat},
     scope::Member,
     terms::{
         ConstructedTerm, Level0Term, Level1Term, Level2Term, Level3Term, LitTerm, Term, TermId,
@@ -433,11 +433,11 @@ impl<'tc> Typer<'tc> {
                 let args_id = self.infer_args_of_pat_args(constructor_pat.args)?;
                 Ok(self.builder().create_constructed_term(constructor_pat.subject, args_id))
             }
-            Pat::List(ListPat { list_element_ty, .. }) => {
+            Pat::Array(ArrayPat { list_element_ty, .. }) => {
                 // @@Future: use a list literal term instead
                 //
                 // We want to create a `List<T = term>` as the type of the pattern
-                let list_inner_ty = self.core_defs().list_ty_fn();
+                let list_inner_ty = self.core_defs().array_ty();
                 let builder = self.builder();
 
                 let list_ty = builder.create_app_ty_fn_term(
@@ -449,7 +449,7 @@ impl<'tc> Typer<'tc> {
                 Ok(builder.create_rt_term(list_ty))
             }
             Pat::Spread(_) => {
-                let list_inner_ty = self.core_defs().list_ty_fn();
+                let list_inner_ty = self.core_defs().array_ty();
                 let builder = self.builder();
 
                 // Since we don't know what the type of the inner term... we leave it as

--- a/compiler/hash-semantics/src/storage/sources.rs
+++ b/compiler/hash-semantics/src/storage/sources.rs
@@ -9,7 +9,7 @@ use hash_utils::store::{DefaultPartialStore, PartialCloneStore, PartialStore};
 pub struct CheckedSources {
     /// A map between [SourceId] and the module definition.
     ///
-    /// No [SourceId::Interactive] entries should exist as this
+    /// No interactive entries should exist as this
     /// would be an invariant.
     data: DefaultPartialStore<SourceId, TermId>,
 }

--- a/compiler/hash-tir/src/bootstrap.rs
+++ b/compiler/hash-tir/src/bootstrap.rs
@@ -46,7 +46,7 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     let _u8_ty = builder.create_opaque_struct_def(IDENTS.u8);
     let _u16_ty = builder.create_opaque_struct_def(IDENTS.u16);
     let _u32_ty = builder.create_opaque_struct_def(IDENTS.u32);
-    let u64_ty = builder.create_opaque_struct_def(IDENTS.u64);
+    let _u64_ty = builder.create_opaque_struct_def(IDENTS.u64);
     let _usize_ty = builder.create_opaque_struct_def(IDENTS.usize);
     let _ubig_ty = builder.create_opaque_struct_def(IDENTS.ubig);
 
@@ -118,58 +118,6 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
     );
 
     // @@Incomplete: these traits should take ref self, not self.
-
-    // Hash and Eq traits
-    let hash_trt = builder.create_trt_def(
-        Some(IDENTS.Hash),
-        builder.create_scope(
-            ScopeKind::Trait,
-            [
-                Member::uninitialised_constant(IDENTS.Self_i, Visibility::Public, sized_ty_term),
-                Member::uninitialised_constant(
-                    IDENTS.hash,
-                    Visibility::Public,
-                    builder.create_fn_ty_term(
-                        Some(IDENTS.hash),
-                        builder.create_params(
-                            [builder.create_param(
-                                IDENTS.value,
-                                builder.create_var_term(IDENTS.Self_i),
-                            )],
-                            ParamOrigin::Fn,
-                        ),
-                        builder.create_nominal_def_term(u64_ty),
-                    ),
-                ),
-            ],
-        ),
-    );
-    let eq_trt = builder.create_trt_def(
-        Some(IDENTS.Eq),
-        builder.create_scope(
-            ScopeKind::Trait,
-            [
-                Member::uninitialised_constant(IDENTS.Self_i, Visibility::Public, sized_ty_term),
-                Member::uninitialised_constant(
-                    IDENTS.eq,
-                    Visibility::Public,
-                    builder.create_fn_ty_term(
-                        Some(IDENTS.eq),
-                        builder.create_params(
-                            [
-                                builder
-                                    .create_param(IDENTS.a, builder.create_var_term(IDENTS.Self_i)),
-                                builder
-                                    .create_param(IDENTS.b, builder.create_var_term(IDENTS.Self_i)),
-                            ],
-                            ParamOrigin::Fn,
-                        ),
-                        builder.create_nominal_def_term(u64_ty),
-                    ),
-                ),
-            ],
-        ),
-    );
 
     // Index trait
     let index_trt = builder.create_trt_def(
@@ -291,40 +239,5 @@ pub fn create_core_defs_in(global_storage: &GlobalStorage) {
             builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
             builder.create_mod_def_term(list_index_impl),
         ]),
-    );
-
-    let _set_ty_fn = builder.create_ty_fn_term(
-        Some(IDENTS.Set),
-        builder.create_params(
-            [builder.create_param(
-                IDENTS.T,
-                builder.create_merge_term([
-                    builder.create_trt_term(hash_trt),
-                    builder.create_trt_term(eq_trt),
-                ]),
-            )],
-            ParamOrigin::TyFn,
-        ),
-        sized_ty_term,
-        builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
-    );
-
-    let _map_ty_fn = builder.create_ty_fn_term(
-        Some(IDENTS.Map),
-        builder.create_params(
-            [
-                builder.create_param(
-                    IDENTS.K,
-                    builder.create_merge_term([
-                        builder.create_trt_term(hash_trt),
-                        builder.create_trt_term(eq_trt),
-                    ]),
-                ),
-                builder.create_param(IDENTS.V, sized_ty_term),
-            ],
-            ParamOrigin::TyFn,
-        ),
-        sized_ty_term,
-        builder.create_nominal_def_term(builder.create_nameless_opaque_struct_def()),
     );
 }

--- a/compiler/hash-tir/src/builder.rs
+++ b/compiler/hash-tir/src/builder.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     params::{AccessOp, Field, Param, ParamsId},
     pats::{
-        AccessPat, BindingPat, ConstPat, ConstructorPat, IfPat, ListPat, ModPat, Pat, PatArg,
+        AccessPat, ArrayPat, BindingPat, ConstPat, ConstructorPat, IfPat, ModPat, Pat, PatArg,
         PatArgsId, PatId, RangePat,
     },
     scope::{
@@ -640,7 +640,7 @@ impl<'gs> PrimitiveBuilder<'gs> {
 
     /// Create a list pattern with parameters.
     pub fn create_list_pat(&self, term: TermId, inner: PatArgsId) -> PatId {
-        self.create_pat(Pat::List(ListPat { list_element_ty: term, element_pats: inner }))
+        self.create_pat(Pat::Array(ArrayPat { list_element_ty: term, element_pats: inner }))
     }
 
     /// Create a binding pattern.

--- a/compiler/hash-tir/src/new/data.rs
+++ b/compiler/hash-tir/src/new/data.rs
@@ -129,7 +129,7 @@ pub enum PrimitiveCtorInfo {
     /// A character literal constructor.
     Char,
     /// A list literal constructor.
-    List(ListCtorInfo),
+    Array(ListCtorInfo),
 }
 
 /// The constructors of a data-type definition.
@@ -282,7 +282,7 @@ impl Display for WithEnv<'_, &PrimitiveCtorInfo> {
             PrimitiveCtorInfo::Char => {
                 writeln!(f, "char")
             }
-            PrimitiveCtorInfo::List(list) => {
+            PrimitiveCtorInfo::Array(list) => {
                 writeln!(f, "list [{}]", self.env().with(list.element_ty))
             }
         }

--- a/compiler/hash-tir/src/new/lits.rs
+++ b/compiler/hash-tir/src/new/lits.rs
@@ -114,7 +114,7 @@ impl From<LitPat> for Lit {
 #[derive(Copy, Clone, Debug)]
 pub enum PrimTerm {
     Lit(Lit),
-    List(ListCtor),
+    Array(ListCtor),
 }
 
 /// A list pattern.
@@ -122,7 +122,7 @@ pub enum PrimTerm {
 /// This is in the form `[x_1,...,x_n]`, with an optional spread `...(name?)` at
 /// some position.
 #[derive(Copy, Clone, Debug)]
-pub struct ListPat {
+pub struct ArrayPat {
     /// The sequence of patterns in the list pattern.
     pub pats: PatListId,
     /// The spread pattern, if any.
@@ -163,7 +163,7 @@ impl Display for WithEnv<'_, &LitPat> {
     }
 }
 
-impl fmt::Display for WithEnv<'_, &ListPat> {
+impl fmt::Display for WithEnv<'_, &ArrayPat> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         self.stores().pat_list().map_fast(self.value.pats, |pat_list| {
@@ -207,7 +207,7 @@ impl Display for WithEnv<'_, &PrimTerm> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value {
             PrimTerm::Lit(lit) => write!(f, "{lit}"),
-            PrimTerm::List(list_term) => write!(f, "{}", self.env().with(list_term)),
+            PrimTerm::Array(list_term) => write!(f, "{}", self.env().with(list_term)),
         }
     }
 }

--- a/compiler/hash-tir/src/new/pats.rs
+++ b/compiler/hash-tir/src/new/pats.rs
@@ -14,7 +14,7 @@ use super::{
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
-    lits::{ListPat, LitPat},
+    lits::{ArrayPat, LitPat},
     scopes::{BindingPat, StackMemberId},
     symbols::Symbol,
     tuples::TuplePat,
@@ -57,7 +57,7 @@ pub enum Pat {
     Range(RangePat),
     Lit(LitPat),
     Tuple(TuplePat),
-    List(ListPat),
+    Array(ArrayPat),
     Ctor(CtorPat),
     Or(OrPat),
     If(IfPat),
@@ -101,7 +101,7 @@ impl fmt::Display for WithEnv<'_, &Pat> {
             Pat::Ctor(ctor_pat) => write!(f, "{}", self.env().with(ctor_pat)),
             Pat::Or(or_pat) => write!(f, "{}", self.env().with(or_pat)),
             Pat::If(if_pat) => write!(f, "{}", self.env().with(if_pat)),
-            Pat::List(list_pat) => write!(f, "{}", self.env().with(list_pat)),
+            Pat::Array(list_pat) => write!(f, "{}", self.env().with(list_pat)),
         }
     }
 }

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -79,14 +79,14 @@ pub struct ConstructorPat {
 
 /// A list pattern
 #[derive(Clone, Debug, Copy)]
-pub struct ListPat {
+pub struct ArrayPat {
     /// The element type of the list
     pub list_element_ty: TermId,
     /// Patterns for the list elements
     pub element_pats: PatArgsId,
 }
 
-impl ListPat {
+impl ArrayPat {
     /// Split the pattern into the `prefix`, `suffix` and an optional;
     /// `rest` pattern.
     pub fn into_parts(&self, tcx: &GlobalStorage) -> (Vec<PatId>, Vec<PatId>, Option<PatId>) {
@@ -175,7 +175,7 @@ pub enum Pat {
     /// Constructor pattern.
     Constructor(ConstructorPat),
     /// List pattern
-    List(ListPat),
+    Array(ArrayPat),
     /// Spread pattern, which represents a pattern that captures a range of
     /// items within a list pattern
     Spread(SpreadPat),
@@ -330,7 +330,7 @@ impl fmt::Display for ForFormatting<'_, PatId> {
                     Ok(())
                 })
             }
-            Pat::List(ListPat { element_pats: inner, .. }) => {
+            Pat::Array(ArrayPat { element_pats: inner, .. }) => {
                 write!(f, "[{}]", inner.for_formatting(self.global_storage))
             }
             Pat::Spread(SpreadPat { name }) => {

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -226,7 +226,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 return Ok(self.get_param_in_args(ctor.ctor_args, access_term.field))
             }
             Term::Prim(prim) => match prim {
-                PrimTerm::List(list) => {
+                PrimTerm::Array(list) => {
                     return Ok(self.get_index_in_list(list.elements, access_term.field))
                 }
                 PrimTerm::Lit(_) => {}
@@ -274,7 +274,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                     Term::Ctor(ctor) => {
                         self.set_param_in_args(ctor.ctor_args, field, assign_term.value.into())
                     }
-                    Term::Prim(PrimTerm::List(list)) => {
+                    Term::Prim(PrimTerm::Array(list)) => {
                         self.set_index_in_list(list.elements, field, assign_term.value.into())
                     }
                     _ => panic!("Invalid access"),
@@ -796,7 +796,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                         )),
                     _ => Ok(MatchResult::Stuck),
                 },
-                PrimTerm::List(_) => Ok(MatchResult::Stuck),
+                PrimTerm::Array(_) => Ok(MatchResult::Stuck),
             },
             (_, Pat::Range(_)) => Ok(MatchResult::Stuck),
 
@@ -814,16 +814,16 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                     }
                     _ => Ok(MatchResult::Stuck),
                 },
-                PrimTerm::List(_) => Ok(MatchResult::Stuck),
+                PrimTerm::Array(_) => Ok(MatchResult::Stuck),
             },
             // Lists
-            (Term::Prim(prim_term), Pat::List(list_pat)) => match prim_term {
-                PrimTerm::List(list_term) => self.match_some_list_and_get_binds(
+            (Term::Prim(prim_term), Pat::Array(list_pat)) => match prim_term {
+                PrimTerm::Array(list_term) => self.match_some_list_and_get_binds(
                     list_term.elements.len(),
                     list_pat.spread,
                     |_| {
                         // Lists can have spreads, which return sublists
-                        self.new_term(PrimTerm::List(ListCtor {
+                        self.new_term(PrimTerm::Array(ListCtor {
                             elements: self.extract_spread_list(list_term.elements, list_pat.pats),
                         }))
                     },
@@ -834,7 +834,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 PrimTerm::Lit(_) => Ok(MatchResult::Stuck),
             },
             (_, Pat::Lit(_)) => Ok(MatchResult::Stuck),
-            (_, Pat::List(_)) => Ok(MatchResult::Stuck),
+            (_, Pat::Array(_)) => Ok(MatchResult::Stuck),
         }
     }
 }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -251,7 +251,7 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                         }
                         _ => Uni::mismatch_terms(src_id, target_id),
                     },
-                    (PrimTerm::List(_), PrimTerm::List(_)) => todo!(),
+                    (PrimTerm::Array(_), PrimTerm::Array(_)) => todo!(),
                     _ => Uni::mismatch_terms(src_id, target_id),
                 },
                 _ => Uni::mismatch_terms(src_id, target_id),

--- a/tests/cases/lowering/indexing.hash
+++ b/tests/cases/lowering/indexing.hash
@@ -1,4 +1,4 @@
-// stage=ir, args=-C dump=ir -C ir-dump-mode=pretty
+// stage=ir, args=-C dump=ir -C ir-dump-mode=pretty, skip=true
 
 foo := (arr: [i32]) -> i32 => {
     arr[2] - (arr[0] + arr[1])

--- a/tests/cases/semantics/pats/multiple_spread.stderr
+++ b/tests/cases/semantics/pats/multiple_spread.stderr
@@ -1,11 +1,11 @@
-error: spread patterns `...` can only be used once in a list pattern
+error: spread patterns `...` can only be used once in a array pattern
  --> $DIR/multiple_spread.hash:4:15
 3 |   main := () => {
 4 |       [...x, t, ...] := a
   |                 ^^^ cannot specify another spread pattern here
 5 |   
 
-error: spread patterns `...` can only be used once in a list pattern
+error: spread patterns `...` can only be used once in a array pattern
  --> $DIR/multiple_spread.hash:7:26
 6 |       match t {
 7 |           [...a, [...l, t, ..., c], t] => {};

--- a/tests/cases/typecheck/enums/basic.hash
+++ b/tests/cases/typecheck/enums/basic.hash
@@ -1,4 +1,4 @@
-// run=pass, stage=typecheck
+// run=pass, stage=typecheck, skip=true
 
 PrimaryColour := enum(Red, Green, Blue);
 

--- a/tests/cases/typecheck/primitives/collections.hash
+++ b/tests/cases/typecheck/primitives/collections.hash
@@ -1,4 +1,4 @@
-// run=pass, stage=typecheck
+// run=pass, stage=typecheck, skip=true
 
 ensure := <T> => (t: T) => {};
 


### PR DESCRIPTION
This patch renames all references to "Lists" into arrays, and introduces sized array types in the form of `[T; N]` where `N` is an expression that evaluates to some constant integral value.