### PR TITLE
lower+ir: fix issue with fn scoping args and add `Live` and `Dead` statement variants

### DIFF
--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -273,6 +273,9 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> IrVisitorMut<'ir>
                 self.assign(local, reference);
             }
 
+            // Don't do anything for meta context.
+            PlaceContext::Meta(_) => {}
+
             PlaceContext::Immutable(ImmutablePlaceContext::Operand) => {
                 match &mut self.locals[local] {
                     // @@Investigate: do we need to deal with in any way here?

--- a/compiler/hash-codegen/src/lower/statement.rs
+++ b/compiler/hash-codegen/src/lower/statement.rs
@@ -54,6 +54,16 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
             StatementKind::Discriminate(place, discriminant) => {
                 self.codegen_place(builder, place).codegen_set_discriminant(builder, discriminant);
             }
+            StatementKind::Live(local) => {
+                if let LocalRef::Place(place) = self.locals[local] {
+                    place.storage_live(builder);
+                }
+            }
+            StatementKind::Dead(local) => {
+                if let LocalRef::Place(place) = self.locals[local] {
+                    place.storage_dead(builder);
+                }
+            }
             StatementKind::Nop => {}
         }
     }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -814,6 +814,14 @@ pub enum StatementKind {
     /// Set the discriminant on a particular place, this is used to concretely
     /// specify what the discriminant of a particular enum/union type is.
     Discriminate(Place, VariantIdx),
+
+    /// A statement which is used to denote that a [Local] is now "live"
+    /// in terms of the live interval.
+    Live(Local),
+
+    /// A statement which is used to denote that a [Local] is now "dead"
+    /// in terms of live interval.
+    Dead(Local),
 }
 
 /// A [Statement] is a intermediate transformation step within a [BasicBlock].

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -430,7 +430,7 @@ pub enum LocalKind {
 /// is used to store some data within the function body, it contains
 /// an associated [Mutability], and [IrTy], as well as a name if the
 /// information is available.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LocalDecl {
     /// Mutability of the local.
     pub mutability: Mutability,

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -199,6 +199,12 @@ impl fmt::Display for ForFormatting<'_, &Statement> {
             StatementKind::Discriminate(place, index) => {
                 write!(f, "discriminant({}) = {index}", place.for_fmt(self.ctx))
             }
+            StatementKind::Live(local) => {
+                write!(f, "live({local:?})")
+            }
+            StatementKind::Dead(local) => {
+                write!(f, "dead({local:?})")
+            }
         }
     }
 }

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -33,7 +33,7 @@ impl<'ir> IrBodyWriter<'ir> {
     /// the [BodySource] of the [Body]. For function items, the format mimics
     /// a function declaration:
     /// ```ignore
-    /// foo(_0: i32, _1: i32) -> i32 {
+    /// foo := (_0: i32, _1: i32) -> i32 {
     ///    ...
     /// }
     /// ```
@@ -51,7 +51,7 @@ impl<'ir> IrBodyWriter<'ir> {
 
         match self.body.info().source() {
             BodySource::Item | BodySource::Intrinsic => {
-                write!(f, "{}(", self.body.info().name)?;
+                write!(f, "{} := (", self.body.info().name)?;
 
                 for (i, param) in declarations.take(self.body.arg_count).enumerate() {
                     if i > 0 {

--- a/compiler/hash-lower/src/build/block.rs
+++ b/compiler/hash-lower/src/build/block.rs
@@ -41,7 +41,7 @@ impl<'tcx> Builder<'tcx> {
 
                 let next_block = self.control_flow_graph.start_new_block();
 
-                self.enter_breakable_block(loop_body, next_block, place, move |this| {
+                self.enter_breakable_block(loop_body, next_block, move |this| {
                     // We need to create a temporary for the blocks return value which is
                     // always going to be `()`
                     let tmp_place = this.make_tmp_unit();
@@ -125,7 +125,6 @@ impl<'tcx> Builder<'tcx> {
         &mut self,
         loop_body: BasicBlock,
         next_block: BasicBlock,
-        _break_destination: Place,
         f: F,
     ) -> BlockAnd<()>
     where

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -33,7 +33,7 @@ use hash_tir::{
     terms::{Term, TermId, UnsafeTerm},
     tuples::TupleTerm,
     ty_as_variant,
-    utils::{common::CommonUtils, AccessToUtils},
+    utils::common::CommonUtils,
 };
 use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
@@ -149,8 +149,6 @@ impl<'tcx> Builder<'tcx> {
                         let fn_ty = ty_as_variant!(self, self.get_ty(ty), Fn);
 
                         Context::enter_scope_mut(self, fn_ty.into(), |this| {
-                            this.context_utils().add_arg_bindings(fn_ty.params, *args);
-
                             let ty = this.ty_from_tir_ty(ty);
                             this.fn_call_into_dest(destination, block, *subject, ty, *args, span)
                         })

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -1,6 +1,7 @@
 //! Definitions for [Test]s that is used to represent what kind
 //! of test needs to be performed on a particular set of candidates
 //! when deciding where to jump to within the decision tree.
+#![allow(clippy::too_many_arguments)]
 
 use std::cmp::Ordering;
 

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -1,6 +1,5 @@
 //! Defines a IR Builder for function blocks. This is essentially a builder
 //! pattern for lowering declarations into the associated IR.
-#![allow(clippy::too_many_arguments)]
 
 mod block;
 mod category;
@@ -38,7 +37,7 @@ use hash_tir::{
         env::{AccessToEnv, Env},
     },
     fns::{FnBody, FnDef, FnDefId, FnTy},
-    params::ParamsId,
+    params::ParamId,
     scopes::StackMemberId,
     terms::TermId,
     utils::{common::CommonUtils, context::ContextUtils},
@@ -50,9 +49,9 @@ use hash_utils::{
 
 use crate::cfg::ControlFlowGraph;
 
-/// A wrapper type for the kind of AST node that is being lowered, the [Builder]
-/// accepts either a [ast::FnDef] or an [ast::Expr] node. The [ast::Expr] node
-/// case is used when a constant block is being lowered.
+/// A wrapper type for the kind of TIR term that is being lowered, the [Builder]
+/// accepts either a [FnDefId] or a [TermId]. The [TermId] case is used when a
+/// constant block is being lowered.
 #[derive(Clone, Copy)]
 pub(crate) enum BuildItem {
     /// A function body is being lowered.
@@ -97,11 +96,11 @@ impl From<TermId> for BuildItem {
 /// Use to represent a mapping between [BindingKind]s that come from
 /// the TIR to identify a [Local] as either being a reference to a
 /// stack member or a function parameter.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum LocalKey {
     /// The parameter of the current function since they are in a
     /// different binding kind.
-    Param((ParamsId, usize)),
+    Param(ParamId),
 
     /// All references to variables that are declared on the stack
     /// of the function body.

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -108,7 +108,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
         let entry_point = &semantic_storage.entry_point;
 
         // Discover all of the bodies that need to be lowered
-        let discoverer = FnDiscoverer::new(&env);
+        let discoverer = FnDiscoverer::new(&env, source_stage_info);
         let items = discoverer.discover_fns();
 
         // Pre-allocate the vector of lowered bodies.
@@ -147,13 +147,6 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             // add the body to the lowered bodies
             lowered_bodies.push(body);
         }
-
-        // @@TodoTIR: deal with the entry point here.
-
-        //     if let Some(instance) = discoverer.entry_point_instance() {
-        //         let kind = ty_storage.entry_point_state.kind().unwrap();
-        //         ir_storage.entry_point.set(instance, kind);
-        //     }
 
         // Mark all modules now as lowered, and all generated
         // bodies to the store.


### PR DESCRIPTION
This PR fixes an issue with function arguments being placed into scope when they shouldn't be. This caused the scoping to fail when attempting to resolve variables that were referenced in function call arguments.

Additionally, this PR introduces  `Live` and `Dead` statements in order to denote liveness intervals for locals that are declared in the body. Whilst liveness isn't implemented yet, this is one of the needed components for this.