### PR TITLE
Adjust literals during inference to their true type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "hash-pipeline",
  "hash-reporting",
  "hash-source",
+ "hash-target",
  "hash-tir",
  "hash-tree-def",
  "hash-typecheck",

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -126,6 +126,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             &semantic_storage.context,
             &workspace.node_map,
             &workspace.source_map,
+            settings.target(),
             &source_info,
         );
 
@@ -186,7 +187,13 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
 
     fn cleanup(&mut self, entry: SourceId, stage_data: &mut Ctx) {
         let LoweringCtx {
-            semantic_storage, ir_storage, layout_storage, workspace, mut stdout, ..
+            semantic_storage,
+            ir_storage,
+            layout_storage,
+            workspace,
+            mut stdout,
+            settings,
+            ..
         } = stage_data.data();
         let source_info = CurrentSourceInfo { source_id: entry };
         let env = Env::new(
@@ -194,6 +201,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             &semantic_storage.context,
             &workspace.node_map,
             &workspace.source_map,
+            settings.target(),
             &source_info,
         );
 

--- a/compiler/hash-semantics/Cargo.toml
+++ b/compiler/hash-semantics/Cargo.toml
@@ -26,3 +26,4 @@ hash-tir = { path = "../hash-tir" }
 hash-utils = { path = "../hash-utils" }
 hash-intrinsics = { path = "../hash-intrinsics" }
 hash-typecheck = { path = "../hash-typecheck" }
+hash-target = { path = "../hash-target" }

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -26,6 +26,7 @@ use hash_pipeline::{
 };
 use hash_reporting::diagnostic::Diagnostics;
 use hash_source::SourceId;
+use hash_target::Target;
 use hash_tir::environment::{
     context::Context, env::Env, source_info::CurrentSourceInfo, stores::Stores,
 };
@@ -72,6 +73,9 @@ pub struct SemanticAnalysisCtx<'tc> {
 
     /// The user-given settings to semantic analysis.
     pub flags: Flags,
+
+    /// Target info
+    pub target: &'tc Target,
 }
 
 pub trait SemanticAnalysisCtxQuery: CompilerInterface {
@@ -127,7 +131,7 @@ impl<Ctx: SemanticAnalysisCtxQuery> CompilerStage<Ctx> for SemanticAnalysis {
     }
 
     fn run(&mut self, entry_point: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
-        let SemanticAnalysisCtx { workspace, semantic_storage, flags } = ctx.data();
+        let SemanticAnalysisCtx { workspace, semantic_storage, flags, target } = ctx.data();
         let current_source_info = CurrentSourceInfo { source_id: entry_point };
 
         // Construct the core TIR environment.
@@ -136,6 +140,7 @@ impl<Ctx: SemanticAnalysisCtxQuery> CompilerStage<Ctx> for SemanticAnalysis {
             &semantic_storage.context,
             &workspace.node_map,
             &workspace.source_map,
+            target,
             &current_source_info,
         );
 

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -242,6 +242,7 @@ impl SemanticAnalysisCtxQuery for CompilerSession {
                 dump_tir: self.settings.semantic_settings.dump_tir,
                 eval_tir: self.settings.semantic_settings.eval_tir,
             },
+            target: self.settings.target(),
         }
     }
 }

--- a/compiler/hash-tir/src/environment/env.rs
+++ b/compiler/hash-tir/src/environment/env.rs
@@ -1,5 +1,6 @@
 use hash_ast::node_map::NodeMap;
 use hash_source::SourceMap;
+use hash_target::Target;
 
 use super::source_info::CurrentSourceInfo;
 use crate::environment::{context::Context, stores::Stores};
@@ -52,6 +53,7 @@ env! {
     context: Context,
     node_map: NodeMap,
     source_map: SourceMap,
+    target: Target,
     current_source_info: CurrentSourceInfo,
 }
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -5,7 +5,7 @@ use hash_ast::ast::{FloatLitKind, IntLitKind};
 use hash_intrinsics::utils::PrimitiveUtils;
 use hash_reporting::diagnostic::Diagnostics;
 use hash_source::{
-    constant::{FloatTy, IntTy, SIntTy, UIntTy},
+    constant::{FloatTy, IntTy, SIntTy, UIntTy, CONSTANT_MAP},
     entry_point::EntryPointKind,
     identifier::IDENTS,
     ModuleKind,
@@ -22,7 +22,10 @@ use hash_tir::{
         PrimitiveCtorInfo,
     },
     directives::DirectiveTarget,
-    environment::context::{ParamOrigin, ScopeKind},
+    environment::{
+        context::{ParamOrigin, ScopeKind},
+        env::AccessToEnv,
+    },
     fns::{FnBody, FnCallTerm, FnDefId, FnTy},
     lits::Lit,
     mods::{ModDefId, ModMemberId, ModMemberValue},
@@ -419,6 +422,41 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         Ok(Inference(TupleTerm { data: inferred_args }, TupleTy { data: inferred_params }))
     }
 
+    /// Potentially adjust the underlying constant of a literal after its type
+    /// has been inferred.
+    ///
+    /// This might be needed if a literal is unsuffixed in the original source,
+    /// and thus represented as something other than its true type in the
+    /// `CONSTANT_MAP`. After `infer_lit`, its true type will be known, and
+    /// we can then adjust the underlying constant to match the true type.
+    fn adjust_lit_repr(&self, lit: &Lit, inferred_ty: TyId) -> TcResult<()> {
+        // @@Future: we could defer parsing these literals until we have inferred their
+        // type, and here we can then check that the literal is compatible with
+        // the inferred type, and then we create the constant, avoiding much of
+        // the complexity here.
+        match lit {
+            Lit::Float(float_lit) => {
+                if let Some(lit_ty) = self.try_use_ty_as_lit_ty(inferred_ty) {
+                    CONSTANT_MAP.adjust_float(float_lit.underlying.value, lit_ty.into());
+                }
+                // @@Incomplete: it is possible that exotic literal
+                // types are defined, what happens then?
+            }
+            Lit::Int(int_lit) => {
+                if let Some(lit_ty) = self.try_use_ty_as_lit_ty(inferred_ty) {
+                    CONSTANT_MAP.adjust_int(
+                        int_lit.underlying.value,
+                        lit_ty.into(),
+                        self.env().target().pointer_bit_width,
+                    );
+                }
+                // @@Incomplete: as above
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     /// Infer the type of a literal.
     pub fn infer_lit(&self, lit: &Lit, annotation_ty: TyId) -> TcResult<Inference<Lit, TyId>> {
         let inferred_ty = self.new_data_ty(match lit {
@@ -506,7 +544,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             },
         });
 
-        Ok(Inference(*lit, self.check_by_unify(inferred_ty, annotation_ty)?))
+        let inferred_ty = self.check_by_unify(inferred_ty, annotation_ty)?;
+        self.adjust_lit_repr(lit, inferred_ty)?;
+        Ok(Inference(*lit, inferred_ty))
     }
 
     /// Infer the type of a primitive term.


### PR DESCRIPTION
Using the added `adjust_{float,lit}` functions by @feds01, this PR uses them to adjust the size of literals during inference to their true inferred type.