### PR TITLE
lower+codegen: implement casting operations for primitive types

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -121,7 +121,14 @@ defined_intrinsics! {
     size_of,
 
     ptr_offset,
-    transmute
+    transmute,
+
+    // Casting is used to represent a conversion between two types. For example,
+    // converting a `char` to an `u32` but without necessarily going through
+    // transmuting the types and hoping it will be ok. Cast may imply a runtime
+    // operation to convert the value to the desired type whilst the transmute
+    // is more of a type marker to the compiler.
+    cast,
 }
 
 impl Debug for DefinedIntrinsics {
@@ -892,6 +899,25 @@ impl DefinedIntrinsics {
             })
         };
 
+        let cast = {
+            let t_sym = env.new_symbol("T");
+            let a_sym = env.new_symbol("item");
+            let u_sym = env.new_symbol("U");
+            let params = env.param_utils().create_params(
+                [
+                    ParamData { default: None, name: t_sym, ty: env.new_small_universe_ty() },
+                    ParamData { default: None, name: u_sym, ty: env.new_small_universe_ty() },
+                    ParamData { default: None, name: a_sym, ty: env.new_ty(t_sym) },
+                ]
+                .into_iter(),
+            );
+
+            let ret = env.new_ty(u_sym);
+            add("cast", FnTy::builder().params(params).return_ty(ret).build(), |_, _| {
+                unimplemented!("`cast` intrinsic evaluation")
+            })
+        };
+
         DefinedIntrinsics {
             eval,
             implementations,
@@ -908,6 +934,7 @@ impl DefinedIntrinsics {
             size_of,
             ptr_offset,
             transmute,
+            cast,
         }
     }
 

--- a/compiler/hash-ir/src/cast.rs
+++ b/compiler/hash-ir/src/cast.rs
@@ -1,0 +1,108 @@
+//! Contains utility data structures for managing type casts within the IR
+//! and code generation stages. This module defines an auxiliary [CastTy]
+//! to classify what kind of cast occurs between two types. Additionally,
+//! this module provides the [CastKind] type which is used to classify
+//! casts at the top level within RValue positions.
+
+use hash_utils::store::CloneStore;
+
+use crate::{
+    ty::{IrTy, IrTyId},
+    write::WriteIr,
+    IrCtx,
+};
+
+/// A [CastKind] represents all of the different kind of casts that
+/// are permitted in the language. For now, this is just limited to
+/// primitive types, i.e. from a float to an int, or from a char to
+/// an i32, etc.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CastKind {
+    /// A cast from a float to an integral type.
+    FloatToInt,
+
+    /// A cast from a float to an integral type.
+    IntToFloat,
+
+    /// A cast from an integral type to another integral type.
+    IntToInt,
+
+    /// A float to float cast conversion, either converting from a `f32` into a
+    /// `f64` or vice versa.
+    FloatToFloat,
+}
+
+impl CastKind {
+    /// Classify the kind of cast between two types.
+    pub fn classify(ctx: &IrCtx, src: IrTyId, dest: IrTyId) -> Self {
+        let src_ty = CastTy::from_ty(ctx, src);
+        let dest_ty = CastTy::from_ty(ctx, dest);
+
+        match (src_ty, dest_ty) {
+            (Some(CastTy::Int(_)), Some(CastTy::Int(_))) => Self::IntToInt,
+            (Some(CastTy::Int(_)), Some(CastTy::Float)) => Self::IntToFloat,
+            (Some(CastTy::Float), Some(CastTy::Int(_))) => Self::FloatToInt,
+            (Some(CastTy::Float), Some(CastTy::Float)) => Self::FloatToFloat,
+            _ => panic!(
+                "attempting to cast between non-primitive types: src: `{}`, dest: `{}`",
+                src.fmt_with_opts(ctx, true, false),
+                dest.fmt_with_opts(ctx, true, false)
+            ),
+        }
+    }
+}
+
+/// Represents a classification of integer casts that can occur between
+/// integral values within the IR. At code generation, most of these variants
+/// are handled in the same way.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum IntCastKind {
+    /// Converting into a unsigned integer type. Th   e size of the integer
+    /// can be derived from the accompanying IR type.
+    UInt,
+
+    /// Converting into a signed integer type. The size of the integer
+    /// can be derived from the accompanying IR type.
+    Int,
+
+    /// Converting into a `char` type.
+    Char,
+
+    /// Converting into a `bool` type.
+    Bool,
+}
+
+impl IntCastKind {
+    /// Check whether the [IntCastKind] involves a signed integer.
+    pub fn is_signed(self) -> bool {
+        matches!(self, Self::Int)
+    }
+}
+
+/// Represents a classification of type casts that can occur between
+/// various types in the IR. This is a convince type to allow for
+/// easy classification of casts between types when it comes to code
+/// generation.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CastTy {
+    /// Integral type casts.
+    Int(IntCastKind),
+
+    /// Floating-point type casts.
+    Float,
+}
+
+impl CastTy {
+    /// Convert a [IrTy] into a [CastTy] if it is a primitive type. The function
+    /// will return [`None`] if the conversion fails.
+    pub fn from_ty(ctx: &IrCtx, ty: IrTyId) -> Option<Self> {
+        match ctx.tys().get(ty) {
+            IrTy::Int(_) => Some(Self::Int(IntCastKind::Int)),
+            IrTy::UInt(_) => Some(Self::Int(IntCastKind::UInt)),
+            IrTy::Char => Some(Self::Int(IntCastKind::Char)),
+            IrTy::Bool => Some(Self::Int(IntCastKind::Bool)),
+            IrTy::Float(_) => Some(Self::Float),
+            _ => None,
+        }
+    }
+}

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -24,6 +24,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::{
     basic_blocks::BasicBlocks,
+    cast::CastKind,
     ty::{AdtId, IrTy, IrTyId, Mutability, PlaceTy, RefKind, ToIrTy, VariantIdx},
     write::WriteIr,
     IrCtx,
@@ -721,6 +722,10 @@ pub enum RValue {
     /// flag denotes whether the operation violated the check...
     CheckedBinaryOp(BinOp, Box<(Operand, Operand)>),
 
+    /// A cast operation, this will convert the value of the operand to the
+    /// specified type.
+    Cast(CastKind, Operand, IrTyId),
+
     /// Compute the `length` of a place, yielding a `usize`.
     ///
     /// Any `place` that is not an array or slice, is not a valid [RValue].
@@ -766,6 +771,7 @@ impl RValue {
                 let ty = op.ty(ctx, lhs.ty(locals, ctx), rhs.ty(locals, ctx));
                 ctx.tys().create(IrTy::tuple(ctx, &[ty, ctx.tys().common_tys.bool]))
             }
+            RValue::Cast(_, _, ty) => *ty,
             RValue::Len(_) => ctx.tys().common_tys.usize,
             RValue::Ref(mutability, place, kind) => {
                 let ty = place.ty(locals, ctx);

--- a/compiler/hash-ir/src/lib.rs
+++ b/compiler/hash-ir/src/lib.rs
@@ -10,6 +10,7 @@
 )]
 
 pub mod basic_blocks;
+pub mod cast;
 pub mod intrinsics;
 pub mod ir;
 pub mod traversal;

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -401,6 +401,7 @@ pub mod walk_mut {
                 visitor.visit_aggregate_rvalue(*kind, values, reference)
             }
             RValue::Discriminant(place) => visitor.visit_discriminant_rvalue(place, reference),
+            RValue::Cast(_, operand, _) => visitor.visit_operand(operand, reference),
         }
     }
 
@@ -853,6 +854,7 @@ pub mod walk_modifying {
             }
 
             RValue::Discriminant(place) => visitor.visit_discriminant_rvalue(place, reference),
+            RValue::Cast(_, operand, _) => visitor.visit_operand(operand, reference),
         }
     }
 

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -131,6 +131,15 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
                 write!(f, "Checked{op:?}({}, {})", lhs.for_fmt(self.ctx), rhs.for_fmt(self.ctx))
             }
             RValue::Len(place) => write!(f, "len({})", place.for_fmt(self.ctx)),
+            RValue::Cast(_, op, ty) => {
+                // We write out the type fully for the cast.
+                write!(
+                    f,
+                    "cast({}, {})",
+                    ty.fmt_with_opts(self.ctx, true, true),
+                    op.for_fmt(self.ctx)
+                )
+            }
             RValue::UnaryOp(op, operand) => {
                 write!(f, "{op:?}({})", operand.for_fmt(self.ctx))
             }

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -155,7 +155,9 @@ impl<'tcx> Builder<'tcx> {
                             this.fn_call_into_dest(destination, block, *subject, ty, *args, span)
                         })
                     }
-                    FnCallTermKind::UnaryOp(_, _) | FnCallTermKind::BinaryOp(_, _, _) => {
+                    FnCallTermKind::Cast(..)
+                    | FnCallTermKind::UnaryOp(_, _)
+                    | FnCallTermKind::BinaryOp(_, _, _) => {
                         let rvalue = unpack!(block = self.as_rvalue(block, term_id));
                         self.control_flow_graph.push_assign(block, destination, rvalue, span);
                         block.unit()

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -5,7 +5,7 @@
 mod block;
 mod category;
 mod constant;
-mod expr;
+mod into;
 mod matches;
 mod place;
 mod rvalue;

--- a/compiler/hash-tir/src/fns.rs
+++ b/compiler/hash-tir/src/fns.rs
@@ -113,8 +113,10 @@ pub struct FnCallTerm {
     /// This could be a function definition, a value of a function type, or a
     /// trait method.
     pub subject: TermId,
+
     // The arguments to the function, sorted by the parameters of the function
     pub args: ArgsId,
+
     /// Whether the function call is implicit.
     ///
     /// Implicit function calls look like `A<B>`, where as explicit function

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -2,6 +2,18 @@ transmute := <T,U> => (item: T) -> U => {
     Intrinsics::transmute(T, U, item)
 }
 
+dbg := <T> => (item: T) -> T => {
+    Intrinsics::debug_print(T, item)
+    item
+}
+
+
+/// The `cast(..)` function is used to cast some value into another 
+/// type provided that the types are cast compatible. 
+cast := <T> => (U: Type, item: T) -> U => {
+    Intrinsics::cast(T, U, item)
+}
+
 
 #repr_c SizedPointer := struct(&raw u8, usize);
 
@@ -16,11 +28,6 @@ transmute := <T,U> => (item: T) -> U => {
 #foreign malloc := (size: usize) -> &raw u8 => { Intrinsics::abort() }
 
 #foreign free := (ptr: &raw u8) -> () => { Intrinsics::abort() }
-
-dbg := <T> => (item: T) -> T => {
-    Intrinsics::debug_print(T, item)
-    item
-}
 
 print := (item: str) => {
     STDIN := 0


### PR DESCRIPTION
This PR implements the casting intrinsic which allows for primitive types to be converted between one and the other.

closes #645 