### PR TITLE
codegen: fix handling of string and slice types, implement `transmute()` intrinsic

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/debug_info.rs
+++ b/compiler/hash-codegen-llvm/src/translation/debug_info.rs
@@ -15,7 +15,7 @@ impl<'b, 'm> BuildDebugInfoMethods for Builder<'_, 'b, 'm> {
         _fn_abi: &FnAbi,
         _value: Option<Self::Function>,
     ) -> Self::DebugInfoScope {
-        todo!()
+        unimplemented!()
     }
 
     fn create_debug_info_for_variable(
@@ -26,7 +26,7 @@ impl<'b, 'm> BuildDebugInfoMethods for Builder<'_, 'b, 'm> {
         _kind: VariableKind,
         _span: SourceLocation,
     ) -> Self::DebugInfoVariable {
-        todo!()
+        unimplemented!()
     }
 
     fn create_debug_info_location(
@@ -34,10 +34,10 @@ impl<'b, 'm> BuildDebugInfoMethods for Builder<'_, 'b, 'm> {
         _scope: Self::DebugInfoScope,
         _span: SourceLocation,
     ) -> Self::DebugInfoLocation {
-        todo!()
+        unimplemented!()
     }
 
     fn finalise_debug_info(&self) {
-        todo!()
+        unimplemented!()
     }
 }

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -458,13 +458,13 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
         match scalar.kind() {
             ScalarKind::Int { kind, .. } => ctx.type_from_integer(kind),
             ScalarKind::Float { kind } => ctx.type_from_float(kind),
-            ScalarKind::Pointer => {
-                let (ty, addr) = if let Some(info) =
+            ScalarKind::Pointer(addr) => {
+                let ty = if let Some(info) =
                     ctx.layout_computer().compute_layout_info_of_pointee_at(*self, offset)
                 {
-                    (ctx.type_pointee_for_alignment(info.alignment), info.address_space)
+                    ctx.type_pointee_for_alignment(info.alignment)
                 } else {
-                    (ctx.type_i8p(), AddressSpace::DATA)
+                    ctx.type_i8p()
                 };
 
                 ctx.type_ptr_to_ext(ty, addr)

--- a/compiler/hash-codegen/src/lower/intrinsics.rs
+++ b/compiler/hash-codegen/src/lower/intrinsics.rs
@@ -2,10 +2,18 @@
 //! code and resolving references to intrinsic function calls.
 
 use hash_abi::FnAbi;
-use hash_ir::{intrinsics::Intrinsic, ty::IrTy};
+use hash_ir::{intrinsics::Intrinsic, ir, ty::IrTy};
+use hash_target::abi::{AbiRepresentation, ScalarKind};
+use hash_utils::store::Store;
 
-use super::{abi::compute_fn_abi_from_instance, FnBuilder};
-use crate::traits::{builder::BlockBuilderMethods, ctx::HasCtxMethods, misc::MiscBuilderMethods};
+use super::{abi::compute_fn_abi_from_instance, locals::LocalRef, place::PlaceRef, FnBuilder};
+use crate::{
+    lower::operands::OperandValue,
+    traits::{
+        builder::BlockBuilderMethods, ctx::HasCtxMethods, misc::MiscBuilderMethods,
+        ty::TypeBuilderMethods,
+    },
+};
 
 impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// Resolve a reference to an [Intrinsic].
@@ -26,5 +34,95 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
 
         let abi = compute_fn_abi_from_instance(builder, instance).unwrap();
         (abi, builder.get_fn_ptr(instance))
+    }
+
+    /// Generate code for a `transmute` intrinsic call. The `transmute`
+    /// intrinsic allows for any type to be transmuted into any other type.
+    /// This is powerful mechanism that allows for interfacing with code
+    /// that requires converting from a potentially opaque type into a known
+    /// type.
+    pub(super) fn codegen_transmute(
+        &mut self,
+        builder: &mut Builder,
+        src: &ir::Operand,
+        dest: ir::Place,
+    ) {
+        if let Some(local) = dest.as_local() {
+            match self.locals[local] {
+                LocalRef::Place(place) => self.codegen_transmute_into(builder, src, place),
+                LocalRef::Operand(None) => {
+                    // We might have to perform some adjustments to the layout of the
+                    // destination and source if they mismatch.
+                    let dest_layout = self.compute_place_ty_info(builder, dest);
+
+                    let place = PlaceRef::new_stack(builder, dest_layout);
+                    place.storage_live(builder);
+
+                    self.codegen_transmute_into(builder, src, place);
+                    let op = builder.load_operand(place);
+                    place.storage_dead(builder);
+
+                    self.locals[local] = LocalRef::Operand(Some(op));
+                }
+                LocalRef::Operand(_) => panic!("assigning to operand twice"),
+            }
+        } else {
+            // Generate the place, and then store the value into it.
+            let place = self.codegen_place(builder, dest);
+            self.codegen_transmute_into(builder, src, place)
+        }
+    }
+
+    /// Helper function that generates code for a `transmute` to store the value
+    /// of `src` into the specified [PlaceRef].
+    fn codegen_transmute_into(
+        &mut self,
+        builder: &mut Builder,
+        src: &ir::Operand,
+        dest: PlaceRef<Builder::Value>,
+    ) {
+        let src = self.codegen_operand(builder, src);
+
+        self.ctx.layouts().map_many_fast([src.info.layout, dest.info.layout], |layouts| {
+            let (src_layout, dest_layout) = (layouts[0], layouts[1]);
+
+            // Special case for transmuting between pointers and integers.
+            if let (AbiRepresentation::Scalar(src_scalar), AbiRepresentation::Scalar(dest_scalar)) =
+                (src_layout.abi, dest_layout.abi)
+            {
+                let is_src_ptr = matches!(src_scalar.kind(), ScalarKind::Pointer(_));
+                let is_dest_ptr = matches!(dest_scalar.kind(), ScalarKind::Pointer(_));
+
+                if is_src_ptr == is_dest_ptr {
+                    debug_assert_eq!(src_layout.size, dest_layout.size);
+
+                    let src = builder.value_from_immediate(src.immediate_value());
+
+                    // If the source and destination are pointers, we need to cast
+                    // the pointer to the destination type.
+                    let src_as_dst = if is_src_ptr {
+                        builder.pointer_cast(src, builder.backend_ty_from_info(dest.info))
+                    } else {
+                        builder.bit_cast(src, builder.backend_ty_from_info(dest.info))
+                    };
+
+                    // Now store the value into the destination
+                    let value = OperandValue::Immediate(
+                        builder.to_immediate_scalar(src_as_dst, dest_scalar),
+                    );
+                    value.store(builder, dest);
+
+                    return;
+                }
+            }
+
+            // Create a pointer cast
+            let ty = builder.backend_ty_from_info(src.info);
+            let cast_ptr = builder.pointer_cast(dest.value, builder.type_ptr_to(ty));
+
+            // Store the value into the `cast_ptr` value
+            let alignment = src_layout.alignment.abi.min(dest.alignment);
+            src.value.store(builder, PlaceRef::new_aligned(cast_ptr, src.info, alignment))
+        })
     }
 }

--- a/compiler/hash-codegen/src/lower/place.rs
+++ b/compiler/hash-codegen/src/lower/place.rs
@@ -53,6 +53,11 @@ impl<'a, 'b, V: CodeGenObject> PlaceRef<V> {
         Self { value, info, alignment, extra: None }
     }
 
+    /// Create a new [PlaceRef] with a specified [Alignment].
+    pub fn new_aligned(value: V, info: TyInfo, alignment: Alignment) -> Self {
+        Self { value, info, alignment, extra: None }
+    }
+
     /// Create a new [PlaceRef] which refers to a value allocated on the
     /// function stack.
     pub fn new_stack<Builder: BlockBuilderMethods<'a, 'b, Value = V>>(

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -74,12 +74,11 @@ impl<'tcx> Builder<'tcx> {
     /// bound within the pattern since we have already checked that all pattern
     /// variants declare the same binds of the same type, on the same
     /// pattern level.
-    fn declare_bindings(&mut self, pat: PatId) {
+    pub(super) fn declare_bindings(&mut self, pat: PatId) {
         self.visit_primary_pattern_bindings(pat, &mut |this, mutability, name, _span, ty| {
             let key = this.local_key_from_symbol(name);
             let name = this.symbol_name(name);
             let local = LocalDecl::new(name, mutability, ty);
-
             this.push_local(local, key);
         })
     }

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -194,6 +194,7 @@ impl<'tcx> Builder<'tcx> {
                 self,
                 ScopeKind::Stack(arm.stack_id),
                 |this| {
+                    this.declare_bindings(arm.bind_pat);
                     let arm_block = this.bind_pat(subject_span, arm.bind_pat, candidate);
                     lowered_arms_edges.push(this.term_into_dest(destination, arm_block, arm.value));
                 },

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -11,7 +11,6 @@ use hash_source::{
     location::Span,
 };
 use hash_tir::{
-    arrays::ArrayTerm,
     environment::env::AccessToEnv,
     terms::{Term, TermId},
 };
@@ -38,9 +37,6 @@ impl<'tcx> Builder<'tcx> {
             Term::Lit(lit) => {
                 let value = self.as_constant(&lit).into();
                 block.and(value)
-            }
-            Term::Array(ArrayTerm { .. }) => {
-                todo!()
             }
             Term::FnCall(fn_call) => {
                 match self.classify_fn_call_term(&fn_call) {
@@ -118,7 +114,8 @@ impl<'tcx> Builder<'tcx> {
                 }
             }
 
-            Term::Tuple(_)
+            Term::Array(_)
+            | Term::Tuple(_)
             | Term::Ctor(_)
             | Term::FnRef(_)
             | Term::Block(_)

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -28,7 +28,7 @@ use hash_tir::{
 use hash_utils::store::{PartialStore, SequenceStore, Store};
 
 use super::Builder;
-use crate::ty::TyLoweringCtx;
+use crate::lower_ty::TyLoweringCtx;
 
 /// Convert a [LitTerm] into a [Const] value.
 pub(super) fn constify_lit_pat(term: &LitPat) -> Const {

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -9,8 +9,8 @@ mod build;
 mod cfg;
 
 mod discover;
+mod lower_ty;
 mod optimise;
-mod ty;
 
 use build::{Builder, Tcx};
 use discover::FnDiscoverer;
@@ -40,8 +40,8 @@ use hash_utils::{
     store::{CloneStore, PartialStore, SequenceStore, Store},
     stream_writeln,
 };
+use lower_ty::TyLoweringCtx;
 use optimise::Optimiser;
-use ty::TyLoweringCtx;
 
 /// The Hash IR builder compiler stage.
 #[derive(Default)]

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -94,6 +94,7 @@ impl<'ir> TyLoweringCtx<'ir> {
             IrTy::Int(SIntTy::ISize) => self.lcx.tys().common_tys.isize,
             IrTy::Float(FloatTy::F32) => self.lcx.tys().common_tys.f32,
             IrTy::Float(FloatTy::F64) => self.lcx.tys().common_tys.f64,
+            IrTy::Str => self.lcx.tys().common_tys.str,
             _ => self.lcx.tys().create(ty),
         };
 
@@ -311,16 +312,27 @@ impl<'ir> TyLoweringCtx<'ir> {
                         }
                     }
 
-                    // @@Verify: does `str` now imply that it is a `&str`, or should we create a
-                    // `&str` type here.
-                    PrimitiveCtorInfo::Str => IrTy::Str,
+                    // @@Temporary: `str` implies that it is a `&str`
+                    PrimitiveCtorInfo::Str => IrTy::Ref(
+                        self.lcx.tys().common_tys.byte_slice,
+                        Mutability::Immutable,
+                        ty::RefKind::Normal,
+                    ),
                     PrimitiveCtorInfo::Char => IrTy::Char,
                     PrimitiveCtorInfo::Array(ArrayCtorInfo { element_ty, length }) => {
                         match length.and_then(|l| self.try_use_term_as_integer_lit(l)) {
                             Some(length) => {
                                 IrTy::Array { ty: self.ty_id_from_tir_ty(element_ty), length }
                             }
-                            None => IrTy::Slice(self.ty_id_from_tir_ty(element_ty)),
+                            // @@Temporary: `[]` implies that it is a `&[]`, and there is no
+                            // information about mutability and reference kind, so for now we
+                            // assume that it is immutable and a normal reference kind.
+                            None => {
+                                let slice = IrTy::Slice(self.ty_id_from_tir_ty(element_ty));
+                                let id = self.lcx.tys().create(slice);
+
+                                IrTy::Ref(id, Mutability::Immutable, ty::RefKind::Normal)
+                            }
                         }
                     }
                 }

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -242,6 +242,8 @@ core_idents! {
     // Language items
     intrinsics: "intrinsics",
     entry_point: "entry_point",
+    transmute: "transmute",
+    cast: "cast",
 
     // Language attributes
     no_mangle: "no_mangle",

--- a/compiler/hash-target/src/abi.rs
+++ b/compiler/hash-target/src/abi.rs
@@ -120,7 +120,7 @@ pub enum ScalarKind {
     Float { kind: FloatTy },
 
     /// A pointer primitive scalar value.
-    Pointer,
+    Pointer(AddressSpace),
 }
 
 impl fmt::Display for ScalarKind {
@@ -131,7 +131,7 @@ impl fmt::Display for ScalarKind {
                 write!(f, "{}{}", prefix, kind.size().bits())
             }
             ScalarKind::Float { kind } => write!(f, "{kind}"),
-            ScalarKind::Pointer => write!(f, "<ptr>"),
+            ScalarKind::Pointer(_) => write!(f, "<ptr>"),
         }
     }
 }
@@ -145,7 +145,7 @@ impl ScalarKind {
         match self {
             ScalarKind::Int { kind, .. } => kind.align(ctx),
             ScalarKind::Float { kind } => kind.align(ctx),
-            ScalarKind::Pointer => dl.pointer_align,
+            ScalarKind::Pointer(_) => dl.pointer_align,
         }
     }
 
@@ -157,7 +157,7 @@ impl ScalarKind {
         match self {
             ScalarKind::Int { kind, .. } => kind.size(),
             ScalarKind::Float { kind } => kind.size(),
-            ScalarKind::Pointer => dl.pointer_size,
+            ScalarKind::Pointer(_) => dl.pointer_size,
         }
     }
 

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -1,3 +1,21 @@
+/// The Hash Compiler Prelude, this defines core language functionality
+/// that is expected to be available to all running contexts.
+
+/// This is powerful mechanism that
+/// allows for interfacing with code that requires converting from a potentially
+/// opaque type into a known type. An example of such code might be to access information
+/// about the `&str` type, such as its length or the pointer to its data. To
+/// do this, the type `SizedPointer` which is defined in the prelude can be used
+/// to transmute the `&str` into a `SizedPointer` and further access information
+/// about it. This is done like so:
+/// ```ignore
+/// SizedPointer(bytes, length) := transmute<SizedPointer>(message);
+/// ...
+/// ```
+///
+/// Here, the `message` of string type is transmuted into `SizedPointer` type, This
+/// allows for the program to now read the `bytes` and `length` fields of the
+/// `SizedPointer` type.
 transmute := <T,U> => (item: T) -> U => {
     Intrinsics::transmute(T, U, item)
 }
@@ -8,8 +26,8 @@ dbg := <T> => (item: T) -> T => {
 }
 
 
-/// The `cast(..)` function is used to cast some value into another 
-/// type provided that the types are cast compatible. 
+/// The `cast(..)` function is used to cast some value into another
+/// type provided that the types are cast compatible.
 cast := <T> => (U: Type, item: T) -> U => {
     Intrinsics::cast(T, U, item)
 }

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -20,6 +20,26 @@ transmute := <T,U> => (item: T) -> U => {
     Intrinsics::transmute(T, U, item)
 }
 
+
+/// The printing function, this allows for printing of strings to the
+/// standard output.
+print := (msg: str, /* end: char = '\n' */) => {
+    STDIN := 0
+    STDOUT := 1
+    STDERR := 2
+
+    // We transmute the message into a SizedPointer and then write it out to
+    // stdout.
+    SizedPointer(bytes, len) := Intrinsics::transmute(type str, type SizedPointer, msg);
+    write(1, bytes, len);
+
+    // @@Todo: un-comment this when default parameters are working
+    // write the end character
+    // end_sep := Intrinsics::cast(type char, type u8, end);
+    // write(1, &raw end_sep, 1);
+}
+
+
 dbg := <T> => (item: T) -> T => {
     Intrinsics::debug_print(T, item)
     item
@@ -46,15 +66,6 @@ cast := <T> => (U: Type, item: T) -> U => {
 #foreign malloc := (size: usize) -> &raw u8 => { Intrinsics::abort() }
 
 #foreign free := (ptr: &raw u8) -> () => { Intrinsics::abort() }
-
-print := (item: str) => {
-    STDIN := 0
-    STDOUT := 1
-    STDERR := 2
-
-    // data := transmute<_, SizedPointer>(item)
-    // write(STDOUT, data.0, data.1)
-}
 
 // #dump_ir panic := (item: str) -> ! => {
 //     print(item);


### PR DESCRIPTION
This patch fixes the handling of string and slice types within code generation. This patch also implements the `Intrinsic::transmute()` function, which allows for converting between a type to another type whilst it is permitted in the type system.

With these changes, it is now possible to define a simple printing function in the standard library prelude!