### PR TITLE
Implement monomorphisation of terms

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -894,8 +894,9 @@ impl DefinedIntrinsics {
             );
 
             let ret = env.new_ty(u_sym);
-            add("transmute", FnTy::builder().params(params).return_ty(ret).build(), |_, _| {
-                unimplemented!("`transmute` intrinsic evaluation")
+            add("transmute", FnTy::builder().params(params).return_ty(ret).build(), |_, args| {
+                // No-op
+                Ok(args[2])
             })
         };
 

--- a/compiler/hash-intrinsics/src/utils.rs
+++ b/compiler/hash-intrinsics/src/utils.rs
@@ -243,9 +243,10 @@ pub trait PrimitiveUtils: AccessToPrimitives {
     fn try_use_term_as_integer_lit<L: TryFrom<BigInt>>(&self, term: TermId) -> Option<L> {
         match self.get_term(term) {
             Term::Lit(Lit::Int(i)) => i.value().try_into().ok(),
-            Term::Var(sym) => {
-                self.try_use_term_as_integer_lit(self.context_utils().get_binding_value(sym))
-            }
+            Term::Var(sym) => self
+                .context_utils()
+                .try_get_binding_value(sym)
+                .and_then(|result| self.try_use_term_as_integer_lit(result)),
 
             _ => None,
         }

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -212,6 +212,21 @@ fn parse_arg_configuration(
                 }
             }
         }
+        "mono" => {
+            let value = value.ok_or_else(expected_value)?;
+
+            match value.as_str() {
+                "off" => {
+                    settings.semantic_settings.mono_tir = false;
+                }
+                "on" => {
+                    settings.semantic_settings.mono_tir = true;
+                }
+                _ => {
+                    return Err(PipelineError::InvalidValue(key, value));
+                }
+            }
+        }
         "backend" => {
             let value = value.ok_or_else(expected_value)?;
 

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -341,7 +341,7 @@ pub enum IrDumpMode {
 }
 
 /// All settings related to semantic analysis and typechecking.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SemanticSettings {
     /// Whether the compiler should dump the generated TIR (typed intermediate
     /// representation).
@@ -349,6 +349,15 @@ pub struct SemanticSettings {
 
     /// Whether the compiler should evaluate the generated TIR
     pub eval_tir: bool,
+
+    /// Whether the compiler should monomorphise the generated TIR
+    pub mono_tir: bool,
+}
+
+impl Default for SemanticSettings {
+    fn default() -> Self {
+        Self { dump_tir: false, eval_tir: false, mono_tir: true }
+    }
 }
 
 /// All settings that are related to compiler backend and code generation.

--- a/compiler/hash-semantics/src/environment/sem_env.rs
+++ b/compiler/hash-semantics/src/environment/sem_env.rs
@@ -131,6 +131,10 @@ impl<'tc> AccessToTypechecking for SemEnv<'tc> {
     fn entry_point(&self) -> &EntryPointState<FnDefId> {
         self.entry_point
     }
+
+    fn should_monomorphise(&self) -> bool {
+        self.flags.mono_tir
+    }
 }
 
 /// A reference to [`SemEnv`] alongside a value.
@@ -180,6 +184,10 @@ impl<'tc, T> AccessToTypechecking for WithSemEnv<'tc, T> {
 
     fn entry_point(&self) -> &EntryPointState<FnDefId> {
         AccessToSemEnv::entry_point(self)
+    }
+
+    fn should_monomorphise(&self) -> bool {
+        self.sem_env.should_monomorphise()
     }
 }
 
@@ -260,6 +268,10 @@ macro_rules! impl_access_to_sem_env {
                 &self,
             ) -> &hash_source::entry_point::EntryPointState<hash_tir::fns::FnDefId> {
                 $crate::environment::sem_env::AccessToSemEnv::entry_point(self)
+            }
+
+            fn should_monomorphise(&self) -> bool {
+                self.sem_env().should_monomorphise()
             }
         }
     };

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -58,6 +58,9 @@ pub struct Flags {
 
     /// Dump the generated TIR.
     pub dump_tir: bool,
+
+    /// Monomorphise the generated TIR.
+    pub mono_tir: bool,
 }
 
 /// The [SemanticAnalysisCtx] represents all of the information that is required

--- a/compiler/hash-semantics/src/passes/evaluation/mod.rs
+++ b/compiler/hash-semantics/src/passes/evaluation/mod.rs
@@ -9,7 +9,7 @@ use hash_source::ModuleKind;
 use hash_tir::{
     environment::env::AccessToEnv, fns::FnCallTerm, terms::TermId, utils::common::CommonUtils,
 };
-use hash_typecheck::AccessToTypechecking;
+use hash_typecheck::{normalisation::NormalisationMode, AccessToTypechecking};
 use hash_utils::stream_less_writeln;
 
 use super::ast_utils::AstPass;
@@ -74,7 +74,10 @@ impl<'tc> AstPass for EvaluationPass<'tc> {
         }
 
         // Interactive mode is always evaluated.
-        let result = self.normalisation_ops().normalise(term.into())?;
+        let result = self
+            .norm_ops()
+            .with_mode(NormalisationMode::Full { eval_impure_fns: true })
+            .normalise(term.into())?;
         stream_less_writeln!("{}", self.env().with(result));
 
         Ok(())
@@ -95,7 +98,10 @@ impl<'tc> AstPass for EvaluationPass<'tc> {
 
         if self.flags().eval_tir {
             if let Some(term) = main_call_term {
-                let _ = self.normalisation_ops().normalise(term.into())?;
+                let _ = self
+                    .norm_ops()
+                    .with_mode(NormalisationMode::Full { eval_impure_fns: true })
+                    .normalise(term.into())?;
             }
         }
 

--- a/compiler/hash-semantics/src/passes/inference/mod.rs
+++ b/compiler/hash-semantics/src/passes/inference/mod.rs
@@ -70,11 +70,9 @@ impl<'tc> AstPass for InferencePass<'tc> {
         // Infer the expression
         let (term, _) = self.infer_fully(
             (self.ast_info().terms().get_data_by_node(node.id()).unwrap(), self.new_ty_hole()),
-            |(term_id, ty_id)| self.inference_ops().infer_term(term_id, ty_id).map(|x| x.into()),
+            |(term_id, ty_id)| self.infer_ops().infer_term(term_id, ty_id).map(|x| x.into()),
             |(term_id, ty_id)| {
-                self.substitution_ops()
-                    .atom_has_holes(term_id)
-                    .or(self.substitution_ops().atom_has_holes(ty_id))
+                self.sub_ops().atom_has_holes(term_id).or(self.sub_ops().atom_has_holes(ty_id))
             },
         )?;
         self.ast_info().terms().insert(node.id(), term);
@@ -89,7 +87,7 @@ impl<'tc> AstPass for InferencePass<'tc> {
         let _ = self.infer_fully(
             self.ast_info().mod_defs().get_data_by_node(node.id()).unwrap(),
             |mod_def_id| {
-                self.inference_ops()
+                self.infer_ops()
                     .infer_mod_def(
                         mod_def_id,
                         match self.get_current_progress() {
@@ -100,7 +98,7 @@ impl<'tc> AstPass for InferencePass<'tc> {
                     )
                     .map(|()| mod_def_id)
             },
-            |mod_def_id| self.substitution_ops().mod_def_has_holes(mod_def_id),
+            |mod_def_id| self.sub_ops().mod_def_has_holes(mod_def_id),
         )?;
         // Mod def is already registered in the ast info
         Ok(())

--- a/compiler/hash-semantics/src/passes/resolution/defs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/defs.rs
@@ -241,29 +241,11 @@ impl<'tc> ResolutionPass<'tc> {
                         }
                     }
                     ModMemberValue::Fn(_) => {
-                        // Must be a function definition node.
-                        match member_rhs_expr.body() {
-                            ast::Expr::TyFnDef(ty_fn_def) => {
-                                if self
-                                    .try_or_add_error(self.make_term_from_ast_ty_fn_def(
-                                        member_rhs_expr.with_body(ty_fn_def),
-                                    ))
-                                    .is_none()
-                                {
-                                    found_error = true;
-                                }
-                            }
-                            ast::Expr::FnDef(fn_def) => {
-                                if self
-                                    .try_or_add_error(self.make_term_from_ast_fn_def(
-                                        member_rhs_expr.with_body(fn_def),
-                                    ))
-                                    .is_none()
-                                {
-                                    found_error = true;
-                                }
-                            }
-                            _ => unreachable!(),
+                        if self
+                            .try_or_add_error(self.make_term_from_ast_expr(member_rhs_expr))
+                            .is_none()
+                        {
+                            found_error = true;
                         }
                     }
                 }

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -241,6 +241,7 @@ impl SemanticAnalysisCtxQuery for CompilerSession {
             flags: Flags {
                 dump_tir: self.settings.semantic_settings.dump_tir,
                 eval_tir: self.settings.semantic_settings.eval_tir,
+                mono_tir: self.settings.semantic_settings.mono_tir,
             },
             target: self.settings.target(),
         }

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -253,6 +253,12 @@ core_idents! {
     repr_c: "repr_c",
     layout_of: "layout_of",
 
+    // Function flags
+    pure: "pure",
+
+    // Running at compile time
+    run: "run",
+
     // Intrinsic function item names
     sqrt_f32: "sqrtf32",
     sqrt_f64: "sqrtf64",

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -103,10 +103,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
         let mut push_param = |i: usize, arg: Arg, param: &Param| {
             // Apply the running substitution to the parameter
-            let subbed_param = Param {
-                ty: self.substitution_ops().apply_sub_to_ty(param.ty, &running_sub),
-                ..*param
-            };
+            let subbed_param =
+                Param { ty: self.sub_ops().apply_sub_to_ty(param.ty, &running_sub), ..*param };
 
             // Infer the type of the argument
             match error_state.try_or_add_error(infer_arg(&arg, &subbed_param)) {
@@ -122,21 +120,16 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     // If the original parameter has holes, then we use the
                     // inferred parameter. Otherwise use the original parameter. @@Correctness: do
                     // we need to unify here?
-                    if self.substitution_ops().atom_has_holes(param.ty).is_some() {
+                    if self.sub_ops().atom_has_holes(param.ty).is_some() {
                         collected_params.push(inferred_param);
                     } else {
                         collected_params.push((*param).into());
                     }
 
-                    let applied_param_ty =
-                        self.substitution_ops().apply_sub_to_ty(param.ty, &running_sub);
+                    let applied_param_ty = self.sub_ops().apply_sub_to_ty(param.ty, &running_sub);
 
                     running_sub.extend(
-                        &self
-                            .unification_ops()
-                            .unify_tys(inferred_param.ty, applied_param_ty)
-                            .unwrap()
-                            .sub,
+                        &self.uni_ops().unify_tys(inferred_param.ty, applied_param_ty).unwrap().sub,
                     );
                 }
                 // Error occurred
@@ -187,7 +180,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         for &item in items {
             match infer_item(item, item_annotation_ty) {
                 Ok(Inference(inferred_item, ty)) => {
-                    match self.unification_ops().unify_tys(ty, current_ty) {
+                    match self.uni_ops().unify_tys(ty, current_ty) {
                         Ok(Uni { result, sub, .. }) => {
                             // Unification succeeded
                             current_ty = result;
@@ -222,7 +215,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             &terms,
             element_annotation_ty,
             |term, ty| self.infer_term(term, ty),
-            |term, sub| self.substitution_ops().apply_sub_to_term(term, sub),
+            |term, sub| self.sub_ops().apply_sub_to_term(term, sub),
         )?;
         Ok(Inference(self.new_term_list(inferred_term_vec), inferred_ty_id))
     }
@@ -248,7 +241,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             },
             |pat, sub| match pat {
                 PatOrCapture::Pat(pat) => {
-                    let pat = self.substitution_ops().apply_sub_to_pat(pat, sub);
+                    let pat = self.sub_ops().apply_sub_to_pat(pat, sub);
                     PatOrCapture::Pat(pat)
                 }
                 PatOrCapture::Capture => PatOrCapture::Capture,
@@ -373,7 +366,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// annotation type and return it (or to the inferred type if the annotation
     /// type is not given).
     pub fn check_by_unify(&self, inferred_ty: TyId, annotation_ty: TyId) -> TcResult<TyId> {
-        let Uni { result, .. } = self.unification_ops().unify_tys(inferred_ty, annotation_ty)?;
+        let Uni { result, .. } = self.uni_ops().unify_tys(inferred_ty, annotation_ty)?;
         Ok(result)
     }
 
@@ -383,7 +376,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Ty::Hole(_) => Ok(ty),
             _ => {
                 let Inference(checked_ty, _) = self.infer_ty(ty, self.new_ty_hole())?;
-                let norm = self.normalisation_ops();
+                let norm = self.norm_ops();
                 let reduced_ty = norm.to_ty(norm.normalise(checked_ty.into())?);
                 Ok(reduced_ty)
             }
@@ -583,7 +576,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                                 self.infer_args(data.args, data_def.params)?;
 
                             let param_uni = self
-                                .unification_ops()
+                                .uni_ops()
                                 .unify_params(
                                     inferred_data_params,
                                     data_def.params,
@@ -593,18 +586,18 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
                             // Create a substitution from the inferred data arguments
                             let data_sub = self
-                                .substitution_ops()
+                                .sub_ops()
                                 .create_sub_from_args_of_params(inferred_data_args, data_def.params)
                                 .join(&param_uni.sub);
 
                             self.context().enter_scope(data_def.id.into(), || {
                                 let subbed_element_ty = self
-                                    .substitution_ops()
+                                    .sub_ops()
                                     .apply_sub_to_ty(array_prim.element_ty, &data_sub);
 
-                                let subbed_index = array_prim.length.map(|l| {
-                                    self.substitution_ops().apply_sub_to_term(l, &data_sub)
-                                });
+                                let subbed_index = array_prim
+                                    .length
+                                    .map(|l| self.sub_ops().apply_sub_to_term(l, &data_sub));
 
                                 Ok((subbed_element_ty, subbed_index))
                             })
@@ -625,7 +618,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         // Ensure the array lengths match if given
         if let Some(len) = list_len {
             let inferred_len_term = self.create_term_from_integer_lit(inferred_list.len());
-            if !self.unification_ops().terms_are_equal(len, inferred_len_term) {
+            if !self.uni_ops().terms_are_equal(len, inferred_len_term) {
                 return Err(TcError::MismatchingArrayLengths {
                     expected_len: len,
                     got_len: inferred_len_term,
@@ -635,7 +628,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
         // Unify the inner annotation type with the inferred type
         let inner_ty_uni =
-            self.unification_ops().unify_tys(inferred_list_inner_ty, list_annotation_inner_ty)?;
+            self.uni_ops().unify_tys(inferred_list_inner_ty, list_annotation_inner_ty)?;
 
         // Either create a default list type or apply the substitution to the annotation
         // type
@@ -646,9 +639,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     args: self.new_args(&[self.new_term(inner_ty_uni.result)]),
                 });
 
-                self.unification_ops().unify_tys(normalised_ty, list_ty)?.result
+                self.uni_ops().unify_tys(normalised_ty, list_ty)?.result
             }
-            _ => self.substitution_ops().apply_sub_to_ty(normalised_ty, &inner_ty_uni.sub),
+            _ => self.sub_ops().apply_sub_to_ty(normalised_ty, &inner_ty_uni.sub),
         };
 
         Ok(Inference(ArrayTerm { elements: inferred_list }, list_ty))
@@ -664,7 +657,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let ctor = self.stores().ctor_defs().map_fast(term.ctor.0, |defs| defs[term.ctor.1]);
         let data_def = self.get_data_def(ctor.data_def_id);
 
-        let norm = self.normalisation_ops();
+        let norm = self.norm_ops();
         let reduced_ty = norm.to_ty(norm.normalise(annotation_ty.into())?);
 
         let annotation_data_ty = match self.get_ty(reduced_ty) {
@@ -694,28 +687,26 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
         self.context().enter_scope(data_def.id.into(), || {
             let data_args_uni =
-                self.unification_ops().unify_args(term_data_args, annotation_data_ty.args)?;
+                self.uni_ops().unify_args(term_data_args, annotation_data_ty.args)?;
 
             // First infer the data arguments
             let Inference(inferred_data_args, inferred_data_params) =
                 self.infer_args(data_args_uni.result, data_def.params)?;
 
             let param_uni = self
-                .unification_ops()
+                .uni_ops()
                 .unify_params(inferred_data_params, data_def.params, ParamOrigin::Data(data_def.id))
                 .unwrap();
 
             // Create a substitution from the inferred data arguments
-            let data_sub = self
-                .substitution_ops()
-                .create_sub_from_args_of_params(inferred_data_args, data_def.params);
+            let data_sub =
+                self.sub_ops().create_sub_from_args_of_params(inferred_data_args, data_def.params);
 
             self.context().enter_scope(ctor.id.into(), || {
                 // Apply the substitution to the constructor parameters
-                let subbed_ctor_params = self.substitution_ops().apply_sub_to_params(
-                    self.substitution_ops().apply_sub_to_params(
-                        self.substitution_ops()
-                            .apply_sub_to_params(ctor.params, &data_args_uni.sub),
+                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(
+                    self.sub_ops().apply_sub_to_params(
+                        self.sub_ops().apply_sub_to_params(ctor.params, &data_args_uni.sub),
                         &param_uni.sub,
                     ),
                     &data_sub,
@@ -727,10 +718,10 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
                 // Create a substitution from the inferred constructor arguments
                 let ctor_val_sub = self
-                    .substitution_ops()
+                    .sub_ops()
                     .create_sub_from_args_of_params(inferred_ctor_args, subbed_ctor_params);
 
-                let ctor_ty_sub = self.unification_ops().unify_params(
+                let ctor_ty_sub = self.uni_ops().unify_params(
                     inferred_ctor_params,
                     subbed_ctor_params,
                     ParamOrigin::Ctor(ctor.id),
@@ -738,19 +729,17 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 let ctor_sub = ctor_val_sub.join(&ctor_ty_sub.sub);
 
                 // Apply the substitution to the constructor result args
-                let subbed_result_args = self.substitution_ops().apply_sub_to_args(
-                    self.substitution_ops().apply_sub_to_args(
-                        self.substitution_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
+                let subbed_result_args = self.sub_ops().apply_sub_to_args(
+                    self.sub_ops().apply_sub_to_args(
+                        self.sub_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
                         &data_sub,
                     ),
                     &ctor_sub,
                 );
 
                 // Try to unify given annotation with inferred eventual type.
-                let result_data_def_args = self
-                    .unification_ops()
-                    .unify_args(subbed_result_args, inferred_data_args)?
-                    .result;
+                let result_data_def_args =
+                    self.uni_ops().unify_args(subbed_result_args, inferred_data_args)?.result;
 
                 // Evaluate the result args.
                 Ok(Inference(
@@ -765,13 +754,26 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         })
     }
 
+    /// Potentially monomorphise a term.
+    ///
+    /// This is applied to function calls starting from root.
+    pub fn potentially_monomorphise_term(&self, term: TermId) -> TcResult<TermId> {
+        if self.should_monomorphise() {
+            let norm_ops = self.norm_ops();
+            let result = norm_ops.to_term(norm_ops.normalise_pure(term.into())?);
+            Ok(result)
+        } else {
+            Ok(term)
+        }
+    }
+
     /// Infer the type of a function call.
     pub fn infer_fn_call_term(
         &self,
         fn_call_term: &FnCallTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<FnCallTerm, TyId>> {
+    ) -> TcResult<Inference<TermId, TyId>> {
         let Inference(subject_term, subject_ty) =
             self.infer_term(fn_call_term.subject, self.new_ty_hole())?;
         let normalised_subject_ty = self.normalise_and_check_ty(subject_ty)?;
@@ -802,17 +804,16 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                             self.infer_args(fn_call_term.args, fn_ty.params)?;
 
                         let param_uni = self
-                            .unification_ops()
+                            .uni_ops()
                             .unify_params(fn_ty.params, inferred_params, ParamOrigin::FnTy(fn_ty))
                             .unwrap();
 
                         let sub = self
-                            .substitution_ops()
+                            .sub_ops()
                             .create_sub_from_args_of_params(inferred_fn_call_args, inferred_params);
 
-                        let subbed_return_ty = self.substitution_ops().apply_sub_to_ty(
-                            self.substitution_ops()
-                                .apply_sub_to_ty(fn_ty.return_ty, &param_uni.sub),
+                        let subbed_return_ty = self.sub_ops().apply_sub_to_ty(
+                            self.sub_ops().apply_sub_to_ty(fn_ty.return_ty, &param_uni.sub),
                             &sub,
                         );
 
@@ -820,26 +821,32 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                         let return_ty = self.normalise_and_check_ty(subbed_return_ty)?;
 
                         // @@Todo: implicit check
-                        let uni = self.unification_ops().unify_tys(return_ty, annotation_ty)?;
+                        let uni = self.uni_ops().unify_tys(return_ty, annotation_ty)?;
 
-                        let subject = self.substitution_ops().apply_sub_to_term(
-                            self.substitution_ops().apply_sub_to_term(subject_term, &param_uni.sub),
+                        let subject = self.sub_ops().apply_sub_to_term(
+                            self.sub_ops().apply_sub_to_term(subject_term, &param_uni.sub),
                             &uni.sub,
                         );
-                        let subject_ty = self.substitution_ops().apply_sub_to_ty(
-                            self.substitution_ops().apply_sub_to_ty(subject_ty, &param_uni.sub),
+                        let subject_ty = self.sub_ops().apply_sub_to_ty(
+                            self.sub_ops().apply_sub_to_ty(subject_ty, &param_uni.sub),
                             &uni.sub,
                         );
                         self.register_atom_inference(fn_call_term.subject, subject, subject_ty);
 
-                        Ok(Inference(
-                            FnCallTerm {
-                                subject,
-                                args: inferred_fn_call_args,
-                                implicit: fn_call_term.implicit,
-                            },
+                        let resulting_fn_call = self.new_term(FnCallTerm {
+                            subject,
+                            args: inferred_fn_call_args,
+                            implicit: fn_call_term.implicit,
+                        });
+                        self.register_atom_inference(
+                            original_term_id,
+                            resulting_fn_call,
                             uni.result,
-                        ))
+                        );
+
+                        let monomorphised =
+                            self.potentially_monomorphise_term(resulting_fn_call)?;
+                        Ok(Inference(monomorphised, uni.result))
                     })
                 };
 
@@ -975,8 +982,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
                     // Ensure the modalities match if the annotation is given.
                     if let Some(annotation_fn_ty) = annotation_fn_ty {
-                        if !self.unification_ops().fn_modalities_match(annotation_fn_ty, fn_def.ty)
-                        {
+                        if !self.uni_ops().fn_modalities_match(annotation_fn_ty, fn_def.ty) {
                             return Err(TcError::MismatchingTypes {
                                 expected: self.new_ty(annotation_fn_ty),
                                 actual: self.new_ty(fn_def.ty),
@@ -987,7 +993,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
                     // Ensure that the parameters match
                     let inferred_params_result = if let Some(annotation_fn_ty) = annotation_fn_ty {
-                        self.unification_ops().unify_params(
+                        self.uni_ops().unify_params(
                             annotation_fn_ty.params,
                             fn_def.ty.params,
                             ParamOrigin::Fn(fn_def_id),
@@ -1036,21 +1042,21 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     };
 
                     // Ensure that the return types match
-                    let Inference(inferred_ret, inferred_ret_ty) =
-                        if let Some(annotation_fn_ty) = annotation_fn_ty {
-                            let subbed_annotation_ty = self.substitution_ops().apply_sub_to_ty(
-                                annotation_fn_ty.return_ty,
-                                &inferred_params_result.sub,
-                            );
+                    let Inference(inferred_ret, inferred_ret_ty) = if let Some(annotation_fn_ty) =
+                        annotation_fn_ty
+                    {
+                        let subbed_annotation_ty = self.sub_ops().apply_sub_to_ty(
+                            annotation_fn_ty.return_ty,
+                            &inferred_params_result.sub,
+                        );
 
-                            let unified_return_ty = self
-                                .unification_ops()
-                                .unify_tys(fn_def.ty.return_ty, subbed_annotation_ty)?;
+                        let unified_return_ty =
+                            self.uni_ops().unify_tys(fn_def.ty.return_ty, subbed_annotation_ty)?;
 
-                            infer_body_if_not_first_pass(fn_body, unified_return_ty.result)?
-                        } else {
-                            infer_body_if_not_first_pass(fn_body, fn_def.ty.return_ty)?
-                        };
+                        infer_body_if_not_first_pass(fn_body, unified_return_ty.result)?
+                    } else {
+                        infer_body_if_not_first_pass(fn_body, fn_def.ty.return_ty)?
+                    };
 
                     let inferred_fn_ty = FnTy {
                         implicit: fn_def.ty.implicit,
@@ -1156,6 +1162,16 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             DerefTerm { subject: subject_term },
             self.check_by_unify(inferred_ty, annotation_ty)?,
         ))
+    }
+
+    pub fn use_term_in_ty_pos(&self, term: TermId) -> TcResult<TyId> {
+        match self.infer_ty(self.new_ty(Ty::Eval(term)), self.new_small_universe_ty()) {
+            Ok(inferred) => Ok(inferred.0),
+            Err(_) => {
+                let Inference(_, inferred_ty) = self.infer_term(term, self.new_ty_hole())?;
+                Err(TcError::CannotUseInTyPos { location: term.into(), inferred_ty })
+            }
+        }
     }
 
     /// Infer the type of a type, and return it.
@@ -1283,7 +1299,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     inferred_statements.push(inferred_statement);
 
                     // If the statement diverges, we can already exit
-                    if self.unification_ops().is_uninhabitable(inferred_statement_ty)? {
+                    if self.uni_ops().is_uninhabitable(inferred_statement_ty)? {
                         diverges = true;
                         break;
                     }
@@ -1298,10 +1314,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     let Inference(return_term, return_ty) =
                         self.infer_term(block_term.return_value, annotation_ty)?;
 
-                    let sub = self.substitution_ops().create_sub_from_current_stack_members();
-                    let subbed_return_ty = self.substitution_ops().apply_sub_to_ty(return_ty, &sub);
-                    let subbed_return_value =
-                        self.substitution_ops().apply_sub_to_term(return_term, &sub);
+                    let sub = self.sub_ops().create_sub_from_current_stack_members();
+                    let subbed_return_ty = self.sub_ops().apply_sub_to_ty(return_ty, &sub);
+                    let subbed_return_value = self.sub_ops().apply_sub_to_term(return_term, &sub);
 
                     (subbed_return_value, subbed_return_ty)
                 };
@@ -1373,9 +1388,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     ) -> TcResult<Inference<CastTerm, TyId>> {
         let Inference(inferred_term, inferred_term_ty) =
             self.infer_term(cast_term.subject_term, cast_term.target_ty)?;
-        let Uni { sub, .. } = self.unification_ops().unify_tys(inferred_term_ty, annotation_ty)?;
-        let subbed_ty = self.substitution_ops().apply_sub_to_ty(inferred_term_ty, &sub);
-        let subbed_term = self.substitution_ops().apply_sub_to_term(inferred_term, &sub);
+        let Uni { sub, .. } = self.uni_ops().unify_tys(inferred_term_ty, annotation_ty)?;
+        let subbed_ty = self.sub_ops().apply_sub_to_ty(inferred_term_ty, &sub);
+        let subbed_term = self.sub_ops().apply_sub_to_term(inferred_term, &sub);
 
         Ok(Inference(
             CastTerm { subject_term: subbed_term, target_ty: subbed_ty },
@@ -1431,9 +1446,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     Some(ctor) => {
                         let data_def = self.get_data_def(data_ty.data_def);
                         let sub = self
-                            .substitution_ops()
+                            .sub_ops()
                             .create_sub_from_args_of_params(data_ty.args, data_def.params);
-                        self.substitution_ops().apply_sub_to_params(ctor.params, &sub)
+                        self.sub_ops().apply_sub_to_params(ctor.params, &sub)
                     }
                     None => {
                         // Not a record type because it has more than one constructor
@@ -1463,10 +1478,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             //
             // i.e. `x: (T: Type, t: T);  x.t: x.T`
             let param_access_sub =
-                self.substitution_ops().create_sub_from_param_access(params, inferred_subject);
+                self.sub_ops().create_sub_from_param_access(params, inferred_subject);
 
-            let subbed_param_ty =
-                self.substitution_ops().apply_sub_to_ty(param.ty, &param_access_sub);
+            let subbed_param_ty = self.sub_ops().apply_sub_to_ty(param.ty, &param_access_sub);
 
             let unified_ty = self.check_by_unify(subbed_param_ty, annotation_ty)?;
 
@@ -1514,10 +1528,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     data_def.ctors
                 {
                     let sub = self
-                        .substitution_ops()
+                        .sub_ops()
                         .create_sub_from_args_of_params(data_ty.args, data_def.params);
-                    let array_ty =
-                        self.substitution_ops().apply_sub_to_ty(array_primitive.element_ty, &sub);
+                    let array_ty = self.sub_ops().apply_sub_to_ty(array_primitive.element_ty, &sub);
                     Ok(array_ty)
                 } else {
                     wrong_ty()
@@ -1573,7 +1586,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     self.infer_term(case_data.value, normalised_annotation_ty)?;
 
                 let new_unified_ty = self.check_by_unify(inferred_body_ty, unified_ty)?;
-                if !self.unification_ops().is_uninhabitable(new_unified_ty)? {
+                if !self.uni_ops().is_uninhabitable(new_unified_ty)? {
                     unified_ty = new_unified_ty;
                 }
 
@@ -1660,9 +1673,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Ctor(ctor_term) => self
                 .infer_ctor_term(ctor_term, annotation_ty, term_id)
                 .map(|i| self.generalise_term_and_ty_inference(i)),
-            Term::FnCall(fn_call_term) => self
-                .infer_fn_call_term(fn_call_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_inference(i)),
+            Term::FnCall(fn_call_term) => {
+                self.infer_fn_call_term(fn_call_term, annotation_ty, term_id)
+            }
             Term::FnRef(fn_def_id) => self
                 .infer_fn_def(*fn_def_id, annotation_ty, term_id, FnInferMode::Body)
                 .map(|i| self.generalise_term_and_ty_inference(i)),
@@ -1738,7 +1751,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let Inference(_, start_ty) = self.infer_lit(&range_pat.start.into(), annotation_ty)?;
         let Inference(_, end_ty) = self.infer_lit(&range_pat.end.into(), annotation_ty)?;
 
-        let Uni { sub, result } = self.unification_ops().unify_tys(start_ty, end_ty)?;
+        let Uni { sub, result } = self.uni_ops().unify_tys(start_ty, end_ty)?;
         assert!(sub.is_empty()); // @@Todo: specialised unification for no sub
         Ok(result)
     }
@@ -1826,7 +1839,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let ctor = self.stores().ctor_defs().map_fast(pat.ctor.0, |defs| defs[pat.ctor.1]);
         let data_def = self.get_data_def(ctor.data_def_id);
 
-        let norm = self.normalisation_ops();
+        let norm = self.norm_ops();
         let reduced_ty = norm.to_ty(norm.normalise(annotation_ty.into())?);
 
         let annotation_data_ty = match self.get_ty(reduced_ty) {
@@ -1855,28 +1868,26 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
 
         self.context().enter_scope(data_def.id.into(), || {
             let data_args_uni =
-                self.unification_ops().unify_args(pat_data_args, annotation_data_ty.args)?;
+                self.uni_ops().unify_args(pat_data_args, annotation_data_ty.args)?;
 
             // First infer the data arguments
             let Inference(inferred_data_args, inferred_data_params) =
                 self.infer_args(data_args_uni.result, data_def.params)?;
 
             let param_uni = self
-                .unification_ops()
+                .uni_ops()
                 .unify_params(inferred_data_params, data_def.params, ParamOrigin::Data(data_def.id))
                 .unwrap();
 
             // Create a substitution from the inferred data arguments
-            let data_sub = self
-                .substitution_ops()
-                .create_sub_from_args_of_params(inferred_data_args, data_def.params);
+            let data_sub =
+                self.sub_ops().create_sub_from_args_of_params(inferred_data_args, data_def.params);
 
             self.context().enter_scope(ctor.id.into(), || {
                 // Apply the substitution to the constructor parameters
-                let subbed_ctor_params = self.substitution_ops().apply_sub_to_params(
-                    self.substitution_ops().apply_sub_to_params(
-                        self.substitution_ops()
-                            .apply_sub_to_params(ctor.params, &data_args_uni.sub),
+                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(
+                    self.sub_ops().apply_sub_to_params(
+                        self.sub_ops().apply_sub_to_params(ctor.params, &data_args_uni.sub),
                         &param_uni.sub,
                     ),
                     &data_sub,
@@ -1889,26 +1900,24 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     subbed_ctor_params,
                 )?;
 
-                let ctor_ty_sub = self.unification_ops().unify_params(
+                let ctor_ty_sub = self.uni_ops().unify_params(
                     inferred_ctor_params,
                     subbed_ctor_params,
                     ParamOrigin::Ctor(ctor.id),
                 )?;
 
                 // Apply the substitution to the constructor result args
-                let subbed_result_args = self.substitution_ops().apply_sub_to_args(
-                    self.substitution_ops().apply_sub_to_args(
-                        self.substitution_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
+                let subbed_result_args = self.sub_ops().apply_sub_to_args(
+                    self.sub_ops().apply_sub_to_args(
+                        self.sub_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
                         &data_sub,
                     ),
                     &ctor_ty_sub.sub,
                 );
 
                 // Try to unify given annotation with inferred eventual type.
-                let result_data_def_args = self
-                    .unification_ops()
-                    .unify_args(subbed_result_args, inferred_data_args)?
-                    .result;
+                let result_data_def_args =
+                    self.uni_ops().unify_args(subbed_result_args, inferred_data_args)?.result;
 
                 // Evaluate the result args.
                 Ok(Inference(

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -1342,7 +1342,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     let Inference(return_term, return_ty) =
                         self.infer_term(block_term.return_value, annotation_ty)?;
 
-                    let sub = self.sub_ops().create_sub_from_current_stack_members();
+                    let sub = self.sub_ops().create_sub_from_current_scope();
                     let subbed_return_ty = self.sub_ops().apply_sub_to_ty(return_ty, &sub);
                     let subbed_return_value = self.sub_ops().apply_sub_to_term(return_term, &sub);
 

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -42,6 +42,9 @@ pub trait AccessToTypechecking:
     /// Get the entry point of the current compilation, if any.
     fn entry_point(&self) -> &EntryPointState<FnDefId>;
 
+    /// Whether the typechecker should monomorphise all pure functions.
+    fn should_monomorphise(&self) -> bool;
+
     /// Absorb an error state into the diagnostics.
     ///
     /// Returns the error or the closure result if successful.
@@ -57,19 +60,19 @@ pub trait AccessToTypechecking:
         }
     }
 
-    fn inference_ops(&self) -> InferenceOps<Self> {
+    fn infer_ops(&self) -> InferenceOps<Self> {
         InferenceOps::new(self)
     }
 
-    fn substitution_ops(&self) -> SubstitutionOps<Self> {
+    fn sub_ops(&self) -> SubstitutionOps<Self> {
         SubstitutionOps::new(self)
     }
 
-    fn unification_ops(&self) -> UnificationOps<Self> {
+    fn uni_ops(&self) -> UnificationOps<Self> {
         UnificationOps::new(self)
     }
 
-    fn normalisation_ops(&self) -> normalisation::NormalisationOps<Self> {
+    fn norm_ops(&self) -> normalisation::NormalisationOps<Self> {
         normalisation::NormalisationOps::new(self)
     }
 
@@ -84,7 +87,7 @@ pub struct IntrinsicAbilitiesWrapper<'tc, T: AccessToTypechecking> {
 
 impl<T: AccessToTypechecking> IntrinsicAbilities for IntrinsicAbilitiesWrapper<'_, T> {
     fn normalise_term(&self, term: TermId) -> Result<TermId, String> {
-        let norm = self.tc.normalisation_ops();
+        let norm = self.tc.norm_ops();
 
         norm.normalise(term.into()).map(|result| norm.to_term(result)).map_err(|e| {
             self.tc.diagnostics().add_error(self.tc.convert_tc_error(e));

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -166,25 +166,6 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
         Self { env, mode: Cell::new(NormalisationMode::Weak) }
     }
 
-    /// Normalise the given atom if it does not contain any side effects.
-    ///
-    /// This is meant to be used for function calls.
-    pub fn normalise_pure(&self, atom: Atom) -> TcResult<Atom> {
-        if !self.atom_has_effects(atom) {
-            match self.eval(atom) {
-                Ok(t) => Ok(t),
-                Err(e) => match e {
-                    Signal::Break | Signal::Continue | Signal::Return(_) => {
-                        panic!("Got signal when normalising: {e:?}")
-                    }
-                    Signal::Err(e) => Err(e),
-                },
-            }
-        } else {
-            Ok(atom)
-        }
-    }
-
     /// Normalise the given atom.
     pub fn normalise(&self, atom: Atom) -> TcResult<Atom> {
         match self.eval(atom) {

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -589,7 +589,6 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
                     }
                     MatchResult::Failed => {}
                     MatchResult::Stuck => {
-                        info!("Stuck evaluating match: {}", self.env().with(&match_term));
                         outcome = Some(stuck_evaluating());
                     }
                 }

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -1,7 +1,7 @@
 //! Operations for normalising terms and types.
-use std::ops::ControlFlow;
+use std::{cell::Cell, ops::ControlFlow};
 
-use derive_more::{Constructor, Deref, From};
+use derive_more::{Deref, From};
 use hash_ast::ast::RangeEnd;
 use hash_intrinsics::utils::PrimitiveUtils;
 use hash_tir::{
@@ -22,10 +22,15 @@ use hash_tir::{
     terms::{Term, TermId, TermListId, UnsafeTerm},
     tuples::TupleTerm,
     tys::{Ty, TyId, TypeOfTerm},
-    utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
+    utils::{
+        common::CommonUtils,
+        traversing::{Atom, TraversingUtils},
+        AccessToUtils,
+    },
 };
 use hash_utils::{
     itertools::Itertools,
+    log::info,
     store::{PartialStore, SequenceStore, SequenceStoreKey, Store},
 };
 
@@ -35,8 +40,24 @@ use crate::{
     AccessToTypechecking, IntrinsicAbilitiesWrapper,
 };
 
-#[derive(Constructor, Deref)]
-pub struct NormalisationOps<'a, T: AccessToTypechecking>(&'a T);
+#[derive(Deref)]
+pub struct NormalisationOps<'a, T: AccessToTypechecking> {
+    #[deref]
+    env: &'a T,
+    mode: Cell<NormalisationMode>,
+}
+
+/// The mode in which to normalise terms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormalisationMode {
+    /// Normalise the term as much as possible.
+    Full {
+        /// Whether to normalise impure function calls too.
+        eval_impure_fns: bool,
+    },
+    /// Normalise the term to a single step.
+    Weak,
+}
 
 /// Represents a normalisation result.
 #[derive(Debug, Clone, From)]
@@ -48,6 +69,7 @@ pub enum Signal {
 }
 
 /// The result of matching a pattern against a term.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MatchResult {
     /// The pattern matched successfully.
     Successful,
@@ -57,7 +79,112 @@ enum MatchResult {
     Stuck,
 }
 
-impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
+pub type Evaluation<T> = Result<Option<T>, Signal>;
+pub type FullEvaluation<T> = Result<T, Signal>;
+
+pub type AtomEvaluation = Evaluation<Atom>;
+
+fn already_evaluated<T>() -> Evaluation<T> {
+    Ok(None)
+}
+
+fn stuck_evaluating<T>() -> Evaluation<T> {
+    Ok(None)
+}
+
+fn evaluation_if<T, I: Into<T>>(atom: impl FnOnce() -> I, state: &EvalState) -> Evaluation<T> {
+    if state.has_evaluated() {
+        Ok(Some(atom().into()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn full_evaluation_to<T>(atom: impl Into<T>) -> FullEvaluation<T> {
+    Ok(atom.into())
+}
+
+fn evaluation_to<T>(atom: impl Into<T>) -> Evaluation<T> {
+    Ok(Some(atom.into()))
+}
+
+fn evaluation_option<T>(atom: Option<impl Into<T>>) -> Evaluation<T> {
+    match atom {
+        Some(eval) => evaluation_to(eval),
+        None => already_evaluated(),
+    }
+}
+
+fn ctrl_map_full<T>(t: FullEvaluation<T>) -> Evaluation<ControlFlow<T>> {
+    Ok(Some(ControlFlow::Break(t?)))
+}
+
+fn ctrl_map<T>(t: Evaluation<T>) -> Evaluation<ControlFlow<T>> {
+    Ok(t?.map(|t| ControlFlow::Break(t)))
+}
+
+fn ctrl_continue<T>() -> Evaluation<ControlFlow<T>> {
+    Ok(Some(ControlFlow::Continue(())))
+}
+
+/// Whether a term has been evaluated or not.
+pub struct EvalState {
+    has_evaluated: Cell<bool>,
+}
+
+fn eval_state() -> EvalState {
+    EvalState { has_evaluated: Cell::new(false) }
+}
+
+impl EvalState {
+    fn has_evaluated(&self) -> bool {
+        self.has_evaluated.get()
+    }
+
+    fn set_evaluated(&self) {
+        self.has_evaluated.set(true);
+    }
+
+    fn update_from_evaluation<T>(
+        &self,
+        previous: T,
+        evaluation: Evaluation<T>,
+    ) -> Result<T, Signal> {
+        if let Ok(Some(new)) = evaluation {
+            self.set_evaluated();
+            Ok(new)
+        } else if let Err(e) = evaluation {
+            Err(e)
+        } else {
+            Ok(previous)
+        }
+    }
+}
+
+impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
+    pub fn new(env: &'tc T) -> Self {
+        Self { env, mode: Cell::new(NormalisationMode::Weak) }
+    }
+
+    /// Normalise the given atom if it does not contain any side effects.
+    ///
+    /// This is meant to be used for function calls.
+    pub fn normalise_pure(&self, atom: Atom) -> TcResult<Atom> {
+        if !self.atom_has_effects(atom) {
+            match self.eval(atom) {
+                Ok(t) => Ok(t),
+                Err(e) => match e {
+                    Signal::Break | Signal::Continue | Signal::Return(_) => {
+                        panic!("Got signal when normalising: {e:?}")
+                    }
+                    Signal::Err(e) => Err(e),
+                },
+            }
+        } else {
+            Ok(atom)
+        }
+    }
+
     /// Normalise the given atom.
     pub fn normalise(&self, atom: Atom) -> TcResult<Atom> {
         match self.eval(atom) {
@@ -78,6 +205,12 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             Atom::Ty(ty) => Some(ty),
             _ => None,
         }
+    }
+
+    /// Change the normalisation mode.
+    pub fn with_mode(&self, mode: NormalisationMode) -> &Self {
+        self.mode.set(mode);
+        self
     }
 
     /// Try to use the given atom as a type.
@@ -102,60 +235,212 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             .unwrap_or_else(|| panic!("Cannot convert {} to a term", self.env().with(atom)))
     }
 
-    /// Evaluate an atom.
+    fn atom_has_effects_once(
+        &self,
+        traversing_utils: &TraversingUtils,
+        atom: Atom,
+        has_effects: &mut bool,
+    ) -> Result<ControlFlow<()>, !> {
+        match atom {
+            Atom::Term(term) => match self.get_term(term) {
+                // Never has effects
+                Term::Hole(_) | Term::FnRef(_) => Ok(ControlFlow::Break(())),
+
+                // These have effects if their constituents do
+                Term::Lit(_)
+                | Term::Ctor(_)
+                | Term::Tuple(_)
+                | Term::Var(_)
+                | Term::Match(_)
+                | Term::Decl(_)
+                | Term::Unsafe(_)
+                | Term::Access(_)
+                | Term::Array(_)
+                | Term::Index(_)
+                | Term::Cast(_)
+                | Term::TypeOf(_)
+                | Term::Ty(_)
+                | Term::Block(_) => Ok(ControlFlow::Continue(())),
+
+                Term::FnCall(fn_call) => {
+                    // Get its inferred type and check if it is pure
+                    let fn_ty = self.get_inferred_ty(fn_call.subject);
+                    match self.get_ty(fn_ty) {
+                        Ty::Fn(fn_ty) => {
+                            // If it is a function, check if it is pure
+                            if fn_ty.pure {
+                                // Check its args too
+                                traversing_utils
+                                    .visit_args::<!, _>(fn_call.args, &mut |atom| {
+                                        self.atom_has_effects_once(
+                                            traversing_utils,
+                                            atom,
+                                            has_effects,
+                                        )
+                                    })
+                                    .into_ok();
+                                Ok(ControlFlow::Break(()))
+                            } else {
+                                *has_effects = true;
+                                Ok(ControlFlow::Break(()))
+                            }
+                        }
+                        _ => {
+                            // If it is not a function, it is a function reference, which is
+                            // pure
+                            info!(
+                                "Found a function term that is not typed as a function: {}",
+                                self.env().with(fn_call.subject)
+                            );
+                            Ok(ControlFlow::Break(()))
+                        }
+                    }
+                }
+
+                // These always have effects
+                Term::Ref(_)
+                | Term::Deref(_)
+                | Term::Assign(_)
+                | Term::Loop(_)
+                | Term::LoopControl(_)
+                | Term::Return(_) => {
+                    *has_effects = true;
+                    Ok(ControlFlow::Break(()))
+                }
+            },
+            Atom::Ty(_) => Ok(ControlFlow::Continue(())),
+            Atom::FnDef(fn_def_id) => {
+                let fn_ty = self.get_fn_def(fn_def_id).ty;
+                // Check its params and return type only (no body)
+                traversing_utils.visit_params(fn_ty.params, &mut |atom| {
+                    self.atom_has_effects_once(traversing_utils, atom, has_effects)
+                })?;
+                traversing_utils.visit_ty(fn_ty.return_ty, &mut |atom| {
+                    self.atom_has_effects_once(traversing_utils, atom, has_effects)
+                })?;
+                Ok(ControlFlow::Break(()))
+            }
+            Atom::Pat(_) => Ok(ControlFlow::Continue(())),
+        }
+    }
+
+    /// Whether the given atom will produce effects when evaluated.
+    fn atom_has_effects(&self, atom: Atom) -> bool {
+        let mut has_effects = false;
+        let traversing_utils = self.traversing_utils();
+        traversing_utils
+            .visit_atom::<!, _>(atom, &mut |atom| {
+                self.atom_has_effects_once(&traversing_utils, atom, &mut has_effects)
+            })
+            .into_ok();
+        has_effects
+    }
+
+    /// Evaluate an atom with the current mode, performing at least a single
+    /// step of normalisation.
     fn eval(&self, atom: Atom) -> Result<Atom, Signal> {
-        let mut traversal = self.traversing_utils();
-        traversal.set_visit_fns_once(false);
-        let result = traversal.fmap_atom(atom, |atom| self.eval_once(atom))?;
-        self.stores().location().copy_location(atom, result);
-        Ok(result)
+        match self.potentially_eval(atom)? {
+            Some(atom) => Ok(atom),
+            None => Ok(atom),
+        }
+    }
+
+    /// Same as `eval`, but also sets the `evaluated` flag in the given
+    /// `EvalState`.
+    fn eval_and_record(&self, atom: Atom, state: &EvalState) -> Result<Atom, Signal> {
+        match self.potentially_eval(atom)? {
+            Some(atom) => {
+                state.set_evaluated();
+                Ok(atom)
+            }
+            None => Ok(atom),
+        }
+    }
+
+    /// Evaluate an atom in full, even if it has no effects, and including
+    /// impure function calls.
+    fn eval_fully(&self, atom: Atom) -> Result<Atom, Signal> {
+        let old_mode = self.mode.replace(NormalisationMode::Full { eval_impure_fns: true });
+        let result = self.eval(atom);
+        self.mode.set(old_mode);
+        result
+    }
+
+    /// Same as `eval_fully`, but also sets the `evaluated` flag in the given
+    /// `EvalState`.
+    fn eval_fully_and_record(&self, atom: Atom, state: &EvalState) -> Result<Atom, Signal> {
+        let old_mode = self.mode.replace(NormalisationMode::Full { eval_impure_fns: true });
+        let result = self.eval_and_record(atom, state);
+        self.mode.set(old_mode);
+        result
+    }
+
+    // /// Evaluate an atom fully if it has effects.
+    fn eval_if_effectful_and_record(&self, atom: Atom, state: &EvalState) -> Result<Atom, Signal> {
+        if self.atom_has_effects(atom) {
+            // If the atom has effects, we need to evaluate it fully
+            self.eval_fully_and_record(atom, state)
+        } else {
+            // Otherwise, we can just return it as is
+            Ok(atom)
+        }
+    }
+
+    /// Same as `eval_nested`, but with a given evaluation state.
+    fn eval_nested_and_record(&self, atom: Atom, state: &EvalState) -> Result<Atom, Signal> {
+        match self.mode.get() {
+            NormalisationMode::Full { eval_impure_fns: _ } => self.eval_and_record(atom, state),
+            NormalisationMode::Weak => self.eval_if_effectful_and_record(atom, state),
+        }
     }
 
     /// Evaluate a block term.
-    fn eval_block(&self, block_term: BlockTerm) -> Result<Atom, Signal> {
+    fn eval_block(&self, block_term: BlockTerm) -> AtomEvaluation {
         self.context().enter_scope(ScopeKind::Stack(block_term.stack_id), || {
+            let st = eval_state();
+
             for statement in block_term
                 .statements
                 .to_index_range()
                 .map(|i| self.stores().term_list().get_at_index(block_term.statements, i))
             {
-                let _ = self.eval(statement.into())?;
+                let _ = self.eval_and_record(statement.into(), &st)?;
             }
 
-            let sub = self.substitution_ops().create_sub_from_current_stack_members();
-            let result_term = self.eval(block_term.return_value.into())?;
-            let subbed_result_term = self.substitution_ops().apply_sub_to_atom(result_term, &sub);
-            Ok(subbed_result_term)
+            let sub = self.sub_ops().create_sub_from_current_stack_members();
+            let result_term = self.eval_and_record(block_term.return_value.into(), &st)?;
+            let subbed_result_term = self.sub_ops().apply_sub_to_atom(result_term, &sub);
+
+            evaluation_if(|| subbed_result_term, &st)
         })
     }
 
     /// Evaluate a variable.
-    fn eval_var(&self, var: Symbol) -> Result<Atom, Signal> {
+    fn eval_var(&self, var: Symbol) -> AtomEvaluation {
         match self.context_utils().try_get_binding_value(var) {
-            Some(result) => {
-                let evaluated = self.eval(result.into())?;
-                Ok(evaluated)
-            }
-            None => Ok(self.new_term(var).into()),
+            Some(result) => evaluation_option(self.potentially_eval(result.into())?),
+            None => already_evaluated(),
         }
     }
 
     /// Evaluate a cast term.
-    fn eval_cast(&self, cast_term: CastTerm) -> Result<Atom, Signal> {
-        // @@Todo: will not play well with typeof?; no-op for now
-        self.eval(cast_term.subject_term.into())
+    fn eval_cast(&self, cast_term: CastTerm) -> AtomEvaluation {
+        // @@Todo: will not play well with typeof?;
+        evaluation_option(self.potentially_eval(cast_term.subject_term.into())?)
     }
 
     /// Evaluate a dereference term.
-    fn eval_deref(&self, mut deref_term: DerefTerm) -> Result<ControlFlow<Atom>, Signal> {
-        deref_term.subject = self.to_term(self.eval(deref_term.subject.into())?);
+    fn eval_deref(&self, mut deref_term: DerefTerm) -> AtomEvaluation {
+        let st = eval_state();
+        deref_term.subject = self.to_term(self.eval_and_record(deref_term.subject.into(), &st)?);
 
         // Reduce:
         if let Term::Ref(ref_expr) = self.get_term(deref_term.subject) {
-            return Ok(ControlFlow::Break(ref_expr.subject.into()));
+            // Should never be effectful
+            return evaluation_to(ref_expr.subject);
         }
 
-        Ok(ControlFlow::Break(self.new_term(deref_term).into()))
+        evaluation_if(|| self.new_term(deref_term), &st)
     }
 
     /// Get the parameter at the given index in the given argument list.
@@ -191,39 +476,41 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate an access term.
-    fn eval_access(&self, mut access_term: AccessTerm) -> Result<Atom, Signal> {
-        access_term.subject = self.to_term(self.eval(access_term.subject.into())?);
+    fn eval_access(&self, mut access_term: AccessTerm) -> AtomEvaluation {
+        let st = eval_state();
+        access_term.subject = self.to_term(self.eval_and_record(access_term.subject.into(), &st)?);
 
-        match self.get_term(access_term.subject) {
-            Term::Tuple(tuple) => return Ok(self.get_param_in_args(tuple.data, access_term.field)),
-            Term::Ctor(ctor) => {
-                return Ok(self.get_param_in_args(ctor.ctor_args, access_term.field))
+        let result = match self.get_term(access_term.subject) {
+            Term::Tuple(tuple) => self.get_param_in_args(tuple.data, access_term.field),
+            Term::Ctor(ctor) => self.get_param_in_args(ctor.ctor_args, access_term.field),
+            _ => {
+                return stuck_evaluating();
             }
-            _ => {}
-        }
+        };
 
-        // Couldn't reduce
-        Ok(self.new_term(access_term).into())
+        let result = self.eval_and_record(result, &st)?;
+        evaluation_if(|| result, &st)
     }
 
     /// Evaluate an index term.
-    fn eval_index(&self, mut index_term: IndexTerm) -> Result<Atom, Signal> {
-        index_term.subject = self.to_term(self.eval(index_term.subject.into())?);
+    fn eval_index(&self, mut index_term: IndexTerm) -> AtomEvaluation {
+        let st = eval_state();
+        index_term.subject = self.to_term(self.eval_and_record(index_term.subject.into(), &st)?);
 
         if let Term::Array(arr) = self.get_term(index_term.subject) &&
            let Some(result) = self.get_index_in_array(arr.elements, index_term.index)
         {
-            return Ok(result);
+            let result = self.eval_and_record(result, &st)?;
+            evaluation_if(|| result, &st)
+        } else {
+            stuck_evaluating()
         }
-
-        // Couldn't reduce
-        Ok(self.new_term(index_term).into())
     }
 
     /// Evaluate an unsafe term.
-    fn eval_unsafe(&self, unsafe_term: UnsafeTerm) -> Result<Atom, Signal> {
+    fn eval_unsafe(&self, unsafe_term: UnsafeTerm) -> AtomEvaluation {
         // @@Todo: handle unsafe safety
-        self.eval(unsafe_term.inner.into())
+        evaluation_option(self.potentially_eval(unsafe_term.inner.into())?)
     }
 
     /// Evaluate a `typeof` term.
@@ -232,9 +519,13 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
         match self.try_get_inferred_ty(type_of_term.term) {
             Some(ty) => Ok(ty.into()),
             None => {
+                info!(
+                    "Not found type of {} while inferring, so inferring it now",
+                    self.env().with(type_of_term.term)
+                );
                 // Ask the type checker to infer the type:
                 let Inference(inferred_term, inferred_ty) =
-                    self.inference_ops().infer_term(type_of_term.term, self.new_ty_hole())?;
+                    self.infer_ops().infer_term(type_of_term.term, self.new_ty_hole())?;
                 self.register_atom_inference(type_of_term.term, inferred_term, inferred_ty);
 
                 Ok(inferred_ty.into())
@@ -251,7 +542,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate an assignment term.
-    fn eval_assign(&self, mut assign_term: AssignTerm) -> Result<Atom, Signal> {
+    fn eval_assign(&self, mut assign_term: AssignTerm) -> FullEvaluation<Atom> {
         assign_term.value = self.to_term(self.eval(assign_term.value.into())?);
 
         match self.get_term(assign_term.subject) {
@@ -271,7 +562,6 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                     _ => panic!("Invalid access"),
                 }
             }
-            // @@Todo: deref
             Term::Var(var) => {
                 let (member, _, _) = self.context_utils().get_stack_binding(var);
                 self.set_stack_member(member, assign_term.value);
@@ -279,7 +569,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             _ => panic!("Invalid assign {}", self.env().with(&assign_term)),
         }
 
-        Ok(self.new_void_term().into())
+        full_evaluation_to(self.new_void_term())
     }
 
     /// Push the given stack member to the stack with no value.
@@ -298,8 +588,9 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate a match term.
-    fn eval_match(&self, mut match_term: MatchTerm) -> Result<ControlFlow<Atom>, Signal> {
-        match_term.subject = self.to_term(self.eval(match_term.subject.into())?);
+    fn eval_match(&self, mut match_term: MatchTerm) -> AtomEvaluation {
+        let st = eval_state();
+        match_term.subject = self.to_term(self.eval_and_record(match_term.subject.into(), &st)?);
 
         for case_id in match_term.cases.iter() {
             let case = self.stores().match_cases().get_element(case_id);
@@ -312,11 +603,13 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                     &mut |stack_member_id, term_id| self.push_stack(stack_member_id, term_id),
                 )? {
                     MatchResult::Successful => {
-                        outcome = Some(Ok(ControlFlow::Break(self.eval(case.value.into())?)));
+                        let result = self.eval_and_record(case.value.into(), &st)?;
+                        outcome = Some(evaluation_to(result));
                     }
                     MatchResult::Failed => {}
                     MatchResult::Stuck => {
-                        outcome = Some(Ok(ControlFlow::Break(self.new_term(match_term).into())));
+                        info!("Stuck evaluating match: {}", self.env().with(&match_term));
+                        outcome = Some(stuck_evaluating());
                     }
                 }
 
@@ -333,11 +626,14 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate a declaration term.
-    fn eval_decl(&self, mut decl_term: DeclTerm) -> Result<ControlFlow<Atom>, Signal> {
+    fn eval_decl(&self, mut decl_term: DeclTerm) -> AtomEvaluation {
+        let st = eval_state();
         let current_stack_id = self.context_utils().get_current_stack();
         decl_term.value = decl_term
             .value
-            .map(|v| -> Result<_, Signal> { Ok(self.to_term(self.eval(v.into())?)) })
+            .map(|v| -> Result<_, Signal> {
+                Ok(self.to_term(self.eval_nested_and_record(v.into(), &st)?))
+            })
             .transpose()?;
 
         match decl_term.value {
@@ -348,18 +644,21 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             )? {
                 MatchResult::Successful => {
                     // All good
-                    Ok(ControlFlow::Break(self.new_void_term().into()))
+                    evaluation_to(self.new_void_term())
                 }
                 MatchResult::Failed => {
                     panic!("Non-exhaustive let-binding: {}", self.env().with(&decl_term))
                 }
-                MatchResult::Stuck => Ok(ControlFlow::Break(self.new_term(decl_term).into())),
+                MatchResult::Stuck => {
+                    info!("Stuck evaluating let-binding: {}", self.env().with(&decl_term));
+                    evaluation_if(|| self.new_term(decl_term), &st)
+                }
             },
             None => {
                 for i in decl_term.iter_stack_indices() {
                     self.push_stack_uninit((current_stack_id, i))
                 }
-                Ok(ControlFlow::Break(self.new_void_term().into()))
+                evaluation_to(self.new_void_term())
             }
         }
     }
@@ -371,7 +670,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
     }
 
     /// Evaluate a `loop` term.
-    fn eval_loop(&self, loop_term: LoopTerm) -> Result<Atom, Signal> {
+    fn eval_loop(&self, loop_term: LoopTerm) -> FullEvaluation<Atom> {
         loop {
             match self.eval_block(loop_term.block) {
                 Ok(_) | Err(Signal::Continue) => continue,
@@ -379,71 +678,73 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 Err(e) => return Err(e),
             }
         }
-        Ok(self.new_void_term().into())
+        full_evaluation_to(self.new_void_term())
     }
 
     /// Evaluate a term and use it as a type.
-    fn eval_ty_eval(&self, term: TermId) -> Result<Atom, Signal> {
-        let evaluated = self.eval(term.into())?;
+    fn eval_ty_eval(&self, term: TermId) -> AtomEvaluation {
+        let st = eval_state();
+        let evaluated = self.eval_and_record(term.into(), &st)?;
         match evaluated {
-            Atom::Ty(_) => Ok(evaluated),
+            Atom::Ty(_) => evaluation_to(evaluated),
             Atom::Term(term) => match self.get_term(term) {
-                Term::Ty(ty) => Ok(ty.into()),
-                _ => Ok(evaluated),
+                Term::Ty(ty) => evaluation_to(Atom::Ty(ty)),
+                _ => evaluation_if(|| term, &st),
             },
             Atom::FnDef(_) | Atom::Pat(_) => unreachable!(),
         }
     }
 
     /// Evaluate some arguments
-    fn eval_args(&self, args: ArgsId) -> Result<ArgsId, Signal> {
+    fn eval_args(&self, args: ArgsId) -> Evaluation<ArgsId> {
         let args = self.stores().args().get_vec(args);
-        Ok(self.param_utils().create_args(
-            args.into_iter()
-                .map(|arg| -> Result<_, Signal> {
-                    Ok(ArgData {
-                        target: arg.target,
-                        value: self.to_term(self.eval(arg.value.into())?),
-                    })
+        let st = eval_state();
+
+        let evaluated_arg_data = args
+            .into_iter()
+            .map(|arg| -> Result<_, Signal> {
+                Ok(ArgData {
+                    target: arg.target,
+                    value: self.to_term(self.eval_nested_and_record(arg.value.into(), &st)?),
                 })
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter(),
-        ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        evaluation_if(|| self.param_utils().create_args(evaluated_arg_data.into_iter()), &st)
     }
 
     /// Evaluate a function call.
-    fn eval_fn_call(&self, mut fn_call: FnCallTerm) -> Result<Atom, Signal> {
-        let evaluated_inner = self.maybe_to_term(self.eval(fn_call.subject.into())?);
-        let evaluated_args = self.eval_args(fn_call.args)?;
+    fn eval_fn_call(&self, mut fn_call: FnCallTerm) -> AtomEvaluation {
+        let st = eval_state();
+
+        fn_call.subject = self.to_term(self.eval_and_record(fn_call.subject.into(), &st)?);
+        fn_call.args = st.update_from_evaluation(fn_call.args, self.eval_args(fn_call.args))?;
 
         // Beta-reduce:
-        if let Some(term) = evaluated_inner {
-            fn_call.subject = term;
-
-            if let Term::FnRef(fn_def_id) = self.get_term(term) {
-                let fn_def = self.get_fn_def(fn_def_id);
-                // @@Todo: handle pure/impure
-
+        if let Term::FnRef(fn_def_id) = self.get_term(fn_call.subject) {
+            let fn_def = self.get_fn_def(fn_def_id);
+            if fn_def.ty.pure
+                || matches!(self.mode.get(), NormalisationMode::Full { eval_impure_fns: true })
+            {
                 match fn_def.body {
                     FnBody::Defined(defined_fn_def) => {
                         // Make a substitution from the arguments to the parameters:
                         let sub = self
-                            .substitution_ops()
-                            .create_sub_from_args_of_params(evaluated_args, fn_def.ty.params);
+                            .sub_ops()
+                            .create_sub_from_args_of_params(fn_call.args, fn_def.ty.params);
 
                         // Apply substitution to body:
-                        let result =
-                            self.substitution_ops().apply_sub_to_term(defined_fn_def, &sub);
+                        let result = self.sub_ops().apply_sub_to_term(defined_fn_def, &sub);
 
                         // Evaluate result:
                         return match self.eval(result.into()) {
-                            Err(Signal::Return(result)) | Ok(result) => Ok(result),
+                            Err(Signal::Return(result)) | Ok(result) => evaluation_to(result),
                             Err(e) => Err(e),
                         };
                     }
 
                     FnBody::Intrinsic(intrinsic_id) => {
-                        let args_as_terms = self.stores().args().map_fast(evaluated_args, |args| {
+                        let args_as_terms = self.stores().args().map_fast(fn_call.args, |args| {
                             args.iter().map(|arg| arg.value).collect_vec()
                         });
 
@@ -454,13 +755,13 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                             .map_fast(intrinsic_id, |intrinsic| {
                                 let intrinsic = intrinsic.unwrap();
                                 (intrinsic.implementation)(
-                                    &IntrinsicAbilitiesWrapper { tc: self.0 },
+                                    &IntrinsicAbilitiesWrapper { tc: self.env },
                                     &args_as_terms,
                                 )
                             })
                             .map_err(TcError::Intrinsic)?;
 
-                        return Ok(result.into());
+                        return evaluation_to(result);
                     }
 
                     FnBody::Axiom => {
@@ -470,15 +771,52 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
             }
         }
 
-        Ok(self.new_term(fn_call).into())
+        evaluation_if(|| self.new_term(fn_call), &st)
+    }
+
+    /// Evaluate an atom, performing at least a single step of normalisation.
+    ///
+    /// Returns `None` if the atom is already normalised.
+    fn potentially_eval(&self, atom: Atom) -> AtomEvaluation {
+        let mut traversal = self.traversing_utils();
+        traversal.set_visit_fns_once(false);
+
+        let st = eval_state();
+        let result = traversal.fmap_atom(atom, |atom| -> Result<_, Signal> {
+            let old_mode =
+                if self.mode.get() == NormalisationMode::Weak && self.atom_has_effects(atom) {
+                    // If the atom has effects, we need to evaluate it fully
+                    self.mode.replace(NormalisationMode::Full { eval_impure_fns: true })
+                } else {
+                    // Otherwise, we can just evaluate it normally
+                    self.mode.get()
+                };
+
+            let result = match self.eval_once(atom)? {
+                Some(atom) => {
+                    st.set_evaluated();
+                    Ok(atom)
+                }
+                None => Ok(ControlFlow::Break(atom)),
+            };
+
+            self.mode.set(old_mode);
+            result
+        })?;
+
+        self.stores().location().copy_location(atom, result);
+        evaluation_if(|| result, &st)
     }
 
     /// Evaluate an atom once, for use with `fmap`.
-    fn eval_once(&self, atom: Atom) -> Result<ControlFlow<Atom>, Signal> {
+    ///
+    /// Invariant: if `self.atom_has_effects(atom)`, then `self.eval_once(atom)
+    /// != ctrl_continue()`.
+    fn eval_once(&self, atom: Atom) -> Evaluation<ControlFlow<Atom>> {
         match atom {
             Atom::Term(term) => match self.get_term(term) {
                 // Types
-                Term::Ty(_) => Ok(ControlFlow::Continue(())),
+                Term::Ty(_) => ctrl_continue(),
 
                 // Introduction forms:
                 Term::Ref(_)
@@ -487,39 +825,39 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                 | Term::FnRef(_)
                 | Term::Ctor(_)
                 | Term::Lit(_)
-                | Term::Array(_) => Ok(ControlFlow::Continue(())),
+                | Term::Array(_) => ctrl_continue(),
 
                 // Potentially reducible forms:
-                Term::TypeOf(term) => Ok(ControlFlow::Break(self.eval_type_of(term)?)),
-                Term::Unsafe(unsafe_expr) => Ok(ControlFlow::Break(self.eval_unsafe(unsafe_expr)?)),
-                Term::Match(match_term) => self.eval_match(match_term),
-                Term::FnCall(fn_call) => Ok(ControlFlow::Break(self.eval_fn_call(fn_call)?)),
-                Term::Cast(cast_term) => Ok(ControlFlow::Break(self.eval_cast(cast_term)?)),
-                Term::Var(var) => Ok(ControlFlow::Break(self.eval_var(var)?)),
-                Term::Deref(deref_term) => self.eval_deref(deref_term),
-                Term::Access(access_term) => Ok(ControlFlow::Break(self.eval_access(access_term)?)),
-                Term::Index(index_term) => Ok(ControlFlow::Break(self.eval_index(index_term)?)),
+                Term::TypeOf(term) => ctrl_map_full(self.eval_type_of(term)),
+                Term::Unsafe(unsafe_expr) => ctrl_map(self.eval_unsafe(unsafe_expr)),
+                Term::Match(match_term) => ctrl_map(self.eval_match(match_term)),
+                Term::FnCall(fn_call) => ctrl_map(self.eval_fn_call(fn_call)),
+                Term::Cast(cast_term) => ctrl_map(self.eval_cast(cast_term)),
+                Term::Var(var) => ctrl_map(self.eval_var(var)),
+                Term::Deref(deref_term) => ctrl_map(self.eval_deref(deref_term)),
+                Term::Access(access_term) => ctrl_map(self.eval_access(access_term)),
+                Term::Index(index_term) => ctrl_map(self.eval_index(index_term)),
 
                 // Imperative:
                 Term::LoopControl(loop_control) => Err(self.eval_loop_control(loop_control)),
-                Term::Assign(assign_term) => Ok(ControlFlow::Break(self.eval_assign(assign_term)?)),
-                Term::Decl(decl_term) => self.eval_decl(decl_term),
+                Term::Assign(assign_term) => ctrl_map_full(self.eval_assign(assign_term)),
+                Term::Decl(decl_term) => ctrl_map(self.eval_decl(decl_term)),
                 Term::Return(return_expr) => self.eval_return(return_expr)?,
-                Term::Block(block_term) => Ok(ControlFlow::Break(self.eval_block(block_term)?)),
-                Term::Loop(loop_term) => Ok(ControlFlow::Break(self.eval_loop(loop_term)?)),
+                Term::Block(block_term) => ctrl_map(self.eval_block(block_term)),
+                Term::Loop(loop_term) => ctrl_map_full(self.eval_loop(loop_term)),
             },
             Atom::Ty(ty) => match self.get_ty(ty) {
-                Ty::Eval(term) => Ok(ControlFlow::Break(self.eval_ty_eval(term)?)),
-                Ty::Var(var) => Ok(ControlFlow::Break(self.eval_var(var)?)),
+                Ty::Eval(term) => ctrl_map(self.eval_ty_eval(term)),
+                Ty::Var(var) => ctrl_map(self.eval_var(var)),
                 Ty::Fn(_)
                 | Ty::Tuple(_)
                 | Ty::Data(_)
                 | Ty::Universe(_)
                 | Ty::Ref(_)
-                | Ty::Hole(_) => Ok(ControlFlow::Break(atom)),
+                | Ty::Hole(_) => already_evaluated(),
             },
-            Atom::FnDef(_) => Ok(ControlFlow::Break(atom)),
-            Atom::Pat(_) => Ok(ControlFlow::Continue(())),
+            Atom::FnDef(_) => already_evaluated(),
+            Atom::Pat(_) => ctrl_continue(),
         }
     }
 
@@ -695,7 +1033,8 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
         pat_id: PatId,
         f: &mut impl FnMut(StackMemberId, TermId),
     ) -> Result<MatchResult, Signal> {
-        match (self.get_term(term_id), self.get_pat(pat_id)) {
+        let evaluated = self.get_term(self.to_term(self.eval(term_id.into())?));
+        match (evaluated, self.get_pat(pat_id)) {
             (_, Pat::Or(pats)) => {
                 // Try each alternative in turn:
                 for pat in pats.alternatives.iter() {
@@ -723,7 +1062,7 @@ impl<T: AccessToTypechecking> NormalisationOps<'_, T> {
                     self.match_value_and_get_binds(term_id, if_pat.pat, f)?
                 {
                     // Check the condition:
-                    let cond = self.eval(if_pat.condition.into())?;
+                    let cond = self.eval_fully(if_pat.condition.into())?;
                     if self.is_true(cond) {
                         return Ok(MatchResult::Successful);
                     }

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -65,7 +65,7 @@ impl<'s> SemanticAnalyser<'s> {
                 Expr::FnDef(_) => {}
                 _ => self.invalid_argument(DirectiveArgument::FnDef, directive, value.ast_ref()),
             }
-        } else {
+        } else if !matches!(subject.body(), Expr::FnDef(_)) {
             self.invalid_argument(DirectiveArgument::Declaration, directive, subject);
         }
     }
@@ -210,7 +210,10 @@ impl<'s> SemanticAnalyser<'s> {
                     )
                 }
             }
-        } else if directive.is(IDENTS.entry_point) || directive.is(IDENTS.foreign) {
+        } else if directive.is(IDENTS.entry_point)
+            || directive.is(IDENTS.foreign)
+            || directive.is(IDENTS.pure)
+        {
             // Check that the supplied argument to a function modifying directive
             // is a declaration of a function that the directive will apply to.
             self.validate_fn_decl_directive(directive, subject)
@@ -221,7 +224,6 @@ impl<'s> SemanticAnalyser<'s> {
         } else if !directive.is(IDENTS.dump_ast)
             && !directive.is(IDENTS.dump_tir)
             && !directive.is(IDENTS.run)
-            && !directive.is(IDENTS.pure)
         {
             // @@Future: use some kind of scope validation in order to verify that
             // the used directives are valid

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -218,7 +218,11 @@ impl<'s> SemanticAnalyser<'s> {
             // Check that the supplied argument to a function modifying directive
             // is a declaration of a function that the directive will apply to.
             self.validate_data_def_directive(directive, subject)
-        } else if !directive.is(IDENTS.dump_ast) && !directive.is(IDENTS.dump_tir) {
+        } else if !directive.is(IDENTS.dump_ast)
+            && !directive.is(IDENTS.dump_tir)
+            && !directive.is(IDENTS.run)
+            && !directive.is(IDENTS.pure)
+        {
             // @@Future: use some kind of scope validation in order to verify that
             // the used directives are valid
             self.append_warning(


### PR DESCRIPTION
This PR adds monomorphisation support to TC. Every `pure` function or an expression with `#run` will be evaluated at compile-time. In effect, generic calls are reduced to their monomorphised equivalents, appropriate for lowering.

This PR also:
- Adds the `#pure` directive for functions, to label them as pure without having to use the `<>` syntax.
- Adds the `#run` directive to run any expression at compile time
- Implements weak-head normalisation so that the unification can use it.

There are still a few things to do:
- Assign atom info to all monomorphised terms so that the lowering can actually process them
- Assign nice names to monomorphised functions

The monomorphisation can be turned off with `-Cmono=off` if needed (for debugging).

Closes #835