### PR TITLE
lower+codegen: tackle some todos and properly support slices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ version = "0.1.0"
 dependencies = [
  "hash-reporting",
  "hash-source",
+ "hash-target",
  "hash-token",
  "num-bigint",
  "num-traits",
@@ -609,6 +610,7 @@ dependencies = [
  "hash-pipeline",
  "hash-reporting",
  "hash-source",
+ "hash-target",
  "hash-token",
  "hash-utils",
  "num-bigint",

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -74,9 +74,7 @@ impl AstVisitor for AstTreeGenerator {
         &self,
         node: ast::AstNodeRef<ast::StrLit>,
     ) -> Result<Self::StrLitRet, Self::Error> {
-        // Printing an interned string uses the debug formatter, which
-        // deals with escaping exotic characters.
-        Ok(TreeNode::leaf(labelled("str", node.data, "")))
+        Ok(TreeNode::leaf(labelled("str", format!("{:?}", node.data), "")))
     }
 
     type CharLitRet = TreeNode;

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -74,7 +74,9 @@ impl AstVisitor for AstTreeGenerator {
         &self,
         node: ast::AstNodeRef<ast::StrLit>,
     ) -> Result<Self::StrLitRet, Self::Error> {
-        Ok(TreeNode::leaf(labelled("str", node.data, "\"")))
+        // Printing an interned string uses the debug formatter, which
+        // deals with escaping exotic characters.
+        Ok(TreeNode::leaf(labelled("str", node.data, "")))
     }
 
     type CharLitRet = TreeNode;

--- a/compiler/hash-codegen-llvm/src/translation/abi.rs
+++ b/compiler/hash-codegen-llvm/src/translation/abi.rs
@@ -44,6 +44,10 @@ impl<'b, 'm> AbiBuilderMethods<'b> for Builder<'_, 'b, 'm> {
     ) {
         arg_abi.store_fn_arg(self, index, destination)
     }
+
+    fn arg_ty(&mut self, arg_abi: &ArgAbi) -> Self::Type {
+        self.backend_ty_from_info(arg_abi.info)
+    }
 }
 
 pub trait ExtendedArgAbiMethods<'m> {

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -2,7 +2,7 @@
 //! [hash_codegen::traits::builder::BlockBuilderMethods] using the Inkwell
 //! wrapper around LLVM.
 
-use std::{borrow::Cow, iter};
+use std::{borrow::Cow, ffi::CString, iter};
 
 use hash_codegen::{
     abi::FnAbi,
@@ -28,11 +28,12 @@ use inkwell::{
     basic_block::BasicBlock,
     types::{AnyType, AnyTypeEnum, AsTypeRef, BasicTypeEnum},
     values::{
-        AggregateValueEnum, AnyValue, AnyValueEnum, BasicMetadataValueEnum, BasicValue,
-        BasicValueEnum, FunctionValue, InstructionValue, PhiValue, UnnamedAddress,
+        AggregateValueEnum, AnyValue, AnyValueEnum, AsValueRef, BasicMetadataValueEnum, BasicValue,
+        BasicValueEnum, FunctionValue, InstructionValue, IntMathValue, IntValue, PhiValue,
+        UnnamedAddress,
     },
 };
-use llvm_sys::core::LLVMGetTypeKind;
+use llvm_sys::core::{LLVMBuildExactUDiv, LLVMGetTypeKind};
 use rayon::iter::Either;
 
 use super::{
@@ -326,12 +327,24 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
     }
 
     fn exactudiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
-        let _lhs = lhs.into_int_value();
-        let _rhs = rhs.into_int_value();
+        let lhs = lhs.into_int_value();
+        let rhs = rhs.into_int_value();
 
         // @@Todo: patch inkwell to allow for exact unsigned division
-        // self.builder.build_int_exact_unsigned_div(lhs, rhs, "").into()
-        panic!("inkwell doesn't have the ability to emit `exactudiv` yet")
+
+        // create an empty c_str
+        let c_string = CString::new("").unwrap();
+
+        let value = unsafe {
+            LLVMBuildExactUDiv(
+                self.builder.as_mut_ptr(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { IntValue::new(value) }.into()
     }
 
     fn sdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
@@ -840,7 +853,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
 
                 // Check here if the need to load it in a as global value, i.e.
                 // a constant...
-                // @@Todo: need to patch inkwell to be able to check if things are
+                // @@PatchInkwell: need to patch inkwell to be able to check if things are
                 // global variables, and constant.
                 //
                 // if let Some(global) = self.module.get_global(name) {

--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -538,7 +538,7 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
         lhs: Self::Value,
         rhs: Self::Value,
     ) -> (Self::Value, Self::Value) {
-        let ptr_width = self.ctx.settings().target().pointer_bit_width;
+        let ptr_width = self.ctx.settings().target().ptr_size();
 
         let int_ty = self.ir_ctx().map_ty(ty, |ty| match ty {
             IrTy::Int(ty @ SIntTy::ISize) => IntTy::Int(ty.normalise(ptr_width)),

--- a/compiler/hash-codegen-llvm/src/translation/ty.rs
+++ b/compiler/hash-codegen-llvm/src/translation/ty.rs
@@ -338,7 +338,6 @@ impl<'m> ExtendedTyBuilderMethods<'m> for TyInfo {
                         // @@Todo: make emitting names optional in order to improve speed
                         // of LLVM builds.
                         let name: Option<String> = match ty {
-                            IrTy::Str => Some("str".to_string()),
                             IrTy::Adt(adt) => {
                                 ctx.ir_ctx().map_adt(*adt, |_, adt| {
                                     // We don't create a name for tuple types, they are just

--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -10,11 +10,7 @@
 //! whether two blocks have been merged together.
 
 use hash_abi::{ArgAbi, FnAbi, PassMode};
-use hash_ir::{
-    intrinsics::Intrinsic,
-    ir::{self},
-    ty::{Instance, IrTy},
-};
+use hash_ir::{intrinsics::Intrinsic, ir, lang_items::LangItem};
 use hash_pipeline::settings::{CodeGenBackend, OptimisationLevel};
 use hash_source::{constant::CONSTANT_MAP, identifier::IDENTS};
 use hash_target::abi::{AbiRepresentation, ValidScalarRange};
@@ -328,7 +324,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
     /// through an argument to the function rather than the actual pointer
     /// directly ( which is then represented as a
     /// [`ReturnDestinationKind::Store`]).
-    fn compute_fn_return_destination(
+    pub(super) fn compute_fn_return_destination(
         &mut self,
         builder: &mut Builder,
         destination: ir::Place,
@@ -554,9 +550,8 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
         let (bytes, len) = builder.const_str(CONSTANT_MAP.create_string(assert_kind.message()));
         let args = &[bytes, len];
 
-        // @@Todo: we need to create a call to `panic`, as in resolve the function
-        // abi to `panic` and the relative function pointer.
-        let (fn_abi, fn_ptr) = self.resolve_intrinsic(builder, Intrinsic::Panic);
+        // Get the `panic` lang item.
+        let (fn_abi, fn_ptr) = self.resolve_lang_item(builder, LangItem::Panic);
 
         // Finally we emit this as a call to panic...
         self.codegen_fn_call(builder, &fn_abi, fn_ptr, args, &[], None, false)

--- a/compiler/hash-codegen/src/traits/abi.rs
+++ b/compiler/hash-codegen/src/traits/abi.rs
@@ -10,6 +10,9 @@ pub trait AbiBuilderMethods<'b>: BackendTypes {
     /// Get a particular parameter from the ABI.
     fn get_param(&mut self, index: usize) -> Self::Value;
 
+    /// Get the type of the provided [ArgAbi].
+    fn arg_ty(&mut self, arg_abi: &ArgAbi) -> Self::Type;
+
     /// Store an argument that is passed or returned from a
     /// function call.
     fn store_arg(

--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -112,6 +112,7 @@ defined_intrinsics! {
     prim_type_eq_op,
     un_op,
     abort,
+    panic,
     user_error,
     eval,
     debug_print,
@@ -739,6 +740,19 @@ impl DefinedIntrinsics {
             |_, _| process::exit(1),
         );
 
+        // Panicking
+        let panic = add(
+            "panic",
+            FnTy::builder()
+                .params(env.new_params(&[env.new_data_ty(prim.str())]))
+                .return_ty(env.new_never_ty())
+                .build(),
+            |env, args| {
+                stream_less_writeln!("{}", env.env().with(args[1]));
+                process::exit(1);
+            },
+        );
+
         // User errors
         let user_error = add(
             "user_error",
@@ -929,6 +943,7 @@ impl DefinedIntrinsics {
             endo_bin_op,
             un_op,
             abort,
+            panic,
             user_error,
             debug_print,
             align_of,

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -583,6 +583,19 @@ impl Place {
         Self { local, projections: ctx.projections().create_empty() }
     }
 
+    /// Create a new [Place] from an existing [Place] whilst also
+    /// applying a [`PlaceProjection::Deref`] on the old one.
+    pub fn deref(&self, ctx: &IrCtx) -> Self {
+        let projections = ctx.projections().get_vec(self.projections);
+
+        Self {
+            local: self.local,
+            projections: ctx.projections().create_from_iter_fast(
+                projections.iter().copied().chain(once(PlaceProjection::Deref)),
+            ),
+        }
+    }
+
     /// Create a new [Place] from an existing place whilst also
     /// applying a a [PlaceProjection::Field] on the old one.
     pub fn field(&self, field: usize, ctx: &IrCtx) -> Self {

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -106,7 +106,10 @@ impl fmt::Display for Const {
             Self::Char(c) => write!(f, "'{c}'"),
             Self::Int(i) => write!(f, "{i}"),
             Self::Float(flt) => write!(f, "{flt}"),
-            Self::Str(s) => write!(f, "\"{s}\""),
+
+            // Printing interned strings will use the debug formatter which deals 
+            // with escaping exotic characters.
+            Self::Str(s) => write!(f, "{s}"),
         }
     }
 }

--- a/compiler/hash-ir/src/ir.rs
+++ b/compiler/hash-ir/src/ir.rs
@@ -106,10 +106,7 @@ impl fmt::Display for Const {
             Self::Char(c) => write!(f, "'{c}'"),
             Self::Int(i) => write!(f, "{i}"),
             Self::Float(flt) => write!(f, "{flt}"),
-
-            // Printing interned strings will use the debug formatter which deals 
-            // with escaping exotic characters.
-            Self::Str(s) => write!(f, "{s}"),
+            Self::Str(s) => write!(f, "{s:?}"),
         }
     }
 }
@@ -1254,8 +1251,6 @@ pub enum BodySource {
     Const,
     /// The item is a normal function.
     Item,
-    /// The item is an intrinsic function.
-    Intrinsic,
 }
 
 impl fmt::Display for BodySource {
@@ -1263,7 +1258,6 @@ impl fmt::Display for BodySource {
         match self {
             BodySource::Const => write!(f, "constant block"),
             BodySource::Item => write!(f, "function"),
-            BodySource::Intrinsic => write!(f, "intrinsic function"),
         }
     }
 }

--- a/compiler/hash-ir/src/lang_items.rs
+++ b/compiler/hash-ir/src/lang_items.rs
@@ -1,0 +1,68 @@
+//! Defines all of the intrinsics that are expected to be
+//! declared within the language prelude.
+
+use crate::ty::{InstanceId, IrTyId};
+
+/// Defines all of the language items that are required for
+/// facilitating the feature's of the language.
+pub enum LangItem {
+    /// The `panic` intrinsic function. This will cause the program
+    /// to terminate.
+    Panic,
+}
+
+impl LangItem {
+    /// Get the appropriate [LangItem] for the specified name.
+    pub fn from_str_name(name: &str) -> Self {
+        match name {
+            "panic" => Self::Panic,
+            _ => panic!("unknown language item: {name}"),
+        }
+    }
+}
+
+/// Stored information about an intrinsic that has been referenced within
+/// the program. The name "intrinsic" in this context refers to something
+/// that is an intrinsic operation that must be filled in by the compiler i.e.
+/// "ptr_offset", or it is an item definition that is crucial to the language
+/// runtime i.e. "panic".
+#[derive(Debug, Clone, Copy)]
+pub struct LangItemData {
+    /// The defined instance that corresponds to the intrinsic.
+    instance: InstanceId,
+
+    /// The type of the lang item.
+    ty: IrTyId,
+}
+
+/// This struct is used to map the [Intrinsic] enum to the
+/// associated type that is used to represent the intrinsic.
+#[derive(Default)]
+pub struct LangItems {
+    /// The intrinsic map.
+    items: [Option<LangItemData>; std::mem::variant_count::<LangItem>()],
+}
+
+impl LangItems {
+    /// Create a new [Intrinsics] map instance. This will create
+    /// all the associated types for the intrinsics, and will populate
+    /// the map with them.
+    pub fn new() -> Self {
+        Self { items: [None; std::mem::variant_count::<LangItem>()] }
+    }
+
+    /// Set the [IrTyId] for the specified intrinsic.
+    pub fn set(&mut self, item: LangItem, instance: InstanceId, ty: IrTyId) {
+        self.items[item as usize] = Some(LangItemData { instance, ty });
+    }
+
+    /// Get the [InstanceId] for the specified intrinsic.
+    pub fn get(&self, item: LangItem) -> Option<InstanceId> {
+        self.items[item as usize].map(|item| item.instance)
+    }
+
+    /// Get the [IrTyId] for the specified intrinsic.
+    pub fn get_ty(&self, item: LangItem) -> Option<IrTyId> {
+        self.items[item as usize].map(|item| item.ty)
+    }
+}

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -131,8 +131,6 @@ impl Instance {
         params: IrTyListId,
         ret_ty: IrTyId,
     ) -> Self {
-        // @@Todo: deal with generic functions being properly instantiated
-        // here.
         Self {
             name,
             params,

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -119,6 +119,10 @@ pub struct Instance {
     /// id as the disambiguator.
     pub source: Option<SourceId>,
 
+    /// If the instance refers to an intrinsic function, and will be converted
+    /// into possibly some different code.
+    pub is_intrinsic: bool,
+
     /// If the function instance originates from a generic function.
     generic_origin: bool,
 }
@@ -133,6 +137,7 @@ impl Instance {
     ) -> Self {
         Self {
             name,
+            is_intrinsic: false,
             params,
             source,
             ret_ty,
@@ -149,6 +154,11 @@ impl Instance {
     /// Check if the instance is of a generic origin.
     pub fn is_generic_origin(&self) -> bool {
         self.generic_origin
+    }
+
+    /// Check if the [Instance] is an intrinsic function.
+    pub fn is_intrinsic(&self) -> bool {
+        self.is_intrinsic
     }
 }
 
@@ -269,17 +279,6 @@ pub enum IrTy {
 }
 
 impl IrTy {
-    /// Create a pointer to a unit item. This is used as the
-    /// "opaque" pointer type in order to just represent a
-    /// pointer type.
-    pub fn unit_ptr(ctx: &IrCtx) -> IrTyId {
-        ctx.tys().create(IrTy::Ref(
-            ctx.tys().common_tys.unit,
-            Mutability::Immutable,
-            RefKind::Normal,
-        ))
-    }
-
     /// Make a tuple type, i.e. `(T1, T2, T3, ...)`
     pub fn tuple(ctx: &IrCtx, tys: &[IrTyId]) -> Self {
         let variants = index_vec![AdtVariant {
@@ -295,6 +294,11 @@ impl IrTy {
         let adt_id = ctx.adts().create(adt);
 
         Self::Adt(adt_id)
+    }
+
+    /// Create a reference type to the provided [IrTy].
+    pub fn make_ref(ty: IrTy, ctx: &IrCtx) -> Self {
+        Self::Ref(ctx.tys().create(ty), Mutability::Immutable, RefKind::Normal)
     }
 
     /// Check if the [IrTy] is an integral type.
@@ -356,6 +360,15 @@ impl IrTy {
         match self {
             Self::Adt(adt_id) => *adt_id,
             ty => panic!("expected ADT, but got {ty:?}"),
+        }
+    }
+
+    /// Assuming that the [IrTy] is an ADT, return the [AdtId]
+    /// of the underlying ADT.
+    pub fn as_instance(&self) -> InstanceId {
+        match self {
+            Self::FnDef { instance } => *instance,
+            ty => panic!("expected fn def, but got {ty:?}"),
         }
     }
 
@@ -453,6 +466,17 @@ impl IrTy {
             | IrTy::Array { .. }
             | IrTy::FnDef { .. }
             | IrTy::Fn { .. } => ctx.tys().common_tys.u8,
+        }
+    }
+
+    /// Attempt to compute the type of an element from an [`IrTy::Slice`] or
+    /// [`IrTy::Array`]. If the type is not a slice or array, then `None` is
+    /// returned.
+    pub fn element_ty(&self, ctx: &IrCtx) -> Option<IrTyId> {
+        match self {
+            IrTy::Slice(ty) | IrTy::Array { ty, .. } => Some(*ty),
+            IrTy::Ref(ty, _, _) => ctx.tys().map_fast(*ty, |ty| ty.element_ty(ctx)),
+            _ => None,
         }
     }
 }
@@ -825,8 +849,11 @@ macro_rules! create_common_ty_table {
             /// A string, i.e. `&str`.
             pub str: IrTyId,
 
-            /// A general pointer to bytes, i.e. `&[u8]`.
+            /// A general pointer to bytes, i.e. `&u8`.
             pub ptr: IrTyId,
+
+            /// A general pointer to bytes, i.e. `&raw u8`.
+            pub raw_ptr: IrTyId,
 
             /// A void pointer, i.e. `&()`.
             pub void_ptr: IrTyId,
@@ -838,6 +865,7 @@ macro_rules! create_common_ty_table {
                     $($name: data.create($value), )*
                     byte_slice: IrTyId::from_index_unchecked(0),
                     ptr: IrTyId::from_index_unchecked(0),
+                    raw_ptr: IrTyId::from_index_unchecked(0),
                     void_ptr: IrTyId::from_index_unchecked(0),
                     str: IrTyId::from_index_unchecked(0),
                 };
@@ -847,12 +875,14 @@ macro_rules! create_common_ty_table {
                 // they are defined...
                 let byte_slice = data.create(IrTy::Slice(table.u8));
                 let ptr = data.create(IrTy::Ref(table.u8, Mutability::Immutable, RefKind::Normal));
+                let raw_ptr = data.create(IrTy::Ref(table.u8, Mutability::Immutable, RefKind::Raw));
                 let void_ptr = data.create(IrTy::Ref(table.unit, Mutability::Immutable, RefKind::Raw));
                 let str = data.create(IrTy::Ref(table.unsized_str, Mutability::Immutable, RefKind::Normal));
 
                 CommonIrTys {
                     byte_slice,
                     ptr,
+                    raw_ptr,
                     void_ptr,
                     str,
                     ..table
@@ -1161,7 +1191,7 @@ impl ToIrTy for ScalarKind {
             }
             ScalarKind::Float { kind: FloatTy::F32 } => ctx.tys().common_tys.f32,
             ScalarKind::Float { kind: FloatTy::F64 } => ctx.tys().common_tys.f64,
-            ScalarKind::Pointer(_) => IrTy::unit_ptr(ctx),
+            ScalarKind::Pointer(_) => ctx.tys().common_tys.void_ptr,
         }
     }
 }

--- a/compiler/hash-ir/src/write/graphviz.rs
+++ b/compiler/hash-ir/src/write/graphviz.rs
@@ -81,7 +81,7 @@ impl<'ir> IrGraphWriter<'ir> {
         let header = format!("{}", self.body.info().ty().fmt_with_opts(self.ctx, true, false));
 
         match self.body.info().source() {
-            BodySource::Item | BodySource::Intrinsic => {
+            BodySource::Item => {
                 write!(w, "  label=<{}{}", encode_text(&header), LINE_SEPARATOR)?;
             }
             BodySource::Const => {

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -11,7 +11,10 @@ use std::{
 };
 
 use compute::LayoutComputer;
-use hash_ir::ty::{IrTy, IrTyId, ToIrTy, VariantIdx};
+use hash_ir::{
+    ty::{IrTy, IrTyId, ToIrTy, VariantIdx},
+    write::WriteIr,
+};
 use hash_target::{
     abi::{AbiRepresentation, Scalar},
     alignment::{Alignment, Alignments},
@@ -230,7 +233,10 @@ impl TyInfo {
             | IrTy::Char
             | IrTy::Never
             | IrTy::FnDef { .. }
-            | IrTy::Fn { .. } => panic!("TyInfo::field on a type that does not contain fields"),
+            | IrTy::Fn { .. } => panic!(
+                "TyInfo::field on a type `{}` that does not contain fields",
+                ty.for_fmt(ctx.ir_ctx())
+            ),
 
             // Handle pointers that might have additional information attached to them, i.e.
             // `str` and `[T]` types.

--- a/compiler/hash-lexer/Cargo.toml
+++ b/compiler/hash-lexer/Cargo.toml
@@ -11,3 +11,4 @@ num-traits = "0.2.15"
 hash-reporting = {path = "../hash-reporting" }
 hash-source = {path = "../hash-source" }
 hash-token = {path = "../hash-token" }
+hash-target = {path = "../hash-target" }

--- a/compiler/hash-lexer/src/lib.rs
+++ b/compiler/hash-lexer/src/lib.rs
@@ -11,6 +11,7 @@ use hash_source::{
     location::{SourceLocation, Span},
     SourceId,
 };
+use hash_target::size::Size;
 use hash_token::{
     delimiter::{Delimiter, DelimiterVariant},
     keyword::Keyword,
@@ -47,7 +48,10 @@ pub struct Lexer<'a> {
     // how to tokenise `usize` and `isize` literals.
     ///
     /// The size of the machine word in bytes.
-    word_size: usize,
+    ///
+    /// @@Future: remove literal parsing until later when we can properly
+    /// normalise everything, the lexer should just normalise this value.
+    word_size: Size,
 
     /// Representing the last character the lexer encountered. This is only set
     /// by [Lexer::advance_token] so that [Lexer::eat_token_tree] can perform a
@@ -67,7 +71,7 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     /// Create a new [Lexer] from the given string input.
-    pub fn new(contents: &'a str, source_id: SourceId, word_size: usize) -> Self {
+    pub fn new(contents: &'a str, source_id: SourceId, word_size: Size) -> Self {
         Lexer {
             offset: Cell::new(0),
             source_id,

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -17,7 +17,7 @@ use hash_ast::ast;
 use hash_ir::{
     ir::{BasicBlock, Place, PlaceProjection},
     ty::{AdtId, IrTy, Mutability},
-}; 
+};
 use hash_source::location::Span;
 use hash_target::size::Size;
 use hash_tir::{

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -311,7 +311,8 @@ impl<'tcx> Builder<'tcx> {
 
                 // get the range and bias of this range pattern from
                 // the `lo`
-                let lo_ty = self.ty_from_tir_ty(self.get_inferred_ty(pair.pat));
+                let id = self.ty_id_from_tir_ty(self.get_inferred_ty(pair.pat));
+                let lo_ty = self.ctx().tys().get(id);
 
                 // The range is the minimum value, maximum value, and the size of
                 // the item that is being compared.

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -17,7 +17,7 @@ use hash_ast::ast;
 use hash_ir::{
     ir::{BasicBlock, Place, PlaceProjection},
     ty::{AdtId, IrTy, Mutability},
-};
+}; 
 use hash_source::location::Span;
 use hash_target::size::Size;
 use hash_tir::{

--- a/compiler/hash-lower/src/build/matches/candidate.rs
+++ b/compiler/hash-lower/src/build/matches/candidate.rs
@@ -290,7 +290,7 @@ impl<'tcx> Builder<'tcx> {
                     } else {
                         Mutability::Immutable
                     },
-                    source: pair.place.into_place(self.ctx),
+                    source: pair.place.into_place(self.ctx()),
                     name,
 
                     // @@Todo: introduce a way of specifying what the binding
@@ -307,7 +307,7 @@ impl<'tcx> Builder<'tcx> {
                 Ok(())
             }
             Pat::Range(RangePat { start, end, range_end }) => {
-                let ptr_width = self.settings.target().pointer_bit_width / 8;
+                let ptr_width = self.settings.target().ptr_size();
 
                 // get the range and bias of this range pattern from
                 // the `lo`
@@ -362,7 +362,7 @@ impl<'tcx> Builder<'tcx> {
                 // get the type of the tuple so that we can read all of the
                 // fields
                 let ty = self.ty_id_from_tir_pat(pair.pat);
-                let adt = self.ctx.map_ty(ty, IrTy::as_adt);
+                let adt = self.ctx().map_ty(ty, IrTy::as_adt);
 
                 candidate.pairs.extend(self.match_pat_fields(data, adt, pair.place));
                 Ok(())
@@ -371,10 +371,10 @@ impl<'tcx> Builder<'tcx> {
                 let ty = self.ty_id_from_tir_pat(pair.pat);
 
                 // If the type is a boolean, then we can't simplify this pattern any further...
-                let adt = self.ctx.map_ty(ty, |ty| match ty {
+                let adt = self.ctx().map_ty(ty, |ty| match ty {
                     IrTy::Bool => None,
                     IrTy::Adt(id) => {
-                        self.ctx.map_adt(*id, |id, adt| adt.flags.is_struct().then_some(id))
+                        self.ctx().map_adt(*id, |id, adt| adt.flags.is_struct().then_some(id))
                     }
                     ty => panic!("unexpected type: {ty:?}"),
                 });
@@ -439,7 +439,7 @@ impl<'tcx> Builder<'tcx> {
         ty: AdtId,
         place: PlaceBuilder,
     ) -> Vec<MatchPair> {
-        self.ctx.adts().map_fast(ty, |adt| {
+        self.ctx().adts().map_fast(ty, |adt| {
             debug_assert!(adt.flags.is_struct() || adt.flags.is_tuple());
 
             let variant = adt.variants.first().unwrap();

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -101,7 +101,7 @@ impl<'tcx> Builder<'tcx> {
                     return;
                 }
 
-                // @@Todo: when we support `k @ ...` patterns, we need to know
+                // @@Future: when we support `k @ ...` patterns, we need to know
                 // when this is a primary pattern or not.
 
                 let ty = self.ty_id_from_tir_pat(pat_id);

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -207,7 +207,7 @@ impl<'tcx> Builder<'tcx> {
                 // we lookup the local from the current scope, and get the place of where
                 // to place this value.
                 if let Some(local) = self.lookup_local_symbol(name) {
-                    let place = Place::from_local(local, self.ctx);
+                    let place = Place::from_local(local, self.ctx());
 
                     unpack!(block = self.term_into_dest(place, block, term));
                     block.unit()

--- a/compiler/hash-lower/src/build/matches/mod.rs
+++ b/compiler/hash-lower/src/build/matches/mod.rs
@@ -124,7 +124,7 @@ impl<'tcx> Builder<'tcx> {
         let place = unpack!(block = self.as_place(block, expr, Mutability::Mutable));
         let then_block = self.control_flow_graph.start_new_block();
 
-        let terminator = TerminatorKind::make_if(place.into(), then_block, else_block, self.ctx);
+        let terminator = TerminatorKind::make_if(place.into(), then_block, else_block, self.ctx());
         self.control_flow_graph.terminate(block, span, terminator);
 
         then_block.unit()
@@ -530,7 +530,7 @@ impl<'tcx> Builder<'tcx> {
 
         // we know the exact size of the targets, so we can pre-allocate
         // the size we need
-        target_table.resize_with(test.targets(self.ctx), Default::default);
+        target_table.resize_with(test.targets(self.ctx()), Default::default);
 
         let candidate_count = candidates.len();
 
@@ -695,7 +695,7 @@ impl<'tcx> Builder<'tcx> {
         // soundness of later match checks.
         for binding in bindings {
             let value_place =
-                Place::from_local(self.lookup_local_symbol(binding.name).unwrap(), self.ctx);
+                Place::from_local(self.lookup_local_symbol(binding.name).unwrap(), self.ctx());
 
             // @@Todo: we might have to do some special rules for the `by-ref` case
             //         when we start to think about reference rules more concretely.
@@ -722,7 +722,7 @@ impl<'tcx> Builder<'tcx> {
             // Now resolve where the binding place from, and then push
             // an assign onto the binding source.
             let value_place =
-                Place::from_local(self.lookup_local_symbol(binding.name).unwrap(), self.ctx);
+                Place::from_local(self.lookup_local_symbol(binding.name).unwrap(), self.ctx());
 
             self.control_flow_graph.push_assign(block, value_place, rvalue, binding.span);
         }

--- a/compiler/hash-lower/src/build/matches/optimise.rs
+++ b/compiler/hash-lower/src/build/matches/optimise.rs
@@ -64,7 +64,7 @@ impl<'tcx> Builder<'tcx> {
         rest: Option<Spread>,
         suffix: &[PatId],
     ) {
-        let (min_length, exact_size) = self.ctx.map_ty(ty, |ty| match ty {
+        let (min_length, exact_size) = self.ctx().map_ty(ty, |ty| match ty {
             IrTy::Array { length: size, .. } => (*size, true),
             _ => (prefix.len() + suffix.len(), false),
         });

--- a/compiler/hash-lower/src/build/matches/test.rs
+++ b/compiler/hash-lower/src/build/matches/test.rs
@@ -25,6 +25,7 @@ use hash_tir::{
     control::IfPat,
     data::CtorPat,
     environment::env::AccessToEnv,
+    lits::LitPat,
     params::ParamIndex,
     pats::{Pat, PatId, RangePat, Spread},
 };
@@ -35,7 +36,16 @@ use super::{
     candidate::{Candidate, MatchPair},
     const_range::ConstRange,
 };
-use crate::build::{place::PlaceBuilder, ty::constify_lit_pat, Builder};
+use crate::build::{place::PlaceBuilder, Builder};
+
+/// Convert a [LitPat] into a [Const] value.
+fn constify_lit_pat(term: &LitPat) -> Const {
+    match term {
+        LitPat::Int(lit) => Const::Int(lit.interned_value()),
+        LitPat::Str(lit) => Const::Str(lit.interned_value()),
+        LitPat::Char(lit) => Const::Char(lit.value()),
+    }
+}
 
 #[derive(PartialEq, Eq, Debug)]
 pub(super) enum TestKind {

--- a/compiler/hash-lower/src/build/place.rs
+++ b/compiler/hash-lower/src/build/place.rs
@@ -96,7 +96,7 @@ impl<'tcx> Builder<'tcx> {
         mutability: Mutability,
     ) -> BlockAnd<Place> {
         let place_builder = unpack!(block = self.as_place_builder(block, term, mutability));
-        block.and(place_builder.into_place(self.ctx))
+        block.and(place_builder.into_place(self.ctx()))
     }
 
     pub(crate) fn as_place_builder(
@@ -175,7 +175,7 @@ impl<'tcx> Builder<'tcx> {
     /// using a [ParamIndex]. This function assumes that the underlying type
     /// is a [IrTy::Adt].
     fn lookup_field_index(&mut self, ty: IrTyId, field: ParamIndex) -> usize {
-        self.ctx.map_ty_as_adt(ty, |adt, _| {
+        self.ctx().map_ty_as_adt(ty, |adt, _| {
             // @@Todo: deal with unions here.
             if adt.flags.is_struct() || adt.flags.is_tuple() {
                 // So we get the first variant of the ADT since structs, tuples always

--- a/compiler/hash-lower/src/build/temp.rs
+++ b/compiler/hash-lower/src/build/temp.rs
@@ -21,7 +21,7 @@ impl<'tcx> Builder<'tcx> {
         let local = LocalDecl::new_auxiliary(ty, mutability);
 
         let temp = self.declarations.push(local);
-        let temp_place = Place::from_local(temp, self.ctx);
+        let temp_place = Place::from_local(temp, self.ctx());
 
         unpack!(block = self.term_into_dest(temp_place, block, term));
         block.and(temp)
@@ -31,6 +31,6 @@ impl<'tcx> Builder<'tcx> {
     pub(crate) fn temp_place(&mut self, ty: IrTyId) -> Place {
         let decl = LocalDecl::new_auxiliary(ty, Mutability::Immutable);
 
-        Place::from_local(self.declarations.push(decl), self.ctx)
+        Place::from_local(self.declarations.push(decl), self.ctx())
     }
 }

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -11,7 +11,7 @@ use hash_intrinsics::{
 };
 use hash_ir::{
     ir::{self, Const},
-    ty::{IrTy, IrTyId},
+    ty::IrTyId,
 };
 use hash_source::constant::CONSTANT_MAP;
 use hash_tir::{
@@ -25,18 +25,9 @@ use hash_tir::{
     tys::TyId,
     utils::common::CommonUtils,
 };
-use hash_utils::store::{SequenceStore, Store};
+use hash_utils::store::SequenceStore;
 
 use super::Builder;
-
-/// Convert a [LitTerm] into a [Const] value.
-pub(super) fn constify_lit_pat(term: &LitPat) -> Const {
-    match term {
-        LitPat::Int(lit) => Const::Int(lit.interned_value()),
-        LitPat::Str(lit) => Const::Str(lit.interned_value()),
-        LitPat::Char(lit) => Const::Char(lit.value()),
-    }
-}
 
 /// An auxiliary data structure that represents the underlying [FnCallTerm]
 /// as either being a function call, a binary operation (of various kinds), or
@@ -75,17 +66,18 @@ impl<'tcx> Builder<'tcx> {
         self.ctx.ty_id_from_tir_ty(ty)
     }
 
-    /// Get the [IrTy] from a given [TermId].
-    pub(super) fn ty_from_tir_term(&mut self, term: TermId) -> IrTy {
-        self.ty_from_tir_ty(self.get_inferred_ty(term))
+    /// Get the [IrTyId] for a give [PatId].
+    pub(super) fn ty_id_from_tir_pat(&self, pat: PatId) -> IrTyId {
+        let ty = self.get_inferred_ty(pat);
+        self.ty_id_from_tir_ty(ty)
     }
 
-    /// Create an [IrTy] from a defined [DataTy].
+    /// Create an ADT from a defined [DataTy].
     pub(crate) fn ty_id_from_tir_data(&self, data_ty: DataTy) -> IrTyId {
-        self.ctx.ty_id_from_tir_data(data_ty)
+        self.ctx.ty_from_tir_data(data_ty)
     }
 
-    /// Create an [`IrTy::FnDef`] from the given [FnDefId].
+    /// Create an function type from the given [FnDefId].
     pub(super) fn ty_id_from_tir_fn_def(&mut self, fn_def: FnDefId) -> IrTyId {
         self.ctx.ty_id_from_tir_fn_def(fn_def)
     }
@@ -95,17 +87,6 @@ impl<'tcx> Builder<'tcx> {
     /// duplicate work.
     pub(super) fn ty_id_from_tir_ty(&self, ty: TyId) -> IrTyId {
         self.ctx.ty_id_from_tir_ty(ty)
-    }
-
-    /// Get the [IrTy] from a given [TyId].
-    pub(super) fn ty_from_tir_ty(&self, ty_id: TyId) -> IrTy {
-        self.stores().ty().map_fast(ty_id, |ty| self.ctx.ty_from_tir_ty(ty_id, ty))
-    }
-
-    /// Get the [IrTyId] for a give [PatId].
-    pub(super) fn ty_id_from_tir_pat(&self, pat: PatId) -> IrTyId {
-        let ty = self.get_inferred_ty(pat);
-        self.ty_id_from_tir_ty(ty)
     }
 
     /// Function which is used to classify a [FnCallTerm] into a

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -4,18 +4,25 @@
 //! types.
 
 use hash_ir::{
-    ir::{AssertKind, BasicBlock, Local, LocalDecl, Operand, Place, TerminatorKind},
-    ty::Mutability,
+    ir::{
+        AggregateKind, AssertKind, BasicBlock, Const, Local, LocalDecl, Operand, Place, RValue,
+        TerminatorKind,
+    },
+    ty::{IrTyId, Mutability},
+    IrCtx,
 };
-use hash_source::{
-    identifier::{Identifier, IDENTS},
-    location::Span,
-};
+use hash_source::{constant::CONSTANT_MAP, location::Span};
 use hash_tir::{
-    environment::env::AccessToEnv, fns::FnDefId, pats::PatId, symbols::Symbol, terms::TermId,
-    utils::common::CommonUtils,
+    data::DataTy,
+    environment::env::AccessToEnv,
+    fns::FnDefId,
+    mods::{ModMember, ModMemberValue},
+    pats::PatId,
+    symbols::Symbol,
+    terms::TermId,
+    utils::{common::CommonUtils, AccessToUtils},
 };
-use hash_utils::log;
+use hash_utils::{log, store::SequenceStore};
 
 use super::{Builder, LocalKey};
 
@@ -23,6 +30,11 @@ use super::{Builder, LocalKey};
 const DUMMY_SPAN: Span = Span::new(0, 0);
 
 impl<'tcx> Builder<'tcx> {
+    /// Get a reference to a [IrCtx].
+    pub(crate) fn ctx(&self) -> &IrCtx {
+        self.ctx.lcx
+    }
+
     /// Get the [Span] of a given [PatId].
     pub(crate) fn span_of_pat(&self, id: PatId) -> Span {
         self.get_location(id).map(|loc| loc.span).unwrap_or_else(|| {
@@ -63,11 +75,62 @@ impl<'tcx> Builder<'tcx> {
         self.lookup_local(&key)
     }
 
-    /// Get the underlying name for a [Symbol], if the symbol
-    /// has no name, then the name is set as `_`.
-    pub(crate) fn symbol_name(&self, symbol: Symbol) -> Identifier {
-        let data = self.get_symbol(symbol);
-        data.name.unwrap_or(IDENTS.underscore)
+    /// Lookup the definition of an item within the prelude defined
+    /// LibC module definition. This is useful for looking up items
+    /// and function definitions such as `malloc` and `free`.
+    ///
+    /// @@Future: ideally, we can remove this and just use `#lang_item`
+    /// declaration to find the appropriate items.
+    pub(crate) fn lookup_libc_fn(&mut self, name: &str) -> Option<IrTyId> {
+        let libc_mod = match self.mod_utils().get_mod_member_by_ident(self.ctx.prelude, "libc") {
+            Some(ModMember { value: ModMemberValue::Mod(libc_mod), .. }) => libc_mod,
+            _ => return None,
+        };
+
+        // Now lookup the item in the libc module
+        let Some(fn_def) = self.mod_utils().get_mod_fn_member_by_ident(libc_mod, name) else {
+            return None;
+        };
+
+        Some(self.ty_id_from_tir_fn_def(fn_def))
+    }
+
+    /// Lookup the definition of an item within the prelude. This is used
+    /// to lookup items such as `SizedPointer`.
+    ///
+    /// N.B. This assumes that the items have no type arguments.
+    pub(crate) fn lookup_prelude_item(&mut self, name: &str) -> Option<IrTyId> {
+        // Now lookup the item in the libc module
+        let Some(member) = self.mod_utils().get_mod_member_by_ident(self.ctx.prelude, name) else {
+            return None;
+        };
+
+        match member.value {
+            ModMemberValue::Data(data_def) => {
+                let args = self.stores().args().create_empty();
+                let ty_id = self.ty_id_from_tir_data(DataTy { data_def, args });
+                Some(ty_id)
+            }
+            ModMemberValue::Mod(_) => unreachable!("tried to lookup a module as an item"),
+            ModMemberValue::Fn(fn_def) => Some(self.ty_id_from_tir_fn_def(fn_def)),
+        }
+    }
+
+    /// Create a new [RValue] that represents a pointer with metadata, this uses
+    /// the prelude defined `SizedPointer` type.
+    pub(crate) fn create_ptr_with_metadata(
+        &mut self,
+        ty: IrTyId,
+        ptr: Operand,
+        metadata: usize,
+    ) -> RValue {
+        let id = self.ctx().map_ty_as_adt(ty, |_, id| id);
+
+        let ptr_width = self.settings.target().ptr_size();
+        let metadata =
+            Operand::Const(Const::Int(CONSTANT_MAP.create_usize_int(metadata, ptr_width)).into());
+
+        RValue::Aggregate(AggregateKind::Struct(id), vec![ptr, metadata])
     }
 
     /// Function to create a new [Place] that is used to ignore
@@ -76,11 +139,13 @@ impl<'tcx> Builder<'tcx> {
         match &self.tmp_place {
             Some(tmp) => *tmp,
             None => {
-                let local =
-                    LocalDecl::new_auxiliary(self.ctx.tys().common_tys.unit, Mutability::Immutable);
+                let local = LocalDecl::new_auxiliary(
+                    self.ctx().tys().common_tys.unit,
+                    Mutability::Immutable,
+                );
                 let local_id = self.declarations.push(local);
 
-                let place = Place::from_local(local_id, self.ctx);
+                let place = Place::from_local(local_id, self.ctx());
                 self.tmp_place = Some(place);
                 place
             }

--- a/compiler/hash-lower/src/ctx.rs
+++ b/compiler/hash-lower/src/ctx.rs
@@ -1,0 +1,109 @@
+//! Defines the [BuilderCtx] which is a collection of all the
+//! information required to lower all the TIR into IR, among
+//! other operations.
+
+use hash_intrinsics::{
+    intrinsics::{AccessToIntrinsics, DefinedIntrinsics},
+    primitives::{AccessToPrimitives, DefinedPrimitives},
+};
+use hash_ir::{ty::IrTyId, IrCtx};
+use hash_layout::{
+    compute::{LayoutComputer, LayoutError},
+    LayoutCtx, LayoutId,
+};
+use hash_semantics::SemanticStorage;
+use hash_tir::{
+    environment::env::{AccessToEnv, Env},
+    mods::ModDefId,
+};
+
+/// The [BuilderCtx] is a collection of all the information and data stores that
+/// are needed to lower the TIR into IR. This is only used during the initial
+/// building of the IR, and is not used when optimising the IR or when code
+/// generation is happening.
+#[derive(Clone, Copy)]
+pub(crate) struct BuilderCtx<'ir> {
+    /// A reference to the lowering context that is used for
+    /// lowering the TIR.
+    pub lcx: &'ir IrCtx,
+
+    /// The type layout context stores all relevant information to layouts and
+    /// computing them.
+    layouts: &'ir LayoutCtx,
+
+    /// The type storage needed for accessing the types of the traversed terms
+    pub env: &'ir Env<'ir>,
+
+    /// The primitive definitions that are needed for creating and comparing
+    /// primitive types with the TIR.
+    pub primitives: &'ir DefinedPrimitives,
+
+    /// The intrinsic definitions that are needed for
+    /// dealing with intrinsic functions within the TIR.
+    pub intrinsics: &'ir DefinedIntrinsics,
+
+    /// The prelude that is used for lowering the TIR.
+    pub prelude: ModDefId,
+}
+
+impl<'ir> AccessToEnv for BuilderCtx<'ir> {
+    fn env(&self) -> &Env {
+        self.env
+    }
+}
+
+impl<'ir> AccessToPrimitives for BuilderCtx<'ir> {
+    fn primitives(&self) -> &DefinedPrimitives {
+        self.primitives
+    }
+}
+
+impl<'ir> AccessToIntrinsics for BuilderCtx<'ir> {
+    fn intrinsics(&self) -> &DefinedIntrinsics {
+        self.intrinsics
+    }
+}
+
+impl<'ir> BuilderCtx<'ir> {
+    /// Create a new [Ctx] from the given [Env] and
+    /// [SemanticStorage].
+    pub fn new(
+        lcx: &'ir IrCtx,
+        layouts: &'ir LayoutCtx,
+        env: &'ir Env<'ir>,
+        storage: &'ir SemanticStorage,
+    ) -> Self {
+        let primitives = match storage.primitives_or_unset.get() {
+            Some(primitives) => primitives,
+            None => panic!("Tried to get primitives but they are not set yet"),
+        };
+
+        let intrinsics = match storage.intrinsics_or_unset.get() {
+            Some(intrinsics) => intrinsics,
+            None => panic!("Tried to get intrinsics but they are not set yet"),
+        };
+
+        let prelude = match storage.prelude_or_unset.get() {
+            Some(prelude) => *prelude,
+            None => panic!("Tried to get prelude but it is not set yet"),
+        };
+
+        Self { env, lcx, layouts, primitives, intrinsics, prelude }
+    }
+
+    /// Get a [LayoutComputer] which can be used to compute layouts and
+    /// other layout related operations.
+    pub fn layout_computer(&self) -> LayoutComputer {
+        LayoutComputer::new(self.layouts, self.lcx)
+    }
+
+    /// Compute the layout of a given [IrTyId].
+    pub fn layout_of(&self, ty: IrTyId) -> Result<LayoutId, LayoutError> {
+        self.layout_computer().layout_of_ty(ty)
+    }
+
+    /// Compute the size of a given [IrTyId].
+    pub fn size_of(&self, ty: IrTyId) -> Result<usize, LayoutError> {
+        Ok(self.layouts.size_of(self.layout_of(ty)?).bytes().try_into().unwrap())
+    }
+}

--- a/compiler/hash-lower/src/discover.rs
+++ b/compiler/hash-lower/src/discover.rs
@@ -18,12 +18,14 @@ use hash_tir::{
 use hash_utils::store::{PartialCloneStore, Store};
 use indexmap::IndexSet;
 
+use crate::ctx::BuilderCtx;
+
 /// Discoverer for functions to lower in the TIR tree.
 #[derive(Constructor)]
-pub struct FnDiscoverer<'a, T: AccessToEnv> {
+pub(crate) struct FnDiscoverer<'a> {
     /// The TIR environment which can be used to read information about
     /// all TIR terms and definitions.
-    env: &'a T,
+    ctx: &'a BuilderCtx<'a>,
 
     /// A reference to [StageInfo] which refers to what the current
     /// status of each source is. This is used to avoid re-queuing modules
@@ -31,9 +33,9 @@ pub struct FnDiscoverer<'a, T: AccessToEnv> {
     stage_info: &'a StageInfo,
 }
 
-impl<T: AccessToEnv> AccessToEnv for FnDiscoverer<'_, T> {
+impl AccessToEnv for FnDiscoverer<'_> {
     fn env(&self) -> &Env {
-        self.env.env()
+        self.ctx.env()
     }
 }
 
@@ -59,7 +61,7 @@ impl DiscoveredFns {
     }
 }
 
-impl<T: AccessToEnv> FnDiscoverer<'_, T> {
+impl FnDiscoverer<'_> {
     /// Check whether a function definition needs to be lowered. The function
     /// should be lowered if it adheres to the following conditions:
     /// - It is not pure (for now)
@@ -94,12 +96,9 @@ impl<T: AccessToEnv> FnDiscoverer<'_, T> {
 
                 true
             }
-            FnBody::Intrinsic(_) | FnBody::Axiom => {
-                // Intrinsic and axiom functions have no defined
-                // bodies
 
-                false
-            }
+            // Intrinsics and axioms have no effect on the IR lowering
+            FnBody::Intrinsic(_) | FnBody::Axiom => false,
         }
     }
 

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -208,23 +208,23 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             &source_info,
         );
 
-        let tcx = BuilderCtx::new(&ir_storage.ctx, layout_storage, &env, semantic_storage);
+        let ctx = BuilderCtx::new(&ir_storage.ctx, layout_storage, &env, semantic_storage);
 
         // @@Future: support generic substitutions here.
         let empty_args = semantic_storage.stores.args().create_empty();
 
         semantic_storage.stores.directives().internal_data().borrow().iter().for_each(|(id, directives)| {
             if directives.contains(IDENTS.layout_of) && let DirectiveTarget::DataDefId(data_def) = *id {
-                let ty = tcx.ty_id_from_tir_data(DataTy { args: empty_args, data_def });
+                let ty = ctx.ty_from_tir_data(DataTy { args: empty_args, data_def });
 
                 // @@ErrorHandling: propagate this error if it occurs.
-                if let Ok(layout) = tcx.layout_of(ty) {
+                if let Ok(layout) = ctx.layout_of(ty) {
                     // Print the layout and add spacing between all of the specified layouts
                     // that were requested.
                     stream_writeln!(
                         stdout,
                         "{}",
-                        LayoutWriter::new(TyInfo { ty, layout }, tcx.layout_computer())
+                        LayoutWriter::new(TyInfo { ty, layout }, ctx.layout_computer())
                     );
                 }
             }

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod build;
 mod cfg;
+mod ctx;
 
 mod discover;
 mod lower_ty;
@@ -14,14 +15,15 @@ mod optimise;
 
 use std::{collections::BTreeMap, time::Duration};
 
-use build::{Builder, Tcx};
+use build::Builder;
+use ctx::BuilderCtx;
 use discover::FnDiscoverer;
 use hash_ir::{
     ty::IrTy,
     write::{graphviz, pretty},
     IrStorage,
 };
-use hash_layout::{compute::LayoutComputer, write::LayoutWriter, LayoutCtx, TyInfo};
+use hash_layout::{write::LayoutWriter, LayoutCtx, TyInfo};
 use hash_pipeline::{
     interface::{
         CompilerInterface, CompilerOutputStream, CompilerResult, CompilerStage, StageMetrics,
@@ -45,7 +47,6 @@ use hash_utils::{
     stream_writeln,
     timing::{time_item, AccessToMetrics},
 };
-use lower_ty::TyLoweringCtx;
 use optimise::Optimiser;
 
 /// The Hash IR builder compiler stage.
@@ -117,7 +118,9 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
     /// Additionally, this module is responsible for performing
     /// optimisations on the IR (if specified via the [CompilerSettings]).
     fn run(&mut self, entry: SourceId, ctx: &mut Ctx) -> CompilerResult<()> {
-        let LoweringCtx { semantic_storage, workspace, ir_storage, settings, .. } = ctx.data();
+        let LoweringCtx {
+            semantic_storage, workspace, ir_storage, layout_storage, settings, ..
+        } = ctx.data();
         let source_stage_info = &mut workspace.source_stage_info;
 
         let source_info = CurrentSourceInfo::new(entry);
@@ -132,9 +135,11 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
 
         let entry_point = &semantic_storage.entry_point;
 
+        let ctx = BuilderCtx::new(&ir_storage.ctx, layout_storage, &env, semantic_storage);
+
         // Discover all of the bodies that need to be lowered
         let items = time_item(self, "discover", |_| {
-            let discoverer = FnDiscoverer::new(&env, source_stage_info);
+            let discoverer = FnDiscoverer::new(&ctx, source_stage_info);
             discoverer.discover_fns()
         });
 
@@ -155,9 +160,7 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
                     panic!("function `{name}` has no defined source location");
                 };
 
-                let tcx = Tcx::new(&env, semantic_storage);
-                let mut builder =
-                    Builder::new(name, (*func).into(), id, tcx, &mut ir_storage.ctx, settings);
+                let mut builder = Builder::new(name, (*func).into(), id, ctx, settings);
                 builder.build();
 
                 let body = builder.finish();
@@ -205,28 +208,23 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
             &source_info,
         );
 
-        let ty_lowerer = TyLoweringCtx::new(
-            &ir_storage.ctx,
-            &env,
-            semantic_storage.primitives_or_unset.get().unwrap(),
-        );
+        let tcx = BuilderCtx::new(&ir_storage.ctx, layout_storage, &env, semantic_storage);
 
         // @@Future: support generic substitutions here.
         let empty_args = semantic_storage.stores.args().create_empty();
 
         semantic_storage.stores.directives().internal_data().borrow().iter().for_each(|(id, directives)| {
             if directives.contains(IDENTS.layout_of) && let DirectiveTarget::DataDefId(data_def) = *id {
-                let ty = ty_lowerer.ty_id_from_tir_data(DataTy { args: empty_args, data_def });
-                let layout_computer = LayoutComputer::new(layout_storage, &ir_storage.ctx);
+                let ty = tcx.ty_id_from_tir_data(DataTy { args: empty_args, data_def });
 
                 // @@ErrorHandling: propagate this error if it occurs.
-                if let Ok(layout) = layout_computer.layout_of_ty(ty) {
+                if let Ok(layout) = tcx.layout_of(ty) {
                     // Print the layout and add spacing between all of the specified layouts
                     // that were requested.
                     stream_writeln!(
                         stdout,
                         "{}",
-                        LayoutWriter::new(TyInfo { ty, layout }, layout_computer)
+                        LayoutWriter::new(TyInfo { ty, layout }, tcx.layout_computer())
                     );
                 }
             }

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -9,17 +9,15 @@ use hash_ir::{
         self, AdtData, AdtField, AdtFlags, AdtId, AdtVariant, AdtVariants, Instance, IrTy, IrTyId,
         Mutability, RepresentationFlags,
     },
+    TyCacheEntry,
 };
 use hash_reporting::macros::panic_on_span;
-use hash_source::{
-    attributes::Attribute,
-    constant::{FloatTy, SIntTy, UIntTy},
-    identifier::IDENTS,
-};
+use hash_source::{attributes::Attribute, identifier::IDENTS};
 use hash_target::size::Size;
 use hash_tir::{
     data::{
-        ArrayCtorInfo, DataDefCtors, DataTy, NumericCtorBits, NumericCtorInfo, PrimitiveCtorInfo,
+        ArrayCtorInfo, CtorDefsId, DataDef, DataDefCtors, DataTy, NumericCtorBits, NumericCtorInfo,
+        PrimitiveCtorInfo,
     },
     environment::env::AccessToEnv,
     fns::{FnDef, FnDefId, FnTy},
@@ -37,74 +35,43 @@ use hash_utils::{
 use crate::ctx::BuilderCtx;
 
 impl<'ir> BuilderCtx<'ir> {
+    /// Perform a type lowering operation whilst also caching the result of the
+    /// lowering operation. This is used to avoid duplicated work when lowering
+    /// types.
+    fn with_cache<T>(&self, item: T, f: impl FnOnce() -> IrTyId) -> IrTyId
+    where
+        T: Copy + Into<TyCacheEntry>,
+    {
+        // Check if the term is present within the cache, and if so, return the
+        // cached value.
+        if let Some(ty) = self.lcx.ty_cache().borrow().get(&item.into()) {
+            return *ty;
+        }
+
+        // Otherwise, create a new type and cache it.
+        let ty = f();
+        self.lcx.ty_cache().borrow_mut().insert(item.into(), ty);
+        ty
+    }
+
     /// Get the [IrTyId] from a given [TyId]. This function will internally
     /// cache results of lowering a [TyId] into an [IrTyId] to avoid
     /// duplicate work.
     pub(crate) fn ty_id_from_tir_ty(&self, id: TyId) -> IrTyId {
-        // Check if the term is present within the cache, and if so, return the
-        // cached value.
-        if let Some(ty) = self.lcx.ty_cache().borrow().get(&id.into()) {
-            return *ty;
-        }
-
-        // @@Hack: avoid re-creating "commonly" used types in order
-        // to allow for type_id equality to work
-        let create_new_ty = |ty: IrTy| match ty {
-            IrTy::Char => self.lcx.tys().common_tys.char,
-            IrTy::Bool => self.lcx.tys().common_tys.bool,
-            IrTy::UInt(UIntTy::U8) => self.lcx.tys().common_tys.u8,
-            IrTy::UInt(UIntTy::U16) => self.lcx.tys().common_tys.u16,
-            IrTy::UInt(UIntTy::U32) => self.lcx.tys().common_tys.u32,
-            IrTy::UInt(UIntTy::U64) => self.lcx.tys().common_tys.u64,
-            IrTy::UInt(UIntTy::U128) => self.lcx.tys().common_tys.u128,
-            IrTy::UInt(UIntTy::USize) => self.lcx.tys().common_tys.usize,
-            IrTy::Int(SIntTy::I8) => self.lcx.tys().common_tys.i8,
-            IrTy::Int(SIntTy::I16) => self.lcx.tys().common_tys.i16,
-            IrTy::Int(SIntTy::I32) => self.lcx.tys().common_tys.i32,
-            IrTy::Int(SIntTy::I64) => self.lcx.tys().common_tys.i64,
-            IrTy::Int(SIntTy::I128) => self.lcx.tys().common_tys.i128,
-            IrTy::Int(SIntTy::ISize) => self.lcx.tys().common_tys.isize,
-            IrTy::Float(FloatTy::F32) => self.lcx.tys().common_tys.f32,
-            IrTy::Float(FloatTy::F64) => self.lcx.tys().common_tys.f64,
-            IrTy::Str => self.lcx.tys().common_tys.str,
-            _ => self.lcx.tys().create(ty),
-        };
-
-        // Lower the type into ir type.
-        self.map_ty(id, |ty| {
-            if let Ty::Data(data_ty) = ty {
-                let data_ty = *data_ty;
-
-                if let Some(ty) = self.lcx.ty_cache().borrow().get(&data_ty.into()) {
-                    return *ty;
+        self.with_cache(id, || {
+            self.map_ty(id, |ty| {
+                if let Ty::Data(data_ty) = ty {
+                    self.ty_from_tir_data(*data_ty)
+                } else {
+                    self.uncached_ty_from_tir_ty(id, ty)
                 }
-
-                // Convert the data-type into an ir type, cache it and return it
-                let ty = create_new_ty(self.ty_from_tir_data(data_ty));
-
-                // Add entries for both the data type and the type id.
-                let mut cache = self.lcx.ty_cache().borrow_mut();
-                cache.insert(data_ty.into(), ty);
-                cache.insert(id.into(), ty);
-
-                ty
-            } else {
-                // Add an entry into the cache for this term
-                let ty = create_new_ty(self.ty_from_tir_ty(id, ty));
-                self.lcx.ty_cache().borrow_mut().insert(id.into(), ty);
-                ty
-            }
+            })
         })
     }
 
-    /// Get an [IrTy] from the given [Ty].
-    pub(crate) fn ty_from_tir_ty_id(&self, id: TyId) -> IrTy {
-        self.map_ty(id, |ty| self.ty_from_tir_ty(id, ty))
-    }
-
     /// Get the [IrTy] from the given [Ty].
-    pub(crate) fn ty_from_tir_ty(&self, id: TyId, ty: &Ty) -> IrTy {
-        match ty {
+    fn uncached_ty_from_tir_ty(&self, id: TyId, ty: &Ty) -> IrTyId {
+        let ty = match ty {
             Ty::Tuple(TupleTy { data }) => {
                 let mut flags = AdtFlags::empty();
                 flags |= AdtFlags::TUPLE;
@@ -147,14 +114,18 @@ impl<'ir> BuilderCtx<'ir> {
 
                 IrTy::Ref(ty, mutability, ref_kind)
             }
-            Ty::Data(data_ty) => self.ty_from_tir_data(*data_ty),
+            Ty::Data(data_ty) => return self.ty_from_tir_data(*data_ty),
             Ty::Eval(_) | Ty::Universe(_) => IrTy::Adt(AdtId::UNIT),
 
+            // This is a type variable that should be found in the scope. It is
+            // resolved and substituted in the `Ty::Var` case below.
             Ty::Var(sym) => {
                 // @@Temporary
                 if self.context().try_get_binding(*sym).is_some() {
                     let term = self.context_utils().get_binding_value(*sym);
-                    self.ty_from_tir_ty_id(self.use_term_as_ty(term))
+                    return self.map_ty(self.use_term_as_ty(term), |ty| {
+                        self.uncached_ty_from_tir_ty(id, ty)
+                    });
                 } else {
                     info!("couldn't resolve type variable `{}`", self.env().with(*sym));
 
@@ -174,46 +145,44 @@ impl<'ir> BuilderCtx<'ir> {
                     panic!("{message}")
                 }
             }
-        }
+        };
+
+        // Create the type
+        self.lcx.tys().create(ty)
     }
 
     /// Create a new [IrTyId] from the given function definition whilst
     /// caching the result in the
     pub(crate) fn ty_id_from_tir_fn_def(&self, def: FnDefId) -> IrTyId {
-        // Check if we have already lowered this function definition, and
-        // if so we can just return the cached value.
-        if let Some(ty) = self.lcx.ty_cache().borrow().get(&def.into()) {
-            return *ty;
-        }
+        self.with_cache(def, || {
+            let instance = self.create_instance_from_fn_def(def);
 
-        let instance = self.create_instance_from_fn_def(def);
+            let is_lang = instance.attributes.contains("lang".into());
+            let name = instance.name();
 
-        let is_lang = instance.attributes.contains("lang".into());
-        let name = instance.name();
+            // Check if the instance has the `lang` attribute, specifying that it is
+            // the lang-item attribute.
+            let instance = self.lcx.instances().create(instance);
+            let ty = self.lcx.tys().create(IrTy::FnDef { instance });
 
-        // Check if the instance has the `lang` attribute, specifying that it is
-        // the lang-item attribute.
-        let instance = self.lcx.instances().create(instance);
-        let ty = self.lcx.tys().create(IrTy::FnDef { instance });
+            if is_lang {
+                let item = LangItem::from_str_name(name.into());
+                self.lcx.lang_items_mut().set(item, instance, ty);
+            }
 
-        if is_lang {
-            let item = LangItem::from_str_name(name.into());
-            self.lcx.lang_items_mut().set(item, instance, ty);
-        }
+            // Specify here that the function might be an intrinsic function
+            if self.stores().fn_def().map_fast(def, |def| def.is_intrinsic()) {
+                let item =
+                    Intrinsic::from_str_name(name.into()).expect("unknown intrinsic function");
+                self.lcx.intrinsics_mut().set(item, instance, ty);
+            }
 
-        // Specify here that the function might be an intrinsic function
-        if self.stores().fn_def().map_fast(def, |def| def.is_intrinsic()) {
-            let item = Intrinsic::from_str_name(name.into()).expect("unknown intrinsic function");
-            self.lcx.intrinsics_mut().set(item, instance, ty);
-        }
-
-        // Save in the cache that the definition has been lowered.
-        self.lcx.ty_cache().borrow_mut().insert(def.into(), ty);
-        ty
+            ty
+        })
     }
 
     /// Create a [Instance] from a [FnDefId]. This represents the function
-    /// instance including the name, types (monormorphised), and attributes
+    // / instance including the name, types (monomorphised), and attributes
     /// that are associated with the function definition.
     fn create_instance_from_fn_def(&self, fn_def: FnDefId) -> Instance {
         let FnDef { name, ty, .. } = self.env().stores().fn_def().get(fn_def);
@@ -258,78 +227,79 @@ impl<'ir> BuilderCtx<'ir> {
     /// data definition and a collection of arguments to the data
     /// definition. The arguments correspond to generic parameters that the
     /// definition has.
-    pub(crate) fn ty_id_from_tir_data(&self, data_ty: DataTy) -> IrTyId {
-        // Check if the data type has already been converted into
-        // an ir type.
-        let key = data_ty.into();
-        if let Some(ty) = self.lcx.ty_cache().borrow().get(&key) {
-            return *ty;
-        }
-
-        let ty = self.ty_from_tir_data(data_ty);
-        let id = self.lcx.tys().create(ty);
-
-        // Add an entry into the cache for this term
-        self.lcx.ty_cache().borrow_mut().insert(key, id);
-        id
+    pub(crate) fn ty_from_tir_data(&self, data_ty: DataTy) -> IrTyId {
+        self.with_cache(data_ty, || self.uncached_ty_from_tir_data(data_ty))
     }
 
-    fn create_data_def(&self, DataTy { data_def, .. }: DataTy) -> IrTy {
-        let data_ty = self.get_data_def(data_def);
+    fn adt_ty_from_data(&self, def: &DataDef, ctor_defs: CtorDefsId) -> IrTyId {
+        // If data_def has more than one constructor, then it is assumed that this
+        // is a enum.
+        let mut flags = AdtFlags::empty();
 
-        match data_ty.ctors {
-            DataDefCtors::Defined(ctor_defs) => {
-                // If data_def has more than one constructor, then it is assumed that this
-                // is a enum.
-                let mut flags = AdtFlags::empty();
+        match ctor_defs.len() {
+            0 => return self.lcx.tys().common_tys.never, // This must be the never type.
+            1 => flags |= AdtFlags::STRUCT,
+            _ => flags |= AdtFlags::ENUM,
+        }
 
-                match ctor_defs.len() {
-                    0 => return IrTy::Never, // This must be the never type.
-                    1 => flags |= AdtFlags::STRUCT,
-                    _ => flags |= AdtFlags::ENUM,
-                }
+        // Lower each variant as a constructor.
+        let variants = self.stores().ctor_defs().map_fast(ctor_defs, |defs| {
+            defs.iter()
+                .map(|ctor| {
+                    let name = self.get_symbol(ctor.name).name.unwrap_or(IDENTS.underscore);
 
-                // Lower each variant as a constructor.
-                let variants = self.stores().ctor_defs().map_fast(ctor_defs, |defs| {
-                    defs.iter()
-                        .map(|ctor| {
-                            let name = self.get_symbol(ctor.name).name.unwrap_or(IDENTS.underscore);
+                    self.stores().params().map_fast(ctor.params, |fields| {
+                        let fields = fields
+                            .iter()
+                            .map(|field| {
+                                let ty = self.ty_id_from_tir_ty(field.ty);
+                                let name =
+                                    self.get_symbol(field.name).name.unwrap_or(IDENTS.underscore);
 
-                            self.stores().params().map_fast(ctor.params, |fields| {
-                                let fields = fields
-                                    .iter()
-                                    .map(|field| {
-                                        let ty = self.ty_id_from_tir_ty(field.ty);
-                                        let name = self
-                                            .get_symbol(field.name)
-                                            .name
-                                            .unwrap_or(IDENTS.underscore);
-
-                                        AdtField { name, ty }
-                                    })
-                                    .collect::<Vec<_>>();
-
-                                AdtVariant { name, fields }
+                                AdtField { name, ty }
                             })
-                        })
-                        .collect::<AdtVariants>()
-                });
+                            .collect::<Vec<_>>();
 
-                // Get the name of the data type, if no name exists we default to
-                // using `_`.
-                let name = self.get_symbol(data_ty.name).name.unwrap_or(IDENTS.underscore);
-                let mut adt = AdtData::new_with_flags(name, variants, flags);
+                        AdtVariant { name, fields }
+                    })
+                })
+                .collect::<AdtVariants>()
+        });
 
-                // Deal with any specific attributes that were set on the type, i.e.
-                // `#repr_c`.
-                if let Some(directives) = self.stores().directives().get(data_def.into()) {
-                    if directives.contains(IDENTS.repr_c) {
-                        adt.metadata.add_flags(RepresentationFlags::C_LIKE);
-                    }
+        // Get the name of the data type, if no name exists we default to
+        // using `_`.
+        let name = self.get_symbol(def.name).name.unwrap_or(IDENTS.underscore);
+        let mut adt = AdtData::new_with_flags(name, variants, flags);
+
+        // Deal with any specific attributes that were set on the type, i.e.
+        // `#repr_c`.
+        if let Some(directives) = self.stores().directives().get(def.id.into()) {
+            if directives.contains(IDENTS.repr_c) {
+                adt.metadata.add_flags(RepresentationFlags::C_LIKE);
+            }
+        }
+
+        let id = self.lcx.adts().create(adt);
+        self.lcx.tys().create(IrTy::Adt(id))
+    }
+
+    /// Function that converts a [DataTy] into the corresponding [IrTyId].
+    fn uncached_ty_from_tir_data(&self, ty: DataTy) -> IrTyId {
+        let data_def = self.get_data_def(ty.data_def);
+
+        match data_def.ctors {
+            DataDefCtors::Defined(ctor_defs) => {
+                // Booleans are defined as a data type with two constructors,
+                // check here if we are dealing with a boolean.
+                if self.primitives().bool() == ty.data_def {
+                    return self.lcx.tys().common_tys.bool;
                 }
 
-                let id = self.lcx.adts().create(adt);
-                IrTy::Adt(id)
+                // Apply the arguments as the scope of the data type.
+                self.context().enter_scope(ty.data_def.into(), || {
+                    self.context_utils().add_arg_bindings(data_def.params, ty.args);
+                    self.adt_ty_from_data(&data_def, ctor_defs)
+                })
             }
 
             // Primitive are numerics, strings, arrays, etc.
@@ -338,8 +308,8 @@ impl<'ir> BuilderCtx<'ir> {
                     PrimitiveCtorInfo::Numeric(NumericCtorInfo { bits, is_signed, is_float }) => {
                         if is_float {
                             match bits {
-                                NumericCtorBits::Bounded(32) => IrTy::Float(FloatTy::F32),
-                                NumericCtorBits::Bounded(64) => IrTy::Float(FloatTy::F64),
+                                NumericCtorBits::Bounded(32) => self.lcx.tys().common_tys.f32,
+                                NumericCtorBits::Bounded(64) => self.lcx.tys().common_tys.f64,
 
                                 // Other bits widths are not supported.
                                 _ => unreachable!(),
@@ -350,59 +320,61 @@ impl<'ir> BuilderCtx<'ir> {
                                     let size = Size::from_bits(bits);
 
                                     if is_signed {
-                                        IrTy::Int(SIntTy::from_size(size))
+                                        match size.bytes() {
+                                            1 => self.lcx.tys().common_tys.i8,
+                                            2 => self.lcx.tys().common_tys.i16,
+                                            4 => self.lcx.tys().common_tys.i32,
+                                            8 => self.lcx.tys().common_tys.i64,
+                                            16 => self.lcx.tys().common_tys.i128,
+                                            _ => unreachable!(), /* Other bits widths are not
+                                                                  * supported. */
+                                        }
                                     } else {
-                                        IrTy::UInt(UIntTy::from_size(size))
+                                        match size.bytes() {
+                                            1 => self.lcx.tys().common_tys.u8,
+                                            2 => self.lcx.tys().common_tys.u16,
+                                            4 => self.lcx.tys().common_tys.u32,
+                                            8 => self.lcx.tys().common_tys.u64,
+                                            16 => self.lcx.tys().common_tys.u128,
+                                            _ => unreachable!(), /* Other bits widths are not
+                                                                  * supported. */
+                                        }
                                     }
                                 }
-                                // We don't implement bigints yet
-                                _ => unimplemented!(),
+                                _ => unimplemented!(), // We don't implement big-ints yet
                             }
                         }
                     }
 
                     // @@Temporary: `str` implies that it is a `&str`
-                    PrimitiveCtorInfo::Str => IrTy::Ref(
-                        self.lcx.tys().common_tys.byte_slice,
-                        Mutability::Immutable,
-                        ty::RefKind::Normal,
-                    ),
-                    PrimitiveCtorInfo::Char => IrTy::Char,
+                    PrimitiveCtorInfo::Str => self.lcx.tys().common_tys.str,
+                    PrimitiveCtorInfo::Char => self.lcx.tys().common_tys.char,
                     PrimitiveCtorInfo::Array(ArrayCtorInfo { element_ty, length }) => {
-                        match length.and_then(|l| self.try_use_term_as_integer_lit(l)) {
-                            Some(length) => {
-                                IrTy::Array { ty: self.ty_id_from_tir_ty(element_ty), length }
-                            }
-                            // @@Temporary: `[]` implies that it is a `&[]`, and there is no
-                            // information about mutability and reference kind, so for now we
-                            // assume that it is immutable and a normal reference kind.
-                            None => {
-                                let slice = IrTy::Slice(self.ty_id_from_tir_ty(element_ty));
-                                let id = self.lcx.tys().create(slice);
+                        // Apply the arguments as the scope of the data type.
+                        self.context().enter_scope(ty.data_def.into(), || {
+                            self.context_utils().add_arg_bindings(data_def.params, ty.args);
 
-                                IrTy::Ref(id, Mutability::Immutable, ty::RefKind::Normal)
-                            }
-                        }
+                            let ty = match length.and_then(|l| self.try_use_term_as_integer_lit(l))
+                            {
+                                Some(length) => {
+                                    IrTy::Array { ty: self.ty_id_from_tir_ty(element_ty), length }
+                                }
+                                // @@Temporary: `[]` implies that it is a `&[]`, and there is no
+                                // information about mutability and reference kind, so for now we
+                                // assume that it is immutable and a normal reference kind.
+                                None => {
+                                    let slice = IrTy::Slice(self.ty_id_from_tir_ty(element_ty));
+                                    let id = self.lcx.tys().create(slice);
+
+                                    IrTy::Ref(id, Mutability::Immutable, ty::RefKind::Normal)
+                                }
+                            };
+
+                            self.lcx.tys().create(ty)
+                        })
                     }
                 }
             }
         }
-    }
-
-    /// Convert the [DataDefType] into an [`IrTy::Adt`].
-    fn ty_from_tir_data(&self, ty: DataTy) -> IrTy {
-        // If the data type is a primitive boolean, then return the boolean type.
-        if ty.data_def == self.primitives().bool() {
-            return IrTy::Bool;
-        }
-
-        // Apply the arguments as the scope of the data type.
-        let kind = ty.data_def.into();
-        let data_params = self.stores().data_def().map_fast(ty.data_def, |data| data.params);
-
-        self.context().enter_scope(kind, || {
-            self.context_utils().add_arg_bindings(data_params, ty.args);
-            self.create_data_def(ty)
-        })
     }
 }

--- a/compiler/hash-parser/Cargo.toml
+++ b/compiler/hash-parser/Cargo.toml
@@ -20,3 +20,4 @@ hash-reporting = {path = "../hash-reporting"}
 hash-source = {path = "../hash-source" }
 hash-token = {path = "../hash-token" }
 hash-utils = {path = "../hash-utils" }
+hash-target = {path = "../hash-target"}

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -22,6 +22,7 @@ use hash_pipeline::{
 };
 use hash_reporting::{diagnostic::AccessToDiagnosticsMut, report::Report};
 use hash_source::{InteractiveId, ModuleId, ModuleKind, SourceId};
+use hash_target::size::Size;
 use import_resolver::ImportResolver;
 use parser::AstGen;
 use source::ParseSource;
@@ -177,7 +178,7 @@ fn parse_source(source: ParseSource, sender: Sender<ParserAction>) {
     // This means we don't have to care about the target pointer width. If
     // we were to cross compile, this would need to have access to the
     // target pointer width.
-    let ptr_byte_width = std::mem::size_of::<usize>();
+    let ptr_byte_width = Size::from_bytes(std::mem::size_of::<usize>());
 
     // Lex the contents of the module or interactive block
     let mut lexer = Lexer::new(&contents, source_id, ptr_byte_width);

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -724,9 +724,10 @@ counter! {
 
 impl fmt::Display for InternedStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", CONSTANT_MAP.lookup_string(*self))
+        write!(f, "{:?}", CONSTANT_MAP.lookup_string(*self))
     }
 }
+
 
 // Utility methods for converting from a InternedString to an InternedStrLit and
 // vice versa.

--- a/compiler/hash-source/src/constant.rs
+++ b/compiler/hash-source/src/constant.rs
@@ -720,14 +720,20 @@ counter! {
     counter_name: STR_LIT_COUNTER,
     visibility: pub,
     method_visibility:,
+    derives: (Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd),
 }
 
 impl fmt::Display for InternedStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", CONSTANT_MAP.lookup_string(*self))
+        write!(f, "{}", CONSTANT_MAP.lookup_string(*self))
     }
 }
 
+impl fmt::Debug for InternedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", CONSTANT_MAP.lookup_string(*self))
+    }
+}
 
 // Utility methods for converting from a InternedString to an InternedStrLit and
 // vice versa.

--- a/compiler/hash-source/src/identifier.rs
+++ b/compiler/hash-source/src/identifier.rs
@@ -240,6 +240,7 @@ core_idents! {
     dump_tir: "dump_tir",
 
     // Language items
+    lang: "lang",
     intrinsics: "intrinsics",
     entry_point: "entry_point",
     transmute: "transmute",

--- a/compiler/hash-target/src/lib.rs
+++ b/compiler/hash-target/src/lib.rs
@@ -173,6 +173,11 @@ pub struct Target {
 }
 
 impl Target {
+    /// Get the size of the pointer for the target in bits.
+    pub fn ptr_size(&self) -> Size {
+        Size::from_bits(self.pointer_bit_width as u64)
+    }
+
     /// Find and load the specified target from a target triple.
     ///
     /// @@Future: support a more custom way of loading in target specifications.

--- a/compiler/hash-tir/src/fns.rs
+++ b/compiler/hash-tir/src/fns.rs
@@ -100,6 +100,14 @@ pub struct FnDef {
     /// This depends on `ty.params` and `ty.conditions`.
     pub body: FnBody,
 }
+
+impl FnDef {
+    /// Check if the definition has an intrinsic body.
+    pub fn is_intrinsic(&self) -> bool {
+        matches!(self.body, FnBody::Intrinsic(_))
+    }
+}
+
 new_store_key!(pub FnDefId);
 
 /// Function definitions live in a store

--- a/compiler/hash-tir/src/old/storage.rs
+++ b/compiler/hash-tir/src/old/storage.rs
@@ -6,7 +6,7 @@
 use std::cell::Cell;
 
 use hash_source::{entry_point::EntryPointState, SourceId};
-use hash_target::Target;
+use hash_target::{size::Size, Target};
 use hash_utils::store::Store;
 
 use crate::old::{
@@ -72,8 +72,8 @@ pub struct GlobalStorage {
     /// queried.
     pub root_scope: ScopeId,
 
-    /// The pointer width in **bytes** on the current target architecture.
-    pub pointer_width: usize,
+    /// The pointer width of the target platform.
+    pub pointer_width: Size,
 }
 
 impl GlobalStorage {
@@ -83,7 +83,7 @@ impl GlobalStorage {
         let root_scope = scope_store.create(Scope::empty(ScopeKind::Mod));
 
         let gs = Self {
-            pointer_width: target.pointer_bit_width / 8,
+            pointer_width: target.ptr_size(),
             location_store: LocationStore::new(),
             term_store: TermStore::new(),
             term_list_store: TermListStore::new(),

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -1,6 +1,9 @@
 // @@Docs
 
-use hash_source::{identifier::Identifier, location::SourceLocation};
+use hash_source::{
+    identifier::{Identifier, IDENTS},
+    location::SourceLocation,
+};
 use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
 use crate::{
@@ -239,6 +242,12 @@ pub trait CommonUtils: AccessToEnv {
     /// Get the default value of a parameter, if any
     fn get_param_default(&self, param_id: ParamId) -> Option<TermId> {
         self.stores().params().map_fast(param_id.0, |params| params[param_id.1].default)
+    }
+
+    /// Get the name of the given symbol. If the symbol has no name, return the
+    /// underscore symbol.
+    fn symbol_name(&self, symbol: Symbol) -> Identifier {
+        self.stores().symbol().map_fast(symbol, |s| s.name.unwrap_or(IDENTS.underscore))
     }
 
     /// Duplicate a symbol by creating a new symbol with the same name.

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -441,7 +441,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     CONSTANT_MAP.adjust_int(
                         int_lit.underlying.value,
                         int_ty,
-                        self.env().target().pointer_bit_width / 8,
+                        self.env().target().ptr_size(),
                     );
                 }
                 // @@Incomplete: as above

--- a/compiler/hash-untyped-semantics/src/visitor.rs
+++ b/compiler/hash-untyped-semantics/src/visitor.rs
@@ -213,6 +213,7 @@ impl<'s> SemanticAnalyser<'s> {
         } else if directive.is(IDENTS.entry_point)
             || directive.is(IDENTS.foreign)
             || directive.is(IDENTS.pure)
+            || directive.is(IDENTS.lang)
         {
             // Check that the supplied argument to a function modifying directive
             // is a declaration of a function that the directive will apply to.

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -52,6 +52,24 @@ dbg := <T> => (item: T) -> T => {
     item
 }
 
+// Define this in the prelude
+// Intrinsics: := () => #intrinsics mod {
+//     // Defined in here... but can still 
+//     // be referenced in compiler by for example `self.intrinsics().abort()`
+//     panic := (msg: str) -> ! => {
+//         print(msg);
+//         Intrinsics::abort();
+//     }
+
+//     // Defined in the compiler...
+//     abort: () -> !;
+// }
+
+#lang panic := (msg: str) -> ! => {
+    print(msg);
+    Intrinsics::abort()
+}
+
 
 libc := mod {
     #foreign write := (fd: i32, buf: &raw u8, len: usize) -> isize => { Intrinsics::abort() }


### PR DESCRIPTION
This PR does the following:

- cleans up some of the lowering implementation by switching to a `BuilderCtx` which stores all the necessary information needed to convert TIR into IR. With this change, the type-lowering logic also underwent a cleanup.
- Added the `#lang` directive was added to mark a function as a language item. Language items are needed by the compiler in order to provide the expected functionality of the language or to be referenced when generating code. With the language items, this led to changes to intrinsics being correctly handled in the lowering and code generation stages.
- Implement logic for properly lowering list initialisations.
- Fix printing of strings in the AST and IR
- Fix comment lines not being properly aligned when dumping IR
- Fix `ptr_width` inconsistencies across the compiler by using `Size`