### PR TITLE
various fixes 

### DIFF
--- a/compiler/hash-ast-desugaring/src/lib.rs
+++ b/compiler/hash-ast-desugaring/src/lib.rs
@@ -121,7 +121,7 @@ impl<Ctx: AstDesugaringCtxQuery> CompilerStage<Ctx> for AstDesugaringPass {
         let mut stdout = ctx.output_stream();
 
         if settings.stage > CompilerStageKind::Parse && settings.ast_settings().dump {
-            ctx.workspace().print_sources(entry_point, &mut stdout).unwrap();
+            ctx.workspace().print_sources(entry_point, &mut stdout, settings).unwrap();
         }
     }
 }

--- a/compiler/hash-ir/src/ty.rs
+++ b/compiler/hash-ir/src/ty.rs
@@ -1043,15 +1043,9 @@ impl fmt::Display for ForFormatting<'_, &IrTy> {
             IrTy::Fn { params, return_ty, .. } => {
                 write!(f, "({}) -> {}", params.for_fmt(self.ctx), return_ty.for_fmt(self.ctx))
             }
-            IrTy::FnDef { instance } => self.ctx.instances.map_fast(*instance, |instance| {
-                write!(
-                    f,
-                    "{}({}) -> {}",
-                    instance.name,
-                    instance.params.for_fmt(self.ctx),
-                    instance.ret_ty.for_fmt(self.ctx)
-                )
-            }),
+            IrTy::FnDef { instance } => {
+                self.ctx.instances.map_fast(*instance, |instance| write!(f, "{}", instance.name))
+            }
             IrTy::Slice(ty) => write!(f, "[{}]", ty.for_fmt(self.ctx)),
             IrTy::Array { ty, length: size } => write!(f, "[{}; {size}]", ty.for_fmt(self.ctx)),
         }

--- a/compiler/hash-ir/src/write/mod.rs
+++ b/compiler/hash-ir/src/write/mod.rs
@@ -48,6 +48,17 @@ impl WriteIr for AdtId {}
 
 impl WriteIr for Place {}
 
+impl fmt::Debug for ForFormatting<'_, Place> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.ctx.projections().map_fast(self.item.projections, |projections| {
+            f.debug_struct("Place")
+                .field("local", &self.item.local)
+                .field("projections", &projections)
+                .finish()
+        })
+    }
+}
+
 impl fmt::Display for ForFormatting<'_, Place> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.ctx.projections().map_fast(self.item.projections, |projections| {

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -693,7 +693,7 @@ impl<'l> LayoutComputer<'l> {
         // variants, and try to expand the size of the `prefix_ty` to
         // the alignment size integer.
         //
-        // @@BackendDependant(llvm): this "optimisation" might not necessarily
+        // @@BackendDependent(llvm): this "optimisation" might not necessarily
         // apply to other backends than LLVM, so we might not necessarily
         // want to perform this optimisation.
         let mut starting_alignment = Alignment::from_bytes(256).unwrap();

--- a/compiler/hash-layout/src/lib.rs
+++ b/compiler/hash-layout/src/lib.rs
@@ -114,7 +114,7 @@ impl LayoutCtx {
 
     /// Check if a given [LayoutId] represents a zero-sized type.
     pub fn is_zst(&self, layout: LayoutId) -> bool {
-        self.data.map_fast(layout, |layout| layout.is_zst())
+        self.data.map_fast(layout, Layout::is_zst)
     }
 
     /// Compute the [Size] of a given [LayoutId].
@@ -201,14 +201,7 @@ impl TyInfo {
 
     /// Check if the type is a zero-sized type.
     pub fn is_zst(&self, ctx: LayoutComputer) -> bool {
-        ctx.layouts().map_fast(self.layout, |layout| match layout.abi {
-            AbiRepresentation::Scalar { .. }
-            | AbiRepresentation::Pair(..)
-            | AbiRepresentation::Vector { .. } => false,
-            AbiRepresentation::Aggregate | AbiRepresentation::Uninhabited => {
-                layout.size.bytes() == 0
-            }
-        })
+        ctx.layouts().map_fast(self.layout, Layout::is_zst)
     }
 
     /// Check if the ABI is uninhabited.

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -29,7 +29,7 @@ use hash_ir::{
     write::WriteIr,
 };
 use hash_target::{abi::AbiRepresentation, size::Size};
-use hash_utils::store::Store;
+use hash_utils::{store::Store, tree_writing::CharacterSet};
 
 use crate::{
     compute::LayoutComputer, FieldLayout, Layout, LayoutId, LayoutShape, TyInfo, Variants,
@@ -75,7 +75,15 @@ pub struct LayoutWriterConfig {
 }
 
 impl LayoutWriterConfig {
-    /// Returns a [LayoutWritingConfig] that uses unicode box drawing
+    /// Create a [LayoutWriterConfig] based on the [CharacterSet].
+    pub fn from_character_set(set: CharacterSet) -> Self {
+        match set {
+            CharacterSet::Unicode => Self::unicode(),
+            CharacterSet::Ascii => Self::ascii(),
+        }
+    }
+
+    /// Returns a [LayoutWriterConfig] that uses unicode box drawing
     /// characters.
     pub fn unicode() -> Self {
         Self {
@@ -93,7 +101,7 @@ impl LayoutWriterConfig {
         }
     }
 
-    /// Create a new [LayoutWritingConfig] that uses ASCII characters.
+    /// Create a new [LayoutWriterConfig] that uses ASCII characters.
     pub fn ascii() -> Self {
         Self {
             top_left: '+',
@@ -555,6 +563,15 @@ pub struct LayoutWriter<'l> {
 }
 
 impl<'l> LayoutWriter<'l> {
+    /// Create a new [LayoutWriter] with a config.
+    pub fn new_with_config(
+        ty_info: TyInfo,
+        ctx: LayoutComputer<'l>,
+        config: LayoutWriterConfig,
+    ) -> Self {
+        Self { ty_info, ctx, config }
+    }
+
     /// Create a new [LayoutWriter] that will write the given [Layout] to the
     /// given [fmt::Formatter] using "unicode" characters.
     pub fn new(ty_info: TyInfo, ctx: LayoutComputer<'l>) -> Self {

--- a/compiler/hash-layout/src/write.rs
+++ b/compiler/hash-layout/src/write.rs
@@ -343,7 +343,7 @@ impl BoxRow {
             // The row box doesn't need padding, but the
             // last box in the row will need it's width to be adjusted.
             let last_width = self.widths.len() - 1;
-            self.widths[last_width] += 1;
+            self.widths[last_width] += width - current_width;
         }
     }
 }

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -309,15 +309,15 @@ impl<'tcx> Builder<'tcx> {
                 block.unit()
             }
             Term::Return(ReturnTerm { expression }) => {
-                // In either case, we want to mark that the function has reached the
-                // **terminating** statement of this block and we needn't continue looking
-                // for more statements beyond this point.
-                self.reached_terminator = true;
-
                 unpack!(
                     block =
                         self.term_into_dest(Place::return_place(self.ctx()), block, *expression)
                 );
+
+                // In either case, we want to mark that the function has reached the
+                // **terminating** statement of this block and we needn't continue looking
+                // for more statements beyond this point.
+                self.reached_terminator = true;
 
                 // Create a new block for the `return` statement and make this block
                 // go to the return whilst also starting a new block.

--- a/compiler/hash-lower/src/lib.rs
+++ b/compiler/hash-lower/src/lib.rs
@@ -23,7 +23,10 @@ use hash_ir::{
     write::{graphviz, pretty},
     IrStorage,
 };
-use hash_layout::{write::LayoutWriter, LayoutCtx, TyInfo};
+use hash_layout::{
+    write::{LayoutWriter, LayoutWriterConfig},
+    LayoutCtx, TyInfo,
+};
 use hash_pipeline::{
     interface::{
         CompilerInterface, CompilerOutputStream, CompilerResult, CompilerStage, StageMetrics,
@@ -216,12 +219,14 @@ impl<Ctx: LoweringCtxQuery> CompilerStage<Ctx> for IrGen {
 
                 // @@ErrorHandling: propagate this error if it occurs.
                 if let Ok(layout) = ctx.layout_of(ty) {
+                    let writer_config = LayoutWriterConfig::from_character_set(settings.character_set);
+
                     // Print the layout and add spacing between all of the specified layouts
                     // that were requested.
                     stream_writeln!(
                         stdout,
                         "{}",
-                        LayoutWriter::new(TyInfo { ty, layout }, ctx.layout_computer())
+                        LayoutWriter::new_with_config(TyInfo { ty, layout }, ctx.layout_computer(), writer_config)
                     );
                 }
             }

--- a/compiler/hash-lower/src/optimise/mod.rs
+++ b/compiler/hash-lower/src/optimise/mod.rs
@@ -12,7 +12,7 @@ use hash_source::SourceMap;
 
 // Various passes that are used to optimise the generated IR bodies.
 mod cleanup_locals;
-mod simplify;
+mod simplify_graph;
 
 pub trait IrOptimisationPass {
     /// Get the name of the particular optimisation pass.
@@ -57,7 +57,7 @@ impl<'ir> Optimiser<'ir> {
             _source_map: source_map,
             settings,
             passes: vec![
-                Box::new(simplify::SimplifyGraph),
+                Box::new(simplify_graph::SimplifyGraphPass),
                 Box::new(cleanup_locals::CleanupLocalPass),
             ],
         }

--- a/compiler/hash-parser/src/lib.rs
+++ b/compiler/hash-parser/src/lib.rs
@@ -128,7 +128,7 @@ impl<Ctx: ParserCtxQuery> CompilerStage<Ctx> for Parser {
         let mut stdout = ctx.output_stream();
 
         if settings.stage < CompilerStageKind::UntypedAnalysis && settings.ast_settings().dump {
-            ctx.workspace().print_sources(entry_point, &mut stdout).unwrap();
+            ctx.workspace().print_sources(entry_point, &mut stdout, settings).unwrap();
         }
     }
 }

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -227,6 +227,21 @@ fn parse_arg_configuration(
                 }
             }
         }
+        "checked-operations" => {
+            let value = value.ok_or_else(expected_value)?;
+
+            match value.as_str() {
+                "off" => {
+                    settings.lowering_settings.checked_operations = false;
+                }
+                "on" => {
+                    settings.lowering_settings.checked_operations = true;
+                }
+                _ => {
+                    return Err(PipelineError::InvalidValue(key, value));
+                }
+            }
+        }
         "backend" => {
             let value = value.ok_or_else(expected_value)?;
 

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -3,6 +3,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use hash_target::Target;
+use hash_utils::tree_writing::CharacterSet;
 
 use crate::{
     error::PipelineError,
@@ -191,6 +192,21 @@ fn parse_arg_configuration(
                 }
                 "tir" => {
                     settings.semantic_settings.dump_tir = true;
+                }
+                _ => {
+                    return Err(PipelineError::InvalidValue(key, value));
+                }
+            }
+        }
+        "character-set" => {
+            let value = value.ok_or_else(expected_value)?;
+
+            match value.as_str() {
+                "ascii" => {
+                    settings.character_set = CharacterSet::Ascii;
+                }
+                "unicode" => {
+                    settings.character_set = CharacterSet::Unicode;
                 }
                 _ => {
                     return Err(PipelineError::InvalidValue(key, value));

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -10,6 +10,7 @@ use std::{
 
 use hash_source::constant::CONSTANT_MAP;
 use hash_target::{Target, TargetInfo, HOST_TARGET_TRIPLE};
+use hash_utils::tree_writing::CharacterSet;
 
 use crate::{error::PipelineError, fs::resolve_path};
 
@@ -56,6 +57,11 @@ pub struct CompilerSettings {
     /// Whether the pipeline should output errors and warnings to
     /// standard error
     pub emit_errors: bool,
+
+    /// Which character set to use when printing information
+    /// to the terminal, this affects rendering of characters
+    /// such as the arrow in the error messages.
+    pub character_set: CharacterSet,
 
     /// The optimisation level that is to be performed.
     pub optimisation_level: OptimisationLevel,
@@ -219,6 +225,7 @@ impl Default for CompilerSettings {
             output_metrics: false,
             skip_prelude: false,
             emit_errors: true,
+            character_set: CharacterSet::Unicode,
             worker_count: num_cpus::get(),
             stage: CompilerStageKind::default(),
             optimisation_level: OptimisationLevel::default(),

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -229,7 +229,11 @@ impl UntypedSemanticAnalysisCtxQuery for CompilerSession {
 impl AstExpansionCtxQuery for CompilerSession {
     fn data(&mut self) -> AstExpansionCtx {
         let output_stream = self.output_stream();
-        AstExpansionCtx { workspace: &mut self.workspace, stdout: output_stream }
+        AstExpansionCtx {
+            workspace: &mut self.workspace,
+            settings: &self.settings,
+            stdout: output_stream,
+        }
     }
 }
 

--- a/compiler/hash-utils/src/tree_writing.rs
+++ b/compiler/hash-utils/src/tree_writing.rs
@@ -5,6 +5,17 @@
 use core::fmt;
 use std::{borrow::Cow, iter};
 
+/// What kind of character set to use when printing compiler
+/// messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CharacterSet {
+    /// Use unicode character set, this is used by default.
+    Unicode,
+
+    /// Use the ASCII character set.
+    Ascii,
+}
+
 /// A node in a tree, with a label and children.
 #[derive(Debug, Clone)]
 pub struct TreeNode {
@@ -40,6 +51,14 @@ pub struct TreeWriterConfig {
 }
 
 impl TreeWriterConfig {
+    /// Create a new [TreeWriterConfig] from a [CharacterSet].
+    pub fn from_character_set(set: CharacterSet) -> Self {
+        match set {
+            CharacterSet::Unicode => Self::unicode(),
+            CharacterSet::Ascii => Self::ascii(),
+        }
+    }
+
     /// Draw trees using Unicode box drawing characters.
     pub fn unicode() -> Self {
         Self {

--- a/tests/cases/lowering/return_if.hash
+++ b/tests/cases/lowering/return_if.hash
@@ -1,0 +1,10 @@
+// stage=ir, args=-C dump=ir -C ir-dump-mode=pretty, skip=true
+
+foo := () -> i32 => {
+	mut x := 3;
+	return if x == 3 {
+		x + 1
+	} else {
+		17
+	}
+}

--- a/tests/cases/lowering/return_if.stdout
+++ b/tests/cases/lowering/return_if.stdout
@@ -1,0 +1,40 @@
+IR dump for function `foo` defined at = $DIR/return_if.hash:3:17-10:2
+foo := () -> i32 {
+    mut _0: i32;
+    _1: i32;    // parameter `x`
+    mut _2: bool;
+    _3: (i32, bool);
+
+    bb0 {
+        _1 = const 3_i32;
+        _2 = Eq(_1, const 3_i32);
+        switch(_2) [false -> bb1, otherwise -> bb2];
+    }
+
+    bb1 {
+        _0 = const 17_i32;
+        goto -> bb4;
+    }
+
+    bb2 {
+        _3 = CheckedAdd(_1, const 1_i32);
+        assert((_3.1), false, "attempt to compute `_1 + const 1_i32`, which would overflow") -> bb3;
+    }
+
+    bb3 {
+        _0 = (_3.0);
+        goto -> bb4;
+    }
+
+    bb4 {
+        goto -> bb5;
+    }
+
+    bb5 {
+        return;
+    }
+
+    bb6 {
+        return;
+    }
+}


### PR DESCRIPTION
This fixes some issues with displaying IR types and layouts. This also adds some additional configuration to the compilation in order to specify whether to emit `checked-operations` or which character set to use when printing compiler messages.