### PR TITLE
core: adjust literal representation when inferred type and specified type differ

### DIFF
--- a/compiler/hash-backend/src/lib.rs
+++ b/compiler/hash-backend/src/lib.rs
@@ -31,8 +31,8 @@ impl<Ctx: BackendCtxQuery> CompilerStage<Ctx> for CodeGenPass {
         CompilerStageKind::CodeGen
     }
 
-    fn metrics(&self) -> Option<&StageMetrics> {
-        Some(&self.metrics)
+    fn metrics(&self) -> StageMetrics {
+        self.metrics.clone()
     }
 
     fn reset_metrics(&mut self) {

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -544,14 +544,15 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
 
         let intrinsic_prefix = match (op, int_ty.is_signed()) {
             (CheckedOp::Add, true) => "llvm.sadd",
-            (CheckedOp::Add, false) => "llvm.sadd",
+            (CheckedOp::Add, false) => "llvm.uadd",
             (CheckedOp::Sub, true) => "llvm.ssub",
             (CheckedOp::Sub, false) => "llvm.usub",
             (CheckedOp::Mul, true) => "llvm.smul",
             (CheckedOp::Mul, false) => "llvm.umul",
         };
 
-        let intrinsic_name = format!("{}.with.overflow.{}", intrinsic_prefix, int_ty.to_name());
+        let size = int_ty.size(ptr_width).unwrap();
+        let intrinsic_name = format!("{}.with.overflow.i{}", intrinsic_prefix, size.bits());
 
         let result = self.call_intrinsic(&intrinsic_name, &[lhs, rhs]);
         (self.extract_field_value(result, 0), self.extract_field_value(result, 1))

--- a/compiler/hash-codegen-llvm/src/translation/constants.rs
+++ b/compiler/hash-codegen-llvm/src/translation/constants.rs
@@ -144,7 +144,7 @@ impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
             Const::Bool(val) => self.const_bool(val),
             Const::Char(ch) => self.const_u32(ch as u32),
             Const::Int(interned_int) => {
-                let const_int = CONSTANT_MAP.lookup_int_constant(interned_int);
+                let const_int = CONSTANT_MAP.lookup_int(interned_int);
 
                 // Convert the constant into a u128 and then emit the
                 // correct LLVM constant for it.
@@ -158,7 +158,7 @@ impl<'b, 'm> ConstValueBuilderMethods<'b> for CodeGenCtx<'b, 'm> {
                     })
             }
             Const::Float(interned_float) => {
-                self.const_float(ty, CONSTANT_MAP.lookup_float_constant(interned_float).as_f64())
+                self.const_float(ty, CONSTANT_MAP.lookup_float(interned_float).as_f64())
             }
             Const::Str(str) => self.const_str(str).0,
         }

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -1,5 +1,7 @@
 use hash_ast::ast::{self};
-use hash_source::constant::{IntConstant, IntConstantValue, CONSTANT_MAP};
+use hash_source::constant::{
+    FloatTy, IntConstant, IntConstantValue, IntTy, SIntTy, UIntTy, CONSTANT_MAP,
+};
 use hash_tir::{
     data::{CtorDefId, CtorPat, CtorTerm, DataTy},
     environment::env::AccessToEnv,
@@ -15,6 +17,10 @@ use num_bigint::BigInt;
 
 use crate::primitives::AccessToPrimitives;
 
+/// Primitive literal types.
+///
+/// @@Future: maybe use `IntTy` and `FloatTy` for integer and float types
+/// instead?
 pub enum LitTy {
     I8,
     U8,
@@ -32,6 +38,36 @@ pub enum LitTy {
     F64,
     Bool,
     Char,
+}
+
+impl From<LitTy> for IntTy {
+    fn from(value: LitTy) -> Self {
+        match value {
+            LitTy::U8 => IntTy::UInt(UIntTy::U8),
+            LitTy::U16 => IntTy::UInt(UIntTy::U16),
+            LitTy::U32 => IntTy::UInt(UIntTy::U32),
+            LitTy::U64 => IntTy::UInt(UIntTy::U64),
+            LitTy::U128 => IntTy::UInt(UIntTy::U128),
+            LitTy::UBig => IntTy::UInt(UIntTy::UBig),
+            LitTy::I8 => IntTy::Int(SIntTy::I8),
+            LitTy::I16 => IntTy::Int(SIntTy::I16),
+            LitTy::I32 => IntTy::Int(SIntTy::I32),
+            LitTy::I64 => IntTy::Int(SIntTy::I64),
+            LitTy::I128 => IntTy::Int(SIntTy::I128),
+            LitTy::IBig => IntTy::Int(SIntTy::IBig),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<LitTy> for FloatTy {
+    fn from(value: LitTy) -> Self {
+        match value {
+            LitTy::F32 => FloatTy::F32,
+            LitTy::F64 => FloatTy::F64,
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Utilities relating to creating and inspecting primitive types.
@@ -114,7 +150,7 @@ pub trait PrimitiveUtils: AccessToPrimitives {
         self.new_term(Term::Lit(Lit::Float(FloatLit {
             underlying: ast::FloatLit {
                 kind: ast::FloatLitKind::Unsuffixed,
-                value: CONSTANT_MAP.create_f64_float_constant(lit.into(), None),
+                value: CONSTANT_MAP.create_f64_float(lit.into(), None),
             },
         })))
     }
@@ -132,7 +168,7 @@ pub trait PrimitiveUtils: AccessToPrimitives {
         self.new_term(Term::Lit(Lit::Int(IntLit {
             underlying: ast::IntLit {
                 kind: ast::IntLitKind::Unsuffixed,
-                value: CONSTANT_MAP.create_int_constant(IntConstant::new(
+                value: CONSTANT_MAP.create_int(IntConstant::new(
                     IntConstantValue::Big(Box::new(lit.into())),
                     None,
                 )),

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -119,6 +119,42 @@ pub trait PrimitiveUtils: AccessToPrimitives {
         self.new_ty(RefTy { ty, kind, mutable })
     }
 
+    /// Get the given type as a primitive integer type if possible.
+    fn try_use_ty_as_int_ty(&self, ty: TyId) -> Option<IntTy> {
+        match self.get_ty(ty) {
+            Ty::Data(data) => match data.data_def {
+                d if d == self.primitives().i8() => Some(IntTy::Int(SIntTy::I8)),
+                d if d == self.primitives().u8() => Some(IntTy::UInt(UIntTy::U8)),
+                d if d == self.primitives().i16() => Some(IntTy::Int(SIntTy::I16)),
+                d if d == self.primitives().u16() => Some(IntTy::UInt(UIntTy::U16)),
+                d if d == self.primitives().i32() => Some(IntTy::Int(SIntTy::I32)),
+                d if d == self.primitives().u32() => Some(IntTy::UInt(UIntTy::U32)),
+                d if d == self.primitives().i64() => Some(IntTy::Int(SIntTy::I64)),
+                d if d == self.primitives().u64() => Some(IntTy::UInt(UIntTy::U64)),
+                d if d == self.primitives().i128() => Some(IntTy::Int(SIntTy::I128)),
+                d if d == self.primitives().u128() => Some(IntTy::UInt(UIntTy::U128)),
+                d if d == self.primitives().ibig() => Some(IntTy::Int(SIntTy::IBig)),
+                d if d == self.primitives().ubig() => Some(IntTy::UInt(UIntTy::UBig)),
+                d if d == self.primitives().isize() => Some(IntTy::Int(SIntTy::ISize)),
+                d if d == self.primitives().usize() => Some(IntTy::UInt(UIntTy::USize)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get the given type as a primitive float type if possible.
+    fn try_use_ty_as_float_ty(&self, ty: TyId) -> Option<FloatTy> {
+        match self.get_ty(ty) {
+            Ty::Data(data) => match data.data_def {
+                d if d == self.primitives().f32() => Some(FloatTy::F32),
+                d if d == self.primitives().f64() => Some(FloatTy::F64),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Get the given type as a literal type if possible.
     fn try_use_ty_as_lit_ty(&self, ty: TyId) -> Option<LitTy> {
         match self.get_ty(ty) {
@@ -139,6 +175,20 @@ pub trait PrimitiveUtils: AccessToPrimitives {
                 d if d == self.primitives().f64() => Some(LitTy::F64),
                 d if d == self.primitives().bool() => Some(LitTy::Bool),
                 d if d == self.primitives().char() => Some(LitTy::Char),
+                d if d == self.primitives().isize() => match self.target().pointer_bit_width {
+                    8 => Some(LitTy::I8),
+                    16 => Some(LitTy::I16),
+                    32 => Some(LitTy::I32),
+                    64 => Some(LitTy::I64),
+                    _ => unreachable!(),
+                },
+                d if d == self.primitives().usize() => match self.target().pointer_bit_width {
+                    8 => Some(LitTy::U8),
+                    16 => Some(LitTy::U16),
+                    32 => Some(LitTy::U32),
+                    64 => Some(LitTy::U64),
+                    _ => unreachable!(),
+                },
                 _ => None,
             },
             _ => None,

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -508,7 +508,7 @@ impl<'a> Lexer<'a> {
             IntConstantValue::I32(0)
         });
 
-        let interned = CONSTANT_MAP.create_int_constant(IntConstant { value, suffix });
+        let interned = CONSTANT_MAP.create_int(IntConstant { value, suffix });
         TokenKind::IntLit(interned)
     }
 
@@ -626,9 +626,9 @@ impl<'a> Lexer<'a> {
                         Ok(parsed) => {
                             // Create interned float constant
                             let float_const = if let Some(suffix_ident) = suffix && suffix_ident == IDENTS.f32 {
-                                CONSTANT_MAP.create_f32_float_constant(parsed as f32, suffix)
+                                CONSTANT_MAP.create_f32_float(parsed as f32, suffix)
                             } else {
-                                CONSTANT_MAP.create_f64_float_constant(parsed, suffix)
+                                CONSTANT_MAP.create_f64_float(parsed, suffix)
                             };
 
                             TokenKind::FloatLit(float_const)
@@ -661,7 +661,7 @@ impl<'a> Lexer<'a> {
 
                         // Create interned float constant
                         let float_const = if let Some(suffix_ident) = suffix && suffix_ident == IDENTS.f32 {
-                            CONSTANT_MAP.create_f32_float_constant(value as f32, suffix)
+                            CONSTANT_MAP.create_f32_float(value as f32, suffix)
                         } else {
                             // Check that the suffix is correct for the literal
                             if let Some(suffix_ident) = suffix && suffix_ident != IDENTS.f64 {
@@ -672,7 +672,7 @@ impl<'a> Lexer<'a> {
                                 );
                             }
 
-                            CONSTANT_MAP.create_f64_float_constant(value, suffix)
+                            CONSTANT_MAP.create_f64_float(value, suffix)
                         };
 
                         TokenKind::FloatLit(float_const)

--- a/compiler/hash-lower/src/build/constant.rs
+++ b/compiler/hash-lower/src/build/constant.rs
@@ -48,8 +48,8 @@ impl<'tcx> Builder<'tcx> {
         // future we should also be able to perform folds on `ibig` and `ubig` values.
         if let Const::Int(interned_lhs) = lhs && let Const::Int(interned_rhs) = rhs
         {
-            let lhs_const = CONSTANT_MAP.lookup_int_constant(interned_lhs);
-            let rhs_const = CONSTANT_MAP.lookup_int_constant(interned_rhs);
+            let lhs_const = CONSTANT_MAP.lookup_int(interned_lhs);
+            let rhs_const = CONSTANT_MAP.lookup_int(interned_rhs);
 
             // First we need to coerce the types into the same primitive integer type, we do this
             // by checking the `suffix` and then coercing both ints into that value
@@ -58,8 +58,8 @@ impl<'tcx> Builder<'tcx> {
 
         // Check if these two operands are floating point numbers
         else if let Const::Float(interned_lhs) = lhs && let Const::Float(interned_rhs) = rhs {
-            let lhs_const = CONSTANT_MAP.lookup_float_constant(interned_lhs);
-            let rhs_const = CONSTANT_MAP.lookup_float_constant(interned_rhs);
+            let lhs_const = CONSTANT_MAP.lookup_float(interned_lhs);
+            let rhs_const = CONSTANT_MAP.lookup_float(interned_rhs);
 
             match (lhs_const.value, rhs_const.value) {
                 (FloatConstantValue::F32(lhs), FloatConstantValue::F32(rhs)) => fold_float_const(op, lhs, rhs),
@@ -117,7 +117,7 @@ where
     value.map(|val| {
         // Create the new constant value and return it as a `const`
         let value: IntConstant = val.into();
-        let id = CONSTANT_MAP.create_int_constant(value);
+        let id = CONSTANT_MAP.create_int(value);
         Const::Int(id)
     })
 }
@@ -158,7 +158,7 @@ where
     value.map(|val| {
         // Create the new constant value and return it as a `const`
         let value: FloatConstant = val.into();
-        let id = CONSTANT_MAP.create_float_constant(value);
+        let id = CONSTANT_MAP.create_float(value);
         Const::Float(id)
     })
 }

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -742,10 +742,11 @@ impl<'tcx> Builder<'tcx> {
 
                 // Now, we generate a temporary for the expected length, and then
                 // compare the two.
-                let const_len = Const::Int(CONSTANT_MAP.create_int_constant(IntConstant {
-                    value: IntConstantValue::U64(len),
-                    suffix: None,
-                }));
+                let const_len =
+                    Const::Int(CONSTANT_MAP.create_int(IntConstant {
+                        value: IntConstantValue::U64(len),
+                        suffix: None,
+                    }));
                 let expected = Operand::Const(const_len.into());
 
                 let [success, fail] = *target_blocks else {

--- a/compiler/hash-lower/src/build/rvalue.rs
+++ b/compiler/hash-lower/src/build/rvalue.rs
@@ -147,7 +147,7 @@ impl<'tcx> Builder<'tcx> {
             let n = 1 << (size - 1);
 
             // Create and intern the constant
-            let const_int = CONSTANT_MAP.create_int_constant(IntConstant::from_sint(n, signed_ty));
+            let const_int = CONSTANT_MAP.create_int(IntConstant::from_sint(n, signed_ty));
             Const::Int(const_int).into()
         } else {
             unreachable!()
@@ -261,9 +261,8 @@ impl<'tcx> Builder<'tcx> {
                 // Check for division/modulo of zero...
                 let is_zero = self.temp_place(self.ctx.tys().common_tys.bool);
 
-                let const_val = Const::Int(
-                    CONSTANT_MAP.create_int_constant(IntConstant::from_uint(0, uint_ty)),
-                );
+                let const_val =
+                    Const::Int(CONSTANT_MAP.create_int(IntConstant::from_uint(0, uint_ty)));
                 let zero_val = Operand::Const(const_val.into());
 
                 self.control_flow_graph.push_assign(
@@ -281,9 +280,8 @@ impl<'tcx> Builder<'tcx> {
                 if ty.is_signed() {
                     let sint_ty = int_ty.to_signed();
 
-                    let const_val = Const::Int(
-                        CONSTANT_MAP.create_int_constant(IntConstant::from_sint(-1, sint_ty)),
-                    );
+                    let const_val =
+                        Const::Int(CONSTANT_MAP.create_int(IntConstant::from_sint(-1, sint_ty)));
                     let negative_one_val = Operand::Const(const_val.into());
                     let minimum_value = self.min_value_of_ty(ty);
 

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -225,7 +225,7 @@ impl<'tcx> Builder<'tcx> {
             LitPat::Int(lit) => {
                 let value = lit.interned_value();
 
-                CONSTANT_MAP.map_int_constant(value, |constant| {
+                CONSTANT_MAP.map_int(value, |constant| {
                     (Const::Int(value), constant.value.as_u128().unwrap())
                 })
             }

--- a/compiler/hash-parser/src/parser/expr.rs
+++ b/compiler/hash-parser/src/parser/expr.rs
@@ -816,7 +816,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             // `-` was an unexpected token here...
             if let TokenKind::IntLit(value) = token.kind {
                 // Now read the value and verify that it has no numeric prefix
-                let interned_lit = CONSTANT_MAP.lookup_int_constant(value);
+                let interned_lit = CONSTANT_MAP.lookup_int(value);
 
                 if let Some(suffix) = interned_lit.suffix {
                     return self.err_with_location(ParseErrorKind::DisallowedSuffix(suffix), None, None, token.span)?;

--- a/compiler/hash-parser/src/parser/lit.rs
+++ b/compiler/hash-parser/src/parser/lit.rs
@@ -45,11 +45,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     // If it is specified that we should negate this constant, then we modify the
                     // literal that is stored within the constant map with the modified value.
                     if negate {
-                        CONSTANT_MAP.negate_int_constant(value);
+                        CONSTANT_MAP.negate_int(value);
                     }
 
-                    let (ty, suffix) =
-                        CONSTANT_MAP.map_int_constant(value, |val| (val.ty(), val.suffix));
+                    let (ty, suffix) = CONSTANT_MAP.map_int(value, |val| (val.ty(), val.suffix));
 
                     // Despite the fact that we always know the type, we still want to preserve
                     // information about whether this constant had a specified
@@ -66,11 +65,10 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
                     // If it is specified that we should negate this constant, then we modify the
                     // literal that is stored within the constant map with the modified value.
                     if negate {
-                        CONSTANT_MAP.negate_float_constant(value);
+                        CONSTANT_MAP.negate_float(value);
                     }
 
-                    let (ty, suffix) =
-                        CONSTANT_MAP.map_float_constant(value, |val| (val.ty(), val.suffix));
+                    let (ty, suffix) = CONSTANT_MAP.map_float(value, |val| (val.ty(), val.suffix));
 
                     if suffix.is_some() {
                         Lit::Float(FloatLit { value, kind: FloatLitKind::Suffixed(ty) })

--- a/compiler/hash-pipeline/src/interface.rs
+++ b/compiler/hash-pipeline/src/interface.rs
@@ -19,10 +19,17 @@ use crate::{
 pub type CompilerResult<T> = Result<T, Vec<Report>>;
 
 /// A [StageMetrics] is a collection of timings for each section of a stage.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct StageMetrics {
     /// The collected timings for each section of the stage.
     pub timings: Vec<(&'static str, Duration)>,
+}
+
+impl StageMetrics {
+    /// Create an iterator over the collected timings.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, Duration)> + '_ {
+        self.timings.iter().cloned()
+    }
 }
 
 /// [CompilerStage] represents an abstract stage within the compiler pipeline.
@@ -50,8 +57,8 @@ pub trait CompilerStage<StageCtx> {
     /// it's execution.
     ///
     /// By default, there are no collected metrics.
-    fn metrics(&self) -> Option<&StageMetrics> {
-        None
+    fn metrics(&self) -> StageMetrics {
+        StageMetrics::default()
     }
 
     /// This function is used to "reset" any collected metrics such that

--- a/compiler/hash-semantics/src/old/exhaustiveness/constant.rs
+++ b/compiler/hash-semantics/src/old/exhaustiveness/constant.rs
@@ -31,7 +31,7 @@ impl Constant {
     pub fn from_int(constant: InternedInt, ty: TermId) -> Self {
         // Get the associated bytes with the interned-int so we can convert
         // into a constant.
-        let data = CONSTANT_MAP.lookup_int_constant(constant).value.as_u128().unwrap();
+        let data = CONSTANT_MAP.lookup_int(constant).value.as_u128().unwrap();
         Constant { data, ty }
     }
 

--- a/compiler/hash-semantics/src/old/exhaustiveness/range.rs
+++ b/compiler/hash-semantics/src/old/exhaustiveness/range.rs
@@ -269,7 +269,7 @@ impl<'tc> IntRangeOps<'tc> {
 
         let bias: u128 = match reader.get_term(constant.ty) {
             Term::Level0(Level0Term::Lit(lit)) => match lit {
-                LitTerm::Int { value } if let kind = CONSTANT_MAP.map_int_constant(value, |val| val.ty()) && kind.is_signed() => {
+                LitTerm::Int { value } if let kind = CONSTANT_MAP.map_int(value, |val| val.ty()) && kind.is_signed() => {
                     let ptr_width = self.global_storage().pointer_width;
                     let bits = kind.size(ptr_width).unwrap().bits();
                     1u128 << (bits - 1)

--- a/compiler/hash-semantics/src/old/ops/typing.rs
+++ b/compiler/hash-semantics/src/old/ops/typing.rs
@@ -244,7 +244,7 @@ impl<'tc> Typer<'tc> {
                             // @@Todo: do some more sophisticated inferring here
                             LitTerm::Int { value } => {
                                 let kind: Identifier =
-                                    CONSTANT_MAP.map_int_constant(value, |int| int.ty()).into();
+                                    CONSTANT_MAP.map_int(value, |int| int.ty()).into();
                                 self.core_defs().resolve_core_def(kind)
                             }
                             LitTerm::Char(_) => self.core_defs().char_ty(),

--- a/compiler/hash-semantics/src/old/ops/validate.rs
+++ b/compiler/hash-semantics/src/old/ops/validate.rs
@@ -1220,8 +1220,8 @@ impl<'tc> Validator<'tc> {
                 Term::Level0(Level0Term::Lit(LitTerm::Int { value: rhs })),
             ) => {
                 let ptr_width = self.global_storage().pointer_width;
-                let lhs_kind = CONSTANT_MAP.map_int_constant(lhs, |val| val.ty());
-                let rhs_kind = CONSTANT_MAP.map_int_constant(rhs, |val| val.ty());
+                let lhs_kind = CONSTANT_MAP.map_int(lhs, |val| val.ty());
+                let rhs_kind = CONSTANT_MAP.map_int(rhs, |val| val.ty());
 
                 // Check that the integer type is sized, if it is not then we currently
                 // say that this is not supported...

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -51,7 +51,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
             Box::new(SemanticAnalysis)
         },
         Box::<IrGen>::default(),
-        Box::new(IrOptimiser),
+        Box::<IrOptimiser>::default(),
         Box::<CodeGenPass>::default(),
         Box::new(CompilerLinker),
     ]

--- a/compiler/hash-target/src/primitives.rs
+++ b/compiler/hash-target/src/primitives.rs
@@ -274,7 +274,7 @@ impl SIntTy {
     /// into the normalised type equivalent.
     pub fn normalise(&self, ptr_width: usize) -> Self {
         match self {
-            SIntTy::ISize => SIntTy::from_size(Size::from_bytes(ptr_width)),
+            SIntTy::ISize => SIntTy::from_size(Size::from_bits(ptr_width)),
             _ => *self,
         }
     }

--- a/compiler/hash-tir/src/lits.rs
+++ b/compiler/hash-tir/src/lits.rs
@@ -23,7 +23,7 @@ impl IntLit {
 
     /// Return the value of the integer literal.
     pub fn value(&self) -> BigInt {
-        (&CONSTANT_MAP.lookup_int_constant(self.underlying.value)).try_into().unwrap()
+        (&CONSTANT_MAP.lookup_int(self.underlying.value)).try_into().unwrap()
     }
 }
 
@@ -63,7 +63,7 @@ impl FloatLit {
 
     /// Return the value of the float literal.
     pub fn value(&self) -> f64 {
-        CONSTANT_MAP.lookup_float_constant(self.underlying.value).as_f64()
+        CONSTANT_MAP.lookup_float(self.underlying.value).as_f64()
     }
 }
 

--- a/compiler/hash-tir/src/old/terms.rs
+++ b/compiler/hash-tir/src/old/terms.rs
@@ -754,15 +754,14 @@ impl fmt::Display for ForFormatting<'_, &Level0Term> {
                     }
                     LitTerm::Int { value } => {
                         let pointer_width = self.global_storage.pointer_width;
-                        let kind = CONSTANT_MAP.map_int_constant(*value, |val| val.ty());
+                        let kind = CONSTANT_MAP.map_int(*value, |val| val.ty());
 
                         // It's often the case that users don't include the range of the entire
                         // integer and so we will write `-2147483648..x` and
                         // same for max, what we want to do is write `MIN`
                         // and `MAX for these situations since it is easier for the
                         // user to understand the problem
-                        let value: BigInt =
-                            (&CONSTANT_MAP.lookup_int_constant(*value)).try_into().unwrap();
+                        let value: BigInt = (&CONSTANT_MAP.lookup_int(*value)).try_into().unwrap();
 
                         if let Some(min) = kind.min(pointer_width) && min == value {
                             write!(f, "{kind}::MIN")

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -447,7 +447,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     CONSTANT_MAP.adjust_int(
                         int_lit.underlying.value,
                         int_ty,
-                        self.env().target().pointer_bit_width,
+                        self.env().target().pointer_bit_width / 8,
                     );
                 }
                 // @@Incomplete: as above

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -436,17 +436,17 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         // the complexity here.
         match lit {
             Lit::Float(float_lit) => {
-                if let Some(lit_ty) = self.try_use_ty_as_lit_ty(inferred_ty) {
-                    CONSTANT_MAP.adjust_float(float_lit.underlying.value, lit_ty.into());
+                if let Some(float_ty) = self.try_use_ty_as_float_ty(inferred_ty) {
+                    CONSTANT_MAP.adjust_float(float_lit.underlying.value, float_ty);
                 }
                 // @@Incomplete: it is possible that exotic literal
                 // types are defined, what happens then?
             }
             Lit::Int(int_lit) => {
-                if let Some(lit_ty) = self.try_use_ty_as_lit_ty(inferred_ty) {
+                if let Some(int_ty) = self.try_use_ty_as_int_ty(inferred_ty) {
                     CONSTANT_MAP.adjust_int(
                         int_lit.underlying.value,
-                        lit_ty.into(),
+                        int_ty,
                         self.env().target().pointer_bit_width,
                     );
                 }

--- a/compiler/hash-utils/src/timing.rs
+++ b/compiler/hash-utils/src/timing.rs
@@ -2,7 +2,14 @@
 
 use std::time::{Duration, Instant};
 
-use log::log_enabled;
+use log::{log_enabled, Level};
+
+/// A trait that can be implemented by a compiler stage in order to
+/// store information about the [Duration] of some process within
+/// the stage, later reporting it if requested.
+pub trait AccessToMetrics {
+    fn add_metric(&mut self, name: &'static str, time: Duration);
+}
 
 /// Execute the given closure while timing it, and pass the duration to the
 /// second closure.
@@ -16,4 +23,23 @@ pub fn timed<T>(op: impl FnOnce() -> T, level: log::Level, on_elapsed: impl FnOn
     } else {
         op()
     }
+}
+
+/// Run a stage of the backend whilst also timing it.
+pub fn time_item<U: AccessToMetrics, T>(
+    this: &mut U,
+    stage: &'static str,
+    f: impl FnOnce(&mut U) -> T,
+) -> T {
+    let mut time = Duration::default();
+    let value = timed(
+        || f(this),
+        Level::Info,
+        |duration| {
+            time = duration;
+        },
+    );
+
+    this.add_metric(stage, time);
+    value
 }


### PR DESCRIPTION
This RR fixes an issue with numerical literals not being adjusted when the inferred type of the literal is different to the default value. This caused issues down the line since lowering/codegen assumed that the value was fine, but when the literal was emitted it had a different size than the "expected" size and consequently lead to many bugs. 

This patch introduces logic that will adjust the constant value representation if the types of the constant and the inferred type differ.

Additionally, this patch fixes an issue in the LLVM codegen when invoking unsigned checked integer intrinsics.