### PR TITLE
lower+codegen fixes

### DIFF
--- a/compiler/hash-codegen-llvm/src/translation/builder.rs
+++ b/compiler/hash-codegen-llvm/src/translation/builder.rs
@@ -1027,7 +1027,6 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
         debug_assert!(!flags.contains(MemFlags::NON_TEMPORAL), "non-temporal memcpy not supported");
 
         let size = self.int_cast(size, self.ctx.type_isize(), false).into_int_value();
-        let is_volatile = flags.contains(MemFlags::VOLATILE);
 
         let (destination, destination_align) = destination;
         let (source, source_align) = source;
@@ -1047,8 +1046,12 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
             )
             .unwrap();
 
+        // @@PatchInkewll: inkwell doesn't support specifying volatile flags
+        // on memcpy instructions.
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+
         // Set the volatile flag if necessary
-        if let Some(val) = value.as_instruction_value() {
+        if is_volatile && let Some(val) = value.as_instruction_value() {
             val.set_volatile(is_volatile).unwrap()
         }
     }
@@ -1067,7 +1070,6 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
         );
 
         let size = self.int_cast(size, self.ctx.type_isize(), false).into_int_value();
-        let is_volatile = flags.contains(MemFlags::VOLATILE);
 
         let (destination, destination_align) = destination;
         let (source, source_align) = source;
@@ -1088,7 +1090,9 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
             .unwrap();
 
         // Set the volatile flag if necessary
-        if let Some(val) = value.as_instruction_value() {
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+
+        if is_volatile && let Some(val) = value.as_instruction_value() {
             val.set_volatile(is_volatile).unwrap()
         }
     }
@@ -1101,7 +1105,6 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
         alignment: Alignment,
         flags: MemFlags,
     ) {
-        let is_volatile = flags.contains(MemFlags::VOLATILE);
         let ptr = self.pointer_cast(ptr, self.ctx.type_i8p()).into_pointer_value();
 
         let value = self
@@ -1114,8 +1117,10 @@ impl<'a, 'b, 'm> BlockBuilderMethods<'a, 'b> for Builder<'a, 'b, 'm> {
             )
             .unwrap();
 
+        let is_volatile = flags.contains(MemFlags::VOLATILE);
+
         // Set the volatile flag if necessary
-        if let Some(val) = value.as_instruction_value() {
+        if is_volatile && let Some(val) = value.as_instruction_value() {
             val.set_volatile(is_volatile).unwrap()
         }
     }

--- a/compiler/hash-ir/src/cast.rs
+++ b/compiler/hash-ir/src/cast.rs
@@ -45,8 +45,8 @@ impl CastKind {
             (Some(CastTy::Float), Some(CastTy::Float)) => Self::FloatToFloat,
             _ => panic!(
                 "attempting to cast between non-primitive types: src: `{}`, dest: `{}`",
-                src.fmt_with_opts(ctx, true, false),
-                dest.fmt_with_opts(ctx, true, false)
+                src.fmt_with_opts(ctx, false),
+                dest.fmt_with_opts(ctx, false)
             ),
         }
     }

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -23,9 +23,6 @@ pub struct ForFormatting<'ir, T> {
     /// The item that is being printed.
     pub item: T,
 
-    /// Whether the formatting should be verbose or not.
-    pub verbose: bool,
-
     /// Whether the formatting implementations should write
     /// edges for IR items, this mostly applies to [Terminator]s.
     pub with_edges: bool,
@@ -36,11 +33,11 @@ pub struct ForFormatting<'ir, T> {
 
 pub trait WriteIr: Sized {
     fn for_fmt(self, ctx: &IrCtx) -> ForFormatting<Self> {
-        ForFormatting { item: self, ctx, verbose: false, with_edges: true }
+        ForFormatting { item: self, ctx, with_edges: true }
     }
 
-    fn fmt_with_opts(self, ctx: &IrCtx, verbose: bool, with_edges: bool) -> ForFormatting<Self> {
-        ForFormatting { item: self, ctx, verbose, with_edges }
+    fn fmt_with_opts(self, ctx: &IrCtx, with_edges: bool) -> ForFormatting<Self> {
+        ForFormatting { item: self, ctx, with_edges }
     }
 }
 
@@ -133,12 +130,7 @@ impl fmt::Display for ForFormatting<'_, &RValue> {
             RValue::Len(place) => write!(f, "len({})", place.for_fmt(self.ctx)),
             RValue::Cast(_, op, ty) => {
                 // We write out the type fully for the cast.
-                write!(
-                    f,
-                    "cast({}, {})",
-                    ty.fmt_with_opts(self.ctx, true, true),
-                    op.for_fmt(self.ctx)
-                )
+                write!(f, "cast({}, {})", ty.fmt_with_opts(self.ctx, true), op.for_fmt(self.ctx))
             }
             RValue::UnaryOp(op, operand) => {
                 write!(f, "{op:?}({})", operand.for_fmt(self.ctx))

--- a/compiler/hash-ir/src/write/pretty.rs
+++ b/compiler/hash-ir/src/write/pretty.rs
@@ -152,7 +152,7 @@ impl<'ir> IrBodyWriter<'ir> {
         // Write the terminator of the block. If the terminator is
         // not present, this is an invariant but we don't care here.
         if let Some(terminator) = &block_data.terminator {
-            writeln!(f, "{: <2$}{};", "", terminator.fmt_with_opts(self.ctx, false, true), 8)?;
+            writeln!(f, "{: <2$}{};", "", terminator.fmt_with_opts(self.ctx, true), 8)?;
         }
 
         writeln!(f, "{: <1$}}}", "", 4)

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -211,6 +211,12 @@ impl TyInfo {
         })
     }
 
+    /// Check if the ABI is uninhabited.
+    pub fn is_uninhabited(&self, ctx: LayoutComputer) -> bool {
+        ctx.layouts()
+            .map_fast(self.layout, |layout| matches!(layout.abi, AbiRepresentation::Uninhabited))
+    }
+
     /// Perform a mapping over the [IrTy] and [Layout] associated with
     /// this [LayoutWriter].
     fn with_info<F, T>(&self, ctx: &LayoutComputer, f: F) -> T

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -36,7 +36,7 @@ use hash_tir::{
     ty_as_variant,
     utils::common::CommonUtils,
 };
-use hash_utils::store::{CloneStore, SequenceStore, Store};
+use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
 use super::{
     ty::FnCallTermKind, unpack, BlockAnd, BlockAndExtend, Builder, LocalKey, LoopBlockInfo,
@@ -497,6 +497,11 @@ impl<'tcx> Builder<'tcx> {
                 block,
                 Statement { kind: StatementKind::Discriminate(destination, index), span },
             );
+
+            // We don't need to do anything else if it is just the discriminant.
+            if ctor_args.len() == 0 {
+                return block.unit();
+            }
         }
 
         let args = self.stores().args().map_fast(*ctor_args, |args| {

--- a/compiler/hash-lower/src/build/utils.rs
+++ b/compiler/hash-lower/src/build/utils.rs
@@ -38,7 +38,7 @@ impl<'tcx> Builder<'tcx> {
     /// Get the [Span] of a given [PatId].
     pub(crate) fn span_of_pat(&self, id: PatId) -> Span {
         self.get_location(id).map(|loc| loc.span).unwrap_or_else(|| {
-            log::info!("expected pattern `{}` to have a location", self.env().with(id));
+            log::debug!("expected pattern `{}` to have a location", self.env().with(id));
             DUMMY_SPAN
         })
     }
@@ -46,7 +46,10 @@ impl<'tcx> Builder<'tcx> {
     /// Get the [Span] of a [FnDefId].
     pub(crate) fn span_of_def(&self, id: FnDefId) -> Span {
         self.get_location(id).map(|loc| loc.span).unwrap_or_else(|| {
-            log::info!("expected function definition `{}` to have a location", self.env().with(id));
+            log::debug!(
+                "expected function definition `{}` to have a location",
+                self.env().with(id)
+            );
             DUMMY_SPAN
         })
     }
@@ -54,7 +57,7 @@ impl<'tcx> Builder<'tcx> {
     /// Get the [Span] of a given [TermId].
     pub(crate) fn span_of_term(&self, id: TermId) -> Span {
         self.get_location(id).map(|loc| loc.span).unwrap_or_else(|| {
-            log::info!("expected term `{:?}` to have a location", self.env().with(id));
+            log::debug!("expected term `{:?}` to have a location", self.env().with(id));
             DUMMY_SPAN
         })
     }

--- a/compiler/hash-lower/src/lower_ty.rs
+++ b/compiler/hash-lower/src/lower_ty.rs
@@ -38,7 +38,7 @@ impl<'ir> BuilderCtx<'ir> {
     /// Perform a type lowering operation whilst also caching the result of the
     /// lowering operation. This is used to avoid duplicated work when lowering
     /// types.
-    fn with_cache<T>(&self, item: T, f: impl FnOnce() -> IrTyId) -> IrTyId
+    fn with_cache<T>(&self, item: T, f: impl FnOnce() -> (IrTyId, bool)) -> IrTyId
     where
         T: Copy + Into<TyCacheEntry>,
     {
@@ -48,9 +48,16 @@ impl<'ir> BuilderCtx<'ir> {
             return *ty;
         }
 
-        // Otherwise, create a new type and cache it.
-        let ty = f();
-        self.lcx.ty_cache().borrow_mut().insert(item.into(), ty);
+        // Create the new type
+        let (ty, add_to_cache) = f();
+
+        // If the function returned true, then this means that it has dealt with
+        // adding the item into the cache, and we can skip it here. This is to allow
+        // for recursive type definitions to be lowered.
+        if add_to_cache {
+            self.lcx.ty_cache().borrow_mut().insert(item.into(), ty);
+        }
+
         ty
     }
 
@@ -60,11 +67,18 @@ impl<'ir> BuilderCtx<'ir> {
     pub(crate) fn ty_id_from_tir_ty(&self, id: TyId) -> IrTyId {
         self.with_cache(id, || {
             self.map_ty(id, |ty| {
-                if let Ty::Data(data_ty) = ty {
+                // We compute the "uncached" type, and then it will be added to the
+                // cache if it is not already present. For data types, since they can
+                // be defined in a recursive way, the `ty_from_tir_data` will deal with
+                // its own caching, but we still want to add an entry here for `TyId` since
+                // we want to avoid computing the `ty_from_tir_data` as well.
+                let result = if let Ty::Data(data_ty) = ty {
                     self.ty_from_tir_data(*data_ty)
                 } else {
                     self.uncached_ty_from_tir_ty(id, ty)
-                }
+                };
+
+                (result, false)
             })
         })
     }
@@ -177,7 +191,7 @@ impl<'ir> BuilderCtx<'ir> {
                 self.lcx.intrinsics_mut().set(item, instance, ty);
             }
 
-            ty
+            (ty, false)
         })
     }
 
@@ -231,16 +245,30 @@ impl<'ir> BuilderCtx<'ir> {
         self.with_cache(data_ty, || self.uncached_ty_from_tir_data(data_ty))
     }
 
-    fn adt_ty_from_data(&self, def: &DataDef, ctor_defs: CtorDefsId) -> IrTyId {
+    /// Function to convert a data definition into a [`IrTy::Adt`].
+    ///
+    /// This function that will create a [IrTy] and save it into the
+    /// `reserved_ty` slot.
+    fn adt_ty_from_data(&self, ty: DataTy, def: &DataDef, ctor_defs: CtorDefsId) -> (IrTyId, bool) {
         // If data_def has more than one constructor, then it is assumed that this
         // is a enum.
         let mut flags = AdtFlags::empty();
 
         match ctor_defs.len() {
-            0 => return self.lcx.tys().common_tys.never, // This must be the never type.
+            // This must be the never type.
+            0 => {
+                return (self.lcx.tys().common_tys.never, false);
+            }
             1 => flags |= AdtFlags::STRUCT,
             _ => flags |= AdtFlags::ENUM,
         }
+
+        // Reserve a type slot for the data type, and add it to the cache
+        // so that if any inner types are recursive, they can refer to
+        // this type, and it will be updated once the type is fully defined.
+        // Apply the arguments as the scope of the data type.
+        let reserved_ty = self.lcx.tys().create(IrTy::Never);
+        self.lcx.ty_cache().borrow_mut().insert(ty.into(), reserved_ty);
 
         // Lower each variant as a constructor.
         let variants = self.stores().ctor_defs().map_fast(ctor_defs, |defs| {
@@ -279,12 +307,17 @@ impl<'ir> BuilderCtx<'ir> {
             }
         }
 
+        // Update the type in the slot that was reserved for it.
         let id = self.lcx.adts().create(adt);
-        self.lcx.tys().create(IrTy::Adt(id))
+        self.lcx.tys().modify_fast(reserved_ty, |ty| *ty = IrTy::Adt(id));
+
+        // We created our own cache entry, so we don't need to update the
+        // cache.
+        (reserved_ty, true)
     }
 
     /// Function that converts a [DataTy] into the corresponding [IrTyId].
-    fn uncached_ty_from_tir_data(&self, ty: DataTy) -> IrTyId {
+    fn uncached_ty_from_tir_data(&self, ty: DataTy) -> (IrTyId, bool) {
         let data_def = self.get_data_def(ty.data_def);
 
         match data_def.ctors {
@@ -292,19 +325,18 @@ impl<'ir> BuilderCtx<'ir> {
                 // Booleans are defined as a data type with two constructors,
                 // check here if we are dealing with a boolean.
                 if self.primitives().bool() == ty.data_def {
-                    return self.lcx.tys().common_tys.bool;
+                    return (self.lcx.tys().common_tys.bool, false);
                 }
 
-                // Apply the arguments as the scope of the data type.
                 self.context().enter_scope(ty.data_def.into(), || {
                     self.context_utils().add_arg_bindings(data_def.params, ty.args);
-                    self.adt_ty_from_data(&data_def, ctor_defs)
+                    self.adt_ty_from_data(ty, &data_def, ctor_defs)
                 })
             }
 
             // Primitive are numerics, strings, arrays, etc.
             DataDefCtors::Primitive(primitive) => {
-                match primitive {
+                let ty = match primitive {
                     PrimitiveCtorInfo::Numeric(NumericCtorInfo { bits, is_signed, is_float }) => {
                         if is_float {
                             match bits {
@@ -373,7 +405,11 @@ impl<'ir> BuilderCtx<'ir> {
                             self.lcx.tys().create(ty)
                         })
                     }
-                }
+                };
+
+                // Since we don't do anything with the cache, we can specify that
+                // the result of the operation should be cached.
+                (ty, false)
             }
         }
     }

--- a/compiler/hash-typecheck/src/normalisation.rs
+++ b/compiler/hash-typecheck/src/normalisation.rs
@@ -31,7 +31,7 @@ use hash_tir::{
 };
 use hash_utils::{
     itertools::Itertools,
-    log::info,
+    log::{debug, info},
     store::{PartialStore, SequenceStore, SequenceStoreKey, Store},
 };
 
@@ -507,7 +507,7 @@ impl<'tc, T: AccessToTypechecking> NormalisationOps<'tc, T> {
         match self.try_get_inferred_ty(type_of_term.term) {
             Some(ty) => Ok(ty.into()),
             None => {
-                info!(
+                debug!(
                     "Not found type of {} while inferring, so inferring it now",
                     self.env().with(type_of_term.term)
                 );

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -43,8 +43,13 @@ print := (msg: str, /* end: char = '\n' */) => {
 
     // @@Todo: un-comment this when default parameters are working
     // write the end character
-    // end_sep := Intrinsics::cast(type char, type u8, end);
-    // write(1, &raw end_sep, 1);
+    // end_sep := Intrinsics::cast(type char, type u8, '\n');
+    // libc::write(1, &raw end_sep, 1);
+}
+
+println := (message: str) => {
+    print(message)
+    print("\n")
 }
 
 


### PR DESCRIPTION
This patch fixes the following issues:
- lower: support recursive data types
- lower: don't emit an assignment for enum variants that have no associated data fields.
- codegen: properly generate code for setting enum discriminants
- codegen: disable `volatile` flag setting on `memmove`, `memcpy`, and `memset` since `inkwell`/`llvm-sys` don't support setting this flag.