### PR TITLE
Implement typechecking of matches, arrays, indexing, assign terms

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -6,7 +6,7 @@ use hash_tir::{
     environment::env::{AccessToEnv, Env},
     fns::{FnBody, FnDef, FnDefId, FnTy},
     intrinsics::IntrinsicId,
-    lits::{Lit, PrimTerm},
+    lits::Lit,
     mods::{ModMemberData, ModMemberValue},
     params::ParamData,
     terms::{Term, TermId},
@@ -732,7 +732,7 @@ impl DefinedIntrinsics {
                 .return_ty(env.new_never_ty())
                 .build(),
             |env, args| match env.get_term(args[0]) {
-                Term::Prim(PrimTerm::Lit(Lit::Str(str_lit))) => Err(str_lit.value().to_string()),
+                Term::Lit(Lit::Str(str_lit)) => Err(str_lit.value().to_string()),
                 _ => Err("`user_error` expects a string literal as argument".to_string())?,
             },
         );

--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -69,6 +69,7 @@ defined_primitives! {
     option,
     result,
     list,
+    array,
     equal,
 }
 
@@ -90,6 +91,8 @@ impl DefinedPrimitives {
                 }),
             )
         };
+
+        let usize = numeric("usize", 64, false, false);
 
         DefinedPrimitives {
             // Never
@@ -124,7 +127,7 @@ impl DefinedPrimitives {
             u64: numeric("u64", 64, false, false),
             u128: numeric("u128", 128, false, false),
             ubig: numeric("ubig", 0, false, false),
-            usize: numeric("usize", 64, false, false),
+            usize,
 
             f32: numeric("f32", 32, false, true),
             f64: numeric("f64", 64, false, true),
@@ -150,6 +153,24 @@ impl DefinedPrimitives {
                     PrimitiveCtorInfo::Array(ArrayCtorInfo {
                         element_ty: env.new_var_ty(t_sym),
                         length: None,
+                    })
+                })
+            },
+            array: {
+                let list_sym = env.new_symbol("Array");
+                let t_sym = env.new_symbol("T");
+                let n_sym = env.new_symbol("n");
+                let params = env.param_utils().create_params(
+                    [
+                        ParamData { name: t_sym, ty: env.new_small_universe_ty(), default: None },
+                        ParamData { name: n_sym, ty: env.new_data_ty(usize), default: None },
+                    ]
+                    .into_iter(),
+                );
+                env.data_utils().create_primitive_data_def_with_params(list_sym, params, |_| {
+                    PrimitiveCtorInfo::Array(ArrayCtorInfo {
+                        element_ty: env.new_var_ty(t_sym),
+                        length: Some(env.new_term(n_sym)),
                     })
                 })
             },

--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -149,7 +149,7 @@ impl DefinedPrimitives {
                 env.data_utils().create_primitive_data_def_with_params(list_sym, params, |_| {
                     PrimitiveCtorInfo::Array(ArrayCtorInfo {
                         element_ty: env.new_var_ty(t_sym),
-                        length: 0,
+                        length: None,
                     })
                 })
             },

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -3,7 +3,7 @@ use hash_source::constant::{IntConstant, IntConstantValue, CONSTANT_MAP};
 use hash_tir::{
     data::{CtorDefId, CtorPat, CtorTerm, DataTy},
     environment::env::AccessToEnv,
-    lits::{CharLit, FloatLit, IntLit, Lit, PrimTerm},
+    lits::{CharLit, FloatLit, IntLit, Lit},
     pats::{Pat, PatId},
     terms::{Term, TermId},
     tys::{Ty, TyId},
@@ -105,25 +105,25 @@ pub trait PrimitiveUtils: AccessToPrimitives {
 
     /// Get the given term as a float literal if possible.
     fn create_term_from_float_lit<L: Into<f64>>(&self, lit: L) -> TermId {
-        self.new_term(Term::Prim(PrimTerm::Lit(Lit::Float(FloatLit {
+        self.new_term(Term::Lit(Lit::Float(FloatLit {
             underlying: ast::FloatLit {
                 kind: ast::FloatLitKind::Unsuffixed,
                 value: CONSTANT_MAP.create_f64_float_constant(lit.into(), None),
             },
-        }))))
+        })))
     }
 
     /// Get the given term as a float literal if possible.
     fn try_use_term_as_float_lit<L: From<f64>>(&self, term: TermId) -> Option<L> {
         match self.get_term(term) {
-            Term::Prim(PrimTerm::Lit(Lit::Float(i))) => i.value().try_into().ok(),
+            Term::Lit(Lit::Float(i)) => i.value().try_into().ok(),
             _ => None,
         }
     }
 
     /// Get the given term as a float literal if possible.
     fn create_term_from_integer_lit<L: Into<BigInt>>(&self, lit: L) -> TermId {
-        self.new_term(Term::Prim(PrimTerm::Lit(Lit::Int(IntLit {
+        self.new_term(Term::Lit(Lit::Int(IntLit {
             underlying: ast::IntLit {
                 kind: ast::IntLitKind::Unsuffixed,
                 value: CONSTANT_MAP.create_int_constant(IntConstant::new(
@@ -131,28 +131,26 @@ pub trait PrimitiveUtils: AccessToPrimitives {
                     None,
                 )),
             },
-        }))))
+        })))
     }
 
     /// Get the given term as a float literal if possible.
     fn try_use_term_as_char_lit(&self, term: TermId) -> Option<char> {
         match self.get_term(term) {
-            Term::Prim(PrimTerm::Lit(Lit::Char(c))) => Some(c.underlying.data),
+            Term::Lit(Lit::Char(c)) => Some(c.underlying.data),
             _ => None,
         }
     }
 
     /// Get the given term as a character literal if possible.
     fn create_term_from_char_lit(&self, lit: char) -> TermId {
-        self.new_term(Term::Prim(PrimTerm::Lit(Lit::Char(CharLit {
-            underlying: ast::CharLit { data: lit },
-        }))))
+        self.new_term(Term::Lit(Lit::Char(CharLit { underlying: ast::CharLit { data: lit } })))
     }
 
     /// Get the given term as an integer literal if possible.
     fn try_use_term_as_integer_lit<L: TryFrom<BigInt>>(&self, term: TermId) -> Option<L> {
         match self.get_term(term) {
-            Term::Prim(PrimTerm::Lit(Lit::Int(i))) => i.value().try_into().ok(),
+            Term::Lit(Lit::Int(i)) => i.value().try_into().ok(),
             _ => None,
         }
     }

--- a/compiler/hash-lower/src/build/category.rs
+++ b/compiler/hash-lower/src/build/category.rs
@@ -1,7 +1,7 @@
 //! Defines a category of AST expressions which can be used to determine how to
 //! lower them throughout the lowering stage.
 
-use hash_tir::{lits::PrimTerm, terms::Term};
+use hash_tir::terms::Term;
 
 use super::{ty::FnCallTermKind, Builder};
 
@@ -32,7 +32,7 @@ impl<'tcx> Builder<'tcx> {
         match term {
             // Constants that are not primitive are dealt with as
             // RValues.
-            Term::Prim(PrimTerm::Lit { .. }) => Category::Constant,
+            Term::Lit(_) => Category::Constant,
 
             Term::FnCall(ref term) => match self.classify_fn_call_term(term) {
                 FnCallTermKind::Index(..) => Category::Place,

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -10,11 +10,7 @@ use hash_source::{
     constant::{FloatConstant, FloatConstantValue, IntConstant, CONSTANT_MAP},
     location::Span,
 };
-use hash_tir::{
-    environment::env::AccessToEnv,
-    lits::{Lit, PrimTerm},
-    terms::Term,
-};
+use hash_tir::{environment::env::AccessToEnv, lits::Lit, terms::Term};
 
 use super::Builder;
 
@@ -33,7 +29,7 @@ impl<'tcx> Builder<'tcx> {
     /// Lower a constant expression, i.e. a literal value.
     pub(crate) fn lower_constant_expr(&mut self, term: &Term, span: Span) -> ConstKind {
         match term {
-            Term::Prim(PrimTerm::Lit(lit)) => self.as_constant(lit),
+            Term::Lit(lit) => self.as_constant(lit),
             _ => panic_on_span!(
                 span.into_location(self.source_id),
                 self.source_map(),
@@ -55,7 +51,7 @@ impl<'tcx> Builder<'tcx> {
             let lhs_const = CONSTANT_MAP.lookup_int_constant(interned_lhs);
             let rhs_const = CONSTANT_MAP.lookup_int_constant(interned_rhs);
 
-            // First we need to coerce the types into the same primitive integer type, we do this 
+            // First we need to coerce the types into the same primitive integer type, we do this
             // by checking the `suffix` and then coercing both ints into that value
             fold_int_const(op, lhs_const, rhs_const)
         }

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -8,10 +8,10 @@ use hash_ir::{
 use hash_reporting::macros::panic_on_span;
 use hash_source::location::Span;
 use hash_tir::{
+    arrays::ArrayPat,
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::AccessToEnv,
-    lits::ArrayPat,
     pats::{Pat, PatId},
     scopes::{BindingPat, DeclTerm},
     symbols::Symbol,

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -140,6 +140,10 @@ impl<'tcx> Builder<'tcx> {
                     unpack!(block = self.as_place_builder(block, subject, mutability));
                 block.and(place_builder.deref())
             }
+            Term::Index(_) => {
+                // @@Todo: lower indexing
+                temp(self)
+            }
             Term::FnCall(ref fn_call) => match self.classify_fn_call_term(fn_call) {
                 FnCallTermKind::Index(subject, index) => {
                     let base_place =
@@ -156,7 +160,8 @@ impl<'tcx> Builder<'tcx> {
             },
 
             Term::Tuple(_)
-            | Term::Prim(_)
+            | Term::Lit(_)
+            | Term::Array(_)
             | Term::Ctor(_)
             | Term::FnRef(_)
             | Term::Block(_)

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -10,8 +10,8 @@ use hash_source::{
     location::Span,
 };
 use hash_tir::{
+    arrays::ArrayTerm,
     environment::env::AccessToEnv,
-    lits::{ArrayCtor, PrimTerm},
     terms::{Term, TermId},
 };
 use hash_utils::store::{CloneStore, Store};
@@ -37,11 +37,11 @@ impl<'tcx> Builder<'tcx> {
         };
 
         match term {
-            Term::Prim(PrimTerm::Lit(lit)) => {
+            Term::Lit(lit) => {
                 let value = self.as_constant(&lit).into();
                 block.and(value)
             }
-            Term::Prim(PrimTerm::Array(ArrayCtor { .. })) => {
+            Term::Array(ArrayTerm { .. }) => {
                 todo!()
             }
             Term::FnCall(fn_call) => {
@@ -106,6 +106,7 @@ impl<'tcx> Builder<'tcx> {
             | Term::Assign(_)
             | Term::Unsafe(_)
             | Term::Access(_)
+            | Term::Index(_)
             | Term::Cast(_)
             | Term::TypeOf(_)
             | Term::Ty(_)

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -7,6 +7,7 @@
 
 use hash_intrinsics::{
     intrinsics::{AccessToIntrinsics, BoolBinOp, EndoBinOp, ShortCircuitBinOp, UnOp},
+    primitives::AccessToPrimitives,
     utils::PrimitiveUtils,
 };
 use hash_ir::{
@@ -74,7 +75,7 @@ impl<'tcx> Builder<'tcx> {
     pub(crate) fn ty_id_from_tir_term(&self, term: TermId) -> IrTyId {
         let ty = self.get_inferred_ty(term);
 
-        let ctx = TyLoweringCtx { tcx: self.env(), lcx: self.ctx };
+        let ctx = TyLoweringCtx { tcx: self.env(), lcx: self.ctx, primitives: self.primitives() };
         ctx.ty_id_from_tir_ty(ty)
     }
 
@@ -109,14 +110,15 @@ impl<'tcx> Builder<'tcx> {
     /// cache results of lowering a [TyId] into an [IrTyId] to avoid
     /// duplicate work.
     pub(super) fn ty_id_from_tir_ty(&self, ty: TyId) -> IrTyId {
-        let ctx = TyLoweringCtx { tcx: self.env(), lcx: self.ctx };
+        let ctx = TyLoweringCtx { tcx: self.env(), lcx: self.ctx, primitives: self.primitives() };
         ctx.ty_id_from_tir_ty(ty)
     }
 
     /// Get the [IrTy] from a given [TyId].
     pub(super) fn ty_from_tir_ty(&self, ty: TyId) -> IrTy {
         self.stores().ty().map_fast(ty, |ty| {
-            let ctx = TyLoweringCtx { tcx: self.env(), lcx: self.ctx };
+            let ctx =
+                TyLoweringCtx { tcx: self.env(), lcx: self.ctx, primitives: self.primitives() };
             ctx.ty_from_tir_ty(ty)
         })
     }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -158,7 +158,11 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             &source_info,
         );
 
-        let ty_lowerer = TyLoweringCtx::new(&ir_storage.ctx, &env);
+        let ty_lowerer = TyLoweringCtx::new(
+            &ir_storage.ctx,
+            &env,
+            semantic_storage.primitives_or_unset.get().unwrap(),
+        );
 
         // @@Future: support generic substitutions here.
         let empty_args = semantic_storage.stores.args().create_empty();

--- a/compiler/hash-semantics/src/passes/discovery/defs.rs
+++ b/compiler/hash-semantics/src/passes/discovery/defs.rs
@@ -127,7 +127,6 @@ impl<'tc> DiscoveryPass<'tc> {
 
     /// Add the given definition to the AST info of the given node.
     pub(super) fn add_def_to_ast_info<U>(&self, item_id: ItemId, node: AstNodeRef<U>) {
-        // @@Todo: add locations of params from somewhere
         let ast_info = self.ast_info();
         match item_id {
             ItemId::Def(def_id) => match def_id {

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -23,7 +23,7 @@ use hash_tir::{
     directives::AppliedDirectives,
     environment::{context::ScopeKind, env::AccessToEnv},
     fns::{FnBody, FnCallTerm, FnDefId},
-    lits::{CharLit, FloatLit, IntLit, Lit, PrimTerm, StrLit},
+    lits::{CharLit, FloatLit, IntLit, Lit, StrLit},
     params::ParamIndex,
     refs::{DerefTerm, RefKind, RefTerm},
     scopes::{AssignTerm, BlockTerm, DeclTerm},
@@ -539,9 +539,7 @@ impl<'tc> ResolutionPass<'tc> {
         // Macro to make a literal primitive term
         macro_rules! lit_prim {
             ($name:ident,$lit_name:ident, $contents:expr) => {
-                self.new_term(Term::Prim(PrimTerm::Lit(Lit::$name($lit_name {
-                    underlying: $contents,
-                }))))
+                self.new_term(Term::Lit(Lit::$name($lit_name { underlying: $contents })))
             };
         }
 
@@ -614,13 +612,7 @@ impl<'tc> ResolutionPass<'tc> {
 
         match (lhs, rhs) {
             (Some(lhs), Some(rhs)) => {
-                // Handle access assignments
-                let (lhs, index) = match self.get_term(lhs) {
-                    Term::Access(access) => (access.subject, Some(access.field)),
-                    _ => (lhs, None),
-                };
-
-                Ok(self.new_term(Term::Assign(AssignTerm { subject: lhs, value: rhs, index })))
+                Ok(self.new_term(Term::Assign(AssignTerm { subject: lhs, value: rhs })))
             }
             _ => Err(SemanticError::Signal),
         }

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -11,10 +11,11 @@ use hash_reporting::macros::panic_on_span;
 use hash_source::location::Span;
 use hash_tir::{
     args::{PatArgData, PatArgsId, PatOrCapture},
+    arrays::ArrayPat,
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::{context::BindingKind, env::AccessToEnv},
-    lits::{ArrayPat, CharLit, IntLit, LitPat, StrLit},
+    lits::{CharLit, IntLit, LitPat, StrLit},
     params::ParamIndex,
     pats::{Pat, PatId, PatListId, RangePat, Spread},
     scopes::BindingPat,

--- a/compiler/hash-tir/src/access.rs
+++ b/compiler/hash-tir/src/access.rs
@@ -10,35 +10,17 @@ use super::{
     terms::TermId,
 };
 
-// @@Future: this is currently unused, as all accesses are property accesses at
-// this level.
-
-// /// The kind of an access.
-// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// pub enum AccessKind {
-//     /// Accessing a constructor field, like `f := Foo(name=3); f.name`.
-//     CtorField,
-//     /// Accessing a tuple field, like `f := (2, 3); f.0`.
-//     TupleField,
-// }
-
 /// Term to access a nested value.
 #[derive(Debug, Clone, Copy)]
 pub struct AccessTerm {
     /// The term to access.
     pub subject: TermId,
-    // /// The kind of access.
-    // pub kind: AccessKind,
     /// The target field of the accessing operation.
     pub field: ParamIndex,
 }
 
 impl fmt::Display for WithEnv<'_, &AccessTerm> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // let op = match self.value.kind {
-        //     AccessKind::CtorField => ".",
-        //     AccessKind::TupleField => ".",
-        // };
         write!(
             f,
             "{}.{}",

--- a/compiler/hash-tir/src/arrays.rs
+++ b/compiler/hash-tir/src/arrays.rs
@@ -1,0 +1,97 @@
+use core::fmt;
+use std::fmt::Display;
+
+use hash_utils::store::SequenceStore;
+
+use crate::{
+    environment::env::{AccessToEnv, WithEnv},
+    pats::{PatId, PatListId, Spread},
+    terms::{TermId, TermListId},
+};
+
+/// A term that is used as an index into an array.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexTerm {
+    /// The subject array of the indexing operation.
+    pub subject: TermId,
+    /// The index of the indexing operation.
+    pub index: TermId,
+}
+
+/// A list constructor
+///
+/// Contains a sequence of terms.
+#[derive(Copy, Clone, Debug)]
+pub struct ArrayTerm {
+    pub elements: TermListId,
+}
+
+/// A list pattern.
+///
+/// This is in the form `[x_1,...,x_n]`, with an optional spread `...(name?)` at
+/// some position.
+#[derive(Copy, Clone, Debug)]
+pub struct ArrayPat {
+    /// The sequence of patterns in the list pattern.
+    pub pats: PatListId,
+    /// The spread pattern, if any.
+    pub spread: Option<Spread>,
+}
+
+impl ArrayPat {
+    /// Split the pattern into the `prefix`, `suffix` and an optional;
+    /// `rest` pattern.
+    pub fn into_parts<T>(&self, tcx: &T) -> (Vec<PatId>, Vec<PatId>, Option<Spread>)
+    where
+        T: AccessToEnv,
+    {
+        let mut prefix = vec![];
+        let mut suffix = vec![];
+
+        tcx.stores().pat_list().map_fast(self.pats, |args| {
+            if let Some(pos) = self.spread.map(|s| s.index) {
+                prefix.extend(args[..pos].iter().copied().map(|p| p.assert_pat()));
+                suffix.extend(args[pos..].iter().copied().map(|p| p.assert_pat()));
+            } else {
+                prefix.extend(args.iter().copied().map(|p| p.assert_pat()));
+            }
+        });
+
+        (prefix, suffix, self.spread)
+    }
+}
+
+impl fmt::Display for WithEnv<'_, &IndexTerm> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{}]", self.env().with(self.value.subject), self.env().with(self.value.index),)
+    }
+}
+
+impl fmt::Display for WithEnv<'_, &ArrayPat> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        self.stores().pat_list().map_fast(self.value.pats, |pat_list| {
+            let mut pat_args_formatted =
+                pat_list.iter().map(|arg| self.env().with(*arg).to_string()).collect::<Vec<_>>();
+
+            if let Some(spread) = self.value.spread {
+                pat_args_formatted.insert(spread.index, self.env().with(spread).to_string());
+            }
+
+            for (i, pat_arg) in pat_args_formatted.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{pat_arg}")?;
+            }
+            Ok(())
+        })?;
+        write!(f, "]")
+    }
+}
+
+impl Display for WithEnv<'_, &ArrayTerm> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.env().with(self.value.elements))
+    }
+}

--- a/compiler/hash-tir/src/data.rs
+++ b/compiler/hash-tir/src/data.rs
@@ -16,7 +16,7 @@ use super::{
     pats::Spread,
     tys::TyId,
 };
-use crate::{params::ParamsId, symbols::Symbol};
+use crate::{params::ParamsId, symbols::Symbol, terms::TermId};
 
 /// A constructor of a data-type definition.
 ///
@@ -117,7 +117,7 @@ pub struct ArrayCtorInfo {
     pub element_ty: TyId,
 
     /// The number of elements in the array.
-    pub length: usize,
+    pub length: Option<TermId>,
 }
 
 /// A primitive constructor definition.

--- a/compiler/hash-tir/src/lib.rs
+++ b/compiler/hash-tir/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod access;
 pub mod args;
+pub mod arrays;
 pub mod atom_info;
 pub mod casting;
 pub mod control;

--- a/compiler/hash-tir/src/lits.rs
+++ b/compiler/hash-tir/src/lits.rs
@@ -5,7 +5,7 @@ use hash_ast::ast;
 use hash_source::constant::{InternedFloat, InternedInt, InternedStr, CONSTANT_MAP};
 use num_bigint::BigInt;
 
-use super::{environment::env::WithEnv, terms::TermListId};
+use super::environment::env::WithEnv;
 
 /// An integer literal.
 ///
@@ -80,14 +80,6 @@ impl CharLit {
     pub fn value(&self) -> char {
         self.underlying.data
     }
-}
-
-/// A list constructor
-///
-/// Contains a sequence of terms.
-#[derive(Copy, Clone, Debug)]
-pub struct ArrayCtor {
-    pub elements: TermListId,
 }
 
 /// A literal

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -14,11 +14,12 @@ use super::{
     control::{IfPat, OrPat},
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
-    lits::{ArrayPat, LitPat},
+    lits::LitPat,
     scopes::{BindingPat, StackMemberId},
     symbols::Symbol,
     tuples::TuplePat,
 };
+use crate::arrays::ArrayPat;
 
 /// A spread "pattern" (not part of [`Pat`]), which can appear in list patterns,
 /// tuple patterns, and constructor patterns.

--- a/compiler/hash-tir/src/scopes.rs
+++ b/compiler/hash-tir/src/scopes.rs
@@ -14,7 +14,6 @@ use utility_types::omit;
 
 use super::{
     environment::env::{AccessToEnv, WithEnv},
-    params::ParamIndex,
     pats::Pat,
     terms::Term,
 };
@@ -95,8 +94,8 @@ impl DeclTerm {
 /// Term to assign a value to a subject.
 #[derive(Debug, Clone, Copy)]
 pub struct AssignTerm {
+    // If the subject is assign,
     pub subject: TermId,
-    pub index: Option<ParamIndex>,
     pub value: TermId,
 }
 
@@ -183,18 +182,7 @@ impl fmt::Display for WithEnv<'_, &DeclTerm> {
 
 impl fmt::Display for WithEnv<'_, &AssignTerm> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}{} = {}",
-            self.env().with(self.value.subject),
-            match self.value.index {
-                Some(index) => {
-                    format!(".{}", self.env().with(index))
-                }
-                None => "".to_string(),
-            },
-            self.env().with(self.value.value),
-        )
+        write!(f, "{} = {}", self.env().with(self.value.subject), self.env().with(self.value.value),)
     }
 }
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -482,34 +482,101 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         original_term_id: TermId,
     ) -> TcResult<(ArrayTerm, TyId)> {
         let normalised_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let list_annotation_inner_ty = match self.get_ty(normalised_ty) {
-            Ty::Data(data) if data.data_def == self.primitives().list() => {
-                // Type is already checked
-                assert!(data.args.len() == 1);
-                let inner_term = self.stores().args().get_element((data.args, 0)).value;
-                term_as_variant!(self, self.get_term(inner_term), Ty)
-            }
-            Ty::Hole(_) => self.new_ty_hole(),
-            _ => {
-                return Err(TcError::MismatchingTypes {
-                    expected: annotation_ty,
-                    actual: {
-                        self.new_ty(DataTy {
-                            data_def: self.primitives().list(),
-                            args: self.new_args(&[self.new_term(self.new_ty_hole())]),
-                        })
-                    },
-                    inferred_from: Some(original_term_id.into()),
-                })
-            }
+
+        let mismatch = || {
+            Err(TcError::MismatchingTypes {
+                expected: annotation_ty,
+                actual: {
+                    self.new_ty(DataTy {
+                        data_def: self.primitives().list(),
+                        args: self.new_args(&[self.new_term(self.new_ty_hole())]),
+                    })
+                },
+                inferred_from: Some(original_term_id.into()),
+            })
         };
+
+        let (list_annotation_inner_ty, list_len) = match self.get_ty(normalised_ty) {
+            Ty::Data(data) => {
+                let data_def = self.get_data_def(data.data_def);
+
+                match data_def.ctors {
+                    DataDefCtors::Primitive(primitive) => {
+                        if let PrimitiveCtorInfo::Array(array_prim) = primitive {
+                            // First infer the data arguments
+                            let (inferred_data_args, inferred_data_params) =
+                                self.infer_args(data.args, data_def.params)?;
+
+                            let param_uni = self
+                                .unification_ops()
+                                .unify_params(
+                                    inferred_data_params,
+                                    data_def.params,
+                                    ParamOrigin::Data(data_def.id),
+                                )
+                                .unwrap();
+
+                            // Create a substitution from the inferred data arguments
+                            let data_sub = self
+                                .substitution_ops()
+                                .create_sub_from_args_of_params(inferred_data_args, data_def.params)
+                                .join(&param_uni.sub);
+
+                            self.context().enter_scope(data_def.id.into(), || {
+                                let subbed_element_ty = self
+                                    .substitution_ops()
+                                    .apply_sub_to_ty(array_prim.element_ty, &data_sub);
+
+                                let subbed_index = array_prim.length.map(|l| {
+                                    self.substitution_ops().apply_sub_to_term(l, &data_sub)
+                                });
+
+                                Ok((subbed_element_ty, subbed_index))
+                            })
+                        } else {
+                            mismatch()
+                        }
+                    }
+                    _ => mismatch(),
+                }
+            }
+            Ty::Hole(_) => Ok((self.new_ty_hole(), None)),
+            _ => mismatch(),
+        }?;
 
         let (inferred_list, inferred_list_inner_ty) =
             self.infer_unified_term_list(array_term.elements, list_annotation_inner_ty)?;
-        let list_ty = self.new_ty(DataTy {
-            data_def: self.primitives().list(),
-            args: self.new_args(&[self.new_term(inferred_list_inner_ty)]),
-        });
+
+        // Ensure the array lengths match if given
+        if let Some(len) = list_len {
+            if let Some(len) = self.try_use_term_as_integer_lit::<usize>(len) {
+                if inferred_list.len() != len {
+                    return Err(TcError::MismatchingArrayLengths {
+                        expected_len: self.create_term_from_integer_lit(len),
+                        got_len: self.create_term_from_integer_lit(inferred_list.len()),
+                    });
+                }
+            }
+        }
+
+        // Unify the inner annotation type with the inferred type
+        let inner_ty_uni =
+            self.unification_ops().unify_tys(inferred_list_inner_ty, list_annotation_inner_ty)?;
+
+        // Either create a default list type or apply the substitution to the annotation
+        // type
+        let list_ty = match self.get_ty(normalised_ty) {
+            Ty::Hole(_) => {
+                let list_ty = self.new_ty(DataTy {
+                    data_def: self.primitives().list(),
+                    args: self.new_args(&[self.new_term(inner_ty_uni.result)]),
+                });
+
+                self.unification_ops().unify_tys(normalised_ty, list_ty)?.result
+            }
+            _ => self.substitution_ops().apply_sub_to_ty(normalised_ty, &inner_ty_uni.sub),
+        };
+
         Ok((ArrayTerm { elements: inferred_list }, list_ty))
     }
 
@@ -561,7 +628,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
             let param_uni = self
                 .unification_ops()
-                .unify_params(inferred_data_params, data_def.params, ParamOrigin::Ctor(ctor.id))
+                .unify_params(inferred_data_params, data_def.params, ParamOrigin::Data(data_def.id))
                 .unwrap();
 
             // Create a substitution from the inferred data arguments
@@ -1613,12 +1680,20 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                             Ok(())
                         }
                         PrimitiveCtorInfo::Array(array_ctor_info) => {
-                            // Infer the inner type
+                            // Infer the inner type and length
                             let element_ty =
                                 self.infer_ty(array_ctor_info.element_ty, self.new_ty_hole())?.0;
+                            let length = array_ctor_info
+                                .length
+                                .map(|l| -> TcResult<_> {
+                                    Ok(self
+                                        .infer_term(l, self.new_data_ty(self.primitives().usize()))?
+                                        .0)
+                                })
+                                .transpose()?;
                             self.stores().data_def().modify_fast(data_def_id, |def| {
                                 def.ctors = DataDefCtors::Primitive(PrimitiveCtorInfo::Array(
-                                    ArrayCtorInfo { element_ty, length: array_ctor_info.length },
+                                    ArrayCtorInfo { element_ty, length },
                                 ));
                             });
                             Ok(())

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -7,12 +7,13 @@ use hash_intrinsics::utils::PrimitiveUtils;
 use hash_tir::{
     access::AccessTerm,
     args::{ArgData, ArgsId, PatArgsId, PatOrCapture},
+    arrays::{ArrayTerm, IndexTerm},
     atom_info::ItemInAtomInfo,
     casting::CastTerm,
     control::{LoopControlTerm, LoopTerm, MatchTerm, ReturnTerm},
     environment::context::{Binding, BindingKind, ScopeKind},
     fns::{FnBody, FnCallTerm},
-    lits::{ArrayCtor, Lit, LitPat, PrimTerm},
+    lits::{Lit, LitPat},
     params::ParamIndex,
     pats::{Pat, PatId, PatListId, Spread},
     refs::DerefTerm,
@@ -197,7 +198,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Get the term at the given index in the given term list.
-    fn get_index_in_list(&self, list: TermListId, target: ParamIndex) -> Atom {
+    fn _get_index_in_list(&self, list: TermListId, target: ParamIndex) -> Atom {
         match target {
             ParamIndex::Name(_) => {
                 panic!("Trying to index a list with a name")
@@ -209,7 +210,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Set the term at the given index in the given term list.
-    fn set_index_in_list(&self, list: TermListId, target: ParamIndex, value: Atom) {
+    fn _set_index_in_list(&self, list: TermListId, target: ParamIndex, value: Atom) {
         match target {
             ParamIndex::Name(_) => {
                 panic!("Trying to index a list with a name")
@@ -230,17 +231,16 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             Term::Ctor(ctor) => {
                 return Ok(self.get_param_in_args(ctor.ctor_args, access_term.field))
             }
-            Term::Prim(prim) => match prim {
-                PrimTerm::Array(list) => {
-                    return Ok(self.get_index_in_list(list.elements, access_term.field))
-                }
-                PrimTerm::Lit(_) => {}
-            },
             _ => {}
         }
 
         // Couldn't reduce
         Ok(self.new_term(access_term).into())
+    }
+
+    /// Evaluate an index term.
+    fn eval_index(&self, _index_term: IndexTerm) -> Result<Atom, Signal> {
+        todo!()
     }
 
     /// Evaluate an unsafe term.
@@ -277,30 +277,34 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     fn eval_assign(&self, mut assign_term: AssignTerm) -> Result<Atom, Signal> {
         assign_term.value = self.to_term(self.eval(assign_term.value.into())?);
 
-        match assign_term.index {
-            Some(field) => {
-                assign_term.subject = self.to_term(self.eval(assign_term.subject.into())?);
-                match self.get_term(assign_term.subject) {
-                    Term::Tuple(tuple) => {
-                        self.set_param_in_args(tuple.data, field, assign_term.value.into())
-                    }
-                    Term::Ctor(ctor) => {
-                        self.set_param_in_args(ctor.ctor_args, field, assign_term.value.into())
-                    }
-                    Term::Prim(PrimTerm::Array(list)) => {
-                        self.set_index_in_list(list.elements, field, assign_term.value.into())
-                    }
+        match self.get_term(assign_term.subject) {
+            Term::Access(mut access_term) => {
+                access_term.subject = self.to_term(self.eval(access_term.subject.into())?);
+                match self.get_term(access_term.subject) {
+                    Term::Tuple(tuple) => self.set_param_in_args(
+                        tuple.data,
+                        access_term.field,
+                        assign_term.value.into(),
+                    ),
+                    Term::Ctor(ctor) => self.set_param_in_args(
+                        ctor.ctor_args,
+                        access_term.field,
+                        assign_term.value.into(),
+                    ),
+                    // Term::Prim(PrimTerm::Array(list)) => self.set_index_in_list(
+                    //     list.elements,
+                    //     access_term.field,
+                    //     assign_term.value.into(),
+                    // ),
                     _ => panic!("Invalid access"),
                 }
             }
-            None => match self.get_term(assign_term.subject) {
-                // @@Todo: deref
-                Term::Var(var) => {
-                    let (member, _) = self.context_utils().get_stack_binding(var);
-                    self.set_stack_member(member, assign_term.value);
-                }
-                _ => panic!("Invalid assign {}", self.env().with(&assign_term)),
-            },
+            // @@Todo: deref
+            Term::Var(var) => {
+                let (member, _) = self.context_utils().get_stack_binding(var);
+                self.set_stack_member(member, assign_term.value);
+            }
+            _ => panic!("Invalid assign {}", self.env().with(&assign_term)),
         }
 
         Ok(self.new_void_term().into())
@@ -523,7 +527,8 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 | Term::Hole(_)
                 | Term::FnRef(_)
                 | Term::Ctor(_)
-                | Term::Prim(_) => Ok(ControlFlow::Continue(())),
+                | Term::Lit(_)
+                | Term::Array(_) => Ok(ControlFlow::Continue(())),
 
                 // Potentially reducible forms:
                 Term::TypeOf(term) => Ok(ControlFlow::Break(self.eval_type_of(term)?)),
@@ -534,6 +539,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 Term::Var(var) => Ok(ControlFlow::Break(self.eval_var(var)?)),
                 Term::Deref(deref_term) => self.eval_deref(deref_term),
                 Term::Access(access_term) => Ok(ControlFlow::Break(self.eval_access(access_term)?)),
+                Term::Index(index_term) => Ok(ControlFlow::Break(self.eval_index(index_term)?)),
 
                 // Imperative:
                 Term::LoopControl(loop_control) => Err(self.eval_loop_control(loop_control)),
@@ -806,8 +812,8 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             (_, Pat::Ctor(_)) => Ok(MatchResult::Stuck),
 
             // Ranges
-            (Term::Prim(prim_term), Pat::Range(range_pat)) => match prim_term {
-                PrimTerm::Lit(lit_term) => match (lit_term, range_pat.start, range_pat.end) {
+            (Term::Lit(lit_term), Pat::Range(range_pat)) => {
+                match (lit_term, range_pat.start, range_pat.end) {
                     (Lit::Int(value), LitPat::Int(start), LitPat::Int(end)) => Ok(self
                         .match_literal_to_range(
                             value.value(),
@@ -830,44 +836,37 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                             range_pat.range_end,
                         )),
                     _ => Ok(MatchResult::Stuck),
-                },
-                PrimTerm::Array(_) => Ok(MatchResult::Stuck),
-            },
+                }
+            }
             (_, Pat::Range(_)) => Ok(MatchResult::Stuck),
 
             // Literals
-            (Term::Prim(prim_term), Pat::Lit(lit_pat)) => match prim_term {
-                PrimTerm::Lit(lit_term) => match (lit_term, lit_pat) {
-                    (Lit::Int(a), LitPat::Int(b)) => {
-                        Ok(self.match_literal_to_literal(a.value(), b.value()))
-                    }
-                    (Lit::Str(a), LitPat::Str(b)) => {
-                        Ok(self.match_literal_to_literal(a.value(), b.value()))
-                    }
-                    (Lit::Char(a), LitPat::Char(b)) => {
-                        Ok(self.match_literal_to_literal(a.value(), b.value()))
-                    }
-                    _ => Ok(MatchResult::Stuck),
-                },
-                PrimTerm::Array(_) => Ok(MatchResult::Stuck),
+            (Term::Lit(lit_term), Pat::Lit(lit_pat)) => match (lit_term, lit_pat) {
+                (Lit::Int(a), LitPat::Int(b)) => {
+                    Ok(self.match_literal_to_literal(a.value(), b.value()))
+                }
+                (Lit::Str(a), LitPat::Str(b)) => {
+                    Ok(self.match_literal_to_literal(a.value(), b.value()))
+                }
+                (Lit::Char(a), LitPat::Char(b)) => {
+                    Ok(self.match_literal_to_literal(a.value(), b.value()))
+                }
+                _ => Ok(MatchResult::Stuck),
             },
             // Lists
-            (Term::Prim(prim_term), Pat::Array(list_pat)) => match prim_term {
-                PrimTerm::Array(list_term) => self.match_some_list_and_get_binds(
-                    list_term.elements.len(),
-                    list_pat.spread,
-                    |_| {
-                        // Lists can have spreads, which return sublists
-                        self.new_term(PrimTerm::Array(ArrayCtor {
-                            elements: self.extract_spread_list(list_term.elements, list_pat.pats),
-                        }))
-                    },
-                    |i| self.stores().pat_list().get_at_index(list_pat.pats, i),
-                    |i| self.stores().term_list().get_at_index(list_term.elements, i),
-                    f,
-                ),
-                PrimTerm::Lit(_) => Ok(MatchResult::Stuck),
-            },
+            (Term::Array(array_term), Pat::Array(list_pat)) => self.match_some_list_and_get_binds(
+                array_term.elements.len(),
+                list_pat.spread,
+                |_| {
+                    // Lists can have spreads, which return sublists
+                    self.new_term(Term::Array(ArrayTerm {
+                        elements: self.extract_spread_list(array_term.elements, list_pat.pats),
+                    }))
+                },
+                |i| self.stores().pat_list().get_at_index(list_pat.pats, i),
+                |i| self.stores().term_list().get_at_index(array_term.elements, i),
+                f,
+            ),
             (_, Pat::Lit(_)) => Ok(MatchResult::Stuck),
             (_, Pat::Array(_)) => Ok(MatchResult::Stuck),
         }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -6,7 +6,7 @@ use hash_tir::{
     data::DataTy,
     environment::context::ParamOrigin,
     fns::{FnBody, FnTy},
-    lits::{Lit, PrimTerm},
+    lits::Lit,
     locations::LocationTarget,
     params::{ParamData, ParamsId},
     sub::Sub,
@@ -248,23 +248,19 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                     let sub = Sub::from_pairs([(b.0, src_id)]);
                     Uni::ok_with(sub, src_id)
                 }
-                (Term::Prim(p1), Term::Prim(p2)) => match (p1, p2) {
-                    (PrimTerm::Lit(l1), PrimTerm::Lit(l2)) => match (l1, l2) {
-                        (Lit::Int(i1), Lit::Int(i2)) => {
-                            Uni::ok_iff_terms_match(i1.value() == i2.value(), src_id, target_id)
-                        }
-                        (Lit::Str(s1), Lit::Str(s2)) => {
-                            Uni::ok_iff_terms_match(s1.value() == s2.value(), src_id, target_id)
-                        }
-                        (Lit::Char(c1), Lit::Char(c2)) => {
-                            Uni::ok_iff_terms_match(c1.value() == c2.value(), src_id, target_id)
-                        }
-                        (Lit::Float(f1), Lit::Float(f2)) => {
-                            Uni::ok_iff_terms_match(f1.value() == f2.value(), src_id, target_id)
-                        }
-                        _ => Uni::mismatch_terms(src_id, target_id),
-                    },
-                    (PrimTerm::Array(_), PrimTerm::Array(_)) => todo!(),
+                (Term::Lit(l1), Term::Lit(l2)) => match (l1, l2) {
+                    (Lit::Int(i1), Lit::Int(i2)) => {
+                        Uni::ok_iff_terms_match(i1.value() == i2.value(), src_id, target_id)
+                    }
+                    (Lit::Str(s1), Lit::Str(s2)) => {
+                        Uni::ok_iff_terms_match(s1.value() == s2.value(), src_id, target_id)
+                    }
+                    (Lit::Char(c1), Lit::Char(c2)) => {
+                        Uni::ok_iff_terms_match(c1.value() == c2.value(), src_id, target_id)
+                    }
+                    (Lit::Float(f1), Lit::Float(f2)) => {
+                        Uni::ok_iff_terms_match(f1.value() == f2.value(), src_id, target_id)
+                    }
                     _ => Uni::mismatch_terms(src_id, target_id),
                 },
                 (Term::Access(a1), Term::Access(a2)) => {
@@ -319,6 +315,7 @@ impl<T: AccessToTypechecking> UnificationOps<'_, T> {
                         }
                     })
                 }
+
                 _ => Uni::mismatch_terms(src_id, target_id),
             },
         }?;


### PR DESCRIPTION
This PR adds basic typechecking for these constructs. There are still a few small issues to fix but this should be sufficient for the lowering to be able to deal with these terms. Subsequent PRs will perform further cleanup of some of the inference code and factor out common patterns. Additionally, more sophisticated unification will be added.

Closes #777 