### PR TITLE
Simplify context bindings

### DIFF
--- a/compiler/hash-intrinsics/src/intrinsics.rs
+++ b/compiler/hash-intrinsics/src/intrinsics.rs
@@ -335,11 +335,11 @@ impl DefinedIntrinsics {
         implementations: &DefaultPartialStore<IntrinsicId, Intrinsic>,
     ) -> FnDefId {
         let t_sym = env.new_symbol("T");
-
         let op_sym = env.new_symbol("op");
         let a_sym = env.new_symbol("a");
         let b_sym = env.new_symbol("b");
         let ty = env.new_data_ty(env.primitives().bool());
+
         let params = env.param_utils().create_params(
             [
                 ParamData { default: None, name: t_sym, ty: env.new_small_universe_ty() },
@@ -363,7 +363,7 @@ impl DefinedIntrinsics {
                 const INVALID_OP: &str = "Invalid cond-binary operation parameters";
 
                 // Parse the arguments
-                let (op, lhs, rhs) = (args[0], args[1], args[2]);
+                let (op, lhs, rhs) = (args[1], args[2], args[3]);
 
                 // Parse the operator.
                 let parsed_op = ShortCircuitBinOp::try_from(

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -122,7 +122,7 @@ impl<'ir> IrBodyWriter<'ir> {
             .collect_vec();
 
         for (declaration, comment) in rendered_declarations {
-            write!(f, "    {}", declaration)?;
+            write!(f, "    {declaration}")?;
             if let Some(comment) = comment {
                 writeln!(f, "{: <1$}\t{comment}", "", longest_line - declaration.len())?;
             } else {

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -259,7 +259,7 @@ impl<'tcx> Builder<'tcx> {
 
                 // Here, if the scope is not variable, i.e. constant, then we essentially need
                 // to denote that this a constant that comes from outside of the function body.
-                if !matches!(binding.kind, BindingKind::StackMember(..) | BindingKind::Param(..)) {
+                if !matches!(binding.kind, BindingKind::Decl(..)) {
                     let name = self.get_symbol(binding.name).name.unwrap_or(IDENTS.underscore);
 
                     // here, we emit an un-evaluated constant kind which will be resolved later

--- a/compiler/hash-lower/src/build/matches/declarations.rs
+++ b/compiler/hash-lower/src/build/matches/declarations.rs
@@ -116,58 +116,57 @@ impl<'tcx> Builder<'tcx> {
                     self.visit_primary_pattern_bindings(field.pat.assert_pat(), f);
                 });
 
-                if let Some(spread_pat) = spread && spread_pat.stack_member.is_some() {
-                        //@@Todo: we need to get the type of the spread.
-                        let ty = self.ty_id_from_tir_pat(pat_id);
+                if let Some(spread_pat) = spread {
+                    //@@Todo: we need to get the type of the spread.
+                    let ty = self.ty_id_from_tir_pat(pat_id);
 
-                        f(
-                            self,
-                            // @@Todo: it should be possible to make this a mutable
-                            // pattern reference, for now we assume it is always immutable.
-                            Mutability::Immutable,
-                            spread_pat.name,
-                            span,
-                            ty
-                        )
-                    }
+                    f(
+                        self,
+                        // @@Todo: it should be possible to make this a mutable
+                        // pattern reference, for now we assume it is always immutable.
+                        Mutability::Immutable,
+                        spread_pat.name,
+                        span,
+                        ty,
+                    )
+                }
             }
             Pat::Array(ArrayPat { pats, spread }) => {
-                if let Some(spread_pat) = spread && spread_pat.stack_member.is_some() {
+                if let Some(spread_pat) = spread {
                     let index = spread_pat.index;
 
                     // Create the fields into an iterator, and only take the `prefix`
                     // amount of fields to iterate
                     let pats = self.stores().pat_list().get_vec(pats);
 
-                        let prefix_fields = pats.iter().take(index);
-                        for field in prefix_fields {
-                            self.visit_primary_pattern_bindings(field.assert_pat(), f);
-                        }
+                    let prefix_fields = pats.iter().take(index);
+                    for field in prefix_fields {
+                        self.visit_primary_pattern_bindings(field.assert_pat(), f);
+                    }
 
-                        //@@TodoTIR: we need to get the type of the spread.
-                        let ty = self.ty_id_from_tir_pat(pat_id);
+                    //@@TodoTIR: we need to get the type of the spread.
+                    let ty = self.ty_id_from_tir_pat(pat_id);
 
-                        f(
-                            self,
-                            // @@Todo: it should be possible to make this a mutable
-                            // pattern reference, for now we assume it is always immutable.
-                            Mutability::Immutable,
-                            spread_pat.name,
-                            span,
-                            ty
-                        );
+                    f(
+                        self,
+                        // @@Todo: it should be possible to make this a mutable
+                        // pattern reference, for now we assume it is always immutable.
+                        Mutability::Immutable,
+                        spread_pat.name,
+                        span,
+                        ty,
+                    );
 
-                        // Now deal with the suffix fields.
-                        let suffix_fields = pats.iter().skip(index);
+                    // Now deal with the suffix fields.
+                    let suffix_fields = pats.iter().skip(index);
 
-                        for field in suffix_fields {
-                            self.visit_primary_pattern_bindings(field.assert_pat(), f);
-                        }
+                    for field in suffix_fields {
+                        self.visit_primary_pattern_bindings(field.assert_pat(), f);
+                    }
                 } else {
-                    self.stores().pat_list().get_vec(pats).iter()
-                        .for_each(|pat| {
-                            self.visit_primary_pattern_bindings(pat.assert_pat(), f);
-                        });
+                    self.stores().pat_list().get_vec(pats).iter().for_each(|pat| {
+                        self.visit_primary_pattern_bindings(pat.assert_pat(), f);
+                    });
                 }
             }
             Pat::Or(OrPat { alternatives }) => {

--- a/compiler/hash-lower/src/build/mod.rs
+++ b/compiler/hash-lower/src/build/mod.rs
@@ -35,8 +35,7 @@ use hash_tir::{
         env::{AccessToEnv, Env},
     },
     fns::{FnBody, FnDef, FnDefId, FnTy},
-    params::ParamId,
-    scopes::StackMemberId,
+    symbols::Symbol,
     terms::TermId,
     utils::{common::CommonUtils, context::ContextUtils},
 };
@@ -95,27 +94,12 @@ impl From<TermId> for BuildItem {
 /// the TIR to identify a [Local] as either being a reference to a
 /// stack member or a function parameter.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum LocalKey {
-    /// The parameter of the current function since they are in a
-    /// different binding kind.
-    Param(ParamId),
-
-    /// All references to variables that are declared on the stack
-    /// of the function body.
-    Stack(StackMemberId),
-}
-
-impl From<StackMemberId> for LocalKey {
-    fn from(stack: StackMemberId) -> Self {
-        LocalKey::Stack(stack)
-    }
-}
+pub struct LocalKey(Symbol);
 
 impl From<BindingKind> for LocalKey {
     fn from(binding: BindingKind) -> Self {
         match binding {
-            BindingKind::Param(_, param) => LocalKey::Param(param),
-            BindingKind::StackMember(stack, _, _) => LocalKey::Stack(stack),
+            BindingKind::Decl(decl) => LocalKey(decl.name),
             _ => panic!("unexpected binding kind"),
         }
     }

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -471,7 +471,7 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         node: AstNodeRef<ast::Declaration>,
     ) -> SemanticResult<TermId> {
-        let stack_indices = self.scoping().register_declaration(node);
+        self.scoping().register_declaration(node);
 
         // Pattern
         let pat = self.try_or_add_error(self.make_pat_from_ast_pat(node.pat.ast_ref()));
@@ -492,7 +492,7 @@ impl<'tc> ResolutionPass<'tc> {
 
         match (pat, ty, value) {
             (Some(pat), Some(ty), Some(value)) => {
-                Ok(self.new_term(Term::Decl(DeclTerm { bind_pat: pat, ty, value, stack_indices })))
+                Ok(self.new_term(Term::Decl(DeclTerm { bind_pat: pat, ty, value })))
             }
             _ => {
                 // If pat had an error, then we can't make a term, and the
@@ -644,14 +644,14 @@ impl<'tc> ResolutionPass<'tc> {
         // Convert all the cases and their bodies
         let cases =
             self.stores().match_cases().create_from_iter(node.cases.iter().filter_map(|case| {
-                self.scoping().enter_match_case(case.ast_ref(), |stack_id, stack_indices| {
+                self.scoping().enter_match_case(case.ast_ref(), |stack_id| {
                     let bind_pat =
                         self.try_or_add_error(self.make_pat_from_ast_pat(case.pat.ast_ref()));
                     let value =
                         self.try_or_add_error(self.make_term_from_ast_expr(case.expr.ast_ref()));
                     match (bind_pat, value) {
                         (Some(bind_pat), Some(value)) => {
-                            Some(MatchCase { bind_pat, value, stack_indices, stack_id })
+                            Some(MatchCase { bind_pat, value, stack_id })
                         }
                         _ => None,
                     }

--- a/compiler/hash-semantics/src/passes/resolution/paths.rs
+++ b/compiler/hash-semantics/src/passes/resolution/paths.rs
@@ -27,7 +27,7 @@ use hash_tir::{
     args::ArgsId,
     data::{CtorPat, CtorTerm, DataDefId},
     environment::{
-        context::{Binding, BindingKind, ScopeKind},
+        context::{Binding, BindingKind, Decl, ScopeKind},
         env::AccessToEnv,
     },
     fns::{FnCallTerm, FnDefId},
@@ -126,7 +126,7 @@ pub enum TerminalResolvedPathComponent {
     /// A function call term.
     FnCall(FnCallTerm),
     /// A variable bound in the current context.
-    Var(Binding),
+    Var(Decl),
 }
 
 /// The result of resolving a path component.
@@ -350,16 +350,16 @@ impl<'tc> ResolutionPass<'tc> {
                     None => unreachable!(),
                 }
             }
-            BindingKind::Param(_, _) | BindingKind::StackMember(_, _, _) => {
+            BindingKind::Decl(decl) => {
                 // If the subject has no args, it is a variable, otherwise it is a
                 // function call.
                 match &component.args[..] {
                     [] => Ok(ResolvedAstPathComponent::Terminal(
-                        TerminalResolvedPathComponent::Var(binding),
+                        TerminalResolvedPathComponent::Var(decl),
                     )),
                     args => {
                         let resultant_term = self.wrap_term_in_fn_call_from_ast_args(
-                            self.new_term(Term::Var(binding.name)),
+                            self.new_term(Term::Var(decl.name)),
                             args,
                             component.span(),
                         )?;
@@ -368,11 +368,6 @@ impl<'tc> ResolutionPass<'tc> {
                         ))
                     }
                 }
-            }
-            BindingKind::Arg(_, _) | BindingKind::Equality(_) => {
-                unreachable!(
-                    "No equality judgements or arg bindings should be present during resolution"
-                )
             }
         }
     }

--- a/compiler/hash-semantics/src/passes/resolution/pats.rs
+++ b/compiler/hash-semantics/src/passes/resolution/pats.rs
@@ -15,7 +15,7 @@ use hash_tir::{
     arrays::ArrayPat,
     control::{IfPat, OrPat},
     data::CtorPat,
-    environment::{context::BindingKind, env::AccessToEnv},
+    environment::env::AccessToEnv,
     lits::{CharLit, IntLit, LitPat, StrLit},
     params::ParamIndex,
     pats::{Pat, PatId, PatListId, RangePat, Spread},
@@ -82,28 +82,18 @@ impl ResolutionPass<'_> {
         node: &Option<ast::AstNode<ast::SpreadPat>>,
     ) -> SemanticResult<Option<Spread>> {
         Ok(node.as_ref().map(|node| {
-            let symbol_and_stack_member_id = node.name.as_ref().map(|name| {
-                let symbol = self
+            let symbol = match node.name.as_ref() {
+                Some(name) => self
                     .scoping()
                     .lookup_symbol_by_name_or_error(
                         name.ident,
                         name.span(),
                         self.scoping().get_current_context_kind(),
                     )
-                    .unwrap();
-
-                let (stack_member_id, _, _) = self.context_utils().get_stack_binding(symbol);
-
-                (symbol, stack_member_id)
-            });
-            Spread {
-                name: symbol_and_stack_member_id
-                    .map(|(symbol, _)| symbol)
-                    .unwrap_or_else(|| self.new_fresh_symbol()),
-                index: node.position,
-                stack_member: symbol_and_stack_member_id
-                    .map(|(_, stack_member_id)| stack_member_id),
-            }
+                    .unwrap(),
+                None => self.new_fresh_symbol(),
+            };
+            Spread { name: symbol, index: node.position }
         }))
     }
 
@@ -221,10 +211,6 @@ impl ResolutionPass<'_> {
                     Ok(self.new_pat(Pat::Binding(BindingPat {
                         name: bound_var.name,
                         is_mutable: false,
-                        stack_member: match bound_var.kind {
-                            BindingKind::StackMember(member, _, _) => Some(member),
-                            _ => panic!("Found non-stack member in pattern binding"),
-                        },
                     })))
                 }
                 TerminalResolvedPathComponent::CtorTerm(ctor_term)
@@ -344,7 +330,6 @@ impl ResolutionPass<'_> {
             ast::Pat::Wild(_) => self.new_pat(Pat::Binding(BindingPat {
                 name: self.new_fresh_symbol(),
                 is_mutable: false,
-                stack_member: None,
             })),
             ast::Pat::Range(range_pat) => {
                 let start = self.make_lit_pat_from_non_bool_ast_lit(range_pat.lo.ast_ref());

--- a/compiler/hash-tir/src/ast_info.rs
+++ b/compiler/hash-tir/src/ast_info.rs
@@ -6,11 +6,12 @@ use hash_ast::ast::AstNodeId;
 use crate::{
     args::ArgId,
     data::{CtorDefId, DataDefId},
+    environment::context::Decl,
     fns::FnDefId,
     mods::{ModDefId, ModMemberId},
     params::ParamId,
     pats::PatId,
-    scopes::{StackId, StackMemberId},
+    scopes::StackId,
     terms::TermId,
     tys::TyId,
 };
@@ -90,7 +91,7 @@ ast_info! {
     fn_defs: AstMap<FnDefId>,
 
     stacks: AstMap<StackId>,
-    stack_members: AstMap<StackMemberId>,
+    stack_members: AstMap<Decl>,
 
     terms: AstMap<TermId>,
     tys: AstMap<TyId>,

--- a/compiler/hash-tir/src/control.rs
+++ b/compiler/hash-tir/src/control.rs
@@ -11,7 +11,7 @@ use textwrap::indent;
 use super::{
     environment::env::{AccessToEnv, WithEnv},
     pats::{PatId, PatListId},
-    scopes::{StackId, StackIndices},
+    scopes::StackId,
     utils::common::CommonUtils,
 };
 use crate::{scopes::BlockTerm, terms::TermId};
@@ -46,7 +46,6 @@ pub struct MatchTerm {
 pub struct MatchCase {
     pub bind_pat: PatId,
     pub stack_id: StackId,
-    pub stack_indices: StackIndices,
     pub value: TermId,
 }
 

--- a/compiler/hash-tir/src/environment/context.rs
+++ b/compiler/hash-tir/src/environment/context.rs
@@ -19,6 +19,7 @@ use crate::{
     fns::{FnDefId, FnTy},
     mods::{ModDefId, ModMemberId},
     scopes::StackId,
+    sub::Sub,
     symbols::Symbol,
     terms::TermId,
     tuples::TupleTy,
@@ -131,6 +132,8 @@ pub enum ScopeKind {
     FnTy(FnTy),
     /// A tuple type scope.
     TupleTy(TupleTy),
+    /// A substitution scope.
+    Sub,
 }
 
 impl ScopeKind {
@@ -140,9 +143,11 @@ impl ScopeKind {
     pub fn is_constant(&self) -> bool {
         match self {
             ScopeKind::Mod(_) | ScopeKind::Data(_) | ScopeKind::Ctor(_) => true,
-            ScopeKind::Stack(_) | ScopeKind::Fn(_) | ScopeKind::FnTy(_) | ScopeKind::TupleTy(_) => {
-                false
-            }
+            ScopeKind::Sub
+            | ScopeKind::Stack(_)
+            | ScopeKind::Fn(_)
+            | ScopeKind::FnTy(_)
+            | ScopeKind::TupleTy(_) => false,
         }
     }
 }
@@ -502,6 +507,9 @@ impl fmt::Display for WithEnv<'_, ScopeKind> {
             ),
             ScopeKind::FnTy(fn_ty) => write!(f, "fn ty {}", self.env().with(&fn_ty)),
             ScopeKind::TupleTy(tuple_ty) => write!(f, "tuple ty {}", self.env().with(&tuple_ty)),
+            ScopeKind::Sub => {
+                write!(f, "sub")
+            }
         }
     }
 }

--- a/compiler/hash-tir/src/environment/context.rs
+++ b/compiler/hash-tir/src/environment/context.rs
@@ -19,7 +19,6 @@ use crate::{
     fns::{FnDefId, FnTy},
     mods::{ModDefId, ModMemberId},
     scopes::StackId,
-    sub::Sub,
     symbols::Symbol,
     terms::TermId,
     tuples::TupleTy,

--- a/compiler/hash-tir/src/environment/context.rs
+++ b/compiler/hash-tir/src/environment/context.rs
@@ -15,12 +15,10 @@ use indexmap::IndexMap;
 
 use super::env::{AccessToEnv, WithEnv};
 use crate::{
-    args::ArgId,
     data::{CtorDefId, DataDefId},
     fns::{FnDefId, FnTy},
     mods::{ModDefId, ModMemberId},
-    params::ParamId,
-    scopes::{StackId, StackMemberId},
+    scopes::StackId,
     symbols::Symbol,
     terms::TermId,
     tuples::TupleTy,
@@ -64,6 +62,14 @@ impl ParamOrigin {
     }
 }
 
+/// A binding that contains a type and optional value.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct Decl {
+    pub name: Symbol,
+    pub ty: Option<TyId>,
+    pub value: Option<TermId>,
+}
+
 /// The kind of a binding.
 #[derive(Debug, Clone, Copy)]
 pub enum BindingKind {
@@ -75,24 +81,8 @@ pub enum BindingKind {
     ///
     /// For example, `false`, `None`, `Some(_)`.
     Ctor(DataDefId, CtorDefId),
-    /// A parameter variable
-    ///
-    /// For example, `(x: i32) => x` or `(T: Type, t: T)`
-    Param(ParamOrigin, ParamId),
-    /// Stack member.
-    ///
-    /// For example, `a` in `{ a := 3; a }`
-    ///
-    /// Contains the current value of the stack member, if any.
-    StackMember(StackMemberId, TyId, Option<TermId>),
-    /// Parameter substitution (argument)
-    ///
-    /// For example, `a=3` in `((a: i32) => a + 3)(3)`
-    Arg(ParamId, ArgId),
-    /// Equality judgement
-    ///
-    /// This is a special binding because it cannot be referenced by name.
-    Equality(EqualityJudgement),
+    /// A binding that contains a type and optional value.
+    Decl(Decl),
 }
 
 impl BindingKind {
@@ -100,10 +90,7 @@ impl BindingKind {
     pub fn is_constant(&self) -> bool {
         match self {
             BindingKind::ModMember(_, _) | BindingKind::Ctor(_, _) => true,
-            BindingKind::Param(origin, _) => origin.is_constant(),
-            BindingKind::StackMember(_, _, _)
-            | BindingKind::Arg(_, _)
-            | BindingKind::Equality(_) => false,
+            BindingKind::Decl(_) => false,
         }
     }
 }
@@ -269,6 +256,12 @@ impl Context {
     }
 
     /// Add a new binding to the current scope context.
+    pub fn add_decl(&self, name: Symbol, ty: Option<TyId>, value: Option<TermId>) {
+        self.get_current_scope_ref()
+            .add_binding(Binding { name, kind: BindingKind::Decl(Decl { name, ty, value }) })
+    }
+
+    /// Add a new binding to the current scope context.
     pub fn add_binding(&self, binding: Binding) {
         self.get_current_scope_ref().add_binding(binding)
     }
@@ -362,6 +355,21 @@ impl Context {
 
     /// Iterate over all the bindings in the context for the scope with the
     /// given index (fallible).
+    pub fn try_for_bindings_of_scope_rev<E>(
+        &self,
+        scope_index: usize,
+        mut f: impl FnMut(&Binding) -> Result<(), E>,
+    ) -> Result<(), E> {
+        self.scopes.borrow()[scope_index]
+            .bindings
+            .borrow()
+            .iter()
+            .rev()
+            .try_for_each(|binding| f(&Binding { name: *binding.0, kind: *binding.1 }))
+    }
+
+    /// Iterate over all the bindings in the context for the scope with the
+    /// given index (fallible).
     pub fn try_for_bindings_of_scope<E>(
         &self,
         scope_index: usize,
@@ -378,6 +386,16 @@ impl Context {
     /// index.
     pub fn count_bindings_of_scope(&self, scope_index: usize) -> usize {
         self.scopes.borrow()[scope_index].bindings.borrow().len()
+    }
+
+    /// Iterate over all the bindings in the context for the scope with the
+    /// given index (reversed).
+    pub fn for_bindings_of_scope_rev(&self, scope_index: usize, mut f: impl FnMut(&Binding)) {
+        let _ =
+            self.try_for_bindings_of_scope_rev(scope_index, |binding| -> Result<(), Infallible> {
+                f(binding);
+                Ok(())
+            });
     }
 
     /// Iterate over all the bindings in the context for the scope with the
@@ -406,37 +424,51 @@ impl fmt::Display for WithEnv<'_, EqualityJudgement> {
     }
 }
 
-impl fmt::Display for WithEnv<'_, Binding> {
+impl fmt::Display for WithEnv<'_, Decl> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.value.kind {
+        let ty_or_unknown = {
+            if let Some(ty) = self.value.ty {
+                self.env().with(ty).to_string()
+            } else {
+                "unknown".to_string()
+            }
+        };
+        match self.value.value {
+            Some(value) => {
+                write!(
+                    f,
+                    "{}: {} = {}",
+                    self.env().with(self.value.name),
+                    ty_or_unknown,
+                    self.env().with(value)
+                )
+            }
+            None => {
+                write!(f, "{}: {}", self.env().with(self.value.name), ty_or_unknown)
+            }
+        }
+    }
+}
+
+impl fmt::Display for WithEnv<'_, BindingKind> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
             BindingKind::ModMember(_, member_id) => {
                 write!(f, "{}", self.env().with(member_id))
             }
             BindingKind::Ctor(_, ctor_id) => {
                 write!(f, "{}", self.env().with(ctor_id))
             }
-            BindingKind::Param(_, param_id) => {
-                write!(f, "{}", self.env().with(param_id))
-            }
-            BindingKind::StackMember(stack_member, ty, value) => {
-                write!(
-                    f,
-                    "({}): {} = {}",
-                    self.env().with(stack_member),
-                    self.env().with(ty),
-                    match value {
-                        Some(value) => self.env().with(value).to_string(),
-                        None => "{uninit}".to_string(),
-                    }
-                )
-            }
-            BindingKind::Equality(equality) => {
-                write!(f, "{}", self.env().with(equality))
-            }
-            BindingKind::Arg(_, arg_id) => {
-                write!(f, "{}", self.env().with(arg_id))
+            BindingKind::Decl(decl) => {
+                write!(f, "{}", self.env().with(decl))
             }
         }
+    }
+}
+
+impl fmt::Display for WithEnv<'_, Binding> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.env().with(self.value.kind))
     }
 }
 
@@ -471,6 +503,19 @@ impl fmt::Display for WithEnv<'_, ScopeKind> {
             ScopeKind::FnTy(fn_ty) => write!(f, "fn ty {}", self.env().with(&fn_ty)),
             ScopeKind::TupleTy(tuple_ty) => write!(f, "tuple ty {}", self.env().with(&tuple_ty)),
         }
+    }
+}
+
+impl fmt::Display for WithEnv<'_, &Scope> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}:", self.env().with(self.value.kind))?;
+        for binding in self.value.bindings.borrow().values() {
+            let result = self.env().with(*binding).to_string();
+            for line in result.lines() {
+                writeln!(f, "  {line}")?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -15,7 +15,7 @@ use super::{
     data::CtorPat,
     environment::env::{AccessToEnv, WithEnv},
     lits::LitPat,
-    scopes::{BindingPat, StackMemberId},
+    scopes::BindingPat,
     symbols::Symbol,
     tuples::TuplePat,
 };
@@ -31,8 +31,6 @@ pub struct Spread {
     pub name: Symbol,
     /// The index in the sequence of target patterns, of this spread pattern.
     pub index: usize,
-    /// The stack member that this spread pattern binds to, if any.
-    pub stack_member: Option<StackMemberId>,
 }
 
 /// A range pattern containing two bounds `start` and `end`.

--- a/compiler/hash-tir/src/pats.rs
+++ b/compiler/hash-tir/src/pats.rs
@@ -23,7 +23,7 @@ use crate::arrays::ArrayPat;
 
 /// A spread "pattern" (not part of [`Pat`]), which can appear in list patterns,
 /// tuple patterns, and constructor patterns.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Spread {
     /// The name of the spread bind.
     /// If `name` does not map to a specific `Identifier` name, it means

--- a/compiler/hash-tir/src/scopes.rs
+++ b/compiler/hash-tir/src/scopes.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 /// A binding pattern, which is essentially a declaration left-hand side.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct BindingPat {
     /// The name of the bind.
     /// If `name` does not map to a specific `Identifier` name, it means

--- a/compiler/hash-tir/src/utils/common.rs
+++ b/compiler/hash-tir/src/utils/common.rs
@@ -156,6 +156,11 @@ pub trait CommonUtils: AccessToEnv {
         self.stores().args().map(args_id, f)
     }
 
+    /// Map pattern args by their IDs.
+    fn map_pat_args<T>(&self, args_id: PatArgsId, f: impl FnOnce(&[PatArg]) -> T) -> T {
+        self.stores().pat_args().map(args_id, f)
+    }
+
     /// Map params by their IDs.
     fn map_params<T>(&self, params_id: ParamsId, f: impl FnOnce(&[Param]) -> T) -> T {
         self.stores().params().map(params_id, f)

--- a/compiler/hash-tir/src/utils/stack.rs
+++ b/compiler/hash-tir/src/utils/stack.rs
@@ -3,7 +3,10 @@ use derive_more::Constructor;
 use hash_utils::store::Store;
 
 use crate::{
-    environment::env::{AccessToEnv, Env},
+    environment::{
+        context::Decl,
+        env::{AccessToEnv, Env},
+    },
     impl_access_to_env,
     mods::ModDefId,
     scopes::{Stack, StackId, StackMember, StackMemberData},
@@ -31,11 +34,7 @@ impl<'tc> StackUtils<'tc> {
     }
 
     /// Set the members of the given stack.
-    pub fn set_stack_members(
-        &self,
-        stack_id: StackId,
-        members: impl IntoIterator<Item = StackMember>,
-    ) {
+    pub fn set_stack_members(&self, stack_id: StackId, members: impl IntoIterator<Item = Decl>) {
         self.stores().stack().modify_fast(stack_id, |stack| {
             stack.members.clear();
             stack.members.extend(members);

--- a/compiler/hash-tir/src/utils/traversing.rs
+++ b/compiler/hash-tir/src/utils/traversing.rs
@@ -166,12 +166,7 @@ impl<'env> TraversingUtils<'env> {
                         self.stores().match_cases().try_create_from_iter(cases.iter().map(|case| {
                             let bind_pat = self.fmap_pat(case.bind_pat, f)?;
                             let value = self.fmap_term(case.value, f)?;
-                            Ok(MatchCase {
-                                bind_pat,
-                                stack_indices: case.stack_indices,
-                                value,
-                                stack_id: case.stack_id,
-                            })
+                            Ok(MatchCase { bind_pat, value, stack_id: case.stack_id })
                         }))
                     })?;
                     Ok(self.new_term(MatchTerm { cases, subject }))
@@ -185,12 +180,7 @@ impl<'env> TraversingUtils<'env> {
                     let ty = self.fmap_ty(decl_stack_member_term.ty, f)?;
                     let value =
                         decl_stack_member_term.value.map(|v| self.fmap_term(v, f)).transpose()?;
-                    Ok(self.new_term(DeclTerm {
-                        ty,
-                        bind_pat,
-                        value,
-                        stack_indices: decl_stack_member_term.stack_indices,
-                    }))
+                    Ok(self.new_term(DeclTerm { ty, bind_pat, value }))
                 }
                 Term::Assign(assign_term) => {
                     let subject = self.fmap_term(assign_term.subject, f)?;

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -23,7 +23,7 @@ use hash_tir::{
     },
     directives::DirectiveTarget,
     environment::{
-        context::{Decl, ParamOrigin, ScopeKind},
+        context::{ParamOrigin, ScopeKind},
         env::AccessToEnv,
     },
     fns::{FnBody, FnCallTerm, FnDefId, FnTy},
@@ -1561,7 +1561,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             let case_data = self.stores().match_cases().get_element(case);
 
             self.context().enter_scope(case_data.stack_id.into(), || -> TcResult<_> {
-                let Inference(inferred_pat, inferred_pat_ty) =
+                let Inference(inferred_pat, _inferred_pat_ty) =
                     self.infer_pat(case_data.bind_pat, normalised_subject_ty)?;
 
                 let Inference(inferred_body, inferred_body_ty) =
@@ -1881,7 +1881,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     subbed_ctor_params,
                 )?;
                 // Apply the substitution to the constructor result args
-                let ctor_subbed_ctor_result_args =
+                let _ctor_subbed_ctor_result_args =
                     self.sub_ops().apply_sub_to_args(subbed_ctor_result_args, &ctor_sub);
 
                 let sub_binds_to_holes = self.sub_ops().create_sub_from_args_of_params(

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -12,7 +12,7 @@ use hash_source::{
 };
 use hash_tir::{
     access::AccessTerm,
-    args::{ArgData, ArgId, ArgsId, PatArgData, PatArgsId, PatOrCapture},
+    args::{ArgData, ArgsId, PatArgData, PatArgsId, PatOrCapture},
     arrays::{ArrayPat, ArrayTerm, IndexTerm},
     atom_info::ItemInAtomInfo,
     casting::CastTerm,
@@ -82,6 +82,15 @@ impl<X, T> From<Inference<X, T>> for (X, T) {
     }
 }
 
+pub struct InferenceWithSub<X, T> {
+    /// A substitution occurring from the inference.
+    pub sub: Sub,
+    /// The result of the inference, with the substitution applied.
+    pub result: X,
+    /// The annotation of the result, with the substitution applied.
+    pub annotation: T,
+}
+
 #[derive(Constructor, Deref)]
 pub struct InferenceOps<'a, T: AccessToTypechecking>(&'a T);
 
@@ -93,48 +102,36 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         args: impl Iterator<Item = Arg>,
         annotation_params: ParamsId,
         mut infer_arg: impl FnMut(&Arg, &Param) -> TcResult<Inference<Arg, ParamData>>,
-        get_arg_id: impl Fn(usize) -> Option<ArgId>,
         get_arg_value: impl Fn(&Arg) -> Option<TermId>,
-    ) -> TcResult<Inference<Vec<Arg>, ParamsId>> {
+    ) -> TcResult<InferenceWithSub<Vec<Arg>, ParamsId>> {
         let mut collected_args = vec![];
         let mut collected_params = vec![];
-        let mut running_sub = Sub::identity();
 
         let mut error_state = self.new_error_state();
 
-        let mut push_param = |i: usize, arg: Arg, param: &Param| {
-            // Apply the running substitution to the parameter
-            let subbed_param =
-                Param { ty: self.sub_ops().apply_sub_to_ty(param.ty, &running_sub), ..*param };
-
+        let mut push_param = |_i: usize, arg: Arg, param: &Param| {
             // Infer the type of the argument
-            match error_state.try_or_add_error(infer_arg(&arg, &subbed_param)) {
+            match error_state.try_or_add_error(infer_arg(&arg, param)) {
                 // Type was inferred
                 Some(Inference(inferred_arg, inferred_param)) => {
-                    // Extend the running substitution with the new unification result
-                    if let Some(arg_value) = get_arg_value(&inferred_arg) {
-                        running_sub.insert(param.name, arg_value);
+                    // Extend the context with the new result
+                    if let Some(value) = get_arg_value(&inferred_arg) {
+                        self.context_utils().add_assignment(
+                            inferred_param.name,
+                            inferred_param.ty,
+                            value,
+                        );
                     }
 
                     collected_args.push(inferred_arg);
-
-                    // If the original parameter has holes, then we use the
-                    // inferred parameter. Otherwise use the original parameter. @@Correctness: do
-                    // we need to unify here?
-                    if self.sub_ops().atom_has_holes(param.ty).is_some() {
-                        collected_params.push(inferred_param);
-                    } else {
-                        collected_params.push((*param).into());
-                    }
-
-                    let applied_param_ty = self.sub_ops().apply_sub_to_ty(param.ty, &running_sub);
-
-                    running_sub.extend(
-                        &self.uni_ops().unify_tys(inferred_param.ty, applied_param_ty).unwrap().sub,
-                    );
+                    collected_params.push(inferred_param);
                 }
                 // Error occurred
                 None => {
+                    if let Some(value) = get_arg_value(&arg) {
+                        self.context_utils().add_assignment(param.name, param.ty, value);
+                    }
+
                     // Add holes
                     collected_args.push(arg);
                     collected_params.push(ParamData {
@@ -144,10 +141,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     });
                 }
             }
-
-            if let Some(arg_id) = get_arg_id(i) {
-                self.context_utils().add_arg_binding(arg_id, param.id)
-            }
         };
 
         for (i, (arg, param)) in args.zip(annotation_params.iter()).enumerate() {
@@ -155,12 +148,15 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             push_param(i, arg, &param)
         }
 
+        let running_sub = self.sub_ops().create_sub_from_current_scope();
+
         self.return_or_register_errors(
             || {
-                Ok(Inference(
-                    collected_args,
-                    self.param_utils().create_params(collected_params.into_iter()),
-                ))
+                Ok(InferenceWithSub {
+                    result: collected_args,
+                    annotation: self.param_utils().create_params(collected_params.into_iter()),
+                    sub: running_sub,
+                })
             },
             error_state,
         )
@@ -256,16 +252,16 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         args: ArgsId,
         annotation_params: ParamsId,
-    ) -> TcResult<Inference<ArgsId, ParamsId>> {
+    ) -> TcResult<InferenceWithSub<ArgsId, ParamsId>> {
         self.register_new_atom(args, annotation_params);
 
         let reordered_args_id =
             self.param_ops().validate_and_reorder_args_against_params(args, annotation_params)?;
         let reordered_args = self.stores().args().map_fast(reordered_args_id, |args| {
-            args.iter().map(|arg| ArgData { target: arg.target, value: arg.value }).collect_vec()
+            args.iter().copied().map_into().collect::<Vec<ArgData>>()
         });
 
-        let Inference(inferred_args, inferred_params_id) = self.infer_some_args(
+        let inference = self.infer_some_args(
             reordered_args.iter().copied(),
             annotation_params,
             |arg, param| {
@@ -275,14 +271,17 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     ParamData { name: param.name, ty, default: param.default },
                 ))
             },
-            |i| Some((reordered_args_id, i)),
             |arg| Some(arg.value),
         )?;
 
-        let inferred_args_id = self.param_utils().create_args(inferred_args.into_iter());
+        let inferred_args_id = self.param_utils().create_args(inference.result.into_iter());
 
-        self.register_atom_inference_indexed(args, inferred_args_id, inferred_params_id);
-        Ok(Inference(inferred_args_id, inferred_params_id))
+        self.register_atom_inference_indexed(args, inferred_args_id, inference.annotation);
+        Ok(InferenceWithSub {
+            sub: inference.sub,
+            result: inferred_args_id,
+            annotation: inference.annotation,
+        })
     }
 
     /// Infer the given pattern arguments, producing inferred parameters.
@@ -291,7 +290,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         pat_args: PatArgsId,
         spread: Option<Spread>,
         annotation_params: ParamsId,
-    ) -> TcResult<Inference<PatArgsId, ParamsId>> {
+    ) -> TcResult<InferenceWithSub<PatArgsId, ParamsId>> {
         self.register_new_atom(pat_args, annotation_params);
 
         self.param_ops().validate_and_reorder_pat_args_against_params(
@@ -306,7 +305,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 .collect_vec()
         });
 
-        let Inference(inferred_pat_args, inferred_params_id) = self.infer_some_args(
+        let inference = self.infer_some_args(
             pat_args_data.iter().copied(),
             annotation_params,
             |pat_arg, param| match pat_arg.pat {
@@ -330,21 +329,23 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 )),
             },
             |_| None,
-            |_| None,
         )?;
 
-        let inferred_pat_args_id =
-            self.param_utils().create_pat_args(inferred_pat_args.into_iter());
+        let inferred_pat_args_id = self.param_utils().create_pat_args(inference.result.into_iter());
 
         // @@Fix: add back spread to inferred pat args
-        self.register_atom_inference_indexed(pat_args, inferred_pat_args_id, inferred_params_id);
-        Ok(Inference(inferred_pat_args_id, inferred_params_id))
+        self.register_atom_inference_indexed(pat_args, inferred_pat_args_id, inference.annotation);
+        Ok(InferenceWithSub {
+            sub: inference.sub,
+            result: inferred_pat_args_id,
+            annotation: inference.annotation,
+        })
     }
 
     /// Infer the given parameters.
     ///
     /// This modifies the parameters in-place.
-    pub fn infer_params(&self, params: ParamsId, origin: ParamOrigin) -> TcResult<ParamsId> {
+    pub fn infer_params(&self, params: ParamsId, _origin: ParamOrigin) -> TcResult<ParamsId> {
         // Validate the parameters
         self.param_ops().validate_params(params)?;
         let mut error_state = self.new_error_state();
@@ -356,7 +357,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             {
                 self.stores().params().modify_fast(param_id.0, |params| params[param_id.1].ty = ty);
             }
-            self.context_utils().add_param_binding(param_id, origin);
+            self.context_utils().add_param_binding(param_id);
         }
 
         self.return_or_register_errors(|| Ok(params), error_state)
@@ -405,13 +406,12 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
         };
 
-        let Inference(inferred_args, inferred_params) = self.context().enter_scope(
-            ScopeKind::TupleTy(TupleTy { data: params }),
-            || -> TcResult<_> {
+        let InferenceWithSub { result: inferred_args, annotation: inferred_params, sub: _ } = self
+            .context()
+            .enter_scope(ScopeKind::TupleTy(TupleTy { data: params }), || -> TcResult<_> {
                 let args = self.infer_args(term.data, params)?;
                 Ok(args)
-            },
-        )?;
+            })?;
 
         Ok(Inference(TupleTerm { data: inferred_args }, TupleTy { data: inferred_params }))
     }
@@ -573,32 +573,19 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     DataDefCtors::Primitive(primitive) => {
                         if let PrimitiveCtorInfo::Array(array_prim) = primitive {
                             // First infer the data arguments
-                            let Inference(inferred_data_args, inferred_data_params) =
-                                self.infer_args(data.args, data_def.params)?;
-
-                            let param_uni = self
-                                .uni_ops()
-                                .unify_params(
-                                    inferred_data_params,
-                                    data_def.params,
-                                    ParamOrigin::Data(data_def.id),
-                                )
-                                .unwrap();
-
-                            // Create a substitution from the inferred data arguments
-                            let data_sub = self
-                                .sub_ops()
-                                .create_sub_from_args_of_params(inferred_data_args, data_def.params)
-                                .join(&param_uni.sub);
+                            let InferenceWithSub {
+                                result: _inferred_data_args,
+                                annotation: _inferred_data_params,
+                                sub,
+                            } = self.infer_args(data.args, data_def.params)?;
 
                             self.context().enter_scope(data_def.id.into(), || {
-                                let subbed_element_ty = self
-                                    .sub_ops()
-                                    .apply_sub_to_ty(array_prim.element_ty, &data_sub);
+                                let subbed_element_ty =
+                                    self.sub_ops().apply_sub_to_ty(array_prim.element_ty, &sub);
 
                                 let subbed_index = array_prim
                                     .length
-                                    .map(|l| self.sub_ops().apply_sub_to_term(l, &data_sub));
+                                    .map(|l| self.sub_ops().apply_sub_to_term(l, &sub));
 
                                 Ok((subbed_element_ty, subbed_index))
                             })
@@ -686,72 +673,38 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let annotation_data_ty =
             annotation_data_ty.unwrap_or(DataTy { args: term_data_args, data_def: data_def.id });
 
-        self.context().enter_scope(data_def.id.into(), || {
-            let data_args_uni =
-                self.uni_ops().unify_args(term_data_args, annotation_data_ty.args)?;
+        self.context().enter_scope(ctor.id.into(), || {
+            let _ = self.uni_ops().unify_args(term_data_args, annotation_data_ty.args)?;
 
             // First infer the data arguments
-            let Inference(inferred_data_args, inferred_data_params) =
-                self.infer_args(data_args_uni.result, data_def.params)?;
+            let InferenceWithSub {
+                result: _inferred_data_args,
+                annotation: _inferred_data_params,
+                sub: _data_sub,
+            } = self.infer_args(term_data_args, data_def.params)?;
 
-            let param_uni = self
-                .uni_ops()
-                .unify_params(inferred_data_params, data_def.params, ParamOrigin::Data(data_def.id))
-                .unwrap();
+            // Infer the constructor arguments
+            let InferenceWithSub {
+                result: inferred_ctor_args,
+                annotation: _inferred_ctor_params,
+                sub: _ctor_sub,
+            } = self.infer_args(term.ctor_args, ctor.params)?;
 
-            // Create a substitution from the inferred data arguments
-            let data_sub =
-                self.sub_ops().create_sub_from_args_of_params(inferred_data_args, data_def.params);
+            let sub = self.sub_ops().create_sub_from_current_scope();
 
-            self.context().enter_scope(ctor.id.into(), || {
-                // Apply the substitution to the constructor parameters
-                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(
-                    self.sub_ops().apply_sub_to_params(
-                        self.sub_ops().apply_sub_to_params(ctor.params, &data_args_uni.sub),
-                        &param_uni.sub,
-                    ),
-                    &data_sub,
-                );
+            let result_data_args = self.sub_ops().apply_sub_to_args(ctor.result_args, &sub);
+            let result_ctor_args = self.sub_ops().apply_sub_to_args(inferred_ctor_args, &sub);
 
-                // Infer the constructor arguments
-                let Inference(inferred_ctor_args, inferred_ctor_params) =
-                    self.infer_args(term.ctor_args, subbed_ctor_params)?;
-
-                // Create a substitution from the inferred constructor arguments
-                let ctor_val_sub = self
-                    .sub_ops()
-                    .create_sub_from_args_of_params(inferred_ctor_args, subbed_ctor_params);
-
-                let ctor_ty_sub = self.uni_ops().unify_params(
-                    inferred_ctor_params,
-                    subbed_ctor_params,
-                    ParamOrigin::Ctor(ctor.id),
-                )?;
-                let ctor_sub = ctor_val_sub.join(&ctor_ty_sub.sub);
-
-                // Apply the substitution to the constructor result args
-                let subbed_result_args = self.sub_ops().apply_sub_to_args(
-                    self.sub_ops().apply_sub_to_args(
-                        self.sub_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
-                        &data_sub,
-                    ),
-                    &ctor_sub,
-                );
-
-                // Try to unify given annotation with inferred eventual type.
-                let result_data_def_args =
-                    self.uni_ops().unify_args(subbed_result_args, inferred_data_args)?.result;
-
-                // Evaluate the result args.
-                Ok(Inference(
-                    CtorTerm {
-                        ctor: ctor.id,
-                        data_args: result_data_def_args,
-                        ctor_args: inferred_ctor_args,
-                    },
-                    DataTy { args: result_data_def_args, data_def: data_def.id },
-                ))
-            })
+            // Evaluate the result args.
+            Ok(Inference(
+                CtorTerm {
+                    ctor: ctor.id,
+                    data_args: result_data_args,
+                    ctor_args: result_ctor_args,
+                },
+                DataTy { args: result_data_args, data_def: data_def.id },
+            ))
+            // })
         })
     }
 
@@ -816,66 +769,62 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
             Ty::Fn(fn_ty) => {
                 let infer = || {
-                    self.context().enter_scope(ScopeKind::FnTy(fn_ty), || {
-                        if fn_ty.implicit != fn_call_term.implicit {
-                            return Err(TcError::WrongCallKind {
-                                site: original_term_id,
-                                expected_implicit: fn_ty.implicit,
-                                actual_implicit: fn_call_term.implicit,
-                            });
-                        }
+                    let (inferred_fn_call_args, return_ty, sub) =
+                        self.context().enter_scope(ScopeKind::FnTy(fn_ty), || {
+                            if fn_ty.implicit != fn_call_term.implicit {
+                                return Err(TcError::WrongCallKind {
+                                    site: original_term_id,
+                                    expected_implicit: fn_ty.implicit,
+                                    actual_implicit: fn_call_term.implicit,
+                                });
+                            }
 
-                        // First infer the arguments parameters of the function call.
-                        let Inference(inferred_fn_call_args, inferred_params) =
-                            self.infer_args(fn_call_term.args, fn_ty.params)?;
+                            // First infer the arguments parameters of the function call.
+                            let InferenceWithSub {
+                                result: inferred_fn_call_args,
+                                annotation: _,
+                                sub: _,
+                            } = self.infer_args(fn_call_term.args, fn_ty.params)?;
+                            let return_ty = self.normalise_and_check_ty(fn_ty.return_ty)?;
+                            let _ = self.uni_ops().unify_tys(return_ty, annotation_ty)?;
 
-                        let param_uni = self
-                            .uni_ops()
-                            .unify_params(fn_ty.params, inferred_params, ParamOrigin::FnTy(fn_ty))
-                            .unwrap();
+                            let sub = self.sub_ops().create_sub_from_current_scope();
+                            Ok((inferred_fn_call_args, return_ty, sub))
+                        })?;
 
-                        let sub = self
-                            .sub_ops()
-                            .create_sub_from_args_of_params(inferred_fn_call_args, inferred_params);
+                    let mut shadowed_sub = sub.clone();
+                    for param in fn_ty.params.iter() {
+                        let param = self.get_param(param);
+                        shadowed_sub.remove(param.name);
+                    }
 
-                        let subbed_return_ty = self.sub_ops().apply_sub_to_ty(
-                            self.sub_ops().apply_sub_to_ty(fn_ty.return_ty, &param_uni.sub),
-                            &sub,
-                        );
+                    let subbed_return_ty = self.sub_ops().apply_sub_to_ty(return_ty, &sub);
+                    let subbed_subject_term =
+                        self.sub_ops().apply_sub_to_term(subject_term, &shadowed_sub);
+                    let subbed_subject_ty = self.sub_ops().apply_sub_to_ty(subject_ty, &sub);
 
-                        // Then normalise the return type in their scope.
-                        let return_ty = self.normalise_and_check_ty(subbed_return_ty)?;
+                    self.register_atom_inference(
+                        fn_call_term.subject,
+                        subbed_subject_term,
+                        subbed_subject_ty,
+                    );
 
-                        // @@Todo: implicit check
-                        let uni = self.uni_ops().unify_tys(return_ty, annotation_ty)?;
+                    let resulting_fn_call = self.new_term(FnCallTerm {
+                        subject: subbed_subject_term,
+                        args: inferred_fn_call_args,
+                        implicit: fn_call_term.implicit,
+                    });
+                    self.register_atom_inference(
+                        original_term_id,
+                        resulting_fn_call,
+                        subbed_return_ty,
+                    );
 
-                        let subject = self.sub_ops().apply_sub_to_term(
-                            self.sub_ops().apply_sub_to_term(subject_term, &param_uni.sub),
-                            &uni.sub,
-                        );
-                        let subject_ty = self.sub_ops().apply_sub_to_ty(
-                            self.sub_ops().apply_sub_to_ty(subject_ty, &param_uni.sub),
-                            &uni.sub,
-                        );
-                        self.register_atom_inference(fn_call_term.subject, subject, subject_ty);
+                    let monomorphised =
+                        self.potentially_monomorphise_fn_call(resulting_fn_call, fn_ty)?;
+                    self.register_atom_inference(original_term_id, monomorphised, subbed_return_ty);
 
-                        let resulting_fn_call = self.new_term(FnCallTerm {
-                            subject,
-                            args: inferred_fn_call_args,
-                            implicit: fn_call_term.implicit,
-                        });
-                        self.register_atom_inference(
-                            original_term_id,
-                            resulting_fn_call,
-                            uni.result,
-                        );
-
-                        let monomorphised =
-                            self.potentially_monomorphise_fn_call(resulting_fn_call, fn_ty)?;
-                        self.register_atom_inference(original_term_id, monomorphised, uni.result);
-
-                        Ok(Inference(monomorphised, uni.result))
-                    })
+                    Ok(Inference(monomorphised, subbed_return_ty))
                 };
 
                 // Potentially fill-in implicit args
@@ -1247,12 +1196,15 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Ty::Data(data_ty) => {
                 self.context().enter_scope(ScopeKind::Data(data_ty.data_def), || {
                     let data_def = self.get_data_def(data_ty.data_def);
-                    let Inference(inferred_data_args, _) =
+                    let InferenceWithSub { result: _, .. } =
                         self.infer_args(data_ty.args, data_def.params)?;
+                    let sub = self.sub_ops().create_sub_from_current_scope();
+
+                    let result_data_args = self.sub_ops().apply_sub_to_args(data_ty.args, &sub);
 
                     Ok((
                         self.new_ty(Ty::Data(DataTy {
-                            args: inferred_data_args,
+                            args: result_data_args,
                             data_def: data_ty.data_def,
                         })),
                         self.new_small_universe_ty(),
@@ -1446,12 +1398,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let Inference(inferred_lhs_pat, inferred_ty) =
             self.infer_pat(decl_term.bind_pat, inferred_ty)?;
 
-        let result_decl_term = DeclTerm {
-            bind_pat: inferred_lhs_pat,
-            value: inferred_rhs_value,
-            ty: inferred_ty,
-            stack_indices: decl_term.stack_indices,
-        };
+        let result_decl_term =
+            DeclTerm { bind_pat: inferred_lhs_pat, value: inferred_rhs_value, ty: inferred_ty };
         Ok(Inference(result_decl_term, self.check_by_unify(self.new_void_ty(), annotation_ty)?))
     }
 
@@ -1622,7 +1570,6 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     bind_pat: inferred_pat,
                     value: inferred_body,
                     stack_id: case_data.stack_id,
-                    stack_indices: case_data.stack_indices,
                 });
 
                 Ok(())
@@ -1769,11 +1716,15 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             Term::Hole(_) => Ok(Inference(term_id, annotation_ty)),
         })?;
 
-        self.register_atom_inference(term_id, result.0, result.1);
+        // Unify the result type with the annotation type.
+        let result_ty = self.check_by_unify(result.1, annotation_ty)?;
+        self.register_atom_inference(term_id, result.0, result_ty);
 
+        // Potentially evaluate the term.
         let potentially_evaluated = self.potentially_run_expr(result.0)?;
         self.potentially_dump_tir(potentially_evaluated);
-        Ok(Inference(potentially_evaluated, result.1))
+
+        Ok(Inference(potentially_evaluated, result_ty))
     }
 
     /// Infer a range pattern.
@@ -1807,7 +1758,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
         };
 
-        let Inference(inferred_args, inferred_params) =
+        let InferenceWithSub { result: inferred_args, annotation: inferred_params, .. } =
             self.context().enter_scope(ScopeKind::TupleTy(TupleTy { data: params }), || {
                 self.infer_pat_args(tuple_pat.data, tuple_pat.data_spread, params)
             })?;
@@ -1901,53 +1852,37 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 self.uni_ops().unify_args(pat_data_args, annotation_data_ty.args)?;
 
             // First infer the data arguments
-            let Inference(inferred_data_args, inferred_data_params) =
-                self.infer_args(data_args_uni.result, data_def.params)?;
-
-            let param_uni = self
-                .uni_ops()
-                .unify_params(inferred_data_params, data_def.params, ParamOrigin::Data(data_def.id))
-                .unwrap();
-
-            // Create a substitution from the inferred data arguments
-            let data_sub =
-                self.sub_ops().create_sub_from_args_of_params(inferred_data_args, data_def.params);
+            let InferenceWithSub {
+                result: inferred_data_args,
+                annotation: _inferred_data_params,
+                sub: data_sub,
+            } = self.infer_args(data_args_uni.result, data_def.params)?;
 
             self.context().enter_scope(ctor.id.into(), || {
                 // Apply the substitution to the constructor parameters
-                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(
-                    self.sub_ops().apply_sub_to_params(
-                        self.sub_ops().apply_sub_to_params(ctor.params, &data_args_uni.sub),
-                        &param_uni.sub,
-                    ),
-                    &data_sub,
-                );
+                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(ctor.params, &data_sub);
+                let subbed_ctor_result_args =
+                    self.sub_ops().apply_sub_to_args(ctor.result_args, &data_sub);
 
                 // Infer the constructor arguments
-                let Inference(inferred_ctor_pat_args, inferred_ctor_params) = self.infer_pat_args(
+                let InferenceWithSub {
+                    result: inferred_ctor_pat_args,
+                    annotation: _inferred_ctor_params,
+                    sub: ctor_sub,
+                } = self.infer_pat_args(
                     pat.ctor_pat_args,
                     pat.ctor_pat_args_spread,
                     subbed_ctor_params,
                 )?;
-
-                let ctor_ty_sub = self.uni_ops().unify_params(
-                    inferred_ctor_params,
-                    subbed_ctor_params,
-                    ParamOrigin::Ctor(ctor.id),
-                )?;
-
                 // Apply the substitution to the constructor result args
-                let subbed_result_args = self.sub_ops().apply_sub_to_args(
-                    self.sub_ops().apply_sub_to_args(
-                        self.sub_ops().apply_sub_to_args(ctor.result_args, &param_uni.sub),
-                        &data_sub,
-                    ),
-                    &ctor_ty_sub.sub,
-                );
+                let ctor_subbed_ctor_result_args =
+                    self.sub_ops().apply_sub_to_args(subbed_ctor_result_args, &ctor_sub);
 
                 // Try to unify given annotation with inferred eventual type.
-                let result_data_def_args =
-                    self.uni_ops().unify_args(subbed_result_args, inferred_data_args)?.result;
+                let result_data_def_args = self
+                    .uni_ops()
+                    .unify_args(ctor_subbed_ctor_result_args, inferred_data_args)?
+                    .result;
 
                 // Evaluate the result args.
                 Ok(Inference(
@@ -1997,9 +1932,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let result =
             match self.get_pat(pat_id) {
                 Pat::Binding(var) => {
-                    if let Some(member) = var.stack_member {
-                        self.context_utils().add_stack_binding(member, annotation_ty, None);
-                    }
+                    self.context_utils().add_typing_to_closest_stack(var.name, annotation_ty);
                     Inference(pat_id, annotation_ty)
                 }
                 Pat::Range(range_pat) => {

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -6,7 +6,6 @@ use derive_more::{Constructor, Deref};
 use hash_tir::{
     access::AccessTerm,
     args::ArgsId,
-    environment::context::ScopeKind,
     holes::Hole,
     mods::ModDefId,
     params::{ParamData, ParamId, ParamIndex, ParamsId},

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -8,9 +8,10 @@ use hash_tir::{
     args::ArgsId,
     holes::Hole,
     mods::ModDefId,
-    params::{ParamIndex, ParamsId},
+    params::{ParamData, ParamIndex, ParamsId},
     pats::PatId,
     sub::Sub,
+    symbols::Symbol,
     terms::{Term, TermId},
     tys::{Ty, TyId},
     utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
@@ -92,6 +93,28 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
             },
             Atom::FnDef(_) | Atom::Pat(_) => ControlFlow::Continue(()),
         }
+    }
+
+    /// Apply the given substitution to the given parameters, while handling
+    /// shadowing.
+    ///
+    /// Returns filtered sub, with shadowed variables removed.
+    pub fn properly_apply_sub_to_params(&self, params: ParamsId, sub: &Sub) -> (ParamsId, Sub) {
+        let mut filtered_sub = sub.clone();
+        let mut param_data = vec![];
+
+        for param_id in params.iter() {
+            let param = self.get_param(param_id);
+            param_data.push(ParamData {
+                name: param.name,
+                ty: self.apply_sub_to_ty(param.ty, &filtered_sub),
+                default: param.default.map(|term| self.apply_sub_to_term(term, &filtered_sub)),
+            });
+            filtered_sub.remove(param.name);
+        }
+
+        let new_params = self.param_utils().create_params(param_data.into_iter());
+        (new_params, filtered_sub)
     }
 
     /// Apply the given substitution to the given atom,
@@ -277,14 +300,22 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
         let mut sub = Sub::identity();
 
         let current_scope_index = self.context().get_current_scope_index();
-        self.context().for_bindings_of_scope(current_scope_index, |binding| {
+        self.context().for_bindings_of_scope_rev(current_scope_index, |binding| {
             if let Some(value) = self.context_utils().try_get_binding_value(binding.name) {
-                let subbed_value = self.apply_sub_to_term(value, &sub);
-                sub.insert(binding.name, subbed_value);
+                self.insert_to_sub_if_needed(&mut sub, binding.name, value);
             }
         });
 
         sub
+    }
+
+    /// Insert the given variable and value into the given substitution if
+    /// the value is not a variable with the same name.
+    pub fn insert_to_sub_if_needed(&self, sub: &mut Sub, name: Symbol, value: TermId) {
+        let subbed_value = self.apply_sub_to_term(value, sub);
+        if !matches!(self.get_term(subbed_value), Term::Var(v) if v == name) {
+            sub.insert(name, subbed_value);
+        }
     }
 
     /// Create a substitution from the given arguments.
@@ -298,7 +329,7 @@ impl<T: AccessToTypechecking> SubstitutionOps<'_, T> {
         for (param_id, arg_id) in (params_id.iter()).zip(args_id.iter()) {
             let param = self.stores().params().get_element(param_id);
             let arg = self.stores().args().get_element(arg_id);
-            sub.insert(param.name, arg.value);
+            self.insert_to_sub_if_needed(&mut sub, param.name, arg.value);
         }
         sub
     }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -4,15 +4,18 @@ use std::cell::Cell;
 
 use derive_more::Deref;
 use hash_tir::{
-    args::{ArgData, ArgsId},
+    args::{ArgData, ArgsId, PatArgData, PatArgsId, PatOrCapture},
     data::{DataDefCtors, DataTy},
-    environment::context::ParamOrigin,
+    environment::context::{ParamOrigin, ScopeKind},
     fns::{FnBody, FnTy},
+    holes::Hole,
     lits::Lit,
     locations::LocationTarget,
     params::{ParamData, ParamsId},
+    pats::{Pat, PatId, PatListId},
     refs::RefTy,
     sub::Sub,
+    symbols::Symbol,
     terms::{Term, TermId},
     tuples::TupleTy,
     tys::{Ty, TyId},
@@ -51,14 +54,19 @@ impl<T> Uni<T> {
         Err(TcError::Blocked(loc.into()))
     }
 
-    /// Create a unification result that is an error of mismatching types.
-    pub fn mismatch_types(src_id: TyId, target_id: TyId) -> TcResult<Self> {
-        Err(TcError::MismatchingTypes { expected: target_id, actual: src_id, inferred_from: None })
-    }
-
     /// Create a unification result that is an error of mismatching terms.
-    pub fn mismatch_terms(src_id: TermId, target_id: TermId) -> TcResult<Self> {
-        Err(TcError::UndecidableEquality { a: src_id, b: target_id })
+    ///
+    /// Invariant: `src_id` and `target_id` must be of the same atom kind.
+    pub fn mismatch_atoms(src_id: impl Into<Atom>, target_id: impl Into<Atom>) -> TcResult<Self> {
+        match (src_id.into(), target_id.into()) {
+            (Atom::Term(a), Atom::Term(b)) => Err(TcError::UndecidableEquality { a, b }),
+            (Atom::Ty(a), Atom::Ty(b)) => {
+                Err(TcError::MismatchingTypes { expected: b, actual: a, inferred_from: None })
+            }
+            (Atom::FnDef(a), Atom::FnDef(b)) => Err(TcError::MismatchingFns { a, b }),
+            (Atom::Pat(a), Atom::Pat(b)) => Err(TcError::MismatchingPats { a, b }),
+            _ => unreachable!(),
+        }
     }
 
     pub fn map_result<U>(self, f: impl FnOnce(T) -> U) -> Uni<U> {
@@ -80,7 +88,7 @@ impl Uni<TyId> {
         if cond {
             Uni::ok(target_id)
         } else {
-            Uni::mismatch_types(src_id, target_id)
+            Uni::mismatch_atoms(src_id, target_id)
         }
     }
 }
@@ -88,15 +96,15 @@ impl Uni<TyId> {
 impl Uni<TermId> {
     /// Create a unification result that is an error of mismatching terms if
     /// `cond` is false, and successful otherwise.
-    pub fn ok_iff_terms_match(
+    pub fn ok_iff_atoms_match<I: Into<Atom>>(
         cond: bool,
-        src_id: TermId,
-        target_id: TermId,
-    ) -> TcResult<Uni<TermId>> {
+        src_id: I,
+        target_id: I,
+    ) -> TcResult<Uni<I>> {
         if cond {
             Uni::ok(target_id)
         } else {
-            Uni::mismatch_terms(src_id, target_id)
+            Uni::mismatch_atoms(src_id, target_id)
         }
     }
 }
@@ -127,6 +135,49 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                 Ok(self.unify_terms(src_id, target_id)?.map_into())
             }
             _ => panic!("unify_atoms: mismatching atoms"),
+        }
+    }
+
+    pub fn add_unification_from_sub(&self, sub: &Sub) {
+        if self.add_to_ctx.get() {
+            self.context_utils().add_sub_to_scope(sub);
+        }
+    }
+
+    pub fn add_unification(&self, src: Symbol, target: impl Into<Atom>) -> Sub {
+        let sub = Sub::from_pairs([(src, self.norm_ops().to_term(target.into()))]);
+        self.add_unification_from_sub(&sub);
+        sub
+    }
+
+    /// Unified two function types.
+    pub fn unify_fn_tys(
+        &self,
+        f1: FnTy,
+        f2: FnTy,
+        src_id: impl Into<Atom>,
+        target_id: impl Into<Atom>,
+    ) -> TcResult<Uni<FnTy>> {
+        if !self.fn_modalities_match(f1, f2) {
+            Uni::mismatch_atoms(src_id, target_id)
+        } else {
+            // Unify parameters and apply to return types
+            let (return_ty, shadowed_sub) =
+                self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
+                    let _ = self.unify_params(f2.params, f1.params, ParamOrigin::FnTy(f1))?;
+                    let Uni { result: return_ty, sub: return_ty_sub } =
+                        self.unify_tys(f1.return_ty, f2.return_ty)?;
+                    let scope_sub = self.sub_ops().create_sub_from_current_scope();
+                    let shadowed_sub = self
+                        .sub_ops()
+                        .hide_param_binds(f1.params.iter().chain(f2.params.iter()), &scope_sub);
+
+                    Ok((return_ty, shadowed_sub))
+                })?;
+
+            // Add to context
+            self.add_unification_from_sub(&shadowed_sub);
+            Ok(Uni { result: FnTy { return_ty, params: f1.params, ..f1 }, sub: shadowed_sub })
         }
     }
 
@@ -172,20 +223,20 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                 let result_ty = self.infer_ops().use_term_in_ty_pos(uni.result)?;
                 Ok(uni.map_result(|_| result_ty))
             }
-            (Ty::Eval(_), _) => Uni::mismatch_types(src_id, target_id),
-            (_, Ty::Eval(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Eval(_), _) => Uni::mismatch_atoms(src_id, target_id),
+            (_, Ty::Eval(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Var(a), Ty::Var(b)) => Uni::ok_iff_types_match(a == b, src_id, target_id),
-            (Ty::Var(_), _) | (_, Ty::Var(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Var(_), _) | (_, Ty::Var(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Tuple(t1), Ty::Tuple(t2)) => Ok(self
                 .unify_params(t1.data, t2.data, ParamOrigin::TupleTy(t1))?
                 .map_result(|data| self.new_ty(TupleTy { data }))),
-            (Ty::Tuple(_), _) | (_, Ty::Tuple(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Tuple(_), _) | (_, Ty::Tuple(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Fn(f1), Ty::Fn(f2)) => {
                 if !self.fn_modalities_match(f1, f2) {
-                    Uni::mismatch_types(src_id, target_id)
+                    Uni::mismatch_atoms(src_id, target_id)
                 } else {
                     self.context().enter_scope(f2.into(), || {
                         let Uni { sub: param_sub, result: params } =
@@ -206,17 +257,17 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                     })
                 }
             }
-            (Ty::Fn(_), _) | (_, Ty::Fn(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Fn(_), _) | (_, Ty::Fn(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Ref(r1), Ty::Ref(r2)) => {
                 if r1.mutable == r2.mutable && r1.kind == r2.kind {
                     let result = self.unify_tys(r1.ty, r2.ty)?;
                     Ok(result.map_result(|ty| self.new_ty(RefTy { ty, ..r1 })))
                 } else {
-                    Uni::mismatch_types(src_id, target_id)
+                    Uni::mismatch_atoms(src_id, target_id)
                 }
             }
-            (Ty::Ref(_), _) | (_, Ty::Ref(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Ref(_), _) | (_, Ty::Ref(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Data(d1), Ty::Data(d2)) => {
                 if d1.data_def == d2.data_def {
@@ -224,10 +275,10 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                         .unify_args(d1.args, d2.args)?
                         .map_result(|args| self.new_ty(DataTy { data_def: d1.data_def, args })))
                 } else {
-                    Uni::mismatch_types(src_id, target_id)
+                    Uni::mismatch_atoms(src_id, target_id)
                 }
             }
-            (Ty::Data(_), _) | (_, Ty::Data(_)) => Uni::mismatch_types(src_id, target_id),
+            (Ty::Data(_), _) | (_, Ty::Data(_)) => Uni::mismatch_atoms(src_id, target_id),
 
             (Ty::Universe(u1), Ty::Universe(u2)) => {
                 Uni::ok_iff_types_match(u1.size == u2.size, src_id, target_id)
@@ -236,6 +287,16 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
 
         self.stores().location().copy_location(src_id, result.result);
         Ok(result)
+    }
+
+    pub fn lits_are_equal(&self, src: Lit, target: Lit) -> bool {
+        match (src, target) {
+            (Lit::Int(i1), Lit::Int(i2)) => i1.value() == i2.value(),
+            (Lit::Str(s1), Lit::Str(s2)) => s1.value() == s2.value(),
+            (Lit::Char(c1), Lit::Char(c2)) => c1.value() == c2.value(),
+            (Lit::Float(f1), Lit::Float(f2)) => f1.value() == f2.value(),
+            _ => false,
+        }
     }
 
     /// Unify two terms.
@@ -263,9 +324,9 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
             _ => match (src, target) {
                 (Term::Ty(t1), _) => self.unify_terms(self.use_ty_as_term(t1), target_id),
                 (_, Term::Ty(t2)) => self.unify_terms(src_id, self.use_ty_as_term(t2)),
-                (Term::Var(a), Term::Var(b)) => Uni::ok_iff_terms_match(a == b, src_id, target_id),
+                (Term::Var(a), Term::Var(b)) => Uni::ok_iff_atoms_match(a == b, src_id, target_id),
                 (Term::Hole(a), Term::Hole(b)) => {
-                    Uni::ok_iff_terms_match(a == b, src_id, target_id)
+                    Uni::ok_iff_atoms_match(a == b, src_id, target_id)
                 }
                 (Term::Hole(a), _) => {
                     let sub = Sub::from_pairs([(a.0, target_id)]);
@@ -275,24 +336,12 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                     let sub = Sub::from_pairs([(b.0, src_id)]);
                     Uni::ok_with(sub, src_id)
                 }
-                (Term::Lit(l1), Term::Lit(l2)) => match (l1, l2) {
-                    (Lit::Int(i1), Lit::Int(i2)) => {
-                        Uni::ok_iff_terms_match(i1.value() == i2.value(), src_id, target_id)
-                    }
-                    (Lit::Str(s1), Lit::Str(s2)) => {
-                        Uni::ok_iff_terms_match(s1.value() == s2.value(), src_id, target_id)
-                    }
-                    (Lit::Char(c1), Lit::Char(c2)) => {
-                        Uni::ok_iff_terms_match(c1.value() == c2.value(), src_id, target_id)
-                    }
-                    (Lit::Float(f1), Lit::Float(f2)) => {
-                        Uni::ok_iff_terms_match(f1.value() == f2.value(), src_id, target_id)
-                    }
-                    _ => Uni::mismatch_terms(src_id, target_id),
-                },
+                (Term::Lit(l1), Term::Lit(l2)) => {
+                    Uni::ok_iff_atoms_match(self.lits_are_equal(l1, l2), src_id, target_id)
+                }
                 (Term::Access(a1), Term::Access(a2)) => {
                     let _ = self.unify_terms(a1.subject, a2.subject)?;
-                    Uni::ok_iff_terms_match(a1.field == a2.field, src_id, target_id)
+                    Uni::ok_iff_atoms_match(a1.field == a2.field, src_id, target_id)
                 }
                 (Term::FnCall(c1), Term::FnCall(c2)) => {
                     let _ = self.unify_terms(c1.subject, c2.subject)?;
@@ -333,19 +382,63 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                                 Uni::ok(src_id)
                             }
                             (FnBody::Intrinsic(i1), FnBody::Intrinsic(i2)) => {
-                                Uni::ok_iff_terms_match(i1.0 == i2.0, src_id, target_id)
+                                Uni::ok_iff_atoms_match(i1.0 == i2.0, src_id, target_id)
                             }
                             (FnBody::Axiom, FnBody::Axiom) => Uni::ok(src_id),
-                            _ => Uni::mismatch_terms(src_id, target_id),
+                            _ => Uni::mismatch_atoms(src_id, target_id),
                         }
                     })
                 }
 
-                _ => Uni::mismatch_terms(src_id, target_id),
+                (Term::Match(m1), Term::Match(m2)) => {
+                    let _ = self.unify_terms(m1.subject, m2.subject)?;
+
+                    Uni::ok(src_id)
+                }
+
+                _ => Uni::mismatch_atoms(src_id, target_id),
             },
         }?;
         self.stores().location().copy_location(src_id, result.result);
         Ok(result)
+    }
+
+    pub fn pats_are_equal(&self, src_id: PatId, target_id: PatId) -> bool {
+        match (self.get_pat(src_id), self.get_pat(target_id)) {
+            (Pat::Binding(v1), Pat::Binding(v2)) => {
+                v1.is_mutable == v2.is_mutable && v1.name == v2.name
+            }
+            (_, Pat::Binding(_)) | (Pat::Binding(_), _) => false,
+
+            (Pat::Range(r1), Pat::Range(r2)) => {
+                self.lits_are_equal(r1.start.into(), r2.start.into())
+                    && self.lits_are_equal(r1.end.into(), r2.end.into())
+                    && r1.range_end == r2.range_end
+            }
+            (Pat::Range(_), _) | (_, Pat::Range(_)) => false,
+
+            (Pat::Lit(l1), Pat::Lit(l2)) => self.lits_are_equal(l1.into(), l2.into()),
+            (Pat::Lit(_), _) | (_, Pat::Lit(_)) => false,
+
+            (Pat::Tuple(t1), Pat::Tuple(t2)) => {
+                self.pat_args_are_equal(t1.data, t2.data) && t1.data_spread == t2.data_spread
+            }
+            (Pat::Tuple(_), _) | (_, Pat::Tuple(_)) => false,
+
+            (Pat::Array(a1), Pat::Array(a2)) => {
+                self.pat_lists_are_equal(a1.pats, a2.pats) && a1.spread == a2.spread
+            }
+            (Pat::Array(_), _) | (_, Pat::Array(_)) => false,
+
+            (Pat::Ctor(c1), Pat::Ctor(c2)) => {
+                todo!()
+            }
+            (Pat::Ctor(_), _) | (_, Pat::Ctor(_)) => todo!(),
+            (Pat::Or(_), Pat::Or(_)) => todo!(),
+            (Pat::Or(_), _) | (_, Pat::Or(_)) => todo!(),
+            (Pat::If(_), Pat::If(_)) => todo!(),
+            (Pat::If(_), _) | (_, Pat::If(_)) => todo!(),
+        }
     }
 
     /// Reduce an iterator of unifications into a single unification.
@@ -438,8 +531,56 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
         Ok(Uni { result: param_uni.result, sub: param_uni.sub.join(&name_sub) })
     }
 
-    /// Unify two argument lists, creating a substitution of holes.
+    pub fn pat_lists_are_equal(&self, src_id: PatListId, target_id: PatListId) -> bool {
+        if src_id.len() != target_id.len() {
+            false
+        } else {
+            self.map_pat_list(src_id, |src| {
+                self.map_pat_list(target_id, |target| {
+                    src.iter()
+                        .zip(target.iter())
+                        .map(|(src, target)| match (src, target) {
+                            (PatOrCapture::Pat(src_pat), PatOrCapture::Pat(target_pat)) => {
+                                self.pats_are_equal(*src_pat, *target_pat)
+                            }
+                            (PatOrCapture::Capture, PatOrCapture::Capture) => true,
+                            _ => false,
+                        })
+                        .all(|x| x)
+                })
+            })
+        }
+    }
+
+    /// Unify two pattern argument lists, creating a substitution of holes.
+    pub fn pat_args_are_equal(&self, src_id: PatArgsId, target_id: PatArgsId) -> bool {
+        if src_id.len() != target_id.len() {
+            false
+        } else {
+            self.map_pat_args(src_id, |src| {
+                self.map_pat_args(target_id, |target| {
+                    src.iter()
+                        .zip(target.iter())
+                        .map(|(src, target)| match (src.pat, target.pat) {
+                            (PatOrCapture::Pat(src_pat), PatOrCapture::Pat(target_pat)) => {
+                                self.pats_are_equal(src_pat, target_pat)
+                            }
+                            (PatOrCapture::Capture, PatOrCapture::Capture) => true,
+                            _ => false,
+                        })
+                        .all(|x| x)
+                })
+            })
+        }
+    }
+
     pub fn unify_args(&self, src_id: ArgsId, target_id: ArgsId) -> TcResult<Uni<ArgsId>> {
+        if src_id.len() != target_id.len() {
+            return Err(TcError::DifferentParamOrArgLengths {
+                a: src_id.into(),
+                b: target_id.into(),
+            });
+        }
         self.map_args(src_id, |src| {
             self.map_args(target_id, |target| {
                 self.reduce_unifications(

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -4,11 +4,10 @@ use std::cell::Cell;
 
 use derive_more::Deref;
 use hash_tir::{
-    args::{ArgData, ArgsId, PatArgData, PatArgsId, PatOrCapture},
+    args::{ArgData, ArgsId, PatArgsId, PatOrCapture},
     data::{DataDefCtors, DataTy},
     environment::context::{ParamOrigin, ScopeKind},
     fns::{FnBody, FnTy},
-    holes::Hole,
     lits::Lit,
     locations::LocationTarget,
     params::{ParamData, ParamsId},
@@ -165,7 +164,7 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
             let (return_ty, shadowed_sub) =
                 self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
                     let _ = self.unify_params(f2.params, f1.params, ParamOrigin::FnTy(f1))?;
-                    let Uni { result: return_ty, sub: return_ty_sub } =
+                    let Uni { result: return_ty, sub: _return_ty_sub } =
                         self.unify_tys(f1.return_ty, f2.return_ty)?;
                     let scope_sub = self.sub_ops().create_sub_from_current_scope();
                     let shadowed_sub = self
@@ -430,14 +429,13 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
             }
             (Pat::Array(_), _) | (_, Pat::Array(_)) => false,
 
-            (Pat::Ctor(c1), Pat::Ctor(c2)) => {
+            (Pat::Ctor(_c1), Pat::Ctor(_c2)) => {
                 todo!()
             }
             (Pat::Ctor(_), _) | (_, Pat::Ctor(_)) => todo!(),
             (Pat::Or(_), Pat::Or(_)) => todo!(),
             (Pat::Or(_), _) | (_, Pat::Or(_)) => todo!(),
             (Pat::If(_), Pat::If(_)) => todo!(),
-            (Pat::If(_), _) | (_, Pat::If(_)) => todo!(),
         }
     }
 


### PR DESCRIPTION
This PR fixes some issues with unification, and unifies `StackMemberId`/`ArgId` bindings into `Decl`. This makes a lot of things simpler, and now members can be looked up just by symbol.

Some groundwork has been added to make inference and unification modifying rather than copying, which should greatly improve performance but also retain locations automatically.