### PR TITLE
Fix desugared loops resolution

### DIFF
--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -63,7 +63,7 @@ pub trait PrimitiveUtils: AccessToPrimitives {
     }
 
     /// Create a boolean pattern of the given value.
-    fn bool_pat(&self, value: bool) -> PatId {
+    fn new_bool_pat(&self, value: bool) -> PatId {
         self.new_pat(Pat::Ctor(CtorPat {
             ctor: self.get_bool_ctor(value),
             ctor_pat_args: self.new_empty_pat_args(),

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -7,6 +7,7 @@
 use std::iter::empty;
 
 use hash_ast::ast::{self, AstNodeRef};
+use hash_intrinsics::utils::PrimitiveUtils;
 use hash_reporting::macros::panic_on_span;
 use hash_source::location::Span;
 use hash_tir::{
@@ -258,16 +259,30 @@ impl ResolutionPass<'_> {
     /// Create a literal pattern from the given [`ast::Lit`].
     ///
     /// This panics if the given literal is not a valid literal pattern.
-    fn make_lit_pat_from_ast_lit(&self, lit_pat: AstNodeRef<ast::Lit>) -> LitPat {
+    fn make_pat_from_ast_lit(&self, lit_pat: AstNodeRef<ast::Lit>) -> PatId {
+        match lit_pat.body() {
+            ast::Lit::Str(str_lit) => self.new_pat(LitPat::Str(StrLit { underlying: *str_lit })),
+            ast::Lit::Char(char_lit) => {
+                self.new_pat(LitPat::Char(CharLit { underlying: *char_lit }))
+            }
+            ast::Lit::Int(int_lit) => self.new_pat(LitPat::Int(IntLit { underlying: *int_lit })),
+            ast::Lit::Bool(bool_lit) => self.new_bool_pat(bool_lit.data),
+            ast::Lit::Float(_) | ast::Lit::Array(_) | ast::Lit::Tuple(_) => {
+                panic!("Found invalid literal in pattern")
+            }
+        }
+    }
+
+    /// Create a pattern from the given [`ast::Lit`].
+    ///
+    /// This panics if the given literal is not a valid literal pattern or if it
+    /// is a boolean.
+    fn make_lit_pat_from_non_bool_ast_lit(&self, lit_pat: AstNodeRef<ast::Lit>) -> LitPat {
         match lit_pat.body() {
             ast::Lit::Str(str_lit) => LitPat::Str(StrLit { underlying: *str_lit }),
             ast::Lit::Char(char_lit) => LitPat::Char(CharLit { underlying: *char_lit }),
             ast::Lit::Int(int_lit) => LitPat::Int(IntLit { underlying: *int_lit }),
-            ast::Lit::Bool(_bool_lit) => {
-                // @@Todo: bool constructor
-                todo!("Bool patterns currently not implemented")
-            }
-            ast::Lit::Float(_) | ast::Lit::Array(_) | ast::Lit::Tuple(_) => {
+            ast::Lit::Bool(_) | ast::Lit::Float(_) | ast::Lit::Array(_) | ast::Lit::Tuple(_) => {
                 panic!("Found invalid literal in pattern")
             }
         }
@@ -318,9 +333,7 @@ impl ResolutionPass<'_> {
                 pats: self.make_pat_list_from_ast_pats(&array_pat.fields)?,
                 spread: self.make_spread_from_ast_spread(&array_pat.spread)?,
             })),
-            ast::Pat::Lit(lit_pat) => {
-                self.new_pat(Pat::Lit(self.make_lit_pat_from_ast_lit(lit_pat.data.ast_ref())))
-            }
+            ast::Pat::Lit(lit_pat) => self.make_pat_from_ast_lit(lit_pat.data.ast_ref()),
             ast::Pat::Or(or_pat) => self.new_pat(Pat::Or(OrPat {
                 alternatives: self.make_pat_list_from_ast_pats(&or_pat.variants)?,
             })),
@@ -334,8 +347,8 @@ impl ResolutionPass<'_> {
                 stack_member: None,
             })),
             ast::Pat::Range(range_pat) => {
-                let start = self.make_lit_pat_from_ast_lit(range_pat.lo.ast_ref());
-                let end = self.make_lit_pat_from_ast_lit(range_pat.hi.ast_ref());
+                let start = self.make_lit_pat_from_non_bool_ast_lit(range_pat.lo.ast_ref());
+                let end = self.make_lit_pat_from_non_bool_ast_lit(range_pat.hi.ast_ref());
                 self.new_pat(Pat::Range(RangePat { start, end, range_end: range_pat.end }))
             }
         };


### PR DESCRIPTION
A block term is now always added to the loop contents, independently of what the AST looks like.