### PR TITLE
Track directives in the TIR

### DIFF
--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -436,11 +436,22 @@ impl<'tc> ResolutionPass<'tc> {
         // Pass to the inner expression
         let inner = self.make_term_from_ast_expr(node.subject.ast_ref())?;
 
-        // Register directives:
-        self.stores().directives().insert(
-            inner.into(),
-            AppliedDirectives { directives: node.directives.iter().map(|d| d.ident).collect() },
-        );
+        // Register directives on the term:
+        let directives =
+            AppliedDirectives { directives: node.directives.iter().map(|d| d.ident).collect() };
+        self.stores().directives().insert(inner.into(), directives.clone());
+
+        // If this is a function term, also register the directives on the function
+        // definition:
+        match self.get_term(inner) {
+            Term::FnRef(fn_def_id) => {
+                self.stores().directives().insert(fn_def_id.into(), directives);
+            }
+            Term::Ty(ty_id) => {
+                self.stores().directives().insert(ty_id.into(), directives);
+            }
+            _ => {}
+        }
 
         Ok(inner)
     }

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -20,6 +20,7 @@ use hash_tir::{
     casting::CastTerm,
     control::{LoopControlTerm, LoopTerm, MatchCase, MatchTerm, ReturnTerm},
     data::DataTy,
+    directives::AppliedDirectives,
     environment::{context::ScopeKind, env::AccessToEnv},
     fns::{FnBody, FnCallTerm, FnDefId},
     lits::{CharLit, FloatLit, IntLit, Lit, PrimTerm, StrLit},
@@ -34,7 +35,7 @@ use hash_tir::{
 };
 use hash_utils::{
     itertools::Itertools,
-    store::{SequenceStore, SequenceStoreKey, Store},
+    store::{PartialStore, SequenceStore, SequenceStoreKey, Store},
 };
 
 use super::{
@@ -433,8 +434,15 @@ impl<'tc> ResolutionPass<'tc> {
         node: AstNodeRef<ast::DirectiveExpr>,
     ) -> SemanticResult<TermId> {
         // Pass to the inner expression
-        // @@Future: keep directive in term structure
-        self.make_term_from_ast_expr(node.subject.ast_ref())
+        let inner = self.make_term_from_ast_expr(node.subject.ast_ref())?;
+
+        // Register directives:
+        self.stores().directives().insert(
+            inner.into(),
+            AppliedDirectives { directives: node.directives.iter().map(|d| d.ident).collect() },
+        );
+
+        Ok(inner)
     }
 
     /// Make a term from an [`ast::Declaration`] in non-constant scope.

--- a/compiler/hash-tir/src/directives.rs
+++ b/compiler/hash-tir/src/directives.rs
@@ -1,0 +1,56 @@
+//! Store to keep track of all the directives in the program, and their targets.
+
+use derive_more::From;
+use hash_source::identifier::Identifier;
+use hash_utils::store::DefaultPartialStore;
+use indexmap::IndexSet;
+
+use crate::{
+    data::{CtorDefId, DataDefId},
+    fns::FnDefId,
+    mods::{ModDefId, ModMemberValue},
+    params::ParamId,
+    pats::PatId,
+    terms::TermId,
+    tys::TyId,
+};
+
+macro_rules! directive_targets {
+    ($($name:ident),* $(,)?) => {
+        /// All the atoms in the TIR which are valid targets for directives.
+        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, From)]
+        pub enum DirectiveTarget {
+           $(
+               $name($name),
+           )*
+        }
+    };
+}
+directive_targets! {
+    TermId,
+    TyId,
+    PatId,
+    ParamId,
+    FnDefId,
+    DataDefId,
+    ModDefId,
+    CtorDefId,
+}
+
+impl From<ModMemberValue> for DirectiveTarget {
+    fn from(value: ModMemberValue) -> Self {
+        match value {
+            ModMemberValue::Fn(fn_def) => Self::FnDefId(fn_def),
+            ModMemberValue::Data(data_def) => Self::DataDefId(data_def),
+            ModMemberValue::Mod(mod_def) => Self::ModDefId(mod_def),
+        }
+    }
+}
+
+/// A set of directives that have been applied to a target.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AppliedDirectives {
+    pub directives: IndexSet<Identifier>,
+}
+
+pub type AppliedDirectivesStore = DefaultPartialStore<DirectiveTarget, AppliedDirectives>;

--- a/compiler/hash-tir/src/environment/stores.rs
+++ b/compiler/hash-tir/src/environment/stores.rs
@@ -12,7 +12,9 @@ use super::super::{
     terms::{TermListStore, TermStore},
     tys::TyStore,
 };
-use crate::{atom_info::AtomInfoStore, control::MatchCasesStore};
+use crate::{
+    atom_info::AtomInfoStore, control::MatchCasesStore, directives::AppliedDirectivesStore,
+};
 
 /// This macro creates the `Stores` struct, as well as accompanying creation and
 /// access methods, for the given sequence of stores.
@@ -68,6 +70,7 @@ stores! {
     ty: TyStore,
     match_cases: MatchCasesStore,
     atom_info: AtomInfoStore,
+    directives: AppliedDirectivesStore,
 }
 
 /// A reference to [`Stores`] alongside a value.

--- a/compiler/hash-tir/src/lib.rs
+++ b/compiler/hash-tir/src/lib.rs
@@ -10,6 +10,7 @@ pub mod casting;
 pub mod control;
 pub mod data;
 pub mod defs;
+pub mod directives;
 pub mod environment;
 pub mod fns;
 pub mod holes;

--- a/compiler/hash-tir/src/mod.rs
+++ b/compiler/hash-tir/src/mod.rs
@@ -1,2 +1,0 @@
-//! Contains definitions that are relevant to the typed semantic analysis stage
-//! of the compiler (in other words, typechecking).


### PR DESCRIPTION
This PR adds the ability to access directives on TIR terms, functions, data defs, patterns, params, and types. This is accessed through `AppliedDirectivesStore`, which indexes a list of directive names by a directive target (one of the above).