### PR TITLE
Add better inference for numeric literals and some resolution bug fixes

### DIFF
--- a/compiler/hash-semantics/src/new/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/new/diagnostics/error.rs
@@ -54,6 +54,8 @@ pub enum SemanticError {
     UnexpectedArguments { location: SourceLocation },
     /// Type error, forwarded from the typechecker.
     TypeError { error: TcError },
+    /// Given data definition is not a singleton.
+    DataDefIsNotSingleton { location: SourceLocation },
 }
 
 impl From<TcError> for SemanticError {
@@ -250,6 +252,16 @@ impl<'tc> WithTcEnv<'tc, &SemanticError> {
                 error
                     .add_span(*location)
                     .add_info("cannot use these arguments as the subject does not expect them");
+            }
+            SemanticError::DataDefIsNotSingleton { location } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ValueCannotBeUsedAsType)
+                    .title("cannot construct this data type directly because it is an enum");
+
+                error
+                    .add_span(*location)
+                    .add_info("you need to specify which variant of this data type you want");
             }
         }
     }

--- a/compiler/hash-semantics/src/new/passes/ast_utils.rs
+++ b/compiler/hash-semantics/src/new/passes/ast_utils.rs
@@ -39,7 +39,7 @@ pub trait AstUtils: AccessToTcEnv {
 
     /// Create a [`Symbol`] for the given [`ast::Name`], or a fresh symbol if no
     /// name is provided.
-    fn new_symbol_from_ast_name(&self, name: &Option<ast::AstNode<ast::Name>>) -> Symbol {
+    fn new_symbol_from_ast_name(&self, name: Option<&ast::AstNode<ast::Name>>) -> Symbol {
         match name {
             Some(name) => self.new_symbol(name.ident),
             None => self.new_fresh_symbol(),

--- a/compiler/hash-semantics/src/new/passes/discovery/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/mod.rs
@@ -63,16 +63,6 @@ impl<'tc> DiscoveryPass<'tc> {
         &self.def_state
     }
 
-    /// Create a new symbol from the given optional AST node containing a name.
-    ///
-    /// If the AST node is `None`, a fresh symbol is created.
-    fn create_symbol_from_ast_name(&self, ast_name: &Option<ast::AstNode<ast::Name>>) -> Symbol {
-        match ast_name {
-            Some(ast_name) => self.new_symbol(ast_name.ident),
-            None => self.new_fresh_symbol(),
-        }
-    }
-
     /// Take the currently set name hint, or create a new internal name.
     fn take_name_hint_or_create_internal_name(&self) -> Symbol {
         self.name_hint.take().unwrap_or_else(|| self.new_fresh_symbol())

--- a/compiler/hash-semantics/src/new/passes/discovery/visitor.rs
+++ b/compiler/hash-semantics/src/new/passes/discovery/visitor.rs
@@ -35,7 +35,6 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         TyFnDef,
         TupleTy,
         BodyBlock,
-        MergeDeclaration,
         Expr,
         MatchCase
     );
@@ -372,18 +371,6 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         node: ast::AstNodeRef<ast::TraitDef>,
     ) -> Result<Self::TraitDefRet, Self::Error> {
         // Traits are not yet supported
-        self.diagnostics().add_error(SemanticError::TraitsNotSupported {
-            trait_location: self.node_location(node),
-        });
-        Ok(())
-    }
-
-    type MergeDeclarationRet = ();
-    fn visit_merge_declaration(
-        &self,
-        node: AstNodeRef<ast::MergeDeclaration>,
-    ) -> Result<Self::MergeDeclarationRet, Self::Error> {
-        // Merge declarations are not yet supported
         self.diagnostics().add_error(SemanticError::TraitsNotSupported {
             trait_location: self.node_location(node),
         });


### PR DESCRIPTION
Also, shorthand struct syntax `Dog()` instead of `Dog::Dog()`.
