### PR TITLE
source: refactor `IntConstant` to use value slots rather than scalar

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -146,12 +146,16 @@ impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
             Const::Int(interned_int) => {
                 let const_int = CONSTANT_MAP.lookup_int_constant(interned_int);
 
-                const_int.as_small().map(|value| self.const_uint_big(ty, value)).unwrap_or_else(
-                    || {
+                // Convert the constant into a u128 and then emit the
+                // correct LLVM constant for it.
+                const_int
+                    .value
+                    .as_u128()
+                    .map(|value| self.const_uint_big(ty, value))
+                    .unwrap_or_else(|| {
                         // @@Todo: deal with bigints...
                         unimplemented!()
-                    },
-                )
+                    })
             }
             Const::Float(interned_float) => {
                 self.const_float(ty, CONSTANT_MAP.lookup_float_constant(interned_float).as_f64())

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -66,8 +66,8 @@ impl<'tcx> Builder<'tcx> {
     pub(crate) fn evaluate_const_pat_term(&self, term: TermId) -> (Const, u128) {
         self.tcx.term_store.map_fast(term, |ty| match ty {
             Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => CONSTANT_MAP
-                .map_int_constant(*value, |val| {
-                    (Const::Int(*value), u128::from_be_bytes(val.bytes_be()))
+                .map_int_constant(*value, |constant| {
+                    (Const::Int(*value), constant.value.as_u128().unwrap())
                 }),
             Term::Level0(Level0Term::Lit(LitTerm::Char(char))) => {
                 (Const::Char(*char), u128::from(*char))

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -67,7 +67,7 @@ impl<'tcx> Builder<'tcx> {
         self.tcx.term_store.map_fast(term, |ty| match ty {
             Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => CONSTANT_MAP
                 .map_int_constant(*value, |val| {
-                    (Const::Int(*value), u128::from_be_bytes(val.get_bytes()))
+                    (Const::Int(*value), u128::from_be_bytes(val.bytes_be()))
                 }),
             Term::Level0(Level0Term::Lit(LitTerm::Char(char))) => {
                 (Const::Char(*char), u128::from(*char))

--- a/compiler/hash-lower/src/ty/mod.rs
+++ b/compiler/hash-lower/src/ty/mod.rs
@@ -123,7 +123,7 @@ impl<'ir> TyLoweringCtx<'ir> {
                 Level0Term::Lit(lit_term) => match lit_term {
                     LitTerm::Str(_) => IrTy::Str,
                     LitTerm::Int { value } => {
-                        CONSTANT_MAP.map_int_constant(value, |val| val.ty).into()
+                        CONSTANT_MAP.map_int_constant(value, |val| val.ty()).into()
                     }
                     LitTerm::Char(_) => IrTy::Char,
                 },

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -823,7 +823,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                 }
 
                 self.skip_token();
-                let value = usize::try_from(interned_lit).map_err(|_| {
+                let value = usize::try_from(&interned_lit).map_err(|_| {
                     self.make_err(ParseErrorKind::InvalidPropertyAccess, None, None, Some(token.span))
                 })?;
 

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -49,7 +49,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     }
 
                     let (ty, suffix) =
-                        CONSTANT_MAP.map_int_constant(value, |val| (val.ty, val.suffix));
+                        CONSTANT_MAP.map_int_constant(value, |val| (val.ty(), val.suffix));
 
                     // Despite the fact that we always know the type, we still want to preserve
                     // information about whether this constant had a specified
@@ -70,7 +70,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     }
 
                     let (ty, suffix) =
-                        CONSTANT_MAP.map_float_constant(value, |val| (val.ty, val.suffix));
+                        CONSTANT_MAP.map_float_constant(value, |val| (val.ty(), val.suffix));
 
                     if suffix.is_some() {
                         Lit::Float(FloatLit { value, kind: FloatLitKind::Suffixed(ty) })

--- a/compiler/hash-parser/src/source.rs
+++ b/compiler/hash-parser/src/source.rs
@@ -14,8 +14,10 @@ pub struct ParseSource {
     /// The absolute path for the current source, `current_dir` if it is an
     /// interactive block.
     path: PathBuf,
+
     /// The raw contents of the source.
     contents: String,
+
     /// The [SourceId] of the source
     id: SourceId,
 }

--- a/compiler/hash-semantics/src/exhaustiveness/constant.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/constant.rs
@@ -28,20 +28,10 @@ impl Constant {
     /// Function to convert a [InternedInt] into a [Constant]. The only
     /// constraint is that it can fit into a [u128], otherwise the
     /// function will currently panic.
-    pub fn from_int(value: InternedInt, ty: TermId, ptr_width: usize) -> Self {
-        let kind = CONSTANT_MAP.map_int_constant(value, |value| value.ty);
-        let bytes = kind.size(ptr_width).unwrap().bytes() as usize;
-
+    pub fn from_int(constant: InternedInt, ty: TermId) -> Self {
         // Get the associated bytes with the interned-int so we can convert
         // into a constant.
-        let mut data = CONSTANT_MAP.lookup_int_constant(value).get_bytes();
-
-        // memset the upper 16-kind.size() bytes to zero since they aren't
-        // necessary.
-        if kind.is_signed() {
-            data[0..(16 - bytes)].fill(0);
-        }
-
+        let data = CONSTANT_MAP.lookup_int_constant(constant).bytes_be();
         Constant { data: u128::from_be_bytes(data), ty }
     }
 

--- a/compiler/hash-semantics/src/exhaustiveness/constant.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/constant.rs
@@ -31,8 +31,8 @@ impl Constant {
     pub fn from_int(constant: InternedInt, ty: TermId) -> Self {
         // Get the associated bytes with the interned-int so we can convert
         // into a constant.
-        let data = CONSTANT_MAP.lookup_int_constant(constant).bytes_be();
-        Constant { data: u128::from_be_bytes(data), ty }
+        let data = CONSTANT_MAP.lookup_int_constant(constant).value.as_u128().unwrap();
+        Constant { data, ty }
     }
 
     /// Get the data stored within the [Constant].

--- a/compiler/hash-semantics/src/exhaustiveness/lower.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/lower.rs
@@ -3,7 +3,7 @@
 use std::{iter::once, mem::size_of};
 
 use hash_ast::ast::{ParamOrigin, RangeEnd};
-use hash_source::constant::{IntConstant, IntConstantValue, CONSTANT_MAP};
+use hash_source::constant::u128_to_int_const;
 use hash_tir::{
     mods::ModDef,
     nominals::{EnumVariantValue, NominalDef, StructFields},
@@ -139,8 +139,7 @@ impl<'tc> LowerPatOps<'tc> {
                 Term::Level0(Level0Term::Lit(lit)) => match lit {
                     LitTerm::Str(value) => (DeconstructedCtor::Str(value), vec![]),
                     LitTerm::Int { value } => {
-                        let ptr_width = self.global_storage().pointer_width;
-                        let value = Constant::from_int(value, term, ptr_width);
+                        let value = Constant::from_int(value, term);
                         let range = self.int_range_ops().range_from_constant(value);
                         (DeconstructedCtor::IntRange(range), vec![])
                     }
@@ -509,9 +508,7 @@ impl<'tc> LowerPatOps<'tc> {
                     Constant::from_char(ch, term).data()
                 }
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value })) => {
-                    let ptr_width = self.global_storage().pointer_width;
-
-                    Constant::from_int(value, term, ptr_width).data()
+                    Constant::from_int(value, term).data()
                 }
                 _ => tc_panic!(term, self, "term does not support lowering into range"),
             }
@@ -545,21 +542,9 @@ impl<'tc> LowerPatOps<'tc> {
 
         let (lo, hi) = if let Some(kind) = self.oracle().term_as_int_ty(ty) {
             let ptr_width = self.global_storage().pointer_width;
-            let size = kind.size(ptr_width).unwrap().bytes() as usize;
 
-            // Trim the values within the stored range and then create
-            // literal terms with those values...
-            let lo_val = CONSTANT_MAP.create_int_constant(IntConstant::new(
-                IntConstantValue::from_le_bytes(&lo.to_le_bytes()[0..size]),
-                kind,
-                None,
-            ));
-            let hi_val = CONSTANT_MAP.create_int_constant(IntConstant::new(
-                IntConstantValue::from_le_bytes(&hi.to_le_bytes()[0..size]),
-                kind,
-                None,
-            ));
-
+            let lo_val = u128_to_int_const(lo, kind, ptr_width);
+            let hi_val = u128_to_int_const(hi, kind, ptr_width);
             let lo = self.builder().create_lit_term(LitTerm::Int { value: lo_val });
             let hi = self.builder().create_lit_term(LitTerm::Int { value: hi_val });
 

--- a/compiler/hash-semantics/src/exhaustiveness/range.rs
+++ b/compiler/hash-semantics/src/exhaustiveness/range.rs
@@ -269,7 +269,7 @@ impl<'tc> IntRangeOps<'tc> {
 
         let bias: u128 = match reader.get_term(constant.ty) {
             Term::Level0(Level0Term::Lit(lit)) => match lit {
-                LitTerm::Int { value } if let kind = CONSTANT_MAP.map_int_constant(value, |val| val.ty) && kind.is_signed() => {
+                LitTerm::Int { value } if let kind = CONSTANT_MAP.map_int_constant(value, |val| val.ty()) && kind.is_signed() => {
                     let ptr_width = self.global_storage().pointer_width;
                     let bits = kind.size(ptr_width).unwrap().bits();
                     1u128 << (bits - 1)

--- a/compiler/hash-semantics/src/ops/typing.rs
+++ b/compiler/hash-semantics/src/ops/typing.rs
@@ -244,7 +244,7 @@ impl<'tc> Typer<'tc> {
                             // @@Todo: do some more sophisticated inferring here
                             LitTerm::Int { value } => {
                                 let kind: Identifier =
-                                    CONSTANT_MAP.map_int_constant(value, |int| int.ty).into();
+                                    CONSTANT_MAP.map_int_constant(value, |int| int.ty()).into();
                                 self.core_defs().resolve_core_def(kind)
                             }
                             LitTerm::Char(_) => self.core_defs().char_ty(),

--- a/compiler/hash-semantics/src/ops/validate.rs
+++ b/compiler/hash-semantics/src/ops/validate.rs
@@ -1220,8 +1220,8 @@ impl<'tc> Validator<'tc> {
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs })),
             ) => {
                 let ptr_width = self.global_storage().pointer_width;
-                let lhs_kind = CONSTANT_MAP.map_int_constant(lhs, |val| val.ty);
-                let rhs_kind = CONSTANT_MAP.map_int_constant(rhs, |val| val.ty);
+                let lhs_kind = CONSTANT_MAP.map_int_constant(lhs, |val| val.ty());
+                let rhs_kind = CONSTANT_MAP.map_int_constant(rhs, |val| val.ty());
 
                 // Check that the integer type is sized, if it is not then we currently
                 // say that this is not supported...

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -248,7 +248,7 @@ impl IntConstantValue {
     /// Attempt to convert the given value into a [u128] provided that the
     /// value itself is not [`IntConstantValue::Big`]. If the value is a
     /// big integer, then [`None`] is returned.
-    pub fn as_u128(self) -> Option<u128> {
+    pub fn as_u128(&self) -> Option<u128> {
         match self {
             Self::I8(inner) => {
                 let inner = inner.to_be_bytes();
@@ -278,11 +278,11 @@ impl IntConstantValue {
 
             // For unsigned values, its fine to just cast them since we're
             // zero extending them anyways...
-            Self::U8(inner) => Some(inner as u128),
-            Self::U16(inner) => Some(inner as u128),
-            Self::U32(inner) => Some(inner as u128),
-            Self::U64(inner) => Some(inner as u128),
-            Self::U128(inner) => Some(inner),
+            Self::U8(inner) => Some(*inner as u128),
+            Self::U16(inner) => Some(*inner as u128),
+            Self::U32(inner) => Some(*inner as u128),
+            Self::U64(inner) => Some(*inner as u128),
+            Self::U128(inner) => Some(*inner),
             Self::Big(_) => None,
         }
     }
@@ -455,58 +455,6 @@ impl IntConstant {
         };
 
         Self { value, suffix: None }
-    }
-
-    /// Get the bytes of a constant value assuming that it is
-    /// a primitive integer type.
-    ///
-    /// N.B. This returns bytes in Big Endian order.
-    pub fn bytes_be(&self) -> [u8; 16] {
-        match self.value {
-            IntConstantValue::I8(v) => {
-                let mut data = [0; 16];
-                data[15] = v as u8;
-                data
-            }
-            IntConstantValue::I16(v) => {
-                let mut data = [0; 16];
-                data[14..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::I32(v) => {
-                let mut data = [0; 16];
-                data[12..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::I64(v) => {
-                let mut data = [0; 16];
-                data[8..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::I128(v) => v.to_be_bytes(),
-            IntConstantValue::U8(v) => {
-                let mut data = [0; 16];
-                data[15] = v;
-                data
-            }
-            IntConstantValue::U16(v) => {
-                let mut data = [0; 16];
-                data[14..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::U32(v) => {
-                let mut data = [0; 16];
-                data[12..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::U64(v) => {
-                let mut data = [0; 16];
-                data[8..16].copy_from_slice(&v.to_be_bytes());
-                data
-            }
-            IntConstantValue::U128(v) => v.to_be_bytes(),
-            IntConstantValue::Big(_) => unreachable!(),
-        }
     }
 
     /// Compute the [IntTy] of the constant.

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -13,106 +13,12 @@ use fnv::FnvBuildHasher;
 pub use hash_target::primitives::{FloatTy, IntTy, SIntTy, UIntTy};
 use hash_utils::counter;
 use lazy_static::lazy_static;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Sign};
+use FloatConstantValue::*;
+use IntConstantValue::*;
 
 use crate::identifier::{Identifier, IDENTS};
 
-/// The inner stored value of a [FloatConstant].
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub enum FloatConstantValue {
-    F64(f64),
-    F32(f32),
-}
-
-impl fmt::Display for FloatConstantValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FloatConstantValue::F64(inner) => write!(f, "{inner}"),
-            FloatConstantValue::F32(inner) => write!(f, "{inner}"),
-        }
-    }
-}
-
-/// Interned float constant which stores the value of the float, and
-/// an optional `type ascription` which is a suffix on the literal
-/// describing which float kind it is, either being `f32` or `f64`.
-#[derive(Debug, Clone, Copy)]
-pub struct FloatConstant {
-    /// Raw value of the float
-    pub value: FloatConstantValue,
-
-    /// The type of the float constant,
-    pub ty: FloatTy,
-
-    /// If the constant contains a type ascription, as specified
-    /// when the constant is declared, e.g. `32.4f64`
-    pub suffix: Option<Identifier>,
-}
-
-impl FloatConstant {
-    /// Perform a negation operation on the [FloatConstant].
-    pub fn negate(self) -> Self {
-        let value = match self.value {
-            FloatConstantValue::F64(inner) => FloatConstantValue::F64(-inner),
-            FloatConstantValue::F32(inner) => FloatConstantValue::F32(-inner),
-        };
-
-        Self { value, ty: self.ty, suffix: self.suffix }
-    }
-
-    /// Get the value of the float constant as a [f64].
-    pub fn as_f64(self) -> f64 {
-        match self.value {
-            FloatConstantValue::F64(inner) => inner,
-            FloatConstantValue::F32(inner) => inner as f64,
-        }
-    }
-}
-
-/// Provide implementations for converting primitive floating point types into
-/// [FloatConstant]s.
-macro_rules! float_const_impl_into {
-    ($($ty:ident, $kind: ident);*) => {
-        $(
-            impl From<$ty> for FloatConstant {
-                fn from(value: $ty) -> Self {
-                    Self {
-                        value: FloatConstantValue::$kind(value),
-                        ty: FloatTy::$kind,
-                        suffix: Some(IDENTS.$ty),
-                    }
-                }
-            }
-        )*
-    };
-}
-
-float_const_impl_into!(f32, F32; f64, F64);
-
-counter! {
-    name: InternedFloat,
-    counter_name: INTERNED_FLOAT_COUNTER,
-    visibility: pub,
-    method_visibility:,
-}
-
-impl fmt::Display for FloatConstant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value)?;
-
-        if let Some(suffix) = self.suffix {
-            write!(f, "_{suffix}")?;
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::Display for InternedFloat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", CONSTANT_MAP.lookup_float_constant(*self))
-    }
-}
 impl From<UIntTy> for Identifier {
     fn from(value: UIntTy) -> Self {
         match value {
@@ -174,6 +80,146 @@ impl TryFrom<Identifier> for IntTy {
     }
 }
 
+// -------------------- Floats --------------------
+
+/// The inner stored value of a [FloatConstant].
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum FloatConstantValue {
+    F64(f64),
+    F32(f32),
+}
+
+impl fmt::Display for FloatConstantValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            F64(inner) => write!(f, "{inner}"),
+            F32(inner) => write!(f, "{inner}"),
+        }
+    }
+}
+
+/// Interned float constant which stores the value of the float, and
+/// an optional `type ascription` which is a suffix on the literal
+/// describing which float kind it is, either being `f32` or `f64`.
+#[derive(Debug, Clone, Copy)]
+pub struct FloatConstant {
+    /// Raw value of the float
+    pub value: FloatConstantValue,
+
+    /// If the constant contains a type ascription, as specified
+    /// when the constant is declared, e.g. `32.4f64`
+    pub suffix: Option<Identifier>,
+}
+
+impl FloatConstant {
+    /// Create a new [FloatConstant] from the given value and suffix.
+    pub fn new(value: FloatConstantValue, suffix: Option<Identifier>) -> Self {
+        Self { value, suffix }
+    }
+
+    /// Get the value of the float constant as a [f64].
+    pub fn as_f64(self) -> f64 {
+        match self.value {
+            F64(inner) => inner,
+            F32(inner) => inner as f64,
+        }
+    }
+
+    /// Compute the [FloatTy] of the constant.
+    pub fn ty(self) -> FloatTy {
+        match self.value {
+            F64(_) => FloatTy::F64,
+            F32(_) => FloatTy::F32,
+        }
+    }
+}
+
+impl Neg for FloatConstant {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        let value = match self.value {
+            F64(inner) => F64(-inner),
+            F32(inner) => F32(-inner),
+        };
+
+        Self { value, suffix: self.suffix }
+    }
+}
+
+/// Provide implementations for converting primitive floating point types into
+/// [FloatConstant]s.
+macro_rules! float_const_impl_into {
+    ($($ty:ident, $kind: ident);*) => {
+        $(
+            impl From<$ty> for FloatConstant {
+                fn from(value: $ty) -> Self {
+                    Self {
+                        value: FloatConstantValue::$kind(value),
+                        suffix: Some(IDENTS.$ty),
+                    }
+                }
+            }
+        )*
+    };
+}
+
+float_const_impl_into!(f32, F32; f64, F64);
+
+/// A macro to derive `std::ops` on [FloatConstant].
+macro_rules! derive_float_ops {
+    ($($trt: ident, $op:ident);* $(;)?) => {
+        $(
+            impl std::ops::$trt for FloatConstant {
+                type Output = FloatConstant;
+
+                fn $op(self, rhs: Self) -> Self::Output {
+                    match (self.value, rhs.value) {
+                        (F32(lhs), F32(rhs)) => Self::new(F32(lhs.$op(rhs)), self.suffix),
+                        (F64(lhs), F64(rhs)) => Self::new(F64(lhs.$op(rhs)), self.suffix),
+                        _ => unreachable!()
+                    }
+                }
+            }
+        )*
+    };
+}
+
+derive_float_ops!(
+    Add, add;
+    Sub, sub;
+    Mul, mul;
+    Div, div;
+    Rem, rem;
+);
+
+counter! {
+    name: InternedFloat,
+    counter_name: INTERNED_FLOAT_COUNTER,
+    visibility: pub,
+    method_visibility:,
+}
+
+impl fmt::Display for FloatConstant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)?;
+
+        if let Some(suffix) = self.suffix {
+            write!(f, "_{suffix}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for InternedFloat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", CONSTANT_MAP.lookup_float_constant(*self))
+    }
+}
+
+// -------------------- Integers --------------------
+
 /// Value of the [IntConstant], this kind be either the `inlined`
 /// variant where we just fallback to using `u64` for small sized
 /// integer constants, and then in the unlikely scenario of needing
@@ -181,84 +227,167 @@ impl TryFrom<Identifier> for IntTy {
 /// fallback to [BigInt].
 ///
 /// N.B: Values are always stored and accessed in **Big Endian** format.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum IntConstantValue {
-    /// For small values, we store inline
-    Small([u8; 16]),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+
     /// For bigger values, we just store a pointer to the `BigInt`
     Big(Box<BigInt>),
 }
 
 impl IntConstantValue {
-    /// Create a new [IntConstantValue] from little endian ordered bytes.
-    pub fn from_le_bytes(bytes: &[u8]) -> Self {
-        if bytes.len() <= 16 {
-            let mut arr = [0u8; 16];
-            arr[..bytes.len()].copy_from_slice(bytes);
-
-            // If the last byte is negative, we need to sign extend
-            if bytes.last().map(|b| b & 0x80 != 0).unwrap_or(false) {
-                for i in arr.iter_mut().skip(bytes.len()) {
-                    *i = 0xff;
-                }
+    /// Attempt to convert the given value into a [u128] provided that the
+    /// value itself is not [`IntConstantValue::Big`]. If the value is a
+    /// big integer, then [`None`] is returned.
+    pub fn as_u128(self) -> Option<u128> {
+        match self {
+            Self::I8(inner) => {
+                let inner = inner.to_be_bytes();
+                let mut bytes = [0; 16];
+                bytes[15] = inner[0];
+                Some(u128::from_be_bytes(bytes))
             }
+            Self::I16(inner) => {
+                let inner = inner.to_be_bytes();
+                let mut bytes = [0; 16];
+                bytes[14..].copy_from_slice(&inner);
+                Some(u128::from_be_bytes(bytes))
+            }
+            Self::I32(inner) => {
+                let inner = inner.to_be_bytes();
+                let mut bytes = [0; 16];
+                bytes[12..].copy_from_slice(&inner);
+                Some(u128::from_be_bytes(bytes))
+            }
+            Self::I64(inner) => {
+                let inner = inner.to_be_bytes();
+                let mut bytes = [0; 16];
+                bytes[8..].copy_from_slice(&inner);
+                Some(u128::from_be_bytes(bytes))
+            }
+            Self::I128(inner) => Some(u128::from_be_bytes(inner.to_be_bytes())),
 
-            // Then finally reverse
-            arr.reverse();
-            Self::Small(arr)
-        } else {
-            Self::Big(Box::new(BigInt::from_signed_bytes_le(bytes)))
+            // For unsigned values, its fine to just cast them since we're
+            // zero extending them anyways...
+            Self::U8(inner) => Some(inner as u128),
+            Self::U16(inner) => Some(inner as u128),
+            Self::U32(inner) => Some(inner as u128),
+            Self::U64(inner) => Some(inner as u128),
+            Self::U128(inner) => Some(inner),
+            Self::Big(_) => None,
         }
     }
 
-    /// Create a new [IntConstantValue] from big endian ordered bytes
-    pub fn from_be_bytes(bytes: &[u8]) -> Self {
-        if bytes.len() <= 16 {
-            let mut arr = [0u8; 16];
-            arr[..bytes.len()].copy_from_slice(bytes);
+    /// Create a new [IntConstantValue] from little endian ordered bytes.
+    pub fn from_le_bytes(bytes: &[u8], signed: bool) -> Self {
+        match bytes.len() {
+            1 if signed => {
+                let mut arr = [0u8; 1];
+                arr.copy_from_slice(bytes);
 
-            // If the last byte is negative, we need to sign extend
-            // if bytes.last().map(|b| b & 0x80 != 0).unwrap_or(false) {
-            //     for i in arr.iter_mut().skip(bytes.len()) {
-            //         *i = 0xff;
-            //     }
-            // }
+                Self::I8(i8::from_le_bytes(arr))
+            }
+            1 => Self::U8(bytes[0]),
+            2 => {
+                let mut arr = [0u8; 2];
+                arr.copy_from_slice(bytes);
+                Self::I16(i16::from_le_bytes(arr))
+            }
+            4 => {
+                let mut arr = [0u8; 4];
+                arr.copy_from_slice(bytes);
+                Self::I32(i32::from_le_bytes(arr))
+            }
+            8 => {
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(bytes);
+                Self::I64(i64::from_le_bytes(arr))
+            }
 
-            Self::Small(arr)
-        } else {
-            Self::Big(Box::new(BigInt::from_signed_bytes_be(bytes)))
+            16 => {
+                let mut arr = [0u8; 16];
+                arr.copy_from_slice(bytes);
+                Self::I128(i128::from_le_bytes(arr))
+            }
+
+            _ => {
+                assert!(bytes.len() >= 16, "bigints must be at least 16 bytes");
+                Self::Big(Box::new(BigInt::from_signed_bytes_le(bytes)))
+            }
         }
+    }
+
+    /// Create a new [IntConstantValue] from big endian ordered bytes.
+    ///
+    /// N.B. The kind of int constant value is determined by the length
+    /// of the byte array. If the provided `bytes` is for example 8 bytes
+    /// long no sign, then the returned value will be a
+    /// [`IntConstantValue::U64`].
+    pub fn from_be_bytes(bytes: &mut [u8], signed: bool) -> Self {
+        bytes.reverse();
+        IntConstantValue::from_le_bytes(bytes, signed)
     }
 }
 
-impl From<BigInt> for IntConstantValue {
-    fn from(value: BigInt) -> Self {
-        let bits = value.bits();
+/// A macro to derive `std::ops` on [IntConstantValue].
+macro_rules! derive_int_ops {
+    ($($trt: ident, $op:ident);* $(;)?) => {
+        $(
+            impl std::ops::$trt for IntConstant {
+                type Output = IntConstant;
 
-        // We want to see if we can fit this big-int in a `u128` so we can just copy it
-        // directly
-        if bits <= 128 {
-            let data = (<BigInt as TryInto<i128>>::try_into(value).unwrap()).to_be_bytes();
-            IntConstantValue::Small(data)
-        } else {
-            IntConstantValue::Big(Box::new(value))
-        }
-    }
+                fn $op(self, rhs: Self) -> Self::Output {
+                    match (self.value, rhs.value) {
+                        (I8(lhs), I8(rhs)) => Self::new(I8(lhs.$op(rhs)), self.suffix),
+                        (I16(lhs), I16(rhs)) => Self::new(I16(lhs.$op(rhs)), self.suffix),
+                        (I32(lhs), I32(rhs)) => Self::new(I32(lhs.$op(rhs)), self.suffix),
+                        (I64(lhs), I64(rhs)) => Self::new(I64(lhs.$op(rhs)), self.suffix),
+                        (I128(lhs), I128(rhs)) => Self::new(I128(lhs.$op(rhs)), self.suffix),
+                        (U8(lhs), U8(rhs)) => Self::new(U8(lhs.$op(rhs)), self.suffix),
+                        (U16(lhs), U16(rhs)) => Self::new(U16(lhs.$op(rhs)), self.suffix),
+                        (U32(lhs), U32(rhs)) => Self::new(U32(lhs.$op(rhs)), self.suffix),
+                        (U64(lhs), U64(rhs)) => Self::new(U64(lhs.$op(rhs)), self.suffix),
+                        (U128(lhs), U128(rhs)) => Self::new(U128(lhs.$op(rhs)), self.suffix),
+                        _ => unreachable!()
+                    }
+                }
+            }
+        )*
+    };
+}
+
+derive_int_ops! {
+    Add, add;
+    Sub, sub;
+    Mul, mul;
+    Div, div;
+    Rem, rem;
+    BitAnd, bitand;
+    BitOr, bitor;
+    BitXor, bitxor;
+    Shl, shl;
+    Shr, shr
 }
 
 /// Interned literal constant which stores the raw value of the
 /// integer and an optional `type ascription` which binds the
 /// defined literal value to some ascribed type.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IntConstant {
     /// Raw value of the integer. This is stored as either a `u128` which can be
     /// directly stored as the value which happens in `99%` of cases, if the
     /// constant is not big enough to store this integer, then we resort to
     /// using [IntConstant
-    value: IntConstantValue,
-
-    /// The type of the int constant that is stored.
-    pub ty: IntTy,
+    pub value: IntConstantValue,
 
     /// If the constant contains a type ascription, as specified
     /// when the constant is declared, e.g. `32u64`
@@ -267,54 +396,149 @@ pub struct IntConstant {
 
 impl IntConstant {
     /// Create a new [IntConstant] from a given `value` and `ty`.
-    pub fn new(value: IntConstantValue, ty: IntTy, suffix: Option<Identifier>) -> Self {
-        Self { value, ty, suffix }
+    pub fn new(value: IntConstantValue, suffix: Option<Identifier>) -> Self {
+        Self { value, suffix }
     }
 
-    /// Create a [IntConstant] from the a provided value and suffix, and then
-    /// insert it into the [ConstantMap] returning the [InternedInt].
-    pub fn from_big_int(value: BigInt, ty: IntTy, suffix: Option<Identifier>) -> Self {
-        Self { value: IntConstantValue::from(value), ty, suffix }
+    /// Create a [IntConstant] from a given unsigned integer value and specified
+    /// unsigned integer type.
+    ///
+    /// N.B. This is meant for only converting **unsigned** integers into
+    /// constants.
+    pub fn from_uint(value: u128, ty: UIntTy) -> Self {
+        let value = match ty {
+            UIntTy::U8 => IntConstantValue::U8(value as u8),
+            UIntTy::U16 => IntConstantValue::U16(value as u16),
+            UIntTy::U32 => IntConstantValue::U32(value as u32),
+            UIntTy::U64 => IntConstantValue::U64(value as u64),
+            UIntTy::U128 => IntConstantValue::U128(value),
+            UIntTy::UBig => IntConstantValue::Big(Box::new(BigInt::from(value))),
+            _ => unreachable!("un-normalised integer type"),
+        };
+
+        Self { value, suffix: None }
     }
 
-    /// Create a [IntConstant] from a given value and specified type.
-    pub fn from_uint(value: u128, ty: IntTy) -> Self {
-        Self { value: IntConstantValue::from_be_bytes(&value.to_be_bytes()), ty, suffix: None }
+    /// Create a [IntConstant] from a given signed integer type.
+    ///
+    /// N.B. This is meant for only converting **signed** integers into
+    /// constants.
+    pub fn from_sint(value: i128, ty: SIntTy) -> Self {
+        let value = match ty {
+            SIntTy::I8 => IntConstantValue::I8(value as i8),
+            SIntTy::I16 => IntConstantValue::I16(value as i16),
+            SIntTy::I32 => IntConstantValue::I32(value as i32),
+            SIntTy::I64 => IntConstantValue::I64(value as i64),
+            SIntTy::I128 => IntConstantValue::I128(value),
+            SIntTy::IBig => IntConstantValue::Big(Box::new(BigInt::from(value))),
+            _ => unreachable!("un-normalised integer type"),
+        };
+
+        Self { value, suffix: None }
     }
 
-    /// Create a [IntConstant] from a given value and specified type.
-    pub fn from_int(value: i128, ty: IntTy) -> Self {
-        Self { value: IntConstantValue::from_be_bytes(&value.to_be_bytes()), ty, suffix: None }
+    /// Create a new [IntConstant] from a given `value` and `ty`.
+    ///
+    /// N.B. The scalar value assumes that the values are in big
+    /// endian order.
+    pub fn from_scalar(value: [u8; 16], ty: IntTy, ptr_width: usize) -> Self {
+        let size = ty.size(ptr_width).unwrap();
+
+        // compute the correct slice that we need to use in order to
+        // construct the correct integer value.
+        let index = (16 - size.bytes()) as usize;
+        let mut value = value;
+
+        let value = match ty {
+            IntTy::Int(_) => IntConstantValue::from_be_bytes(&mut value[index..], true),
+            IntTy::UInt(_) => IntConstantValue::from_be_bytes(&mut value[index..], false),
+        };
+
+        Self { value, suffix: None }
     }
 
-    /// Create a [IntConstant] from Little endian bytes and an [IntTy]. It is
-    /// assumed that the correct amount of bytes are provided to this
-    /// function.
-    pub fn from_le_bytes(&self, bytes: &[u8], ty: IntTy) -> Self {
-        IntConstant { value: IntConstantValue::from_le_bytes(bytes), ty, suffix: None }
+    /// Get the bytes of a constant value assuming that it is
+    /// a primitive integer type.
+    ///
+    /// N.B. This returns bytes in Big Endian order.
+    pub fn bytes_be(&self) -> [u8; 16] {
+        match self.value {
+            IntConstantValue::I8(v) => {
+                let mut data = [0; 16];
+                data[15] = v as u8;
+                data
+            }
+            IntConstantValue::I16(v) => {
+                let mut data = [0; 16];
+                data[14..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::I32(v) => {
+                let mut data = [0; 16];
+                data[12..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::I64(v) => {
+                let mut data = [0; 16];
+                data[8..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::I128(v) => v.to_be_bytes(),
+            IntConstantValue::U8(v) => {
+                let mut data = [0; 16];
+                data[15] = v;
+                data
+            }
+            IntConstantValue::U16(v) => {
+                let mut data = [0; 16];
+                data[14..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::U32(v) => {
+                let mut data = [0; 16];
+                data[12..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::U64(v) => {
+                let mut data = [0; 16];
+                data[8..16].copy_from_slice(&v.to_be_bytes());
+                data
+            }
+            IntConstantValue::U128(v) => v.to_be_bytes(),
+            IntConstantValue::Big(_) => unreachable!(),
+        }
     }
 
-    /// Convert the constant into a Big endian order byte stream.
-    pub fn to_bytes_be(&self) -> Vec<u8> {
+    /// Compute the [IntTy] of the constant.
+    pub fn ty(&self) -> IntTy {
+        use IntConstantValue::*;
+
+        // If the suffix is specified, then we use it as that, this
+        // is only specific to the `usize` problem since we don't
+        // store specific `usize` variants in the constant since
+        // we want to make it platform independent.
+        if let Some(suffix) = self.suffix {
+            return suffix.try_into().unwrap();
+        }
+
         match &self.value {
-            IntConstantValue::Small(value) => value.to_vec(),
-            IntConstantValue::Big(value) => value.to_signed_bytes_be(),
-        }
-    }
-
-    /// Convert the constant into the "small" variant.
-    pub fn as_small(self) -> Option<u128> {
-        match self.value {
-            IntConstantValue::Small(inner) => Some(u128::from_be_bytes(inner)),
-            IntConstantValue::Big(_) => None,
-        }
-    }
-
-    /// Convert the constant into a [BigInt].
-    pub fn as_big(self) -> BigInt {
-        match self.value {
-            IntConstantValue::Small(inner) => BigInt::from_signed_bytes_be(&inner),
-            IntConstantValue::Big(inner) => *inner,
+            I8(_) => IntTy::Int(SIntTy::I8),
+            I16(_) => IntTy::Int(SIntTy::I16),
+            I32(_) => IntTy::Int(SIntTy::I32),
+            I64(_) => IntTy::Int(SIntTy::I64),
+            I128(_) => IntTy::Int(SIntTy::I128),
+            U8(_) => IntTy::UInt(UIntTy::U8),
+            U16(_) => IntTy::UInt(UIntTy::U16),
+            U32(_) => IntTy::UInt(UIntTy::U32),
+            U64(_) => IntTy::UInt(UIntTy::U64),
+            U128(_) => IntTy::UInt(UIntTy::U128),
+            Big(value) => {
+                if value.sign() == Sign::NoSign {
+                    IntTy::UInt(UIntTy::UBig)
+                } else {
+                    IntTy::Int(SIntTy::IBig)
+                }
+            }
         }
     }
 
@@ -323,76 +547,79 @@ impl IntConstant {
     /// suffix is specified, the assumed type of the integer constant is `i32`
     /// and therefore this follows the same assumption.
     pub fn is_signed(&self) -> bool {
-        self.ty.is_signed()
-    }
+        use IntConstantValue::*;
 
-    /// Check if the [IntConstant] is represented as the
-    /// [IntConstantValue::Small], as in this is an integer type that is not
-    /// represented using a `ibig` or `ubig` type.
-    pub fn is_small(&self) -> bool {
-        matches!(self.value, IntConstantValue::Small(_))
-    }
-
-    /// Assuming that the [IntConstant] is a represented as a
-    /// [IntConstantValue::Small], then this function will read the bytes of
-    /// this scalar int.
-    pub fn get_bytes(&self) -> [u8; 16] {
-        match &self.value {
-            IntConstantValue::Small(value) => *value,
-            _ => unreachable!(),
+        match self.value {
+            I8(_) | I16(_) | I32(_) | I64(_) | I128(_) => true,
+            Big(ref t) if t.sign() != Sign::NoSign => true,
+            _ => false,
         }
     }
+}
 
-    /// Negate the [IntConstant] provided that the constant is signed. If
-    /// the constant is not signed, then no negation operation is applied.
-    pub fn negate(self) -> Self {
-        // Do nothing if this constant is not signed.
-        if !self.is_signed() {
-            return self;
-        }
+impl Neg for IntConstant {
+    type Output = Self;
 
+    fn neg(self) -> Self::Output {
         let value = match self.value {
-            IntConstantValue::Small(inner) => {
-                // @@Todo: don't always assume that this is a 64 biy integer.
-
-                // Flip the sign, and the convert back to `be` bytes
-                let value = -i128::from_be_bytes(inner);
-                IntConstantValue::Small(value.to_be_bytes())
-            }
-            IntConstantValue::Big(inner) => IntConstantValue::Big(Box::new(inner.neg())),
+            I8(t) => I8(-t),
+            I16(t) => I16(-t),
+            I32(t) => I32(-t),
+            I64(t) => I64(-t),
+            I128(t) => I128(-t),
+            Big(box t) => Big(Box::new(-t)),
+            _ => unreachable!(),
         };
 
-        Self { value, ty: self.ty, suffix: self.suffix }
+        Self { value, suffix: self.suffix }
+    }
+}
+
+impl From<BigInt> for IntConstant {
+    fn from(value: BigInt) -> Self {
+        let (sign, mut bytes) = value.to_bytes_be();
+        let value = IntConstantValue::from_be_bytes(&mut bytes, sign == Sign::NoSign);
+
+        Self { value, suffix: None }
+    }
+}
+
+impl From<IntConstant> for BigInt {
+    fn from(constant: IntConstant) -> Self {
+        match constant.value {
+            I8(v) => BigInt::from(v),
+            I16(v) => BigInt::from(v),
+            I32(v) => BigInt::from(v),
+            I64(v) => BigInt::from(v),
+            I128(v) => BigInt::from(v),
+            U8(v) => BigInt::from(v),
+            U16(v) => BigInt::from(v),
+            U32(v) => BigInt::from(v),
+            U64(v) => BigInt::from(v),
+            U128(v) => BigInt::from(v),
+            Big(v) => (*v).clone(),
+        }
     }
 }
 
 impl PartialOrd for IntConstant {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (self.ty, other.ty) {
-            (IntTy::Int(left), IntTy::Int(right)) if left == right => {
-                // We need to get the value from the constant, and then
-                // perform a comparison on the two values.
-                if self.is_small() && other.is_small() {
-                    let left_val = i128::from_be_bytes(self.get_bytes());
-                    let right_val = i128::from_be_bytes(other.get_bytes());
+        use IntConstantValue::*;
 
-                    Some(left_val.cmp(&right_val))
-                } else {
-                    // Deal with bigints...
-                    unimplemented!()
-                }
-            }
-            (IntTy::UInt(left), IntTy::UInt(right)) if left == right => {
-                if self.is_small() && other.is_small() {
-                    let left_val = u128::from_be_bytes(self.get_bytes());
-                    let right_val = u128::from_be_bytes(other.get_bytes());
-
-                    Some(left_val.cmp(&right_val))
-                } else {
-                    // Deal with bigints...
-                    unimplemented!()
-                }
-            }
+        // We need to get the value from the constant, and then
+        // perform a comparison on the two values.
+        match (&self.value, &other.value) {
+            (I8(left), I8(right)) => Some(left.cmp(right)),
+            (I16(left), I16(right)) => Some(left.cmp(right)),
+            (I32(left), I32(right)) => Some(left.cmp(right)),
+            (I64(left), I64(right)) => Some(left.cmp(right)),
+            (I128(left), I128(right)) => Some(left.cmp(right)),
+            (U8(left), U8(right)) => Some(left.cmp(right)),
+            (U16(left), U16(right)) => Some(left.cmp(right)),
+            (U32(left), U32(right)) => Some(left.cmp(right)),
+            (U64(left), U64(right)) => Some(left.cmp(right)),
+            (U128(left), U128(right)) => Some(left.cmp(right)),
+            (Big(left), Big(right)) => Some(left.cmp(right)),
             _ => None,
         }
     }
@@ -401,51 +628,66 @@ impl PartialOrd for IntConstant {
 /// Provide implementations for converting primitive integer types into
 /// [IntConstant]s.
 macro_rules! int_const_impl_from {
-    ($($ty:ident),*; $into: ty) => {
+    ($($ty:ident: $variant: ident),* $(,)?) => {
         $(
             impl From<$ty> for IntConstant {
                 fn from(value: $ty) -> Self {
                     Self {
-                        value: IntConstantValue::Small((value as $into).to_be_bytes()),
-                        // @@Hack: derive the type into the identifier, this is to
-                        // avoid using a procedural macro to derive the type.
-                        ty: (IDENTS.$ty).try_into().unwrap(),
+                        value: IntConstantValue::$variant(value),
                         suffix: Some(IDENTS.$ty)
                     }
                 }
             }
         )*
     };
-    () => {
-    };
 }
 
-int_const_impl_from!(i8, i16, i32, i64, isize, i128; i128);
-int_const_impl_from!(u8, u16, u32, u64, usize, u128; u128);
+int_const_impl_from!(
+    i8: I8,
+    i16: I16,
+    i32: I32,
+    i64: I64,
+    i128: I128,
+    u8: U8,
+    u16: U16,
+    u32: U32,
+    u64: U64,
+    u128: U128,
+);
 
-/// Provide implementations for converting [IntConstant]s into primitive
-/// integer types. This uses the system defined sizes for the primitive
-/// integer types, and should not be used to reliably convert into target
-/// sized integers.
+// /// Provide implementations for converting [IntConstant]s into primitive
+// /// integer types. This uses the system defined sizes for the primitive
+// /// integer types, and should not be used to reliably convert into target
+// /// sized integers.
 macro_rules! int_const_impl_into {
-    ($($ty:ident),*; $cast: ty) => {
+    ($($ty:ident),* $(,)?) => {
         $(
             impl TryFrom<IntConstant> for $ty {
                 type Error = ();
 
-                fn try_from(value: IntConstant) -> Result<Self, Self::Error> {
-                    debug_assert!(value.is_small());
-                    <$cast>::from_be_bytes(value.get_bytes()).try_into().map_err(|_| ())
+                fn try_from(constant: IntConstant) -> Result<Self, Self::Error> {
+                    use IntConstantValue::*;
+
+                    match constant.value {
+                        I8(value) => value.try_into().map_err(|_| ()),
+                        I16(value) => value.try_into().map_err(|_| ()),
+                        I32(value) => value.try_into().map_err(|_| ()),
+                        I64(value) => value.try_into().map_err(|_| ()),
+                        I128(value) => value.try_into().map_err(|_| ()),
+                        U8(value) => value.try_into().map_err(|_| ()),
+                        U16(value) => value.try_into().map_err(|_| ()),
+                        U32(value) => value.try_into().map_err(|_| ()),
+                        U64(value) => value.try_into().map_err(|_| ()),
+                        U128(value) => value.try_into().map_err(|_| ()),
+                        Big(box value) => value.try_into().map_err(|_| ()),
+                    }
                 }
             }
         )*
     };
-    () => {
-    };
 }
 
-int_const_impl_into!(i8, i16, i32, i64, isize, i128; i128);
-int_const_impl_into!(u8, u16, u32, u64, usize, u128; u128);
+int_const_impl_into!(i8, i16, i32, i64, isize, i128, u8, u16, u32, u64, usize, u128);
 
 counter! {
     name: InternedInt,
@@ -459,17 +701,18 @@ impl fmt::Display for IntConstant {
         match &self.value {
             // We want to snip the value from the `total` value since we don't care about the
             // rest...
-            IntConstantValue::Small(value) => {
-                if self.is_signed() {
-                    write!(f, "{}", i128::from_be_bytes(*value))?;
-                } else {
-                    write!(f, "{}", u128::from_be_bytes(*value))?;
-                }
-            }
-            IntConstantValue::Big(value) => write!(f, "{value}")?,
+            I8(value) => write!(f, "{value}_i8"),
+            I16(value) => write!(f, "{value}_i16"),
+            I32(value) => write!(f, "{value}_i32"),
+            I64(value) => write!(f, "{value}_i64"),
+            I128(value) => write!(f, "{value}_i128"),
+            U8(value) => write!(f, "{value}_u8"),
+            U16(value) => write!(f, "{value}_u16"),
+            U32(value) => write!(f, "{value}_u32"),
+            U64(value) => write!(f, "{value}_u64"),
+            U128(value) => write!(f, "{value}_u128"),
+            Big(value) => write!(f, "{value}"),
         }
-
-        write!(f, "_{}", self.ty)
     }
 }
 
@@ -478,6 +721,18 @@ impl fmt::Display for InternedInt {
         write!(f, "{}", CONSTANT_MAP.lookup_int_constant(*self))
     }
 }
+
+/// Convert a given `i128` value with an associated [IntTy] and convert
+/// it into an IntConstantValue.
+pub fn u128_to_int_const(value: u128, kind: IntTy, ptr_width: usize) -> InternedInt {
+    let size = kind.size(ptr_width).unwrap().bytes() as usize;
+    let is_signed = kind.is_signed();
+
+    let value = IntConstantValue::from_le_bytes(&value.to_le_bytes()[0..size], is_signed);
+    CONSTANT_MAP.create_int_constant(IntConstant { value, suffix: None })
+}
+
+// -------------------- Strings --------------------
 
 counter! {
     name: InternedStr,
@@ -571,8 +826,7 @@ impl ConstantMap {
         value: f64,
         suffix: Option<Identifier>,
     ) -> InternedFloat {
-        let constant =
-            FloatConstant { value: FloatConstantValue::F64(value), ty: FloatTy::F64, suffix };
+        let constant = FloatConstant { value: FloatConstantValue::F64(value), suffix };
         self.create_float_constant(constant)
     }
 
@@ -582,8 +836,7 @@ impl ConstantMap {
         value: f32,
         suffix: Option<Identifier>,
     ) -> InternedFloat {
-        let constant =
-            FloatConstant { value: FloatConstantValue::F32(value), ty: FloatTy::F32, suffix };
+        let constant = FloatConstant { value: FloatConstantValue::F32(value), suffix };
         self.create_float_constant(constant)
     }
 
@@ -602,7 +855,12 @@ impl ConstantMap {
 
     /// Perform a negation operation on an [InternedFloat].
     pub fn negate_float_constant(&self, id: InternedFloat) {
-        self.float_table.alter(&id, |_, value| value.negate());
+        self.float_table.alter(&id, |_, value| -value);
+    }
+
+    /// Perform a negation operation on an [InternedInt].
+    pub fn negate_int_constant(&self, id: InternedInt) {
+        self.int_table.alter(&id, |_, value| -value);
     }
 
     /// Create a [IntConstant] within the [ConstantMap].
@@ -617,14 +875,7 @@ impl ConstantMap {
     /// Get the [IntConstant] behind the [InternedInt]
     pub fn lookup_int_constant(&self, id: InternedInt) -> IntConstant {
         let lookup_value = self.int_table.get(&id).unwrap();
-        let IntConstant { value, ty, suffix } = lookup_value.value();
-
-        let value = match value {
-            IntConstantValue::Small(inner) => IntConstantValue::Small(*inner),
-            IntConstantValue::Big(inner) => IntConstantValue::Big(inner.clone()),
-        };
-
-        IntConstant { value, ty: *ty, suffix: *suffix }
+        lookup_value.value().clone()
     }
 
     /// Perform a transformation on the [IntConstant] behind the [InternedInt]
@@ -644,14 +895,6 @@ impl ConstantMap {
         let lookup_value = self.float_table.get(&id).unwrap();
         f(lookup_value.value())
     }
-
-    /// Perform a negation operation on an [InternedInt].
-    ///
-    /// N.B: This function has no effect on the stored constant if it is not
-    /// signed.
-    pub fn negate_int_constant(&self, id: InternedInt) {
-        self.int_table.alter(&id, |_, value| value.negate());
-    }
 }
 
 #[cfg(test)]
@@ -661,8 +904,6 @@ mod tests {
         size::Size,
     };
     use num_bigint::BigInt;
-
-    use crate::constant::IntConstantValue;
 
     #[test]
     fn test_max_signed_int_value() {
@@ -688,33 +929,5 @@ mod tests {
 
         assert_eq!(UIntTy::USize.size(4), Some(Size::from_bytes(4)));
         assert_eq!(UIntTy::USize.size(8), Some(Size::from_bytes(8)));
-    }
-
-    #[test]
-    fn test_int_constant_conversions() {
-        let value = -7i32;
-        let constant = IntConstantValue::from_le_bytes(&value.to_le_bytes());
-        assert_eq!(
-            IntConstantValue::Small([
-                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 249
-            ]),
-            constant
-        );
-
-        let value = -7i32;
-        let constant = IntConstantValue::from_le_bytes(&value.to_le_bytes());
-        assert_eq!(
-            IntConstantValue::Small([
-                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 249
-            ]),
-            constant
-        );
-
-        let value = 7i32;
-        let constant = IntConstantValue::from_le_bytes(&value.to_le_bytes());
-        assert_eq!(
-            IntConstantValue::Small([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7]),
-            constant
-        );
     }
 }

--- a/compiler/hash-source/src/lib.rs
+++ b/compiler/hash-source/src/lib.rs
@@ -1,5 +1,5 @@
 //! Hash Compiler source location definitions.
-#![feature(path_file_prefix, let_chains, once_cell)]
+#![feature(path_file_prefix, let_chains, once_cell, box_patterns)]
 
 pub mod attributes;
 pub mod constant;

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -139,6 +139,20 @@ impl UIntTy {
     }
 }
 
+impl From<SIntTy> for UIntTy {
+    fn from(value: SIntTy) -> Self {
+        match value {
+            SIntTy::I8 => UIntTy::U8,
+            SIntTy::I16 => UIntTy::U16,
+            SIntTy::I32 => UIntTy::U32,
+            SIntTy::I64 => UIntTy::U64,
+            SIntTy::I128 => UIntTy::U128,
+            SIntTy::ISize => UIntTy::USize,
+            SIntTy::IBig => UIntTy::UBig,
+        }
+    }
+}
+
 impl From<Integer> for UIntTy {
     fn from(value: Integer) -> Self {
         match value {
@@ -266,6 +280,20 @@ impl SIntTy {
     }
 }
 
+impl From<UIntTy> for SIntTy {
+    fn from(value: UIntTy) -> Self {
+        match value {
+            UIntTy::U8 => SIntTy::I8,
+            UIntTy::U16 => SIntTy::I16,
+            UIntTy::U32 => SIntTy::I32,
+            UIntTy::U64 => SIntTy::I64,
+            UIntTy::U128 => SIntTy::I128,
+            UIntTy::USize => SIntTy::ISize,
+            UIntTy::UBig => SIntTy::IBig,
+        }
+    }
+}
+
 impl From<Integer> for SIntTy {
     fn from(value: Integer) -> Self {
         match value {
@@ -358,6 +386,31 @@ impl IntTy {
     /// Check if the type is a [BigInt] variant, i.e. `ibig` or `ubig`.
     pub fn is_big_sized_integral(self) -> bool {
         matches!(self, IntTy::Int(SIntTy::IBig) | IntTy::UInt(UIntTy::UBig))
+    }
+
+    /// Normalise an [IntTy] by removing "usize" and "isize" variants into
+    /// known sized variants.
+    pub fn normalise(self, ptr_width: usize) -> Self {
+        match self {
+            IntTy::Int(ty) => IntTy::Int(ty.normalise(ptr_width)),
+            IntTy::UInt(ty) => IntTy::UInt(ty.normalise(ptr_width)),
+        }
+    }
+
+    /// Convert any [IntTy] into a [UIntTy] variant.
+    pub fn to_unsigned(self) -> UIntTy {
+        match self {
+            IntTy::Int(ty) => ty.into(),
+            IntTy::UInt(ty) => ty,
+        }
+    }
+
+    /// Convert any [IntTy] into a [SIntTy] variant.
+    pub fn to_signed(self) -> SIntTy {
+        match self {
+            IntTy::Int(ty) => ty,
+            IntTy::UInt(ty) => ty.into(),
+        }
     }
 }
 

--- a/compiler/hash-tir/src/new/lits.rs
+++ b/compiler/hash-tir/src/new/lits.rs
@@ -23,7 +23,7 @@ pub struct IntLit {
 impl IntLit {
     /// Return the value of the integer literal.
     pub fn value(&self) -> BigInt {
-        CONSTANT_MAP.lookup_int_constant(self.underlying.value).as_big()
+        CONSTANT_MAP.lookup_int_constant(self.underlying.value).into()
     }
 }
 

--- a/compiler/hash-tir/src/new/lits.rs
+++ b/compiler/hash-tir/src/new/lits.rs
@@ -23,7 +23,7 @@ pub struct IntLit {
 impl IntLit {
     /// Return the value of the integer literal.
     pub fn value(&self) -> BigInt {
-        CONSTANT_MAP.lookup_int_constant(self.underlying.value).into()
+        (&CONSTANT_MAP.lookup_int_constant(self.underlying.value)).try_into().unwrap()
     }
 }
 

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -761,7 +761,8 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                         // same for max, what we want to do is write `MIN`
                         // and `MAX for these situations since it is easier for the
                         // user to understand the problem
-                        let value: BigInt = CONSTANT_MAP.lookup_int_constant(*value).into();
+                        let value: BigInt =
+                            (&CONSTANT_MAP.lookup_int_constant(*value)).try_into().unwrap();
 
                         if let Some(min) = kind.min(pointer_width) && min == value {
                             write!(f, "{kind}::MIN")

--- a/compiler/hash-tir/src/terms.rs
+++ b/compiler/hash-tir/src/terms.rs
@@ -16,6 +16,7 @@ use hash_utils::{
         CloneStore, DefaultSequenceStore, DefaultStore, SequenceStore, SequenceStoreKey, Store,
     },
 };
+use num_bigint::BigInt;
 
 use crate::{
     args::ArgsId,
@@ -753,14 +754,14 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                     }
                     LitTerm::Int { value } => {
                         let pointer_width = self.global_storage.pointer_width;
-                        let kind = CONSTANT_MAP.map_int_constant(*value, |val| val.ty);
+                        let kind = CONSTANT_MAP.map_int_constant(*value, |val| val.ty());
 
                         // It's often the case that users don't include the range of the entire
                         // integer and so we will write `-2147483648..x` and
                         // same for max, what we want to do is write `MIN`
                         // and `MAX for these situations since it is easier for the
                         // user to understand the problem
-                        let value = CONSTANT_MAP.lookup_int_constant(*value).as_big();
+                        let value: BigInt = CONSTANT_MAP.lookup_int_constant(*value).into();
 
                         if let Some(min) = kind.min(pointer_width) && min == value {
                             write!(f, "{kind}::MIN")


### PR DESCRIPTION
This PR refactors the handling of integer constants within the compiler to just use integer slots rather than storing them as a singular scalar and converting between one and the other.  