### PR TITLE
Fix bug where locations get unset when adding duplicate entries

### DIFF
--- a/compiler/hash-tir/src/locations.rs
+++ b/compiler/hash-tir/src/locations.rs
@@ -1,6 +1,5 @@
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::HashMap};
 
-use bimap::BiMap;
 use hash_source::location::{SourceLocation, Span};
 use hash_utils::store::SequenceStoreKey;
 
@@ -133,7 +132,7 @@ location_targets! {
 /// since the inner map is behind an [Rc<T>].
 #[derive(Debug, Default)]
 pub struct LocationStore {
-    data: RefCell<BiMap<LocationTarget, SourceLocation>>,
+    data: RefCell<HashMap<LocationTarget, SourceLocation>>,
 }
 
 impl LocationStore {
@@ -167,7 +166,7 @@ impl LocationStore {
 
     /// Get a [SourceLocation] from a specified [LocationTarget]
     pub fn get_location(&self, target: impl Into<LocationTarget>) -> Option<SourceLocation> {
-        self.data.borrow().get_by_left(&target.into()).copied()
+        self.data.borrow().get(&target.into()).copied()
     }
 
     /// Get the associated [Span] with from the specified [LocationTarget]


### PR DESCRIPTION
This bug is due to the usage of `BiMap`. Adding `(k1, v)` when there already exists `(k2, v)` will delete the latter. Location mappings shouldn't really be bijective, so we can just use a regular `HashMap`.