### PR TITLE
Add AtomInfo store to store inference of terms to their types

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -85,6 +85,7 @@ defined_intrinsics! {
     un_op,
     abort,
     user_error,
+    debug_print,
 }
 
 impl Debug for DefinedIntrinsics {
@@ -645,6 +646,27 @@ impl DefinedIntrinsics {
             },
         );
 
+        let debug_print = {
+            let t_sym = env.new_symbol("T");
+            let a_sym = env.new_symbol("a");
+            let params = env.param_utils().create_params(
+                [
+                    ParamData { default: None, name: t_sym, ty: env.new_small_universe_ty() },
+                    ParamData { default: None, name: a_sym, ty: env.new_ty(t_sym) },
+                ]
+                .into_iter(),
+            );
+            let ret = env.new_void_ty();
+            add(
+                "debug_print",
+                FnTy::builder().params(params).return_ty(ret).build(),
+                |env, args| {
+                    println!("{}", env.env().with(args[1]));
+                    Ok(env.new_void_term())
+                },
+            )
+        };
+
         // Primitive type equality
         let prim_type_eq_op = Self::add_prim_type_eq_op(env, &implementations);
 
@@ -665,6 +687,7 @@ impl DefinedIntrinsics {
             un_op,
             abort,
             user_error,
+            debug_print,
         }
     }
 

--- a/compiler/hash-semantics/src/new/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/new/passes/inference/mod.rs
@@ -56,7 +56,7 @@ impl<'tc> AstPass for InferencePass<'tc> {
         node: ast::AstNodeRef<ast::BodyBlock>,
     ) -> crate::new::diagnostics::error::SemanticResult<()> {
         // Infer the expression
-        let (term, ty) = self.infer_fully(
+        let (term, _) = self.infer_fully(
             (self.ast_info().terms().get_data_by_node(node.id()).unwrap(), self.new_ty_hole()),
             |(term_id, ty_id)| self.inference_ops().infer_term(term_id, ty_id),
             |(term_id, ty_id)| {
@@ -68,8 +68,7 @@ impl<'tc> AstPass for InferencePass<'tc> {
 
         // @@Temp:
         let evaluated = self.normalisation_ops().normalise(term.into())?;
-        let evaluated_ty = self.normalisation_ops().normalise(ty.into())?;
-        stream_less_writeln!("{}: {}", self.env().with(evaluated), self.env().with(evaluated_ty));
+        stream_less_writeln!("{}", self.env().with(evaluated));
 
         Ok(())
     }
@@ -86,8 +85,36 @@ impl<'tc> AstPass for InferencePass<'tc> {
             |mod_def_id| mod_def_id.into(),
         )?;
 
-        // @@Temp:
         stream_less_writeln!("{}", self.env().with(mod_def_id));
+
+        // @@Todo: #entry_point directive and main type checking
+        //
+        // if let Some(kind) =
+        //     self.source_map().module_kind_by_id(self.current_source_info().source_id)
+        // {
+        //     match kind {
+        //         ModuleKind::Normal => {}
+        //         ModuleKind::Prelude => {}
+        //         ModuleKind::EntryPoint => {
+        //             // Check that the module has a `main` function
+        //             if let Some(fn_def_id) =
+        //                 self.mod_utils().get_mod_fn_member_by_ident(mod_def_id,
+        // "main")             {
+        //                 let _call_term = self.new_term(FnCallTerm {
+        //                     subject: self.new_term(fn_def_id),
+        //                     implicit: false,
+        //                     args: self.new_empty_args(),
+        //                 });
+
+        //                 // let (inferred_call_term, _) =
+        //                 //     self.inference_ops().infer_term(call_term,
+        //                 // self.new_void_ty())?; let _ =
+        //                 // self.normalisation_ops().
+        //                 // normalise(inferred_call_term.into())?;
+        //             }
+        //         }
+        //     }
+        // }
 
         Ok(())
     }

--- a/compiler/hash-tir/src/new/args.rs
+++ b/compiler/hash-tir/src/new/args.rs
@@ -162,8 +162,8 @@ impl fmt::Display for WithEnv<'_, SomeArgsId> {
 impl fmt::Display for WithEnv<'_, &Arg> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value.target {
-            ParamIndex::Name(name) => {
-                write!(f, "{} = {}", name, self.env().with(self.value.value))
+            ParamIndex::Name(_) => {
+                write!(f, "{}", self.env().with(self.value.value))
             }
             ParamIndex::Position(_) => write!(f, "{}", self.env().with(self.value.value)),
         }

--- a/compiler/hash-tir/src/new/atom_info.rs
+++ b/compiler/hash-tir/src/new/atom_info.rs
@@ -1,0 +1,171 @@
+//! [`AtomInfoStore`] is a store that contains information about atoms in the
+//! program, specifically their types.
+use std::hash::Hash;
+
+use hash_utils::store::{DefaultPartialStore, PartialCloneStore, PartialStore};
+
+use super::{
+    args::{ArgsId, PatArgsId},
+    environment::env::AccessToEnv,
+    params::ParamsId,
+    pats::PatId,
+    terms::TermId,
+    tys::TyId,
+};
+
+/// Information about an atom in the program.
+///
+/// Atoms are terms, types, patterns, argument lists.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AtomInfo<Item: Copy, ItemTy: Copy> {
+    /// The original data for this atom.
+    ///
+    /// The first member is the original item, the second member is the original
+    /// type of the item if provided.
+    original: (Item, Option<ItemTy>),
+    /// The inferred data for this atom.
+    ///
+    /// If present, the first member is the inferred item, the second member is
+    /// the inferred type of the item.
+    inferred: Option<(Item, ItemTy)>,
+}
+
+impl<Item: Copy, ItemTy: Copy> AtomInfo<Item, ItemTy> {
+    /// Create an empty atom info, only containing the original value.
+    pub fn empty(original: Item) -> Self {
+        Self { original: (original, None), inferred: None }
+    }
+
+    /// Create an atom info with the original value and type.
+    pub fn with_original_ty(original: Item, original_ty: ItemTy) -> Self {
+        Self { original: (original, Some(original_ty)), inferred: None }
+    }
+}
+
+pub type AtomInfoStoreData<K, KT> = DefaultPartialStore<K, AtomInfo<K, KT>>;
+
+/// Convenient trait to perform operations on [`AtomInfoStore`] for each key
+/// type.
+pub trait ItemInAtomInfo<Item: Copy + Eq + Hash, ItemTy: Copy>: AccessToEnv {
+    fn data(&self) -> &AtomInfoStoreData<Item, ItemTy>;
+
+    /// Create a new atom info with the given value.
+    fn register_new_atom_without_ty(&self, value: Item) {
+        self.data().insert(value, AtomInfo::empty(value));
+    }
+
+    /// Create a new atom info with the given value and type.
+    fn register_new_atom(&self, value: Item, ty: ItemTy) {
+        self.data().insert(value, AtomInfo::with_original_ty(value, ty));
+    }
+
+    /// Get the atom info for the given value, if it exists.
+    fn try_get_atom_info(&self, value: Item) -> Option<AtomInfo<Item, ItemTy>> {
+        self.data().get(value)
+    }
+
+    /// Get the inferred value for the given atom.
+    fn try_get_inferred_value(&self, value: Item) -> Option<Item> {
+        Some(self.data().get(value)?.inferred?.0)
+    }
+
+    /// Get the inferred type for the given atom.
+    fn try_get_inferred_ty(&self, value: Item) -> Option<ItemTy> {
+        Some(self.data().get(value)?.inferred?.1)
+    }
+
+    /// Get the inferred value for the given atom.
+    ///
+    /// This will panic if no inferred value is
+    /// present.
+    fn get_inferred_value(&self, value: Item) -> Item {
+        self.data().get(value).unwrap().inferred.unwrap().0
+    }
+
+    /// Get the inferred type for the given atom.
+    ///
+    /// This will panic if no inferred type is
+    /// present.
+    fn get_inferred_ty(&self, value: Item) -> ItemTy {
+        self.data().get(value).unwrap().inferred.unwrap().1
+    }
+
+    /// Get the atom info for the given value, or empty atom info if it doesn't.
+    fn get_atom_info(&self, key: Item) -> AtomInfo<Item, ItemTy> {
+        self.data().get(key).unwrap_or_else(|| AtomInfo::empty(key))
+    }
+
+    /// Register the inferred value and type, for the given value.
+    fn register_atom_inference(&self, key: Item, inferred: Item, inferred_ty: ItemTy) {
+        let is_present = self.data().modify_fast(key, |info| match info {
+            Some(info) => {
+                info.inferred = Some((inferred, inferred_ty));
+                true
+            }
+            None => false,
+        });
+        if !is_present {
+            // Add the original value and type, and the inferred value and
+            // type.
+            self.data().insert(
+                key,
+                AtomInfo { original: (key, None), inferred: Some((inferred, inferred_ty)) },
+            );
+        }
+
+        if key != inferred {
+            // Set the mapping from the inferred value to itself too.
+            self.register_atom_inference(inferred, inferred, inferred_ty)
+        }
+    }
+}
+macro_rules! atom_info {
+    ($($name:ident: <$item:ident, $item_ty:ty>),* $(,)?) => {
+        #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+        pub enum AtomInfoStoreItem {
+            $(
+                $item($item),
+            )*
+        }
+
+        #[derive(Debug)]
+        pub struct AtomInfoStore {
+            $(
+                pub $name: AtomInfoStoreData<$item, $item_ty>,
+            )*
+        }
+
+        impl AtomInfoStore {
+            pub fn new() -> Self {
+                Self {
+                    $(
+                        $name: DefaultPartialStore::new(),
+                    )*
+                }
+            }
+        }
+
+        impl Default for AtomInfoStore {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        $(
+            impl<T: AccessToEnv> ItemInAtomInfo<$item, $item_ty> for T {
+                fn data(&self) -> &AtomInfoStoreData<$item, $item_ty> {
+                    &self.stores().atom_info().$name
+                }
+            }
+        )*
+    };
+}
+
+// Each stored atom, its value and its type:
+atom_info! {
+    terms: <TermId, TyId>,
+    tys: <TyId, TyId>,
+    pats: <PatId, TyId>,
+    args: <ArgsId, ParamsId>,
+    pat_args: <PatArgsId, ParamsId>,
+}

--- a/compiler/hash-tir/src/new/environment/stores.rs
+++ b/compiler/hash-tir/src/new/environment/stores.rs
@@ -12,7 +12,7 @@ use super::super::{
     terms::{TermListStore, TermStore},
     tys::TyStore,
 };
-use crate::new::control::MatchCasesStore;
+use crate::new::{atom_info::AtomInfoStore, control::MatchCasesStore};
 
 /// This macro creates the `Stores` struct, as well as accompanying creation and
 /// access methods, for the given sequence of stores.
@@ -67,6 +67,7 @@ stores! {
     term_list: TermListStore,
     ty: TyStore,
     match_cases: MatchCasesStore,
+    atom_info: AtomInfoStore,
 }
 
 /// A reference to [`Stores`] alongside a value.

--- a/compiler/hash-tir/src/new/mod.rs
+++ b/compiler/hash-tir/src/new/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod access;
 pub mod args;
+pub mod atom_info;
 pub mod casting;
 pub mod control;
 pub mod data;

--- a/compiler/hash-tir/src/new/utils/mod.rs
+++ b/compiler/hash-tir/src/new/utils/mod.rs
@@ -23,7 +23,7 @@ macro_rules! utils {
                 }
             )*
         }
-        impl<T: $crate::new::environment::env::AccessToEnv> AccessToUtils for T { }
+        impl<T: $crate::new::environment::env::AccessToEnv + ?Sized> AccessToUtils for T { }
     };
 }
 

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -7,6 +7,7 @@ use hash_intrinsics::utils::PrimitiveUtils;
 use hash_tir::new::{
     access::AccessTerm,
     args::{ArgData, ArgsId, PatArgsId, PatOrCapture},
+    atom_info::ItemInAtomInfo,
     casting::CastTerm,
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     environment::context::{Binding, BindingKind, ScopeKind},
@@ -247,9 +248,10 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     /// Evaluate a `typeof` term.
     fn eval_type_of(&self, type_of_term: TypeOfTerm) -> Result<Atom, Signal> {
         // Infer the type of the term:
-        // @@Todo: use stored IDs only? Do not reduce if un-inferrable?
-        let (_, ty) = self.inference_ops().infer_term(type_of_term.term, self.new_ty_hole())?;
-        Ok(ty.into())
+        match self.try_get_inferred_ty(type_of_term.term) {
+            Some(ty) => Ok(ty.into()),
+            None => Ok(self.new_term(type_of_term).into()),
+        }
     }
 
     /// Evaluate a loop control term.


### PR DESCRIPTION
This PR adds `AtomInfoStore`, available to `AccessToEnv`. This stores the inferred type of each term, as well as its "resolved" version. You can use it like

```rs
t: TermId or PatId or ArgsId or PatArgsId or TyId

self.get_inferred_ty(t) // : TyId or ParamsId (depending on what t is)
self.get_inferred_value(t) // : typeof t
```

There are also fallible equivalents. See `ItemInAstInfo` trait.

Closes #743 