### PR TITLE
Refactor inference, add dependent pattern matching and definitions, optional entry point

### DIFF
--- a/compiler/hash-ast/src/ast.rs
+++ b/compiler/hash-ast/src/ast.rs
@@ -1239,6 +1239,8 @@ define_tree! {
         pub name: Child!(Name),
         /// The parameters of the enum variant, if any.
         pub fields: Children!(Param),
+        /// The type of the enum variant, if any.
+        pub ty: OptionalChild!(Ty),
     }
 
     /// An enum definition, e.g.

--- a/compiler/hash-ast/src/tree.rs
+++ b/compiler/hash-ast/src/tree.rs
@@ -861,11 +861,15 @@ impl AstVisitor for AstTreeGenerator {
         &self,
         node: ast::AstNodeRef<ast::EnumDefEntry>,
     ) -> Result<Self::EnumDefEntryRet, Self::Error> {
-        let walk::EnumDefEntry { name, fields } = walk::walk_enum_def_entry(self, node)?;
-        Ok(TreeNode::branch(
-            labelled("variant", name.label, "\""),
-            if fields.is_empty() { vec![] } else { vec![TreeNode::branch("fields", fields)] },
-        ))
+        let walk::EnumDefEntry { name, fields, ty } = walk::walk_enum_def_entry(self, node)?;
+        let mut children = Vec::new();
+        if !fields.is_empty() {
+            children.push(TreeNode::branch("fields", fields))
+        }
+        if let Some(ty) = ty {
+            children.push(TreeNode::branch("type", vec![ty]))
+        }
+        Ok(TreeNode::branch(labelled("variant", name.label, "\""), children))
     }
 
     type EnumDefRet = TreeNode;

--- a/compiler/hash-intrinsics/src/primitives.rs
+++ b/compiler/hash-intrinsics/src/primitives.rs
@@ -253,7 +253,7 @@ impl DefinedPrimitives {
                 );
 
                 env.data_utils().create_data_def(eq_sym, params, |_| {
-                    vec![(refl_sym, refl_params, refl_result_args)]
+                    vec![(refl_sym, refl_params, Some(refl_result_args))]
                 })
             },
         }

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -34,7 +34,7 @@ use hash_tir::{
     terms::{Term, TermId, UnsafeTerm},
     tuples::TupleTerm,
     ty_as_variant,
-    utils::common::CommonUtils,
+    utils::{common::CommonUtils, AccessToUtils},
 };
 use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
@@ -157,6 +157,7 @@ impl<'tcx> Builder<'tcx> {
                         // if it is just a function, then we make the the type from the function.
 
                         Context::enter_scope_mut(self, fn_ty.into(), |this| {
+                            this.context_utils().add_arg_bindings(fn_ty.params, *args);
                             this.fn_call_into_dest(destination, block, *subject, *args, span)
                         })
                     }

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -34,7 +34,7 @@ use hash_tir::{
     terms::{Term, TermId, UnsafeTerm},
     tuples::TupleTerm,
     ty_as_variant,
-    utils::{common::CommonUtils, AccessToUtils},
+    utils::common::CommonUtils,
 };
 use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey, Store};
 
@@ -157,7 +157,6 @@ impl<'tcx> Builder<'tcx> {
                         // if it is just a function, then we make the the type from the function.
 
                         Context::enter_scope_mut(self, fn_ty.into(), |this| {
-                            this.context_utils().add_arg_bindings(fn_ty.params, *args);
                             this.fn_call_into_dest(destination, block, *subject, *args, span)
                         })
                     }

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -69,7 +69,17 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             self.consume_gen(gen);
         }
 
-        Ok(self.node_with_joined_span(EnumDefEntry { name, fields }, name_span))
+        // Attempt to parse an optional type for the variant
+        // Now try and parse a type if the next token permits it...
+        let ty = match self.parse_token_fast(TokenKind::Colon) {
+            Some(_) => match self.peek() {
+                Some(token) if matches!(token.kind, TokenKind::Eq | TokenKind::Comma) => None,
+                _ => Some(self.parse_ty()?),
+            },
+            None => None,
+        };
+
+        Ok(self.node_with_joined_span(EnumDefEntry { name, fields, ty }, name_span))
     }
 
     /// Parses an nominal definition type field, which could either be a named

--- a/compiler/hash-parser/src/parser/definitions.rs
+++ b/compiler/hash-parser/src/parser/definitions.rs
@@ -73,7 +73,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
         // Now try and parse a type if the next token permits it...
         let ty = match self.parse_token_fast(TokenKind::Colon) {
             Some(_) => match self.peek() {
-                Some(token) if matches!(token.kind, TokenKind::Eq | TokenKind::Comma) => None,
+                Some(token) if matches!(token.kind, TokenKind::Comma) => None,
                 _ => Some(self.parse_ty()?),
             },
             None => None,

--- a/compiler/hash-semantics/src/diagnostics/error.rs
+++ b/compiler/hash-semantics/src/diagnostics/error.rs
@@ -56,6 +56,8 @@ pub enum SemanticError {
     UnexpectedArguments { location: SourceLocation },
     /// Type error, forwarded from the typechecker.
     TypeError { error: TcError },
+    /// Type error, forwarded from the typechecker.
+    EnumTypeAnnotationMustBeOfDefiningType { location: SourceLocation },
     /// Given data definition is not a singleton.
     DataDefIsNotSingleton { location: SourceLocation },
     /// An entry point was not found in the entry module.
@@ -282,6 +284,16 @@ impl<'tc> WithSemEnv<'tc, &SemanticError> {
                 error
                     .add_span(*location)
                     .add_info("cannot use a module pattern yet. Instead, bind to a name and access members through `::`");
+            }
+            SemanticError::EnumTypeAnnotationMustBeOfDefiningType { location } => {
+                let error = reporter
+                    .error()
+                    .code(HashErrorCode::ValueCannotBeUsedAsType)
+                    .title("enum type annotation must be of the defining type");
+
+                error.add_span(*location).add_info(
+                    "cannot use this type annotation as it is not the defining type of the enum",
+                );
             }
         }
     }

--- a/compiler/hash-semantics/src/lib.rs
+++ b/compiler/hash-semantics/src/lib.rs
@@ -61,6 +61,9 @@ pub struct Flags {
 
     /// Monomorphise the generated TIR.
     pub mono_tir: bool,
+
+    /// The compiler stage to run to
+    pub run_to_stage: CompilerStageKind,
 }
 
 /// The [SemanticAnalysisCtx] represents all of the information that is required

--- a/compiler/hash-semantics/src/old/traverse/visitor.rs
+++ b/compiler/hash-semantics/src/old/traverse/visitor.rs
@@ -1111,7 +1111,7 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
                     self.eps_mut().set(fn_ty_term, kind)
                 };
 
-                // If the entry point was declared twice, then we 
+                // If the entry point was declared twice, then we
                 // return an error.
                 result.ok_or_else(|| {
                     TcError::MultipleEntryPoints {
@@ -1416,7 +1416,7 @@ impl<'tc> AstVisitor for TcVisitor<'tc> {
         &self,
         node: AstNodeRef<ast::EnumDefEntry>,
     ) -> Result<Self::EnumDefEntryRet, Self::Error> {
-        let walk::EnumDefEntry { name, fields } = walk::walk_enum_def_entry(self, node)?;
+        let walk::EnumDefEntry { name, fields, ty: _ } = walk::walk_enum_def_entry(self, node)?;
 
         // Create the enum variant parameters
         let fields = if fields.is_empty() {

--- a/compiler/hash-semantics/src/passes/discovery/visitor.rs
+++ b/compiler/hash-semantics/src/passes/discovery/visitor.rs
@@ -206,7 +206,8 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
         let enum_name = self.take_name_hint_or_create_internal_name();
 
         // Create a data definition for the enum
-        let enum_def_id = self.data_utils().create_enum_def(
+
+        let enum_def_id = self.data_utils().create_data_def(
             enum_name,
             self.create_hole_params(&node.ty_params),
             |_| {
@@ -216,6 +217,7 @@ impl<'tc> ast::AstVisitor for DiscoveryPass<'tc> {
                         (
                             self.new_symbol(variant.name.ident),
                             self.create_hole_params(&variant.fields),
+                            None,
                         )
                     })
                     .collect_vec()

--- a/compiler/hash-semantics/src/passes/evaluation/mod.rs
+++ b/compiler/hash-semantics/src/passes/evaluation/mod.rs
@@ -5,6 +5,7 @@
 
 use derive_more::Constructor;
 use hash_ast::ast::{self};
+use hash_pipeline::settings::CompilerStageKind;
 use hash_source::ModuleKind;
 use hash_tir::{
     environment::env::AccessToEnv, fns::FnCallTerm, terms::TermId, utils::common::CommonUtils,
@@ -54,7 +55,18 @@ impl EvaluationPass<'_> {
                         });
                         Ok(Some(call_term))
                     }
-                    None => Err(SemanticError::EntryPointNotFound),
+                    None => {
+                        // We only care about this error if we're running to
+                        // the evaluation stage, or if
+                        // we are continuing after lowering
+                        if self.flags().run_to_stage > CompilerStageKind::Lower
+                            || self.flags().eval_tir
+                        {
+                            Err(SemanticError::EntryPointNotFound)
+                        } else {
+                            Ok(None)
+                        }
+                    }
                 }
             }
         }

--- a/compiler/hash-semantics/src/passes/resolution/defs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/defs.rs
@@ -5,6 +5,7 @@
 
 use hash_ast::ast::{self, AstNodeRef};
 use hash_tir::{
+    data::DataDefCtors,
     directives::AppliedDirectives,
     environment::{context::ScopeKind, env::AccessToEnv},
     mods::{ModDefId, ModMemberValue},
@@ -73,12 +74,12 @@ impl<'tc> ResolutionPass<'tc> {
                     // Struct variant
                     let struct_ctor =
                         self.stores().data_def().map_fast(data_def_id, |def| match def.ctors {
-                            hash_tir::data::DataDefCtors::Defined(id) => {
+                            DataDefCtors::Defined(id) => {
                                 // There should only be one variant
                                 assert!(id.len() == 1);
                                 (id, 0)
                             },
-                            hash_tir::data::DataDefCtors::Primitive(_) => unreachable!() // No primitive user-defined structs
+                            DataDefCtors::Primitive(_) => unreachable!() // No primitive user-defined structs
                         });
 
                     self.scoping().enter_scope(
@@ -115,8 +116,8 @@ impl<'tc> ResolutionPass<'tc> {
                     // Enum variants
                     let data_def_ctors =
                         self.stores().data_def().map_fast(data_def_id, |def| match def.ctors {
-                            hash_tir::data::DataDefCtors::Defined(id) => id,
-                            hash_tir::data::DataDefCtors::Primitive(_) => unreachable!() // No primitive user-defined enums
+                            DataDefCtors::Defined(id) => id,
+                            DataDefCtors::Primitive(_) => unreachable!() // No primitive user-defined enums
                         });
                     assert!(data_def_ctors.len() == enum_def.entries.len());
 

--- a/compiler/hash-semantics/src/passes/resolution/exprs.rs
+++ b/compiler/hash-semantics/src/passes/resolution/exprs.rs
@@ -115,11 +115,6 @@ impl<'tc> ResolutionPass<'tc> {
         &self,
         node: AstNodeRef<ast::Expr>,
     ) -> SemanticResult<TermId> {
-        // Maybe it has already been made:
-        if let Some(term_id) = self.ast_info().terms().get_data_by_node(node.id()) {
-            return Ok(term_id);
-        }
-
         let term_id = match node.body {
             ast::Expr::Variable(variable_expr) => {
                 self.make_term_from_ast_variable_expr(node.with_body(variable_expr))?

--- a/compiler/hash-semantics/src/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/passes/resolution/scoping.rs
@@ -142,11 +142,9 @@ impl<'tc> Scoping<'tc> {
 
         // @@Todo: Ensure that we are in the correct context for the binding.
         // if self.context().get_current_scope_kind().is_constant() {
-        //     println!("{:?}", self.context().get_current_scope_kind());
         //     // If we are in a constant scope, we need to check that the binding
         //     // is also in a constant scope.
         //     if !self.context().get_binding(symbol).kind.is_constant() {
-        //         println!("{:?}", self.context().get_binding(symbol).kind);
         //         return Err(SemanticError::CannotUseNonConstantItem {
         //             location: self.source_location(span),
         //         });

--- a/compiler/hash-semantics/src/passes/resolution/scoping.rs
+++ b/compiler/hash-semantics/src/passes/resolution/scoping.rs
@@ -140,15 +140,18 @@ impl<'tc> Scoping<'tc> {
                 looking_in,
             })?;
 
-        if self.context().get_current_scope_kind().is_constant() {
-            // If we are in a constant scope, we need to check that the binding
-            // is also in a constant scope.
-            if !self.context().get_binding(symbol).kind.is_constant() {
-                return Err(SemanticError::CannotUseNonConstantItem {
-                    location: self.source_location(span),
-                });
-            }
-        }
+        // @@Todo: Ensure that we are in the correct context for the binding.
+        // if self.context().get_current_scope_kind().is_constant() {
+        //     println!("{:?}", self.context().get_current_scope_kind());
+        //     // If we are in a constant scope, we need to check that the binding
+        //     // is also in a constant scope.
+        //     if !self.context().get_binding(symbol).kind.is_constant() {
+        //         println!("{:?}", self.context().get_binding(symbol).kind);
+        //         return Err(SemanticError::CannotUseNonConstantItem {
+        //             location: self.source_location(span),
+        //         });
+        //     }
+        // }
 
         Ok(symbol)
     }

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -246,6 +246,7 @@ impl SemanticAnalysisCtxQuery for CompilerSession {
                 dump_tir: self.settings.semantic_settings.dump_tir,
                 eval_tir: self.settings.semantic_settings.eval_tir,
                 mono_tir: self.settings.semantic_settings.mono_tir,
+                run_to_stage: self.settings.stage,
             },
             target: self.settings.target(),
         }

--- a/compiler/hash-tir/src/tys.rs
+++ b/compiler/hash-tir/src/tys.rs
@@ -25,7 +25,7 @@ pub struct UniverseTy {
     /// the term `Universe(n)` itself.
     ///
     /// Root universe is Universe(0).
-    pub size: usize,
+    pub size: Option<usize>,
 }
 
 /// Represents a type in a Hash program.
@@ -68,8 +68,9 @@ pub struct TypeOfTerm {
 impl fmt::Display for &UniverseTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.size {
-            0 => write!(f, "Type"),
-            n => write!(f, "Type({n})"),
+            None => write!(f, "Type(*)"),
+            Some(0) => write!(f, "Type"),
+            Some(n) => write!(f, "Type({n})"),
         }
     }
 }

--- a/compiler/hash-tir/src/utils/context.rs
+++ b/compiler/hash-tir/src/utils/context.rs
@@ -294,16 +294,21 @@ impl<'env> ContextUtils<'env> {
     /// Add the given substitution to the context.
     pub fn add_sub_to_scope(&self, sub: &Sub) {
         for (name, value) in sub.iter() {
-            self.add_untyped_assignment(name, value);
+            match self.try_get_binding_ty(name) {
+                Some(ty) => {
+                    self.add_assignment(name, ty, value);
+                }
+                None => {
+                    self.add_untyped_assignment(name, value);
+                }
+            }
         }
     }
 
     /// Enter a scope with the given substitution.
     pub fn enter_sub_scope<M>(&self, sub: &Sub, f: impl FnOnce() -> M) -> M {
         self.context().enter_scope(ScopeKind::Sub, || {
-            for (name, value) in sub.iter() {
-                self.context_utils().add_untyped_assignment(name, value);
-            }
+            self.add_sub_to_scope(sub);
             f()
         })
     }

--- a/compiler/hash-tir/src/utils/context.rs
+++ b/compiler/hash-tir/src/utils/context.rs
@@ -67,6 +67,15 @@ impl<'env> ContextUtils<'env> {
         self.context().add_decl(name, Some(ty), Some(value));
     }
 
+    /// Modify the type of an assignment binding.
+    pub fn modify_typing(&self, name: Symbol, new_ty: TyId) {
+        let current_value = self.try_get_binding_value(name);
+        self.context().modify_binding(Binding {
+            name,
+            kind: BindingKind::Decl(Decl { name, ty: Some(new_ty), value: current_value }),
+        })
+    }
+
     /// Modify the value of an assignment binding.
     pub fn modify_assignment(&self, name: Symbol, new_value: TermId) {
         let current_ty = self.try_get_binding_ty(name);

--- a/compiler/hash-tir/src/utils/context.rs
+++ b/compiler/hash-tir/src/utils/context.rs
@@ -50,6 +50,14 @@ impl<'env> ContextUtils<'env> {
     }
 
     /// Add a typing binding to the closest stack scope.
+    pub fn add_assignment_to_closest_stack(&self, name: Symbol, ty: TyId, value: TermId) {
+        self.context().get_closest_stack_scope_ref().add_binding(Binding {
+            name,
+            kind: BindingKind::Decl(Decl { name, ty: Some(ty), value: Some(value) }),
+        })
+    }
+
+    /// Add a typing binding to the closest stack scope.
     pub fn add_typing_to_closest_stack(&self, name: Symbol, ty: TyId) {
         self.context().get_closest_stack_scope_ref().add_binding(Binding {
             name,

--- a/compiler/hash-tir/src/utils/params.rs
+++ b/compiler/hash-tir/src/utils/params.rs
@@ -91,6 +91,7 @@ impl<'env> ParamUtils<'env> {
 
     /// Instantiate the given parameters with holes for each argument.
     pub fn instantiate_params_as_holes(&self, params: ParamsId) -> ArgsId {
+        // @@Todo: locations
         self.create_args(
             params
                 .iter()

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -154,6 +154,9 @@ pub enum TcError {
     /// Invalid range pattern literal
     InvalidRangePatternLiteral { location: SourceLocation },
 
+    /// Invalid range pattern literal
+    TryingToReferenceLocalsInType { ty: TyId },
+
     /// Cannot use the given term in a type position.
     CannotUseInTyPos { location: LocationTarget, inferred_ty: TyId },
 
@@ -638,6 +641,15 @@ impl<'tc> TcErrorReporter<'tc> {
                 }
                 if let Some(location) = locations.get_location(target) {
                     error.add_labelled_span(location, "with this type");
+                }
+            }
+            TcError::TryingToReferenceLocalsInType { ty } => {
+                let error = reporter.error().code(HashErrorCode::DisallowedType).title(format!(
+                    "cannot use locals from this block in type `{}`",
+                    self.env().with(*ty)
+                ));
+                if let Some(location) = locations.get_location(ty) {
+                    error.add_labelled_span(location, "type containing locals");
                 }
             }
         }

--- a/compiler/hash-typecheck/src/errors.rs
+++ b/compiler/hash-typecheck/src/errors.rs
@@ -111,6 +111,9 @@ pub enum TcError {
     /// More type annotations are needed to infer the type of the given term.
     NeedMoreTypeAnnotationsToInfer { atom: Atom },
 
+    /// More type annotations are needed to infer the type of the given term.
+    NeedMoreTypeAnnotationsToUnify { src: Atom, target: Atom },
+
     /// The given arguments do not match the length of the target parameters.
     WrongArgLength { params_id: ParamsId, args_id: SomeParamsOrArgsId },
 
@@ -622,6 +625,19 @@ impl<'tc> TcErrorReporter<'tc> {
                         location,
                         format!("got {} {name_of_args} here", b.len()),
                     );
+                }
+            }
+            TcError::NeedMoreTypeAnnotationsToUnify { src, target } => {
+                let error = reporter.error().code(HashErrorCode::TypeMismatch).title(format!(
+                    "cannot unify `{}` with `{}`",
+                    self.env().with(*src),
+                    self.env().with(*target)
+                ));
+                if let Some(location) = locations.get_location(src) {
+                    error.add_labelled_span(location, "cannot unify this type");
+                }
+                if let Some(location) = locations.get_location(target) {
+                    error.add_labelled_span(location, "with this type");
                 }
             }
         }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -12,24 +12,23 @@ use hash_source::{
 };
 use hash_tir::{
     access::AccessTerm,
-    args::{ArgData, ArgsId, PatArgData, PatArgsId, PatOrCapture},
+    args::{ArgsId, PatArgsId, PatOrCapture},
     arrays::{ArrayPat, ArrayTerm, IndexTerm},
     atom_info::ItemInAtomInfo,
     casting::CastTerm,
-    control::{IfPat, LoopControlTerm, LoopTerm, MatchCase, MatchTerm, OrPat, ReturnTerm},
+    control::{IfPat, LoopControlTerm, LoopTerm, MatchTerm, OrPat, ReturnTerm},
     data::{
-        ArrayCtorInfo, CtorDefId, CtorPat, CtorTerm, DataDefCtors, DataDefId, DataTy,
-        PrimitiveCtorInfo,
+        CtorDef, CtorDefId, CtorPat, CtorTerm, DataDefCtors, DataDefId, DataTy, PrimitiveCtorInfo,
     },
     directives::DirectiveTarget,
     environment::{
-        context::{ParamOrigin, ScopeKind},
+        context::{BindingKind, ScopeKind},
         env::AccessToEnv,
     },
     fns::{FnBody, FnCallTerm, FnDefId, FnTy},
     lits::Lit,
     mods::{ModDefId, ModMemberId, ModMemberValue},
-    params::{Param, ParamData, ParamsId},
+    params::ParamsId,
     pats::{Pat, PatId, PatListId, RangePat, Spread},
     refs::{DerefTerm, RefTerm, RefTy},
     scopes::{AssignTerm, BlockTerm, DeclTerm},
@@ -38,16 +37,14 @@ use hash_tir::{
     term_as_variant,
     terms::{Term, TermId, TermListId, UnsafeTerm},
     tuples::{TuplePat, TupleTerm, TupleTy},
-    ty_as_variant,
     tys::{Ty, TyId, TypeOfTerm},
-    utils::{common::CommonUtils, AccessToUtils},
+    utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
 };
 use hash_utils::{
-    itertools::Itertools,
+    log::info,
     store::{CloneStore, PartialCloneStore, SequenceStore, SequenceStoreKey, Store},
 };
 
-use super::unification::Uni;
 use crate::{
     errors::{TcError, TcResult, WrongTermKind},
     normalisation::NormalisationMode,
@@ -97,69 +94,37 @@ pub struct InferenceOps<'a, T: AccessToTypechecking>(&'a T);
 impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// Infer the given generic arguments (specialised
     /// for args and pat args below).
-    pub fn infer_some_args<Arg: Clone>(
+    ///
+    /// Assumes that they are validated against one another
+    pub fn infer_some_args<U, Arg: Clone>(
         &self,
         args: impl Iterator<Item = Arg>,
         annotation_params: ParamsId,
-        mut infer_arg: impl FnMut(&Arg, &Param) -> TcResult<Inference<Arg, ParamData>>,
+        infer_arg: impl Fn(&Arg, TyId) -> TcResult<()>,
         get_arg_value: impl Fn(&Arg) -> Option<TermId>,
-    ) -> TcResult<InferenceWithSub<Vec<Arg>, ParamsId>> {
-        let mut collected_args = vec![];
-        let mut collected_params = vec![];
-
-        let mut error_state = self.new_error_state();
-
-        let mut push_param = |_i: usize, arg: Arg, param: &Param| {
-            // Infer the type of the argument
-            match error_state.try_or_add_error(infer_arg(&arg, param)) {
-                // Type was inferred
-                Some(Inference(inferred_arg, inferred_param)) => {
-                    // Extend the context with the new result
-                    if let Some(value) = get_arg_value(&inferred_arg) {
-                        self.context_utils().add_assignment(
-                            inferred_param.name,
-                            inferred_param.ty,
-                            value,
-                        );
-                    }
-
-                    collected_args.push(inferred_arg);
-                    collected_params.push(inferred_param);
-                }
-                // Error occurred
-                None => {
+        in_arg_scope: impl FnOnce() -> TcResult<U>,
+    ) -> TcResult<U> {
+        let (result, shadowed_sub) =
+            self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
+                for (arg, param_id) in args.zip(annotation_params.iter()) {
+                    let param = self.get_param(param_id);
+                    infer_arg(&arg, param.ty)?;
                     if let Some(value) = get_arg_value(&arg) {
                         self.context_utils().add_assignment(param.name, param.ty, value);
                     }
-
-                    // Add holes
-                    collected_args.push(arg);
-                    collected_params.push(ParamData {
-                        name: param.name,
-                        ty: param.ty,
-                        default: param.default,
-                    });
                 }
-            }
-        };
+                let result = in_arg_scope()?;
 
-        for (i, (arg, param)) in args.zip(annotation_params.iter()).enumerate() {
-            let param = self.stores().params().get_element(param);
-            push_param(i, arg, &param)
-        }
+                // Only keep the substitutions that do not refer to the parameters
+                let scope_sub = self.sub_ops().create_sub_from_current_scope();
+                let shadowed_sub =
+                    self.sub_ops().hide_param_binds(annotation_params.iter(), &scope_sub);
+                Ok((result, shadowed_sub))
+            })?;
 
-        let running_sub = self.sub_ops().create_sub_from_current_scope();
-
-        self.return_or_register_errors(
-            || {
-                Ok(InferenceWithSub {
-                    result: collected_args,
-                    annotation: self.param_utils().create_params(collected_params.into_iter()),
-                    sub: running_sub,
-                })
-            },
-            error_state,
-        )
+        // Add the shadowed substitutions to the ambient scope
+        self.uni_ops().add_unification_from_sub(&shadowed_sub);
+        Ok(result)
     }
 
     /// Infer the type of a sequence of terms which should all match.
@@ -167,36 +132,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         items: &[U],
         item_annotation_ty: TyId,
-        infer_item: impl Fn(U, TyId) -> TcResult<Inference<U, TyId>>,
-        sub_item: impl Fn(U, &Sub) -> U,
-    ) -> TcResult<Inference<Vec<U>, TyId>> {
-        let mut current_ty = item_annotation_ty;
-        let mut error_state = self.new_error_state();
-        let mut results = vec![];
-
+        infer_item: impl Fn(U, TyId) -> TcResult<()>,
+    ) -> TcResult<()> {
+        let _current_ty = item_annotation_ty;
         for &item in items {
-            match infer_item(item, item_annotation_ty) {
-                Ok(Inference(inferred_item, ty)) => {
-                    match self.uni_ops().unify_tys(ty, current_ty) {
-                        Ok(Uni { result, sub, .. }) => {
-                            // Unification succeeded
-                            current_ty = result;
-                            results.push(sub_item(inferred_item, &sub));
-                        }
-                        Err(err) => {
-                            error_state.add_error(err);
-                            results.push(inferred_item);
-                        }
-                    }
-                }
-                Err(err) => {
-                    error_state.add_error(err);
-                    results.push(item);
-                }
-            }
+            infer_item(item, item_annotation_ty)?;
         }
-
-        self.return_or_register_errors(|| Ok(Inference(results, current_ty)), error_state)
+        Ok(())
     }
 
     /// Infer the given term list as one type.
@@ -206,15 +148,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         term_list_id: TermListId,
         element_annotation_ty: TyId,
-    ) -> TcResult<Inference<TermListId, TyId>> {
+    ) -> TcResult<()> {
         let terms = self.stores().term_list().get_vec(term_list_id);
-        let Inference(inferred_term_vec, inferred_ty_id) = self.infer_unified_list(
-            &terms,
-            element_annotation_ty,
-            |term, ty| self.infer_term(term, ty),
-            |term, sub| self.sub_ops().apply_sub_to_term(term, sub),
-        )?;
-        Ok(Inference(self.new_term_list(inferred_term_vec), inferred_ty_id))
+        self.infer_unified_list(&terms, element_annotation_ty, |term, ty| {
+            self.infer_term(term, ty)?;
+            Ok(())
+        })?;
+        Ok(())
     }
 
     /// Infer the given pattern list as one type.
@@ -224,163 +164,128 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         pat_list_id: PatListId,
         element_annotation_ty: TyId,
-    ) -> TcResult<Inference<PatListId, TyId>> {
+    ) -> TcResult<()> {
         let pats = self.stores().pat_list().get_vec(pat_list_id);
-        let Inference(inferred_pat_vec, inferred_ty_id) = self.infer_unified_list(
-            &pats,
-            element_annotation_ty,
-            |pat, ty| match pat {
-                PatOrCapture::Pat(pat) => {
-                    let Inference(pat, ty) = self.infer_pat(pat, ty)?;
-                    Ok(Inference(PatOrCapture::Pat(pat), ty))
-                }
-                PatOrCapture::Capture => Ok(Inference(PatOrCapture::Capture, ty)),
-            },
-            |pat, sub| match pat {
-                PatOrCapture::Pat(pat) => {
-                    let pat = self.sub_ops().apply_sub_to_pat(pat, sub);
-                    PatOrCapture::Pat(pat)
-                }
-                PatOrCapture::Capture => PatOrCapture::Capture,
-            },
-        )?;
-        Ok(Inference(self.new_pat_list(inferred_pat_vec), inferred_ty_id))
+        self.infer_unified_list(&pats, element_annotation_ty, |pat, ty| match pat {
+            PatOrCapture::Pat(pat) => {
+                self.infer_pat(pat, ty)?;
+                Ok(())
+            }
+            PatOrCapture::Capture => Ok(()),
+        })?;
+        Ok(())
     }
 
     /// Infer the given arguments, producing inferred parameters.
-    pub fn infer_args(
+    pub fn infer_args<U>(
         &self,
         args: ArgsId,
         annotation_params: ParamsId,
-    ) -> TcResult<InferenceWithSub<ArgsId, ParamsId>> {
+        in_arg_scope: impl FnOnce() -> TcResult<U>,
+    ) -> TcResult<U> {
         self.register_new_atom(args, annotation_params);
-
         let reordered_args_id =
             self.param_ops().validate_and_reorder_args_against_params(args, annotation_params)?;
-        let reordered_args = self.stores().args().map_fast(reordered_args_id, |args| {
-            args.iter().copied().map_into().collect::<Vec<ArgData>>()
-        });
 
-        let inference = self.infer_some_args(
-            reordered_args.iter().copied(),
+        let result = self.infer_some_args(
+            reordered_args_id.iter(),
             annotation_params,
-            |arg, param| {
-                let Inference(term, ty) = self.infer_term(arg.value, param.ty)?;
-                Ok(Inference(
-                    ArgData { target: arg.target, value: term },
-                    ParamData { name: param.name, ty, default: param.default },
-                ))
+            |arg, param_ty| {
+                let arg = self.get_arg(*arg);
+                self.infer_term(arg.value, param_ty)?;
+                Ok(())
             },
-            |arg| Some(arg.value),
+            |arg| {
+                let arg = self.get_arg(*arg);
+                Some(arg.value)
+            },
+            in_arg_scope,
         )?;
 
-        let inferred_args_id = self.param_utils().create_args(inference.result.into_iter());
-
-        self.register_atom_inference_indexed(args, inferred_args_id, inference.annotation);
-        Ok(InferenceWithSub {
-            sub: inference.sub,
-            result: inferred_args_id,
-            annotation: inference.annotation,
-        })
+        Ok(result)
     }
 
     /// Infer the given pattern arguments, producing inferred parameters.
-    pub fn infer_pat_args(
+    pub fn infer_pat_args<U>(
         &self,
         pat_args: PatArgsId,
         spread: Option<Spread>,
         annotation_params: ParamsId,
-    ) -> TcResult<InferenceWithSub<PatArgsId, ParamsId>> {
+        in_arg_scope: impl FnOnce() -> TcResult<U>,
+    ) -> TcResult<U> {
         self.register_new_atom(pat_args, annotation_params);
-
-        self.param_ops().validate_and_reorder_pat_args_against_params(
+        let reordered_pat_args_id = self.param_ops().validate_and_reorder_pat_args_against_params(
             pat_args,
             spread,
             annotation_params,
         )?;
-        let pat_args_data = self.stores().pat_args().map(pat_args, |pat_args| {
-            pat_args
-                .iter()
-                .map(|pat_arg| PatArgData { target: pat_arg.target, pat: pat_arg.pat })
-                .collect_vec()
-        });
 
-        let inference = self.infer_some_args(
-            pat_args_data.iter().copied(),
+        self.infer_some_args(
+            reordered_pat_args_id.iter(),
             annotation_params,
-            |pat_arg, param| match pat_arg.pat {
-                PatOrCapture::Pat(pat) => {
-                    let Inference(pat, ty) = self.infer_pat(pat, param.ty)?;
-                    Ok(Inference(
-                        PatArgData {
-                            target: self.get_param_index(param.id),
-
-                            pat: PatOrCapture::Pat(pat),
-                        },
-                        ParamData { name: param.name, ty, default: param.default },
-                    ))
+            |pat_arg, param_ty| {
+                let pat_arg = self.get_pat_arg(*pat_arg);
+                match pat_arg.pat {
+                    PatOrCapture::Pat(pat) => {
+                        self.infer_pat(pat, param_ty)?;
+                        Ok(())
+                    }
+                    PatOrCapture::Capture => Ok(()),
                 }
-                PatOrCapture::Capture => Ok(Inference(
-                    PatArgData {
-                        target: self.get_param_index(param.id),
-                        pat: PatOrCapture::Capture,
-                    },
-                    (*param).into(),
-                )),
             },
             |_| None,
-        )?;
-
-        let inferred_pat_args_id = self.param_utils().create_pat_args(inference.result.into_iter());
-
-        // @@Fix: add back spread to inferred pat args
-        self.register_atom_inference_indexed(pat_args, inferred_pat_args_id, inference.annotation);
-        Ok(InferenceWithSub {
-            sub: inference.sub,
-            result: inferred_pat_args_id,
-            annotation: inference.annotation,
-        })
+            in_arg_scope,
+        )
     }
 
     /// Infer the given parameters.
-    ///
-    /// This modifies the parameters in-place.
-    pub fn infer_params(&self, params: ParamsId, _origin: ParamOrigin) -> TcResult<ParamsId> {
+    pub fn infer_params<U>(
+        &self,
+        params: ParamsId,
+        in_param_scope: impl FnOnce() -> TcResult<U>,
+    ) -> TcResult<U> {
         // Validate the parameters
         self.param_ops().validate_params(params)?;
-        let mut error_state = self.new_error_state();
 
-        for param_id in params.iter() {
-            let param = self.stores().params().get_element(param_id);
-            if let Some(Inference(ty, _)) =
-                error_state.try_or_add_error(self.infer_ty(param.ty, self.new_ty_hole()))
-            {
-                self.stores().params().modify_fast(param_id.0, |params| params[param_id.1].ty = ty);
-            }
-            self.context_utils().add_param_binding(param_id);
-        }
+        let (result, shadowed_sub) =
+            self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
+                for param_id in params.iter() {
+                    let param = self.get_param(param_id);
+                    self.infer_ty(param.ty, self.new_ty_hole())?;
+                    self.context_utils().add_typing(param.name, param.ty);
+                }
 
-        self.return_or_register_errors(|| Ok(params), error_state)
+                let result = in_param_scope()?;
+
+                // Only keep the substitutions that do not refer to the parameters
+                let scope_sub = self.sub_ops().create_sub_from_current_scope();
+                let shadowed_sub = self.sub_ops().hide_param_binds(params.iter(), &scope_sub);
+                Ok((result, shadowed_sub))
+            })?;
+
+        // Add the shadowed substitutions to the ambient scope
+        self.uni_ops().add_unification_from_sub(&shadowed_sub);
+        Ok(result)
     }
 
     /// Given an inferred type, and an optional annotation type, unify the two,
     /// and if the result is successful then apply the substitution to the
     /// annotation type and return it (or to the inferred type if the annotation
     /// type is not given).
-    pub fn check_by_unify(&self, inferred_ty: TyId, annotation_ty: TyId) -> TcResult<TyId> {
-        let Uni { result, .. } = self.uni_ops().unify_tys(inferred_ty, annotation_ty)?;
-        Ok(result)
+    pub fn check_by_unify(&self, inferred_ty: TyId, annotation_ty: TyId) -> TcResult<()> {
+        self.uni_ops().unify_tys(inferred_ty, annotation_ty)
     }
 
     /// Check that the given type is well-formed, and normalise it.
-    pub fn normalise_and_check_ty(&self, ty: TyId) -> TcResult<TyId> {
+    pub fn normalise_and_check_ty(&self, ty: TyId) -> TcResult<()> {
         match self.get_ty(ty) {
-            Ty::Hole(_) => Ok(ty),
+            Ty::Hole(_) => Ok(()),
             _ => {
-                let Inference(checked_ty, _) = self.infer_ty(ty, self.new_ty_hole())?;
+                let ty_of_ty = self.new_ty_hole_of_ty(ty);
+                self.infer_ty(ty, ty_of_ty)?;
                 let norm = self.norm_ops();
-                let reduced_ty = norm.to_ty(norm.normalise(checked_ty.into())?);
-                Ok(reduced_ty)
+                norm.normalise_in_place(ty.into())?;
+                Ok(())
             }
         }
     }
@@ -391,29 +296,26 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         term: &TupleTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<TupleTerm, TupleTy>> {
-        let reduced_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let params = match self.get_ty(reduced_ty) {
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let params = match self.get_ty(annotation_ty) {
             Ty::Tuple(tuple_ty) => tuple_ty.data,
             Ty::Hole(_) => self.param_utils().create_hole_params_from_args(term.data),
             _ => {
                 let inferred = self.param_utils().create_hole_params_from_args(term.data);
                 return Err(TcError::MismatchingTypes {
-                    expected: reduced_ty,
+                    expected: annotation_ty,
                     actual: self.new_ty(TupleTy { data: inferred }),
                     inferred_from: Some(original_term_id.into()),
                 });
             }
         };
+        self.infer_args(term.data, params, || Ok(()))?;
 
-        let InferenceWithSub { result: inferred_args, annotation: inferred_params, sub: _ } = self
-            .context()
-            .enter_scope(ScopeKind::TupleTy(TupleTy { data: params }), || -> TcResult<_> {
-                let args = self.infer_args(term.data, params)?;
-                Ok(args)
-            })?;
-
-        Ok(Inference(TupleTerm { data: inferred_args }, TupleTy { data: inferred_params }))
+        let tuple_ty =
+            self.new_expected_ty_of(original_term_id, self.new_ty(TupleTy { data: params }));
+        self.check_by_unify(tuple_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Potentially adjust the underlying constant of a literal after its type
@@ -452,7 +354,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     }
 
     /// Infer the type of a literal.
-    pub fn infer_lit(&self, lit: &Lit, annotation_ty: TyId) -> TcResult<Inference<Lit, TyId>> {
+    pub fn infer_lit(&self, lit: &Lit, annotation_ty: TyId) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
         let inferred_ty = self.new_data_ty(match lit {
             Lit::Int(int_lit) => {
                 match int_lit.underlying.kind {
@@ -477,9 +380,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                         },
                     },
                     _ => {
-                        let normalised_annotation_ty =
-                            self.normalise_and_check_ty(annotation_ty)?;
-                        (match self.get_ty(normalised_annotation_ty) {
+                        (match self.get_ty(annotation_ty) {
                             Ty::Data(data_ty) => match self.get_data_def(data_ty.data_def).ctors {
                                 DataDefCtors::Primitive(primitive_ctors) => match primitive_ctors {
                                     PrimitiveCtorInfo::Numeric(numeric) => {
@@ -513,8 +414,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     FloatTy::F64 => self.primitives().f64(),
                 },
                 FloatLitKind::Unsuffixed => {
-                    let normalised_annotation_ty = self.normalise_and_check_ty(annotation_ty)?;
-                    (match self.get_ty(normalised_annotation_ty) {
+                    (match self.get_ty(annotation_ty) {
                         Ty::Data(data_ty) => match self.get_data_def(data_ty.data_def).ctors {
                             DataDefCtors::Primitive(primitive_ctors) => match primitive_ctors {
                                 PrimitiveCtorInfo::Numeric(numeric) => {
@@ -538,9 +438,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             },
         });
 
-        let inferred_ty = self.check_by_unify(inferred_ty, annotation_ty)?;
+        self.check_by_unify(inferred_ty, annotation_ty)?;
         self.adjust_lit_repr(lit, inferred_ty)?;
-        Ok(Inference(*lit, inferred_ty))
+        Ok(())
     }
 
     /// Infer the type of a primitive term.
@@ -549,9 +449,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         array_term: &ArrayTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<ArrayTerm, TyId>> {
-        let normalised_ty = self.normalise_and_check_ty(annotation_ty)?;
-
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
         let mismatch = || {
             Err(TcError::MismatchingTypes {
                 expected: annotation_ty,
@@ -565,7 +464,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             })
         };
 
-        let (list_annotation_inner_ty, list_len) = match self.get_ty(normalised_ty) {
+        let (list_annotation_inner_ty, list_len) = match self.get_ty(annotation_ty) {
             Ty::Data(data) => {
                 let data_def = self.get_data_def(data.data_def);
 
@@ -573,20 +472,14 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     DataDefCtors::Primitive(primitive) => {
                         if let PrimitiveCtorInfo::Array(array_prim) = primitive {
                             // First infer the data arguments
-                            let InferenceWithSub {
-                                result: _inferred_data_args,
-                                annotation: _inferred_data_params,
-                                sub,
-                            } = self.infer_args(data.args, data_def.params)?;
-
-                            self.context().enter_scope(data_def.id.into(), || {
+                            let copied_params = self.sub_ops().copy_params(data_def.params);
+                            self.infer_args(data.args, copied_params, || {
+                                let sub = self.sub_ops().create_sub_from_current_scope();
                                 let subbed_element_ty =
                                     self.sub_ops().apply_sub_to_ty(array_prim.element_ty, &sub);
-
                                 let subbed_index = array_prim
                                     .length
                                     .map(|l| self.sub_ops().apply_sub_to_term(l, &sub));
-
                                 Ok((subbed_element_ty, subbed_index))
                             })
                         } else {
@@ -600,12 +493,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             _ => mismatch(),
         }?;
 
-        let Inference(inferred_list, inferred_list_inner_ty) =
-            self.infer_unified_term_list(array_term.elements, list_annotation_inner_ty)?;
+        self.infer_unified_term_list(array_term.elements, list_annotation_inner_ty)?;
 
         // Ensure the array lengths match if given
         if let Some(len) = list_len {
-            let inferred_len_term = self.create_term_from_integer_lit(inferred_list.len());
+            let inferred_len_term = self.create_term_from_integer_lit(array_term.elements.len());
             if !self.uni_ops().terms_are_equal(len, inferred_len_term) {
                 return Err(TcError::MismatchingArrayLengths {
                     expected_len: len,
@@ -614,25 +506,76 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
         }
 
-        // Unify the inner annotation type with the inferred type
-        let inner_ty_uni =
-            self.uni_ops().unify_tys(inferred_list_inner_ty, list_annotation_inner_ty)?;
-
         // Either create a default list type or apply the substitution to the annotation
         // type
-        let list_ty = match self.get_ty(normalised_ty) {
-            Ty::Hole(_) => {
-                let list_ty = self.new_ty(DataTy {
+        if let Ty::Hole(_) = self.get_ty(annotation_ty) {
+            self.check_by_unify(
+                self.new_ty(DataTy {
                     data_def: self.primitives().list(),
-                    args: self.new_args(&[self.new_term(inner_ty_uni.result)]),
-                });
-
-                self.uni_ops().unify_tys(normalised_ty, list_ty)?.result
-            }
-            _ => self.sub_ops().apply_sub_to_ty(normalised_ty, &inner_ty_uni.sub),
+                    args: self.new_args(&[self.new_term(list_annotation_inner_ty)]),
+                }),
+                annotation_ty,
+            )?
         };
 
-        Ok(Inference(ArrayTerm { elements: inferred_list }, list_ty))
+        Ok(())
+    }
+
+    /// Infer a constructor, either a pattern or a term.
+    ///
+    /// This also infers the data arguments of the constructor.
+    pub fn infer_some_ctor(
+        &self,
+        ctor_def_id: CtorDefId,
+        data_args: ArgsId,
+        annotation_ty: TyId,
+        original: impl Into<Atom>,
+        infer_ctor_and_get_data_args: impl FnOnce(&CtorDef) -> TcResult<ArgsId>,
+    ) -> TcResult<()> {
+        let original_atom = original.into();
+        self.normalise_and_check_ty(annotation_ty)?;
+
+        let ctor = self.get_ctor_def(ctor_def_id);
+        let data_def = self.get_data_def(ctor.data_def_id);
+
+        let annotation_data_ty = match self.get_ty(annotation_ty) {
+            Ty::Data(data) if data.data_def == ctor.data_def_id => Some(data),
+            Ty::Hole(_) => None,
+            _ => {
+                return Err(TcError::MismatchingTypes {
+                    expected: annotation_ty,
+                    actual: self.new_ty(DataTy { args: data_args, data_def: ctor.data_def_id }),
+                    inferred_from: Some(original_atom.into()),
+                });
+            }
+        };
+
+        let term_data_args = if data_args.len() == 0 {
+            match annotation_data_ty {
+                Some(t) => t.args,
+                None => self.param_utils().instantiate_params_as_holes(data_def.params),
+            }
+        } else {
+            data_args
+        };
+
+        let annotation_data_ty =
+            annotation_data_ty.unwrap_or(DataTy { args: term_data_args, data_def: data_def.id });
+
+        self.uni_ops().unify_args(term_data_args, annotation_data_ty.args)?;
+
+        let copied_params = self.sub_ops().copy_params(data_def.params);
+        let result_data_args = self.infer_args(term_data_args, copied_params, || {
+            let _data_sub = self.sub_ops().create_sub_from_current_scope();
+            infer_ctor_and_get_data_args(&ctor)
+        })?;
+
+        self.uni_ops().unify_args(term_data_args, result_data_args)?;
+
+        let expected_data_ty =
+            self.new_expected_ty_of(original_atom, self.new_ty(annotation_data_ty));
+        self.check_by_unify(expected_data_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer a constructor term.
@@ -641,77 +584,25 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         term: &CtorTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<CtorTerm, DataTy>> {
-        let ctor = self.stores().ctor_defs().map_fast(term.ctor.0, |defs| defs[term.ctor.1]);
-        let data_def = self.get_data_def(ctor.data_def_id);
-
-        let norm = self.norm_ops();
-        let reduced_ty = norm.to_ty(norm.normalise(annotation_ty.into())?);
-
-        let annotation_data_ty = match self.get_ty(reduced_ty) {
-            Ty::Data(data) if data.data_def == ctor.data_def_id => Some(data),
-            Ty::Hole(_) => None,
-            _ => {
-                return Err(TcError::MismatchingTypes {
-                    expected: annotation_ty,
-                    actual: self
-                        .new_ty(DataTy { args: term.data_args, data_def: ctor.data_def_id }),
-                    inferred_from: Some(original_term_id.into()),
-                });
-            }
-        };
-
-        let term_data_args = if term.data_args.len() == 0 {
-            match annotation_data_ty {
-                Some(t) => t.args,
-                None => self.param_utils().instantiate_params_as_holes(data_def.params),
-            }
-        } else {
-            term.data_args
-        };
-
-        let annotation_data_ty =
-            annotation_data_ty.unwrap_or(DataTy { args: term_data_args, data_def: data_def.id });
-
-        self.context().enter_scope(ctor.id.into(), || {
-            let _ = self.uni_ops().unify_args(term_data_args, annotation_data_ty.args)?;
-
-            // First infer the data arguments
-            let InferenceWithSub {
-                result: _inferred_data_args,
-                annotation: _inferred_data_params,
-                sub: _data_sub,
-            } = self.infer_args(term_data_args, data_def.params)?;
-
-            // Infer the constructor arguments
-            let InferenceWithSub {
-                result: inferred_ctor_args,
-                annotation: _inferred_ctor_params,
-                sub: _ctor_sub,
-            } = self.infer_args(term.ctor_args, ctor.params)?;
-
-            let sub = self.sub_ops().create_sub_from_current_scope();
-
-            let result_data_args = self.sub_ops().apply_sub_to_args(ctor.result_args, &sub);
-            let result_ctor_args = self.sub_ops().apply_sub_to_args(inferred_ctor_args, &sub);
-
-            // Evaluate the result args.
-            Ok(Inference(
-                CtorTerm {
-                    ctor: ctor.id,
-                    data_args: result_data_args,
-                    ctor_args: result_ctor_args,
-                },
-                DataTy { args: result_data_args, data_def: data_def.id },
-            ))
-            // })
+    ) -> TcResult<()> {
+        self.infer_some_ctor(term.ctor, term.data_args, annotation_ty, original_term_id, |ctor| {
+            let data_sub = self.sub_ops().create_sub_from_current_scope();
+            let copied_params = self.sub_ops().copy_params(ctor.params);
+            self.infer_args(term.ctor_args, copied_params, || {
+                let ctor_sub = self.sub_ops().create_sub_from_current_scope();
+                let result_data_args = self.sub_ops().apply_sub_to_args(
+                    self.sub_ops().apply_sub_to_args(ctor.result_args, &data_sub),
+                    &ctor_sub,
+                );
+                Ok(result_data_args)
+            })
         })
     }
 
     /// Potentially run an expression at compile-time.
     ///
     /// This is only done if the expression has a `#run` annotation.
-    pub fn potentially_run_expr(&self, expr: TermId) -> TcResult<TermId> {
+    pub fn potentially_run_expr(&self, expr: TermId, term_ty: TyId) -> TcResult<()> {
         if self.should_monomorphise() {
             let has_run_directive = self
                 .stores()
@@ -722,12 +613,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             if has_run_directive {
                 let norm_ops = self.norm_ops();
                 norm_ops.with_mode(NormalisationMode::Full { eval_impure_fns: true });
-                let result = norm_ops.to_term(norm_ops.normalise(expr.into())?);
-                return Ok(result);
+                norm_ops.normalise_in_place(expr.into())?;
+                self.infer_term(expr, term_ty)?;
             }
         }
-
-        Ok(expr)
+        Ok(())
     }
 
     /// Potentially monomorphise a function call, if it is pure.
@@ -735,15 +625,15 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         fn_call: TermId,
         fn_ty: FnTy,
-    ) -> TcResult<TermId> {
+        fn_call_result_ty: TyId,
+    ) -> TcResult<()> {
         if self.should_monomorphise() && fn_ty.pure {
             let norm_ops = self.norm_ops();
             norm_ops.with_mode(NormalisationMode::Full { eval_impure_fns: true });
-            let result = norm_ops.to_term(norm_ops.normalise(fn_call.into())?);
-            Ok(result)
-        } else {
-            Ok(fn_call)
+            norm_ops.normalise_in_place(fn_call.into())?;
+            self.infer_term(fn_call, fn_call_result_ty)?;
         }
+        Ok(())
     }
 
     /// Infer the type of a function call.
@@ -752,109 +642,52 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         fn_call_term: &FnCallTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<TermId, TyId>> {
-        let Inference(subject_term, subject_ty) =
-            self.infer_term(fn_call_term.subject, self.new_ty_hole())?;
-        let normalised_subject_ty = self.normalise_and_check_ty(subject_ty)?;
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let inferred_subject_ty = self.new_ty_hole_of(fn_call_term.subject);
+        self.infer_term(fn_call_term.subject, inferred_subject_ty)?;
 
-        match self.get_ty(normalised_subject_ty) {
-            Ty::Ref(_) => {
-                // Try the same thing, but with the dereferenced type.
-                let new_subject = self.new_term(Term::Deref(DerefTerm { subject: subject_term }));
-                self.infer_fn_call_term(
-                    &FnCallTerm { subject: new_subject, ..*fn_call_term },
-                    annotation_ty,
-                    original_term_id,
-                )
-            }
+        match self.get_ty(inferred_subject_ty) {
             Ty::Fn(fn_ty) => {
-                let infer = || {
-                    let (inferred_fn_call_args, return_ty, sub) =
-                        self.context().enter_scope(ScopeKind::FnTy(fn_ty), || {
-                            if fn_ty.implicit != fn_call_term.implicit {
-                                return Err(TcError::WrongCallKind {
-                                    site: original_term_id,
-                                    expected_implicit: fn_ty.implicit,
-                                    actual_implicit: fn_call_term.implicit,
-                                });
-                            }
-
-                            // First infer the arguments parameters of the function call.
-                            let InferenceWithSub {
-                                result: inferred_fn_call_args,
-                                annotation: _,
-                                sub: _,
-                            } = self.infer_args(fn_call_term.args, fn_ty.params)?;
-                            let return_ty = self.normalise_and_check_ty(fn_ty.return_ty)?;
-                            let _ = self.uni_ops().unify_tys(return_ty, annotation_ty)?;
-
-                            let sub = self.sub_ops().create_sub_from_current_scope();
-                            Ok((inferred_fn_call_args, return_ty, sub))
-                        })?;
-
-                    let subbed_return_ty = self.sub_ops().apply_sub_to_ty(return_ty, &sub);
-
-                    let subbed_subject_ty = self.sub_ops().apply_sub_to_ty(subject_ty, &sub);
-
-                    let shadowed_sub = self.sub_ops().hide_param_binds(fn_ty.params.iter(), &sub);
-                    let subbed_subject_term =
-                        self.sub_ops().apply_sub_to_term(subject_term, &shadowed_sub);
-
-                    self.register_atom_inference(
-                        fn_call_term.subject,
-                        subbed_subject_term,
-                        subbed_subject_ty,
-                    );
-
-                    let resulting_fn_call = self.new_term(FnCallTerm {
-                        subject: subbed_subject_term,
-                        args: inferred_fn_call_args,
-                        implicit: fn_call_term.implicit,
-                    });
-                    self.register_atom_inference(
-                        original_term_id,
-                        resulting_fn_call,
-                        subbed_return_ty,
-                    );
-
-                    let monomorphised =
-                        self.potentially_monomorphise_fn_call(resulting_fn_call, fn_ty)?;
-                    self.register_atom_inference(original_term_id, monomorphised, subbed_return_ty);
-
-                    Ok(Inference(monomorphised, subbed_return_ty))
-                };
-
                 // Potentially fill-in implicit args
-                match self.get_ty(fn_ty.return_ty) {
-                    Ty::Fn(_) if fn_ty.implicit => infer().or_else(|_| {
-                        let applied_args =
-                            self.param_utils().instantiate_params_as_holes(fn_ty.params);
-
-                        let new_subject = FnCallTerm {
-                            subject: self.new_term(FnCallTerm {
-                                args: applied_args,
-                                subject: subject_term,
-                                implicit: fn_ty.implicit,
-                            }),
-                            args: fn_call_term.args,
-                            implicit: fn_call_term.implicit,
-                        };
-
-                        self.infer_fn_call_term(&new_subject, annotation_ty, original_term_id)
-                    }),
-                    _ => infer(),
+                if let Ty::Fn(_) = self.get_ty(fn_ty.return_ty) && fn_ty.implicit && !fn_call_term.implicit {
+                    let applied_args = self.param_utils().instantiate_params_as_holes(fn_ty.params);
+                    let new_subject = FnCallTerm {
+                        subject: self.new_term(FnCallTerm {
+                            args: applied_args,
+                            subject: fn_call_term.subject,
+                            implicit: fn_ty.implicit,
+                        }),
+                        args: fn_call_term.args,
+                        implicit: fn_call_term.implicit,
+                    };
+                    return self.infer_fn_call_term(&new_subject, annotation_ty, original_term_id);
                 }
+
+                // Check that the function call is of the correct kind.
+                if fn_ty.implicit != fn_call_term.implicit {
+                    return Err(TcError::WrongCallKind {
+                        site: original_term_id,
+                        expected_implicit: fn_ty.implicit,
+                        actual_implicit: fn_call_term.implicit,
+                    });
+                }
+
+                let copied_params = self.sub_ops().copy_params(fn_ty.params);
+                let return_ty = self.infer_args(fn_call_term.args, copied_params, || {
+                    let sub = self.sub_ops().create_sub_from_current_scope();
+                    Ok(self.sub_ops().apply_sub_to_ty(fn_ty.return_ty, &sub))
+                })?;
+                self.check_by_unify(return_ty, annotation_ty)?;
+                self.potentially_monomorphise_fn_call(original_term_id, fn_ty, annotation_ty)?;
+
+                Ok(())
             }
-            Ty::Hole(_)
-            | Ty::Eval(_)
-            | Ty::Universe(_)
-            | Ty::Data(_)
-            | Ty::Tuple(_)
-            | Ty::Var(_) => {
+            _ => {
                 // Not a function type.
                 Err(TcError::WrongTy {
                     kind: WrongTermKind::NotAFunction,
-                    inferred_term_ty: subject_ty,
+                    inferred_term_ty: inferred_subject_ty,
                     term: original_term_id,
                 })
             }
@@ -899,7 +732,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 args: self.new_empty_args(),
             });
 
-            let _ = self.infer_term(call_term, self.new_ty_hole())?;
+            self.infer_term(call_term, self.new_ty_hole())?;
 
             // If successful, flag it as an entry point.
             self.entry_point().set(fn_def_id, entry_point);
@@ -913,35 +746,14 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         fn_def_id: FnDefId,
         annotation_ty: TyId,
-        original_fn_term: TermId,
-        original_annotation_ty: TyId,
     ) -> TcResult<FnTy> {
-        let annotation_ty = self.normalise_and_check_ty(annotation_ty)?;
-
+        self.normalise_and_check_ty(annotation_ty)?;
         let fn_def = self.stores().fn_def().get(fn_def_id);
-        let annotation_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let annotation_fn_ty = match self.get_ty(annotation_ty) {
-            Ty::Fn(annotation_fn_ty) => {
-                self.uni_ops()
-                    .with_no_ctx()
-                    .unify_fn_tys(
-                        fn_def.ty,
-                        annotation_fn_ty,
-                        original_annotation_ty,
-                        annotation_ty, // @@Todo
-                    )?
-                    .result
-            }
-            Ty::Hole(_) => fn_def.ty,
-            _ => {
-                return Err(TcError::WrongTy {
-                    kind: WrongTermKind::NotAFunction,
-                    inferred_term_ty: self.new_ty(fn_def.ty),
-                    term: original_fn_term,
-                })
-            }
-        };
-        Ok(annotation_fn_ty)
+        let fn_ty = self.new_ty(fn_def.ty);
+        self.normalise_and_check_ty(fn_ty)?;
+
+        self.uni_ops().unify_tys(fn_ty, annotation_ty)?;
+        Ok(fn_def.ty)
     }
 
     /// Infer the type of a function definition.
@@ -954,135 +766,84 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         annotation_ty: TyId,
         original_term_id: TermId,
         fn_mode: FnInferMode,
-    ) -> TcResult<Inference<FnDefId, FnTy>> {
-        // Already inferred
-        if let Some(inferred_fn_def_id) = self.try_get_inferred_value(fn_def_id) {
-            return Ok(Inference(inferred_fn_def_id, self.get_inferred_ty(inferred_fn_def_id)));
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        if let Some(fn_ty) = self.try_get_inferred_ty(fn_def_id) {
+            let expected = self.new_expected_ty_of(original_term_id, self.new_ty(fn_ty));
+            self.check_by_unify(expected, annotation_ty)?;
+            return Ok(());
         }
 
-        let fn_def = self.stores().fn_def().get(fn_def_id);
+        let fn_def = self.get_fn_def(fn_def_id);
+        let annotation_fn_ty = self.infer_fn_annotation_ty(fn_def_id, annotation_ty)?;
 
-        // Atom is already registered but not inferred, it means we are in a
-        // recursive call.
-        if self.atom_is_registered(fn_def_id) && fn_mode == FnInferMode::Body {
-            return Ok(Inference(fn_def_id, fn_def.ty));
+        if fn_mode == FnInferMode::Header {
+            // If we are only inferring the header, then also want to check for
+            // immediate body functions.
+            if let FnBody::Defined(fn_body) = fn_def.body {
+                if let Term::FnRef(immediate_body_fn) = self.get_term(fn_body) {
+                    self.context().enter_scope(ScopeKind::Fn(fn_def_id), || {
+                        self.context_utils().add_param_bindings(fn_def.ty.params);
+                        self.infer_fn_def(
+                            immediate_body_fn,
+                            self.new_ty_hole_of(fn_body),
+                            fn_body,
+                            FnInferMode::Header,
+                        )
+                    })?;
+                }
+            }
+            return Ok(());
         }
 
-        if fn_mode == FnInferMode::Body {
-            self.register_new_atom(fn_def_id, fn_def.ty);
+        if self.atom_is_registered(fn_def_id) {
+            // Recursive call
+            return Ok(());
         }
 
-        // Infer the annotation type of the function.
-        let annotation_fn_ty =
-            self.infer_fn_annotation_ty(fn_def_id, annotation_ty, original_term_id, annotation_ty)?;
+        self.register_new_atom(fn_def_id, annotation_fn_ty);
 
         match fn_def.body {
             FnBody::Defined(fn_body) => {
                 self.context().enter_scope(ScopeKind::Fn(fn_def_id), || {
-                    let fn_def = self.stores().fn_def().get(fn_def_id);
-
-                    // Ensure the modalities match if the annotation is given.
-                    if !self.uni_ops().fn_modalities_match(annotation_fn_ty, fn_def.ty) {
-                        return Err(TcError::MismatchingTypes {
-                            expected: self.new_ty(annotation_fn_ty),
-                            actual: self.new_ty(fn_def.ty),
-                            inferred_from: Some(original_term_id.into()),
-                        });
-                    }
-
-                    // Ensure that the parameters match
-                    let inferred_params_result = self.uni_ops().unify_params(
-                        annotation_fn_ty.params,
-                        fn_def.ty.params,
-                        ParamOrigin::Fn(fn_def_id),
-                    )?;
-
-                    // Helper to infer the given body with the given annotation,
-                    // with special handling for the first pass.
-                    //
-                    // In the first pass, we just infer the function type (and potential curried
-                    // functions). In the second pass, we infer the body too.
-                    let infer_body_if_not_first_pass = |body: TermId, ty: TyId| match fn_mode {
-                        FnInferMode::Header => match self.get_term(body) {
-                            Term::FnRef(immediate_body_fn) => self
-                                .infer_fn_def(
-                                    immediate_body_fn,
-                                    annotation_ty,
-                                    body,
-                                    FnInferMode::Header,
-                                )
-                                .map(|i| self.generalise_term_and_ty_inference(i)),
-                            _ => Ok(Inference(body, ty)),
-                        },
-                        _ => {
-                            let inferred_body = self.infer_term(body, ty)?;
-
-                            // Inferring the body might re-set the function type, so we need to
-                            // re-get it.
-                            let return_ty_set_from_return_statement =
-                                self.get_fn_def(fn_def_id).ty.return_ty;
-
-                            Ok(Inference(
-                                inferred_body.0,
-                                self.check_by_unify(
-                                    inferred_body.1,
-                                    return_ty_set_from_return_statement,
-                                )?,
-                            ))
-                        }
-                    };
-
-                    // Ensure that the return types match
-                    let subbed_annotation_ty = self
-                        .sub_ops()
-                        .apply_sub_to_ty(annotation_fn_ty.return_ty, &inferred_params_result.sub);
-                    let unified_return_ty =
-                        self.uni_ops().unify_tys(fn_def.ty.return_ty, subbed_annotation_ty)?;
-                    let Inference(inferred_ret, inferred_ret_ty) =
-                        infer_body_if_not_first_pass(fn_body, unified_return_ty.result)?;
-
-                    let inferred_fn_ty = FnTy {
-                        implicit: fn_def.ty.implicit,
-                        is_unsafe: fn_def.ty.is_unsafe,
-                        pure: fn_def.ty.pure,
-
-                        params: inferred_params_result.result,
-                        return_ty: inferred_ret_ty,
-                    };
-
-                    // Modify the fn def
-                    self.stores().fn_def().modify_fast(fn_def_id, |def| {
-                        def.body = FnBody::Defined(inferred_ret);
-                        def.ty = inferred_fn_ty;
-                    });
-
-                    if fn_mode == FnInferMode::Body {
-                        self.register_atom_inference(fn_def_id, fn_def_id, inferred_fn_ty);
-                    }
-
-                    Ok(Inference(fn_def_id, inferred_fn_ty))
-                })
+                    self.infer_params(annotation_fn_ty.params, || {
+                        self.infer_term(fn_body, annotation_fn_ty.return_ty)
+                    })
+                })?;
             }
-            FnBody::Intrinsic(_) | FnBody::Axiom => {
-                if fn_mode == FnInferMode::Body {
-                    self.register_atom_inference(fn_def_id, fn_def_id, fn_def.ty);
-                }
-                Ok(Inference(fn_def_id, fn_def.ty))
-            }
+            FnBody::Intrinsic(_) | FnBody::Axiom => {}
         }
+
+        let fn_ty_id = self.new_expected_ty_of(original_term_id, self.new_ty(annotation_fn_ty));
+        self.check_by_unify(fn_ty_id, annotation_ty)?;
+
+        self.register_atom_inference(fn_def_id, fn_def_id, fn_def.ty);
+        Ok(())
     }
 
     /// Infer the type of a variable, and return it.
-    pub fn infer_var(&self, term: Symbol, annotation_ty: TyId) -> TcResult<TyId> {
-        let normalised_annotation_ty = self.normalise_and_check_ty(annotation_ty)?;
+    pub fn infer_var(&self, term: Symbol, annotation_ty: TyId) -> TcResult<()> {
         match self.context().try_get_binding(term) {
-            Some(_) => {
-                let binding_ty = self.context_utils().get_binding_ty(term);
-                self.check_by_unify(binding_ty, normalised_annotation_ty)
-            }
+            Some(binding) => match binding.kind {
+                BindingKind::Decl(decl) => {
+                    // Infer the type of the declaration if needed.
+                    let ty = if let Some(ty) = decl.ty {
+                        self.sub_ops().copy_ty(ty)
+                    } else {
+                        info!(
+                            "Found declaration without type during inference: {}",
+                            self.env().with(decl)
+                        );
+                        self.new_ty_hole_of(self.new_term(term))
+                    };
+                    self.uni_ops().with_no_modify().unify_tys(annotation_ty, ty)?;
+                    Ok(())
+                }
+                b => panic!("expected decl, but got {}", self.env().with(b)),
+            },
             None => {
                 if self.diagnostics().has_errors() {
-                    Ok(self.new_ty_hole())
+                    Ok(())
                 } else {
                     panic!("no binding found for symbol '{}'", self.env().with(term))
                 }
@@ -1095,7 +856,8 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         return_term: &ReturnTerm,
         annotation_ty: TyId,
-    ) -> TcResult<Inference<ReturnTerm, TyId>> {
+        original_term: TermId,
+    ) -> TcResult<()> {
         let closest_fn_def = self.context_utils().get_first_fn_def_in_scope();
         match closest_fn_def {
             Some(closest_fn_def) => {
@@ -1104,143 +866,89 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 // If successful, modify the fn def to set the return type to the inferred type.
                 let closest_fn_def_return_ty =
                     self.stores().fn_def().map_fast(closest_fn_def, |def| def.ty.return_ty);
+                self.infer_term(return_term.expression, closest_fn_def_return_ty)?;
 
-                let Inference(inferred_return_term, inferred_return_ty) =
-                    self.infer_term(return_term.expression, closest_fn_def_return_ty)?;
-
-                self.stores()
-                    .fn_def()
-                    .modify_fast(closest_fn_def, |def| def.ty.return_ty = inferred_return_ty);
-
-                let inferred_ty = self.new_never_ty();
-                Ok(Inference(
-                    ReturnTerm { expression: inferred_return_term },
-                    self.check_by_unify(inferred_ty, annotation_ty)?,
-                ))
+                let inferred_ty = self.new_expected_ty_of(original_term, self.new_never_ty());
+                self.check_by_unify(inferred_ty, annotation_ty)?;
+                Ok(())
             }
             None => panic!("no fn def found in scope for return term"),
         }
     }
 
     /// Infer the type of a deref term, and return it.
-    pub fn infer_deref_term(
-        &self,
-        deref_term: &DerefTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<DerefTerm, TyId>> {
-        let Inference(subject_term, subject_ty) =
-            self.infer_term(deref_term.subject, self.new_ty_hole())?;
+    pub fn infer_deref_term(&self, deref_term: &DerefTerm, annotation_ty: TyId) -> TcResult<()> {
+        let deref_inner_inferred = self.new_ty_hole_of(deref_term.subject);
+        self.infer_term(deref_term.subject, deref_inner_inferred)?;
 
-        let inferred_ty = match self.get_ty(subject_ty) {
+        let dereferenced_ty = match self.get_ty(deref_inner_inferred) {
             Ty::Ref(ref_ty) => ref_ty.ty,
             _ => {
                 return Err(TcError::CannotDeref {
-                    subject: subject_term,
-                    actual_subject_ty: subject_ty,
+                    subject: deref_term.subject,
+                    actual_subject_ty: deref_inner_inferred,
                 })
             }
         };
 
-        Ok(Inference(
-            DerefTerm { subject: subject_term },
-            self.check_by_unify(inferred_ty, annotation_ty)?,
-        ))
-    }
-
-    pub fn use_term_in_ty_pos(&self, term: TermId) -> TcResult<TyId> {
-        match self.infer_ty(self.new_ty(Ty::Eval(term)), self.new_small_universe_ty()) {
-            Ok(inferred) => Ok(inferred.0),
-            Err(_) => {
-                let Inference(_, inferred_ty) = self.infer_term(term, self.new_ty_hole())?;
-                Err(TcError::CannotUseInTyPos { location: term.into(), inferred_ty })
-            }
-        }
+        self.check_by_unify(dereferenced_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer the type of a type, and return it.
-    pub fn infer_ty(&self, ty_id: TyId, annotation_ty: TyId) -> TcResult<Inference<TyId, TyId>> {
+    pub fn infer_ty(&self, ty_id: TyId, annotation_ty: TyId) -> TcResult<()> {
+        // @@Todo: properly deal with universes
         self.register_new_atom(ty_id, annotation_ty);
+        let inner_is_ty =
+            |ty: TyId| self.new_expected_ty_of_ty(ty, self.new_flexible_universe_ty());
+        let expects_ty = |ty: TyId| self.check_by_unify(ty, inner_is_ty(ty));
 
-        let result_ty = match self.get_ty(ty_id) {
+        match self.get_ty(ty_id) {
             Ty::Eval(eval) => {
-                let eval_inferred = self.infer_term(eval, annotation_ty)?;
-                TcResult::<_>::Ok((self.new_ty(Ty::Eval(eval_inferred.0)), eval_inferred.1))
+                self.infer_term(eval, annotation_ty)?;
             }
-            Ty::Var(var) => Ok((ty_id, self.infer_var(var, annotation_ty)?)),
-            Ty::Tuple(tuple_ty) => {
-                // Infer the parameters
-                self.infer_params(tuple_ty.data, tuple_ty.into())?;
-                Ok((ty_id, self.new_small_universe_ty()))
-            }
-            Ty::Fn(fn_ty) => {
-                // Infer the parameters
-                self.context().enter_scope(ScopeKind::FnTy(fn_ty), || {
-                    let params = self.infer_params(fn_ty.params, fn_ty.into())?;
-                    // Given the parameters, infer the return type
-                    let return_ty = self.infer_ty(fn_ty.return_ty, self.new_ty_hole())?;
-
-                    Ok((
-                        self.new_ty(Ty::Fn(FnTy {
-                            implicit: fn_ty.implicit,
-                            is_unsafe: fn_ty.is_unsafe,
-                            pure: fn_ty.pure,
-                            params,
-                            return_ty: return_ty.0,
-                        })),
-                        self.new_small_universe_ty(),
-                    ))
-                })
-            }
+            Ty::Var(var) => self.infer_var(var, annotation_ty)?,
+            Ty::Tuple(tuple_ty) => self.infer_params(tuple_ty.data, || Ok(()))?,
+            Ty::Fn(fn_ty) => self.infer_params(fn_ty.params, || {
+                self.infer_ty(fn_ty.return_ty, inner_is_ty(fn_ty.return_ty))
+            })?,
             Ty::Ref(ref_ty) => {
                 // Infer the inner type
-                let Inference(inner_ty, _) = self.infer_ty(ref_ty.ty, self.new_ty_hole())?;
-                Ok((
-                    self.new_ty(RefTy { ty: inner_ty, kind: ref_ty.kind, mutable: ref_ty.mutable }),
-                    self.new_small_universe_ty(),
-                ))
+                self.infer_ty(ref_ty.ty, inner_is_ty(ref_ty.ty))?;
             }
             Ty::Data(data_ty) => {
-                self.context().enter_scope(ScopeKind::Data(data_ty.data_def), || {
-                    let data_def = self.get_data_def(data_ty.data_def);
-                    let InferenceWithSub { result: _, .. } =
-                        self.infer_args(data_ty.args, data_def.params)?;
-                    let sub = self.sub_ops().create_sub_from_current_scope();
-
-                    let result_data_args = self.sub_ops().apply_sub_to_args(data_ty.args, &sub);
-
-                    Ok((
-                        self.new_ty(Ty::Data(DataTy {
-                            args: result_data_args,
-                            data_def: data_ty.data_def,
-                        })),
-                        self.new_small_universe_ty(),
-                    ))
-                })
+                let data_def = self.get_data_def(data_ty.data_def);
+                let copied_params = self.sub_ops().copy_params(data_def.params);
+                self.infer_args(data_ty.args, copied_params, || Ok(()))?
             }
-            Ty::Universe(universe_ty) => Ok((ty_id, self.new_universe_ty(universe_ty.size + 1))),
-            Ty::Hole(_) => Ok((ty_id, annotation_ty)),
-        }?;
+            Ty::Universe(_universe_ty) => {}
+            Ty::Hole(_) => {}
+        };
 
-        self.register_atom_inference(ty_id, result_ty.0, result_ty.1);
-        self.potentially_dump_tir(result_ty.0);
-        Ok(Inference(result_ty.0, self.check_by_unify(result_ty.1, annotation_ty)?))
+        // Ensure it is a type
+        expects_ty(annotation_ty)?;
+
+        self.register_atom_inference(ty_id, ty_id, annotation_ty);
+        self.potentially_dump_tir(ty_id);
+
+        Ok(())
     }
 
     /// Infer the type of a loop control term, and return it.
-    pub fn infer_loop_control_term(&self, _: &LoopControlTerm) -> TyId {
+    pub fn infer_loop_control_term(
+        &self,
+        _: &LoopControlTerm,
+        annotation_ty: TyId,
+    ) -> TcResult<()> {
         // Always `never`.
-        self.new_never_ty()
+        self.check_by_unify(self.new_never_ty(), annotation_ty)
     }
 
     /// Infer the type of an unsafe term, and return it.
-    pub fn infer_unsafe_term(
-        &self,
-        unsafe_term: &UnsafeTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<UnsafeTerm, TyId>> {
+    pub fn infer_unsafe_term(&self, unsafe_term: &UnsafeTerm, annotation_ty: TyId) -> TcResult<()> {
         // @@Todo: unsafe context
-        // For now just forward to the inner term.
-        Ok(Inference(*unsafe_term, self.infer_term(unsafe_term.inner, annotation_ty)?.1))
+        self.infer_term(unsafe_term.inner, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer the type of a loop term, and return it.
@@ -1248,14 +956,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         loop_term: &LoopTerm,
         annotation_ty: TyId,
-    ) -> TcResult<Inference<LoopTerm, TyId>> {
+        original_term_id: TermId,
+    ) -> TcResult<()> {
         // Forward to the inner term.
-        let Inference(inferred_block_term, _) =
-            self.infer_block_term(&loop_term.block, self.new_ty_hole())?;
-        Ok(Inference(
-            LoopTerm { block: inferred_block_term },
-            self.check_by_unify(self.new_void_ty(), annotation_ty)?,
-        ))
+        self.infer_block_term(&loop_term.block, self.new_ty_hole(), original_term_id)?;
+        let loop_term = self.new_expected_ty_of(original_term_id, self.new_void_ty());
+        self.check_by_unify(loop_term, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer the type of a block term, and return it.
@@ -1263,59 +970,47 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         block_term: &BlockTerm,
         annotation_ty: TyId,
-    ) -> TcResult<Inference<BlockTerm, TyId>> {
-        self.stores().term_list().map(block_term.statements, |statements| {
-            self.context().enter_scope(block_term.stack_id.into(), || {
-                // Handle local mod def
-                let stack = self.stores().stack().get(block_term.stack_id);
-                if let Some(local_mod_def) = stack.local_mod_def {
-                    // @@Improvement: it would be nice to pass through local
-                    // mod defs in two stages as well.
-                    self.infer_mod_def(local_mod_def, FnInferMode::Body)?;
+        original_term_id: TermId,
+    ) -> TcResult<()> {
+        self.context().enter_scope(block_term.stack_id.into(), || {
+            // Handle local mod def
+            let stack = self.stores().stack().get(block_term.stack_id);
+            if let Some(local_mod_def) = stack.local_mod_def {
+                // @@Improvement: it would be nice to pass through local
+                // mod defs in two stages as well.
+                self.infer_mod_def(local_mod_def, FnInferMode::Body)?;
+            }
+
+            // Keep track of statements diverging, so we can infer the appropriate return
+            // type.
+            let mut diverges = false;
+
+            for statement in block_term.statements.iter() {
+                let statement = self.stores().term_list().get_element(statement);
+
+                let statement_ty = self.new_ty_hole_of(statement);
+                self.infer_term(statement, statement_ty)?;
+
+                // If the statement diverges, we can already exit
+                if self.uni_ops().is_uninhabitable(statement_ty)? {
+                    diverges = true;
+                    break;
                 }
+            }
 
-                // Keep track of statements diverging, so we can infer the appropirate return
-                // type.
-                let mut diverges = false;
+            if diverges {
+                // If it diverges, we can just infer the return type as `never`.
+                let block_term_ty = self.new_expected_ty_of(original_term_id, self.new_never_ty());
+                self.check_by_unify(block_term_ty, annotation_ty)?;
+            } else {
+                // Infer the return value
+                self.infer_term(block_term.return_value, annotation_ty)?;
+            };
 
-                let mut inferred_statements = vec![];
-                for &statement in statements {
-                    let Inference(inferred_statement, inferred_statement_ty) =
-                        self.infer_term(statement, self.new_ty_hole())?;
-                    inferred_statements.push(inferred_statement);
+            let sub = self.sub_ops().create_sub_from_current_scope();
+            self.sub_ops().apply_sub_to_ty_in_place(annotation_ty, &sub);
 
-                    // If the statement diverges, we can already exit
-                    if self.uni_ops().is_uninhabitable(inferred_statement_ty)? {
-                        diverges = true;
-                        break;
-                    }
-                }
-
-                let (return_term, return_ty) = if diverges {
-                    // If it diverges, we can just infer the return type as `never`.
-                    self.new_never_ty();
-                    (block_term.return_value, self.new_never_ty())
-                } else {
-                    // Infer the return value
-                    let Inference(return_term, return_ty) =
-                        self.infer_term(block_term.return_value, annotation_ty)?;
-
-                    let sub = self.sub_ops().create_sub_from_current_scope();
-                    let subbed_return_ty = self.sub_ops().apply_sub_to_ty(return_ty, &sub);
-                    let subbed_return_value = self.sub_ops().apply_sub_to_term(return_term, &sub);
-
-                    (subbed_return_value, subbed_return_ty)
-                };
-
-                Ok(Inference(
-                    BlockTerm {
-                        statements: self.new_term_list(inferred_statements),
-                        return_value: return_term,
-                        stack_id: block_term.stack_id,
-                    },
-                    self.check_by_unify(return_ty, annotation_ty)?,
-                ))
-            })
+            Ok(())
         })
     }
 
@@ -1324,11 +1019,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         &self,
         type_of_term: TypeOfTerm,
         annotation_ty: TyId,
-    ) -> TcResult<Inference<TypeOfTerm, TyId>> {
-        let Inference(inferred_term, inferred_ty) =
-            self.infer_term(type_of_term.term, self.new_ty_hole())?;
-        let Inference(_, inferred_ty_of_ty) = self.infer_ty(inferred_ty, annotation_ty)?;
-        Ok(Inference(TypeOfTerm { term: inferred_term }, inferred_ty_of_ty))
+    ) -> TcResult<()> {
+        let inferred_ty = self.new_ty_hole_of(type_of_term.term);
+        self.infer_term(type_of_term.term, inferred_ty)?;
+        self.infer_ty(inferred_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer a reference term, and return its type.
@@ -1337,9 +1032,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         ref_term: &RefTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<RefTerm, RefTy>> {
-        let normalised_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let annotation_ref_ty = match self.get_ty(normalised_ty) {
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let annotation_ref_ty = match self.get_ty(annotation_ty) {
             Ty::Ref(ref_ty) => ref_ty,
             Ty::Hole(_) => {
                 RefTy { kind: ref_term.kind, mutable: ref_term.mutable, ty: self.new_ty_hole() }
@@ -1357,56 +1052,26 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
         };
 
-        let Inference(inner_term, inner_ty) =
-            self.infer_term(ref_term.subject, annotation_ref_ty.ty)?;
-
-        Ok(Inference(
-            RefTerm { subject: inner_term, ..*ref_term },
-            RefTy { ty: inner_ty, ..annotation_ref_ty },
-        ))
+        self.infer_term(ref_term.subject, annotation_ref_ty.ty)?;
+        Ok(())
     }
 
     /// Infer a cast term, and return its type.
-    pub fn infer_cast_term(
-        &self,
-        cast_term: CastTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<CastTerm, TyId>> {
-        let Inference(inferred_term, inferred_term_ty) =
-            self.infer_term(cast_term.subject_term, cast_term.target_ty)?;
-        let Uni { sub, .. } = self.uni_ops().unify_tys(inferred_term_ty, annotation_ty)?;
-        let subbed_ty = self.sub_ops().apply_sub_to_ty(inferred_term_ty, &sub);
-        let subbed_term = self.sub_ops().apply_sub_to_term(inferred_term, &sub);
-
-        Ok(Inference(
-            CastTerm { subject_term: subbed_term, target_ty: subbed_ty },
-            inferred_term_ty,
-        ))
+    pub fn infer_cast_term(&self, cast_term: CastTerm, annotation_ty: TyId) -> TcResult<()> {
+        self.infer_term(cast_term.subject_term, cast_term.target_ty)?;
+        self.check_by_unify(cast_term.target_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer a stack declaration term, and return its type.
-    pub fn infer_decl_term(
-        &self,
-        decl_term: &DeclTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<DeclTerm, TyId>> {
-        let decl_term_ty = self.normalise_and_check_ty(decl_term.ty)?;
-
-        let (inferred_rhs_value, inferred_ty) = match decl_term.value {
-            Some(value) => {
-                let Inference(inferred_value, inferred_ty) =
-                    self.infer_term(value, decl_term_ty)?;
-                (Some(inferred_value), inferred_ty)
-            }
-            None => (None, decl_term_ty),
+    pub fn infer_decl_term(&self, decl_term: &DeclTerm, annotation_ty: TyId) -> TcResult<()> {
+        self.normalise_and_check_ty(decl_term.ty)?;
+        if let Some(value) = decl_term.value {
+            self.infer_term(value, decl_term.ty)?;
         };
-
-        let Inference(inferred_lhs_pat, inferred_ty) =
-            self.infer_pat(decl_term.bind_pat, inferred_ty)?;
-
-        let result_decl_term =
-            DeclTerm { bind_pat: inferred_lhs_pat, value: inferred_rhs_value, ty: inferred_ty };
-        Ok(Inference(result_decl_term, self.check_by_unify(self.new_void_ty(), annotation_ty)?))
+        self.infer_pat(decl_term.bind_pat, decl_term.ty)?;
+        self.check_by_unify(self.new_void_ty(), annotation_ty)?;
+        Ok(())
     }
 
     /// Infer an access term.
@@ -1415,13 +1080,11 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         access_term: &AccessTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<AccessTerm, TyId>> {
-        let Inference(inferred_subject, inferred_subject_ty) =
-            self.infer_term(access_term.subject, self.new_ty_hole())?;
+    ) -> TcResult<()> {
+        let subject_ty = self.new_ty_hole_of(access_term.subject);
+        self.infer_term(access_term.subject, subject_ty)?;
 
-        let normalised_subject_ty = self.normalise_and_check_ty(inferred_subject_ty)?;
-
-        let params = match self.get_ty(normalised_subject_ty) {
+        let params = match self.get_ty(subject_ty) {
             Ty::Tuple(tuple_ty) => tuple_ty.data,
             Ty::Data(data_ty) => {
                 match self.data_utils().get_single_ctor_of_data_def(data_ty.data_def) {
@@ -1437,7 +1100,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                         // @@ErrorReporting: more information about the error
                         return Err(TcError::WrongTy {
                             kind: WrongTermKind::NotARecord,
-                            inferred_term_ty: normalised_subject_ty,
+                            inferred_term_ty: subject_ty,
                             term: original_term_id,
                         });
                     }
@@ -1448,7 +1111,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             _ => {
                 return Err(TcError::WrongTy {
                     kind: WrongTermKind::NotARecord,
-                    inferred_term_ty: normalised_subject_ty,
+                    inferred_term_ty: subject_ty,
                     term: original_term_id,
                 })
             }
@@ -1460,20 +1123,14 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             //
             // i.e. `x: (T: Type, t: T);  x.t: x.T`
             let param_access_sub =
-                self.sub_ops().create_sub_from_param_access(params, inferred_subject);
-
+                self.sub_ops().create_sub_from_param_access(params, access_term.subject);
             let subbed_param_ty = self.sub_ops().apply_sub_to_ty(param.ty, &param_access_sub);
-
-            let unified_ty = self.check_by_unify(subbed_param_ty, annotation_ty)?;
-
-            Ok(Inference(
-                AccessTerm { subject: inferred_subject, field: access_term.field },
-                unified_ty,
-            ))
+            self.check_by_unify(subbed_param_ty, annotation_ty)?;
+            Ok(())
         } else {
             Err(TcError::PropertyNotFound {
-                term: inferred_subject,
-                term_ty: normalised_subject_ty,
+                term: access_term.subject,
+                term_ty: subject_ty,
                 property: access_term.field,
             })
         }
@@ -1485,25 +1142,27 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         index_term: &IndexTerm,
         annotation_ty: TyId,
         original_term_id: TermId,
-    ) -> TcResult<Inference<IndexTerm, TyId>> {
-        let Inference(inferred_subject, inferred_subject_ty) =
-            self.infer_term(index_term.subject, self.new_ty_hole())?;
-        let normalised_subject_ty = self.normalise_and_check_ty(inferred_subject_ty)?;
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+
+        let subject_ty = self.new_ty_hole_of(index_term.subject);
+        self.infer_term(index_term.subject, subject_ty)?;
 
         // Ensure the index is a usize
-        let Inference(inferred_index, _) =
-            self.infer_term(index_term.index, self.new_data_ty(self.primitives().usize()))?;
+        let index_ty =
+            self.new_expected_ty_of(index_term.index, self.new_data_ty(self.primitives().usize()));
+        self.infer_term(index_term.index, index_ty)?;
 
-        let wrong_ty = || {
+        let wrong_subject_ty = || {
             Err(TcError::WrongTy {
                 term: original_term_id,
-                inferred_term_ty: normalised_subject_ty,
+                inferred_term_ty: subject_ty,
                 kind: WrongTermKind::NotAnArray,
             })
         };
 
         // Ensure that the subject is array-like
-        let inferred_ty = match self.get_ty(normalised_subject_ty) {
+        let inferred_ty = match self.get_ty(subject_ty) {
             Ty::Data(data_ty) => {
                 let data_def = self.get_data_def(data_ty.data_def);
                 if let DataDefCtors::Primitive(PrimitiveCtorInfo::Array(array_primitive)) =
@@ -1515,118 +1174,52 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                     let array_ty = self.sub_ops().apply_sub_to_ty(array_primitive.element_ty, &sub);
                     Ok(array_ty)
                 } else {
-                    wrong_ty()
+                    wrong_subject_ty()
                 }
             }
-            _ => wrong_ty(),
+            _ => wrong_subject_ty(),
         }?;
 
-        let unified_ty = self.check_by_unify(inferred_ty, annotation_ty)?;
-        Ok(Inference(IndexTerm { subject: inferred_subject, index: inferred_index }, unified_ty))
+        self.check_by_unify(inferred_ty, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer an assign term.
     pub fn infer_assign_term(
         &self,
         assign_term: &AssignTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<AssignTerm, TyId>> {
-        let Inference(inferred_lhs, inferred_lhs_ty) =
-            self.infer_term(assign_term.subject, self.new_ty_hole())?;
-        let Inference(inferred_rhs, _inferred_rhs_ty) =
-            self.infer_term(assign_term.value, inferred_lhs_ty)?;
-
-        Ok(Inference(
-            AssignTerm { subject: inferred_lhs, value: inferred_rhs },
-            self.check_by_unify(annotation_ty, self.new_void_ty())?,
-        ))
+        _annotation_ty: TyId,
+    ) -> TcResult<()> {
+        let subject_ty = self.new_ty_hole_of(assign_term.subject);
+        self.infer_term(assign_term.subject, subject_ty)?;
+        self.infer_term(assign_term.value, subject_ty)?;
+        Ok(())
     }
 
     /// Infer a match term.
-    pub fn infer_match_term(
-        &self,
-        match_term: &MatchTerm,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<MatchTerm, TyId>> {
-        let Inference(inferred_subject, inferred_subject_ty) =
-            self.infer_term(match_term.subject, self.new_ty_hole())?;
-        let normalised_subject_ty = self.normalise_and_check_ty(inferred_subject_ty)?;
-        let normalised_annotation_ty = self.normalise_and_check_ty(annotation_ty)?;
-
-        let mut unified_ty = normalised_annotation_ty;
-        let mut inferred_arms = Vec::new();
+    pub fn infer_match_term(&self, match_term: &MatchTerm, annotation_ty: TyId) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let match_subject_ty = self.new_ty_hole_of(match_term.subject);
+        self.infer_term(match_term.subject, match_subject_ty)?;
 
         for case in match_term.cases.iter() {
             // @@Todo: dependent
             let case_data = self.stores().match_cases().get_element(case);
-
             self.context().enter_scope(case_data.stack_id.into(), || -> TcResult<_> {
-                let Inference(inferred_pat, _inferred_pat_ty) =
-                    self.infer_pat(case_data.bind_pat, normalised_subject_ty)?;
+                self.infer_pat(case_data.bind_pat, match_subject_ty)?;
+                self.infer_term(case_data.value, annotation_ty)?;
 
-                let Inference(inferred_body, inferred_body_ty) =
-                    self.infer_term(case_data.value, normalised_annotation_ty)?;
-
-                let new_unified_ty = self.check_by_unify(inferred_body_ty, unified_ty)?;
-                if !self.uni_ops().is_uninhabitable(new_unified_ty)? {
-                    unified_ty = new_unified_ty;
-                }
-
-                inferred_arms.push(MatchCase {
-                    bind_pat: inferred_pat,
-                    value: inferred_body,
-                    stack_id: case_data.stack_id,
-                });
+                // @@Todo: deal with uninhabited
+                // let new_unified_ty = self.check_by_unify(inferred_body_ty, unified_ty)?;
+                // if !self.uni_ops().is_uninhabitable(new_unified_ty)? {
+                //     unified_ty = new_unified_ty;
+                // }
 
                 Ok(())
             })?
         }
 
-        Ok(Inference(
-            MatchTerm {
-                cases: self.stores().match_cases().create_from_iter(inferred_arms),
-                subject: inferred_subject,
-            },
-            unified_ty,
-        ))
-    }
-
-    pub fn generalise_term_inference(
-        &self,
-        inference: Inference<impl Into<Term>, TyId>,
-    ) -> Inference<TermId, TyId> {
-        let Inference(term, ty) = inference;
-        let term_id = self.new_term(term);
-        Inference(term_id, ty)
-    }
-
-    pub fn generalise_term_and_ty_inference(
-        &self,
-        inference: Inference<impl Into<Term>, impl Into<Ty>>,
-    ) -> Inference<TermId, TyId> {
-        let Inference(term, ty) = inference;
-        let term_id = self.new_term(term);
-        let ty_id = self.new_ty(ty);
-        Inference(term_id, ty_id)
-    }
-
-    pub fn generalise_pat_inference(
-        &self,
-        inference: Inference<impl Into<Pat>, TyId>,
-    ) -> Inference<PatId, TyId> {
-        let Inference(term, ty) = inference;
-        let term_id = self.new_pat(term);
-        Inference(term_id, ty)
-    }
-
-    pub fn generalise_pat_and_ty_inference(
-        &self,
-        inference: Inference<impl Into<Pat>, impl Into<Ty>>,
-    ) -> Inference<PatId, TyId> {
-        let Inference(term, ty) = inference;
-        let term_id = self.new_pat(term);
-        let ty_id = self.new_ty(ty);
-        Inference(term_id, ty_id)
+        Ok(())
     }
 
     /// Infer a concrete type for a given term.
@@ -1634,113 +1227,65 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// If this is not possible, return `None`.
     /// To create a hole when this is not possible, use
     /// [`InferOps::infer_ty_of_term_or_hole`].
-    pub fn infer_term(
-        &self,
-        term_id: TermId,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<TermId, TyId>> {
+    pub fn infer_term(&self, term_id: TermId, annotation_ty: TyId) -> TcResult<()> {
         self.register_new_atom(term_id, annotation_ty);
 
-        let result = self.stores().term().map(term_id, |term| match term {
-            Term::Tuple(tuple_term) => self
-                .infer_tuple_term(tuple_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_and_ty_inference(i)),
-            Term::Lit(lit_term) => {
-                self.infer_lit(lit_term, annotation_ty).map(|i| self.generalise_term_inference(i))
+        match self.get_term(term_id) {
+            Term::Tuple(tuple_term) => {
+                self.infer_tuple_term(&tuple_term, annotation_ty, term_id)?
             }
-            Term::Array(prim_term) => self
-                .infer_array_term(prim_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_inference(i)),
-            Term::Ctor(ctor_term) => self
-                .infer_ctor_term(ctor_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_and_ty_inference(i)),
+            Term::Lit(lit_term) => self.infer_lit(&lit_term, annotation_ty)?,
+            Term::Array(prim_term) => self.infer_array_term(&prim_term, annotation_ty, term_id)?,
+            Term::Ctor(ctor_term) => self.infer_ctor_term(&ctor_term, annotation_ty, term_id)?,
             Term::FnCall(fn_call_term) => {
-                self.infer_fn_call_term(fn_call_term, annotation_ty, term_id)
+                self.infer_fn_call_term(&fn_call_term, annotation_ty, term_id)?
             }
-            Term::FnRef(fn_def_id) => self
-                .infer_fn_def(*fn_def_id, annotation_ty, term_id, FnInferMode::Body)
-                .map(|i| self.generalise_term_and_ty_inference(i)),
-            Term::Var(var_term) => {
-                Ok(Inference(term_id, self.infer_var(*var_term, annotation_ty)?))
+            Term::FnRef(fn_def_id) => {
+                self.infer_fn_def(fn_def_id, annotation_ty, term_id, FnInferMode::Body)?
             }
-            Term::Return(return_term) => self
-                .infer_return_term(return_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-            Term::Ty(ty_id) => {
-                self.infer_ty(*ty_id, annotation_ty).map(|i| self.generalise_term_inference(i))
+            Term::Var(var_term) => self.infer_var(var_term, annotation_ty)?,
+            Term::Return(return_term) => {
+                self.infer_return_term(&return_term, annotation_ty, term_id)?
             }
-            Term::Deref(deref_term) => self
-                .infer_deref_term(deref_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
+            Term::Ty(ty_id) => self.infer_ty(ty_id, annotation_ty)?,
+            Term::Deref(deref_term) => self.infer_deref_term(&deref_term, annotation_ty)?,
             Term::LoopControl(loop_control_term) => {
-                Ok(Inference(term_id, self.infer_loop_control_term(loop_control_term)))
+                self.infer_loop_control_term(&loop_control_term, annotation_ty)?
             }
-            Term::Unsafe(unsafe_term) => self
-                .infer_unsafe_term(unsafe_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
+            Term::Unsafe(unsafe_term) => self.infer_unsafe_term(&unsafe_term, annotation_ty)?,
+            Term::Loop(loop_term) => self.infer_loop_term(&loop_term, annotation_ty, term_id)?,
+            Term::Block(block_term) => {
+                self.infer_block_term(&block_term, annotation_ty, term_id)?
+            }
+            Term::TypeOf(ty_of_term) => self.infer_type_of_term(ty_of_term, annotation_ty)?,
+            Term::Ref(ref_term) => self.infer_ref_term(&ref_term, annotation_ty, term_id)?,
+            Term::Cast(cast_term) => self.infer_cast_term(cast_term, annotation_ty)?,
+            Term::Decl(decl_term) => self.infer_decl_term(&decl_term, annotation_ty)?,
+            Term::Access(access_term) => {
+                self.infer_access_term(&access_term, annotation_ty, term_id)?
+            }
+            Term::Index(index_term) => {
+                self.infer_index_term(&index_term, annotation_ty, term_id)?
+            }
+            Term::Match(match_term) => self.infer_match_term(&match_term, annotation_ty)?,
+            Term::Assign(assign_term) => self.infer_assign_term(&assign_term, annotation_ty)?,
+            Term::Hole(_) => {}
+        };
 
-            Term::Loop(loop_term) => self
-                .infer_loop_term(loop_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Block(block_term) => self
-                .infer_block_term(block_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::TypeOf(ty_of_term) => self
-                .infer_type_of_term(*ty_of_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Ref(ref_term) => self
-                .infer_ref_term(ref_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_and_ty_inference(i)),
-
-            Term::Cast(cast_term) => self
-                .infer_cast_term(*cast_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Decl(decl_term) => self
-                .infer_decl_term(decl_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Access(access_term) => self
-                .infer_access_term(access_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Index(index_term) => self
-                .infer_index_term(index_term, annotation_ty, term_id)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Match(match_term) => self
-                .infer_match_term(match_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Assign(assign_term) => self
-                .infer_assign_term(assign_term, annotation_ty)
-                .map(|i| self.generalise_term_inference(i)),
-
-            Term::Hole(_) => Ok(Inference(term_id, annotation_ty)),
-        })?;
-
-        // Unify the result type with the annotation type.
-        let result_ty = self.check_by_unify(result.1, annotation_ty)?;
-        self.register_atom_inference(term_id, result.0, result_ty);
+        self.register_atom_inference(term_id, term_id, annotation_ty);
 
         // Potentially evaluate the term.
-        let potentially_evaluated = self.potentially_run_expr(result.0)?;
-        self.potentially_dump_tir(potentially_evaluated);
+        self.potentially_run_expr(term_id, annotation_ty)?;
+        self.potentially_dump_tir(term_id);
 
-        Ok(Inference(potentially_evaluated, result_ty))
+        Ok(())
     }
 
     /// Infer a range pattern.
-    pub fn infer_range_pat(&self, range_pat: RangePat, annotation_ty: TyId) -> TcResult<TyId> {
-        let Inference(_, start_ty) = self.infer_lit(&range_pat.start.into(), annotation_ty)?;
-        let Inference(_, end_ty) = self.infer_lit(&range_pat.end.into(), annotation_ty)?;
-
-        let Uni { sub, result } = self.uni_ops().unify_tys(start_ty, end_ty)?;
-        assert!(sub.is_empty()); // @@Todo: specialised unification for no sub
-        Ok(result)
+    pub fn infer_range_pat(&self, range_pat: RangePat, annotation_ty: TyId) -> TcResult<()> {
+        self.infer_lit(&range_pat.start.into(), annotation_ty)?;
+        self.infer_lit(&range_pat.end.into(), annotation_ty)?;
+        Ok(())
     }
 
     /// Infer a tuple pattern.
@@ -1749,9 +1294,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         tuple_pat: &TuplePat,
         annotation_ty: TyId,
         original_pat_id: PatId,
-    ) -> TcResult<Inference<TuplePat, TupleTy>> {
-        let reduced_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let params = match self.get_ty(reduced_ty) {
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let params = match self.get_ty(annotation_ty) {
             Ty::Tuple(tuple_ty) => tuple_ty.data,
             Ty::Hole(_) => self.param_utils().create_hole_params_from_args(tuple_pat.data),
             _ => {
@@ -1763,16 +1308,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 });
             }
         };
-
-        let InferenceWithSub { result: inferred_args, annotation: inferred_params, .. } =
-            self.context().enter_scope(ScopeKind::TupleTy(TupleTy { data: params }), || {
-                self.infer_pat_args(tuple_pat.data, tuple_pat.data_spread, params)
-            })?;
-
-        Ok(Inference(
-            TuplePat { data: inferred_args, data_spread: tuple_pat.data_spread },
-            TupleTy { data: inferred_params },
-        ))
+        self.infer_pat_args(tuple_pat.data, tuple_pat.data_spread, params, || Ok(()))
     }
 
     /// Infer a list pattern
@@ -1781,9 +1317,9 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         list_pat: &ArrayPat,
         annotation_ty: TyId,
         original_pat_id: PatId,
-    ) -> TcResult<Inference<ArrayPat, DataTy>> {
-        let normalised_ty = self.normalise_and_check_ty(annotation_ty)?;
-        let list_annotation_inner_ty = match self.get_ty(normalised_ty) {
+    ) -> TcResult<()> {
+        self.normalise_and_check_ty(annotation_ty)?;
+        let list_annotation_inner_ty = match self.get_ty(annotation_ty) {
             Ty::Data(data) if data.data_def == self.primitives().list() => {
                 // Type is already checked
                 assert!(data.args.len() == 1);
@@ -1805,13 +1341,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
             }
         };
 
-        let Inference(inferred_list, inferred_list_inner_ty) =
-            self.infer_unified_pat_list(list_pat.pats, list_annotation_inner_ty)?;
+        self.infer_unified_pat_list(list_pat.pats, list_annotation_inner_ty)?;
         let list_ty = DataTy {
             data_def: self.primitives().list(),
-            args: self.new_args(&[self.new_term(inferred_list_inner_ty)]),
+            args: self.new_args(&[self.new_term(list_annotation_inner_ty)]),
         };
-        Ok(Inference(ArrayPat { pats: inferred_list, spread: list_pat.spread }, list_ty))
+        self.check_by_unify(self.new_ty(list_ty), annotation_ty)?;
+        Ok(())
     }
 
     /// Infer a constructor pattern
@@ -1820,202 +1356,77 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         pat: &CtorPat,
         annotation_ty: TyId,
         original_pat_id: PatId,
-    ) -> TcResult<Inference<CtorPat, DataTy>> {
-        // @@Organisation: factor out because this is almost the same for
-        // infer_ctor_term
-        let ctor = self.stores().ctor_defs().map_fast(pat.ctor.0, |defs| defs[pat.ctor.1]);
-        let data_def = self.get_data_def(ctor.data_def_id);
-
-        let norm = self.norm_ops();
-        let reduced_ty = norm.to_ty(norm.normalise(annotation_ty.into())?);
-
-        let annotation_data_ty = match self.get_ty(reduced_ty) {
-            Ty::Data(data) if data.data_def == ctor.data_def_id => Some(data),
-            Ty::Hole(_) => None,
-            _ => {
-                return Err(TcError::MismatchingTypes {
-                    expected: annotation_ty,
-                    actual: self.new_ty(DataTy { args: pat.data_args, data_def: ctor.data_def_id }),
-                    inferred_from: Some(original_pat_id.into()),
-                });
-            }
-        };
-
-        let pat_data_args = if pat.data_args.len() == 0 {
-            match annotation_data_ty {
-                Some(t) => t.args,
-                None => self.param_utils().instantiate_params_as_holes(data_def.params),
-            }
-        } else {
-            pat.data_args
-        };
-
-        let annotation_data_ty =
-            annotation_data_ty.unwrap_or(DataTy { args: pat_data_args, data_def: data_def.id });
-
-        self.context().enter_scope(data_def.id.into(), || {
-            let data_args_uni =
-                self.uni_ops().unify_args(pat_data_args, annotation_data_ty.args)?;
-
-            // First infer the data arguments
-            let InferenceWithSub {
-                result: inferred_data_args,
-                annotation: _inferred_data_params,
-                sub: data_sub,
-            } = self.infer_args(data_args_uni.result, data_def.params)?;
-
-            self.context().enter_scope(ctor.id.into(), || {
-                // Apply the substitution to the constructor parameters
-                let subbed_ctor_params = self.sub_ops().apply_sub_to_params(ctor.params, &data_sub);
-                let subbed_ctor_result_args =
-                    self.sub_ops().apply_sub_to_args(ctor.result_args, &data_sub);
-
-                // Infer the constructor arguments
-                let InferenceWithSub {
-                    result: inferred_ctor_pat_args,
-                    annotation: _inferred_ctor_params,
-                    sub: ctor_sub,
-                } = self.infer_pat_args(
-                    pat.ctor_pat_args,
-                    pat.ctor_pat_args_spread,
-                    subbed_ctor_params,
-                )?;
-                // Apply the substitution to the constructor result args
-                let _ctor_subbed_ctor_result_args =
-                    self.sub_ops().apply_sub_to_args(subbed_ctor_result_args, &ctor_sub);
-
-                let sub_binds_to_holes = self.sub_ops().create_sub_from_args_of_params(
-                    self.param_utils().instantiate_params_as_holes(ctor.params),
-                    ctor.params,
+    ) -> TcResult<()> {
+        self.infer_some_ctor(pat.ctor, pat.data_args, annotation_ty, original_pat_id, |ctor| {
+            let data_sub = self.sub_ops().create_sub_from_current_scope();
+            self.infer_pat_args(pat.ctor_pat_args, pat.ctor_pat_args_spread, ctor.params, || {
+                let ctor_sub = self.sub_ops().create_sub_from_current_scope();
+                let result_data_args = self.sub_ops().apply_sub_to_args(
+                    self.sub_ops().apply_sub_to_args(ctor.result_args, &data_sub),
+                    &ctor_sub,
                 );
-                let subbed_result_args_with_holes_for_binds =
-                    self.sub_ops().apply_sub_to_args(ctor.result_args, &sub_binds_to_holes);
-
-                // Try to unify given annotation with inferred eventual type.
-                let result_data_def_args_uni = self
-                    .uni_ops()
-                    .unify_args(subbed_result_args_with_holes_for_binds, inferred_data_args)?;
-
-                let sub_holes_to_binds = self.sub_ops().reverse_sub(&sub_binds_to_holes);
-
-                let result_data_def_args_subbed = self
-                    .sub_ops()
-                    .apply_sub_to_args(result_data_def_args_uni.result, &sub_holes_to_binds);
-
-                // Evaluate the result args.
-                Ok(Inference(
-                    CtorPat {
-                        ctor: ctor.id,
-                        data_args: result_data_def_args_subbed,
-                        ctor_pat_args: inferred_ctor_pat_args,
-                        ctor_pat_args_spread: pat.ctor_pat_args_spread,
-                    },
-                    DataTy { args: result_data_def_args_subbed, data_def: data_def.id },
-                ))
+                Ok(result_data_args)
             })
         })
     }
 
     /// Infer an or-pattern
-    pub fn infer_or_pat(
-        &self,
-        pat: &OrPat,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<OrPat, TyId>> {
-        let Inference(result_list, result_list_ty) =
-            self.infer_unified_pat_list(pat.alternatives, annotation_ty)?;
-        Ok(Inference(OrPat { alternatives: result_list }, result_list_ty))
+    pub fn infer_or_pat(&self, pat: &OrPat, annotation_ty: TyId) -> TcResult<()> {
+        self.infer_unified_pat_list(pat.alternatives, annotation_ty)?;
+        Ok(())
     }
 
     /// Infer an if-pattern
-    pub fn infer_if_pat(
-        &self,
-        pat: &IfPat,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<IfPat, TyId>> {
-        let Inference(inner_pat, ty) = self.infer_pat(pat.pat, annotation_ty)?;
-        let Inference(cond, _) =
-            self.infer_term(pat.condition, self.new_data_ty(self.primitives().bool()))?;
-        Ok(Inference(IfPat { pat: inner_pat, condition: cond }, ty))
+    pub fn infer_if_pat(&self, pat: &IfPat, annotation_ty: TyId) -> TcResult<()> {
+        self.infer_pat(pat.pat, annotation_ty)?;
+        self.infer_term(pat.condition, self.new_data_ty(self.primitives().bool()))?;
+        Ok(())
     }
 
     /// Infer the type of a pattern, and return it.
-    pub fn infer_pat(
-        &self,
-        pat_id: PatId,
-        annotation_ty: TyId,
-    ) -> TcResult<Inference<PatId, TyId>> {
+    pub fn infer_pat(&self, pat_id: PatId, annotation_ty: TyId) -> TcResult<()> {
         self.register_new_atom(pat_id, annotation_ty);
 
-        let result =
-            match self.get_pat(pat_id) {
-                Pat::Binding(var) => {
-                    self.context_utils().add_typing_to_closest_stack(var.name, annotation_ty);
-                    Inference(pat_id, annotation_ty)
-                }
-                Pat::Range(range_pat) => {
-                    Inference(pat_id, self.infer_range_pat(range_pat, annotation_ty)?)
-                }
-                Pat::Lit(lit) => Inference(pat_id, self.infer_lit(&lit.into(), annotation_ty)?.1),
-                Pat::Tuple(tuple_pat) => self.generalise_pat_and_ty_inference(
-                    self.infer_tuple_pat(&tuple_pat, annotation_ty, pat_id)?,
-                ),
-                Pat::Array(list_term) => self.generalise_pat_and_ty_inference(
-                    self.infer_array_pat(&list_term, annotation_ty, pat_id)?,
-                ),
-                Pat::Ctor(ctor_pat) => self.generalise_pat_and_ty_inference(self.infer_ctor_pat(
-                    &ctor_pat,
-                    annotation_ty,
-                    pat_id,
-                )?),
-                Pat::Or(or_pat) => {
-                    self.generalise_pat_inference(self.infer_or_pat(&or_pat, annotation_ty)?)
-                }
-                Pat::If(if_pat) => {
-                    self.generalise_pat_inference(self.infer_if_pat(&if_pat, annotation_ty)?)
-                }
-            };
+        match self.get_pat(pat_id) {
+            Pat::Binding(var) => {
+                self.normalise_and_check_ty(annotation_ty)?;
+                self.context_utils().add_typing_to_closest_stack(var.name, annotation_ty);
+            }
+            Pat::Range(range_pat) => self.infer_range_pat(range_pat, annotation_ty)?,
+            Pat::Lit(lit) => self.infer_lit(&lit.into(), annotation_ty)?,
+            Pat::Tuple(tuple_pat) => self.infer_tuple_pat(&tuple_pat, annotation_ty, pat_id)?,
+            Pat::Array(list_term) => self.infer_array_pat(&list_term, annotation_ty, pat_id)?,
+            Pat::Ctor(ctor_pat) => self.infer_ctor_pat(&ctor_pat, annotation_ty, pat_id)?,
+            Pat::Or(or_pat) => self.infer_or_pat(&or_pat, annotation_ty)?,
+            Pat::If(if_pat) => self.infer_if_pat(&if_pat, annotation_ty)?,
+        };
 
-        self.register_atom_inference(pat_id, result.0, result.1);
-        Ok(result)
+        self.register_atom_inference(pat_id, pat_id, annotation_ty);
+        Ok(())
     }
 
     /// Infer the given constructor definition.
     pub fn infer_ctor_def(&self, ctor: CtorDefId) -> TcResult<()> {
-        self.context().enter_scope(ctor.into(), || {
-            let (ctor_data_def_id, ctor_params, ctor_result_args) =
-                self.stores().ctor_defs().map_fast(ctor.0, |ctors| {
-                    (ctors[ctor.1].data_def_id, ctors[ctor.1].params, ctors[ctor.1].result_args)
-                });
-
-            // Infer the parameters and return type of the data type
-            let params = self.infer_params(ctor_params, ctor.into())?;
+        let (ctor_data_def_id, ctor_params, ctor_result_args) =
+            self.stores().ctor_defs().map_fast(ctor.0, |ctors| {
+                (ctors[ctor.1].data_def_id, ctors[ctor.1].params, ctors[ctor.1].result_args)
+            });
+        self.infer_params(ctor_params, || {
             let return_ty =
                 self.new_ty(DataTy { data_def: ctor_data_def_id, args: ctor_result_args });
-            let Inference(return_ty, _) = self.infer_ty(return_ty, self.new_ty_hole())?;
-            let return_ty_args = ty_as_variant!(self, self.get_ty(return_ty), Data).args;
-
-            self.stores().ctor_defs().modify_fast(ctor.0, |ctors| {
-                ctors[ctor.1].params = params;
-                ctors[ctor.1].result_args = return_ty_args;
-            });
-
+            self.infer_ty(return_ty, self.new_ty_hole())?;
             Ok(())
         })
     }
 
     /// Infer the given data definition.
     pub fn infer_data_def(&self, data_def_id: DataDefId) -> TcResult<()> {
-        self.context().enter_scope(data_def_id.into(), || {
-            let (data_def_params, data_def_ctors) = self
-                .stores()
-                .data_def()
-                .map_fast(data_def_id, |data_def| (data_def.params, data_def.ctors));
+        let (data_def_params, data_def_ctors) = self
+            .stores()
+            .data_def()
+            .map_fast(data_def_id, |data_def| (data_def.params, data_def.ctors));
 
-            let inferred_params = self.infer_params(data_def_params, data_def_id.into())?;
-
-            self.stores().data_def().modify_fast(data_def_id, |def| def.params = inferred_params);
-
+        self.infer_params(data_def_params, || {
             match data_def_ctors {
                 DataDefCtors::Defined(data_def_ctors_id) => {
                     let mut error_state = self.new_error_state();
@@ -2038,21 +1449,13 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                         }
                         PrimitiveCtorInfo::Array(array_ctor_info) => {
                             // Infer the inner type and length
-                            let element_ty =
-                                self.infer_ty(array_ctor_info.element_ty, self.new_ty_hole())?.0;
-                            let length = array_ctor_info
-                                .length
-                                .map(|l| -> TcResult<_> {
-                                    Ok(self
-                                        .infer_term(l, self.new_data_ty(self.primitives().usize()))?
-                                        .0)
-                                })
-                                .transpose()?;
-                            self.stores().data_def().modify_fast(data_def_id, |def| {
-                                def.ctors = DataDefCtors::Primitive(PrimitiveCtorInfo::Array(
-                                    ArrayCtorInfo { element_ty, length },
-                                ));
-                            });
+                            self.infer_ty(array_ctor_info.element_ty, self.new_ty_hole())?;
+                            if let Some(length) = array_ctor_info.length {
+                                self.infer_term(
+                                    length,
+                                    self.new_data_ty(self.primitives().usize()),
+                                )?;
+                            }
                             Ok(())
                         }
                     }

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -1610,7 +1610,12 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     /// Infer an if-pattern
     pub fn infer_if_pat(&self, pat: &IfPat, annotation_ty: TyId) -> TcResult<()> {
         self.infer_pat(pat.pat, annotation_ty, None)?;
-        self.infer_term(pat.condition, self.new_data_ty(self.primitives().bool()))?;
+        let expected_condition_ty =
+            self.new_expected_ty_of(pat.condition, self.new_data_ty(self.primitives().bool()));
+        self.infer_term(pat.condition, expected_condition_ty)?;
+        if let Term::Var(v) = self.get_term(pat.condition) {
+            self.context_utils().add_assignment(v, expected_condition_ty, self.new_bool_term(true));
+        }
         Ok(())
     }
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -947,7 +947,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
         let fn_def = self.get_fn_def(fn_def_id);
 
         if fn_mode == FnInferMode::Header {
-            // If we are only inferring the header, then also want to check for
+            // If we are only inferring the header, then we also want to check for
             // immediate body functions.
             self.infer_params(fn_def.ty.params, || {
                 self.infer_ty(fn_def.ty.return_ty, self.new_flexible_universe_ty())?;

--- a/compiler/hash-typecheck/src/lib.rs
+++ b/compiler/hash-typecheck/src/lib.rs
@@ -1,4 +1,12 @@
-#![feature(unwrap_infallible, never_type, try_trait_v2, try_blocks, control_flow_enum, let_chains)]
+#![feature(
+    unwrap_infallible,
+    never_type,
+    try_trait_v2,
+    try_blocks,
+    control_flow_enum,
+    let_chains,
+    if_let_guard
+)]
 
 use errors::{TcError, TcErrorState, TcResult};
 use hash_intrinsics::{

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -423,6 +423,15 @@ impl<'a, T: AccessToTypechecking> SubstitutionOps<'a, T> {
         sub
     }
 
+    pub fn apply_sub_to_sub_in_place(&self, origin: &Sub, target: &Sub) -> Sub {
+        let mut sub = Sub::identity();
+        for (var, value) in target.iter() {
+            let value = self.apply_sub_to_term(value, origin);
+            sub.insert(var, value);
+        }
+        sub
+    }
+
     pub fn apply_sub_to_atom(&self, atom: Atom, sub: &Sub) -> Atom {
         let copy = self.copy_atom(atom);
         self.apply_sub_to_atom_in_place(copy, sub);

--- a/compiler/hash-typecheck/src/substitution.rs
+++ b/compiler/hash-typecheck/src/substitution.rs
@@ -476,9 +476,6 @@ impl<'a, T: AccessToTypechecking> SubstitutionOps<'a, T> {
     /// Invariant: the arguments are ordered to match the
     /// parameters.
     pub fn create_sub_from_args_of_params(&self, args_id: ArgsId, params_id: ParamsId) -> Sub {
-        // assert!(params_id.len() == args_id.len(), "called with mismatched args and
-        // params");
-
         let mut sub = Sub::identity();
         for (param_id, arg_id) in (params_id.iter()).zip(args_id.iter()) {
             let param = self.stores().params().get_element(param_id);

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -367,6 +367,15 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                     self.mismatching_atoms(src_id, target_id)
                 }
 
+                (Term::Ctor(c1), Term::Ctor(c2)) if c1.ctor == c2.ctor => {
+                    self.unify_args(c1.data_args, c2.data_args)?;
+                    self.unify_args(c1.ctor_args, c2.ctor_args)?;
+                    Ok(())
+                }
+                (Term::Ctor(_), _) | (_, Term::Ctor(_)) => {
+                    self.mismatching_atoms(src_id, target_id)
+                }
+
                 (Term::Var(a), Term::Var(b)) => self.unify_vars(a, b, src_id, target_id),
                 (Term::Var(_), _) | (_, Term::Var(_)) => self.mismatching_atoms(src_id, target_id),
 

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -391,6 +391,13 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                     self.mismatching_atoms(src_id, target_id)
                 }
 
+                (Term::Ref(r1), Term::Ref(r2))
+                    if r1.mutable == r2.mutable && r1.kind == r2.kind =>
+                {
+                    self.unify_terms(r1.subject, r2.subject)
+                }
+                (Term::Ref(_), _) | (_, Term::Ref(_)) => self.mismatching_atoms(src_id, target_id),
+
                 (Term::FnCall(c1), Term::FnCall(c2)) => self.unify_fn_calls(c1, c2),
                 (Term::FnCall(_), _) | (_, Term::FnCall(_)) => {
                     self.mismatching_atoms(src_id, target_id)

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -10,7 +10,6 @@ use hash_tir::{
     fns::{FnCallTerm, FnTy},
     holes::Hole,
     lits::Lit,
-    locations::LocationTarget,
     params::ParamsId,
     sub::Sub,
     symbols::Symbol,

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -4,59 +4,124 @@ use std::cell::Cell;
 
 use derive_more::Deref;
 use hash_tir::{
-    args::{ArgData, ArgsId, PatArgsId, PatOrCapture},
-    data::{DataDefCtors, DataTy},
-    environment::context::{ParamOrigin, ScopeKind},
-    fns::{FnBody, FnTy},
+    args::ArgsId,
+    data::DataDefCtors,
+    environment::context::ScopeKind,
+    fns::{FnCallTerm, FnTy},
+    holes::Hole,
     lits::Lit,
     locations::LocationTarget,
-    params::{ParamData, ParamsId},
-    pats::{Pat, PatId, PatListId},
-    refs::RefTy,
+    params::ParamsId,
     sub::Sub,
     symbols::Symbol,
     terms::{Term, TermId},
-    tuples::TupleTy,
     tys::{Ty, TyId},
     utils::{common::CommonUtils, traversing::Atom, AccessToUtils},
 };
-use hash_utils::store::{CloneStore, SequenceStore, SequenceStoreKey};
+use hash_utils::store::{CloneStore, SequenceStoreKey, Store};
 
 use crate::{
     errors::{TcError, TcResult},
-    inference::Inference,
-    params::ParamError,
     AccessToTypechecking,
 };
 
-/// Represents a unification result.
-#[derive(Debug, Clone)]
-pub struct Uni<T> {
-    pub result: T,
-    pub sub: Sub,
+#[derive(Deref)]
+pub struct UnificationOps<'a, T: AccessToTypechecking> {
+    #[deref]
+    env: &'a T,
+    add_to_ctx: Cell<bool>,
+    modify_terms: Cell<bool>,
 }
 
-impl<T> Uni<T> {
-    /// Create a unification result that is successful and has no substitution.
-    pub fn ok(result: T) -> TcResult<Self> {
-        Ok(Uni { sub: Sub::identity(), result })
+impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
+    pub fn new(env: &'tc T) -> Self {
+        Self { env, add_to_ctx: Cell::new(true), modify_terms: Cell::new(true) }
     }
 
-    /// Create a unification result that is successful and has the given
-    /// substitution.
-    pub fn ok_with(sub: Sub, result: T) -> TcResult<Self> {
-        Ok(Uni { sub, result })
+    /// Disable modifying terms
+    pub fn with_no_modify(&self) -> &Self {
+        self.modify_terms.set(false);
+        self
     }
 
-    /// Create a unification result that is blocked.
-    pub fn blocked(loc: impl Into<LocationTarget>) -> TcResult<Self> {
-        Err(TcError::Blocked(loc.into()))
+    /// Disable adding unifications to the context.
+    pub fn with_no_ctx(&self) -> &Self {
+        self.add_to_ctx.set(false);
+        self
     }
 
-    /// Create a unification result that is an error of mismatching terms.
-    ///
-    /// Invariant: `src_id` and `target_id` must be of the same atom kind.
-    pub fn mismatch_atoms(src_id: impl Into<Atom>, target_id: impl Into<Atom>) -> TcResult<Self> {
+    /// Unify two atoms.
+    pub fn unify_atoms(&self, src: Atom, target: Atom) -> TcResult<()> {
+        match (src, target) {
+            (Atom::Ty(src_id), Atom::Ty(target_id)) => {
+                self.unify_tys(src_id, target_id)?;
+                Ok(())
+            }
+            (Atom::Term(src_id), Atom::Term(target_id)) => {
+                self.unify_terms(src_id, target_id)?;
+                Ok(())
+            }
+            (Atom::Pat(_src_id), Atom::Pat(_target_id)) => {
+                // @@Todo
+                // self.unify_pats(src_id, target_id)?;
+                Ok(())
+            }
+            _ => panic!("unify_atoms: mismatching atoms"),
+        }
+    }
+
+    /// Add the given substitutions to the context.
+    pub fn add_unification_from_sub(&self, sub: &Sub) {
+        if self.add_to_ctx.get() {
+            self.context_utils().add_sub_to_scope(sub);
+        }
+    }
+
+    /// Add the given unification to the context, and create a substitution
+    /// from it.
+    pub fn add_unification(&self, src: Symbol, target: impl Into<Atom>) -> Sub {
+        let sub = Sub::from_pairs([(src, self.norm_ops().to_term(target.into()))]);
+        self.add_unification_from_sub(&sub);
+        sub
+    }
+
+    /// Emit an error that the unification cannot continue because it is
+    /// blocked.
+    pub fn blocked<U>(&self, src_id: impl Into<Atom>, target_id: impl Into<Atom>) -> TcResult<U> {
+        Err(TcError::NeedMoreTypeAnnotationsToUnify {
+            src: src_id.into(),
+            target: target_id.into(),
+        })
+    }
+
+    /// Emit an error that the two atoms are mismatching if `cond` is false,
+    pub fn ok_or_mismatching_atoms(
+        &self,
+        cond: bool,
+        src_id: impl Into<Atom>,
+        target_id: impl Into<Atom>,
+    ) -> TcResult<()> {
+        if cond {
+            Ok(())
+        } else {
+            match (src_id.into(), target_id.into()) {
+                (Atom::Term(a), Atom::Term(b)) => Err(TcError::UndecidableEquality { a, b }),
+                (Atom::Ty(a), Atom::Ty(b)) => {
+                    Err(TcError::MismatchingTypes { expected: b, actual: a, inferred_from: None })
+                }
+                (Atom::FnDef(a), Atom::FnDef(b)) => Err(TcError::MismatchingFns { a, b }),
+                (Atom::Pat(a), Atom::Pat(b)) => Err(TcError::MismatchingPats { a, b }),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Emit an error that the two atoms are mismatching.
+    pub fn mismatching_atoms<U>(
+        &self,
+        src_id: impl Into<Atom>,
+        target_id: impl Into<Atom>,
+    ) -> TcResult<U> {
         match (src_id.into(), target_id.into()) {
             (Atom::Term(a), Atom::Term(b)) => Err(TcError::UndecidableEquality { a, b }),
             (Atom::Ty(a), Atom::Ty(b)) => {
@@ -68,226 +133,154 @@ impl<T> Uni<T> {
         }
     }
 
-    pub fn map_result<U>(self, f: impl FnOnce(T) -> U) -> Uni<U> {
-        Uni { result: f(self.result), sub: self.sub }
-    }
-
-    pub fn map_into<U>(self) -> Uni<U>
-    where
-        T: Into<U>,
-    {
-        Uni { result: self.result.into(), sub: self.sub }
-    }
-}
-
-impl Uni<TyId> {
-    /// Create a unification result that is an error of mismatching types if
-    /// `cond` is false, and successful otherwise.
-    pub fn ok_iff_types_match(cond: bool, src_id: TyId, target_id: TyId) -> TcResult<Uni<TyId>> {
-        if cond {
-            Uni::ok(target_id)
-        } else {
-            Uni::mismatch_atoms(src_id, target_id)
-        }
-    }
-}
-
-impl Uni<TermId> {
-    /// Create a unification result that is an error of mismatching terms if
-    /// `cond` is false, and successful otherwise.
-    pub fn ok_iff_atoms_match<I: Into<Atom>>(
-        cond: bool,
-        src_id: I,
-        target_id: I,
-    ) -> TcResult<Uni<I>> {
-        if cond {
-            Uni::ok(target_id)
-        } else {
-            Uni::mismatch_atoms(src_id, target_id)
-        }
-    }
-}
-
-#[derive(Deref)]
-pub struct UnificationOps<'a, T: AccessToTypechecking> {
-    #[deref]
-    env: &'a T,
-    add_to_ctx: Cell<bool>,
-}
-
-impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
-    pub fn new(env: &'tc T) -> Self {
-        Self { env, add_to_ctx: Cell::new(true) }
-    }
-
-    pub fn with_no_ctx(&self) -> &Self {
-        self.add_to_ctx.set(false);
-        self
-    }
-
-    pub fn unify_atoms(&self, src: Atom, target: Atom) -> TcResult<Uni<Atom>> {
-        match (src, target) {
-            (Atom::Ty(src_id), Atom::Ty(target_id)) => {
-                Ok(self.unify_tys(src_id, target_id)?.map_into())
-            }
-            (Atom::Term(src_id), Atom::Term(target_id)) => {
-                Ok(self.unify_terms(src_id, target_id)?.map_into())
-            }
-            _ => panic!("unify_atoms: mismatching atoms"),
-        }
-    }
-
-    pub fn add_unification_from_sub(&self, sub: &Sub) {
-        if self.add_to_ctx.get() {
-            self.context_utils().add_sub_to_scope(sub);
-        }
-    }
-
-    pub fn add_unification(&self, src: Symbol, target: impl Into<Atom>) -> Sub {
-        let sub = Sub::from_pairs([(src, self.norm_ops().to_term(target.into()))]);
-        self.add_unification_from_sub(&sub);
-        sub
-    }
-
-    /// Unified two function types.
+    /// Unify two function types.
     pub fn unify_fn_tys(
         &self,
         f1: FnTy,
         f2: FnTy,
         src_id: impl Into<Atom>,
         target_id: impl Into<Atom>,
-    ) -> TcResult<Uni<FnTy>> {
+    ) -> TcResult<()> {
         if !self.fn_modalities_match(f1, f2) {
-            Uni::mismatch_atoms(src_id, target_id)
+            self.mismatching_atoms(src_id, target_id)
         } else {
             // Unify parameters and apply to return types
-            let (return_ty, shadowed_sub) =
-                self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
-                    let _ = self.unify_params(f2.params, f1.params, ParamOrigin::FnTy(f1))?;
-                    let Uni { result: return_ty, sub: _return_ty_sub } =
-                        self.unify_tys(f1.return_ty, f2.return_ty)?;
-                    let scope_sub = self.sub_ops().create_sub_from_current_scope();
-                    let shadowed_sub = self
-                        .sub_ops()
-                        .hide_param_binds(f1.params.iter().chain(f2.params.iter()), &scope_sub);
-
-                    Ok((return_ty, shadowed_sub))
-                })?;
-
-            // Add to context
-            self.add_unification_from_sub(&shadowed_sub);
-            Ok(Uni { result: FnTy { return_ty, params: f1.params, ..f1 }, sub: shadowed_sub })
+            self.unify_params(f2.params, f1.params, || self.unify_tys(f1.return_ty, f2.return_ty))?;
+            Ok(())
         }
     }
 
+    /// Unify two holes.
+    ///
+    /// This modifies src to have the contents of dest, and adds a unification
+    /// to the context.
+    pub fn unify_hole_with(
+        &self,
+        hole_src: impl Into<Atom>,
+        sub_dest: impl Into<Atom>,
+    ) -> TcResult<()> {
+        let norm_ops = self.norm_ops();
+        let hole_atom: Atom = hole_src.into();
+        let sub_dest_atom: Atom = sub_dest.into();
+
+        let hole_symbol = match hole_atom {
+            Atom::Term(term_id) => {
+                let dest_term = self.get_term(norm_ops.to_term(sub_dest_atom));
+                match self.get_term(term_id) {
+                    Term::Hole(Hole(h)) => {
+                        if self.modify_terms.get() {
+                            self.stores().term().modify_fast(term_id, |term| {
+                                *term = dest_term;
+                            });
+                        }
+                        h
+                    }
+                    _ => panic!("unify_hole_with: expected hole for hole src"),
+                }
+            }
+            Atom::Ty(ty_id) => {
+                let dest_ty = self.get_ty(norm_ops.to_ty(sub_dest_atom));
+                match self.get_ty(ty_id) {
+                    Ty::Hole(Hole(h)) => {
+                        if self.modify_terms.get() {
+                            self.stores().ty().modify_fast(ty_id, |ty| {
+                                *ty = dest_ty;
+                            });
+                        }
+                        h
+                    }
+                    _ => panic!("unify_hole_with: expected hole for hole src"),
+                }
+            }
+            Atom::FnDef(_) | Atom::Pat(_) => {
+                panic!("unify_hole_with: expected term or ty for hole src")
+            }
+        };
+        self.add_unification(hole_symbol, sub_dest_atom);
+        Ok(())
+    }
+
+    /// Unify two holes.
+    pub fn unify_holes(
+        &self,
+        h1: Hole,
+        h2: Hole,
+        src_id: impl Into<Atom>,
+        target_id: impl Into<Atom>,
+    ) -> TcResult<()> {
+        if h1 == h2 {
+            Ok(())
+        } else {
+            // We can't unify two holes, so we have to block
+            self.blocked(src_id, target_id)
+        }
+    }
+
+    pub fn unify_tys_self_contained(&self, src_id: TyId, target_id: TyId) -> TcResult<(TyId, Sub)> {
+        let initial = target_id;
+        let sub = self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
+            self.unify_tys(src_id, target_id)?;
+            Ok(self.sub_ops().create_sub_from_current_scope())
+        })?;
+        let subbed_initial = self.sub_ops().apply_sub_to_ty(initial, &sub);
+        self.add_unification_from_sub(&sub);
+        Ok((subbed_initial, sub))
+    }
+
     /// Unify two types.
-    pub fn unify_tys(&self, src_id: TyId, target_id: TyId) -> TcResult<Uni<TyId>> {
+    pub fn unify_tys(&self, src_id: TyId, target_id: TyId) -> TcResult<()> {
+        if src_id == target_id {
+            return Ok(());
+        }
+
         let norm_ops = self.norm_ops();
 
-        let src_id = norm_ops.to_ty(norm_ops.normalise(src_id.into())?);
-        let target_id = norm_ops.to_ty(norm_ops.normalise(target_id.into())?);
+        norm_ops.normalise_in_place(src_id.into())?;
+        norm_ops.normalise_in_place(target_id.into())?;
 
         let src = self.get_ty(src_id);
         let target = self.get_ty(target_id);
 
-        let result = match (src, target) {
-            (Ty::Hole(a), Ty::Hole(b)) => {
-                if a == b {
-                    // No-op
-                    Uni::ok(target_id)
-                } else {
-                    // We can't unify two holes, so we have to block
-                    Uni::blocked(target_id)
-                }
+        match (src, target) {
+            (Ty::Hole(h1), Ty::Hole(h2)) => self.unify_holes(h1, h2, src_id, target_id),
+            (Ty::Hole(_a), _) => self.unify_hole_with(src_id, target_id),
+            (_, Ty::Hole(_b)) => self.unify_hole_with(target_id, src_id),
+
+            // If the source is uninhabitable, then we can unify it with
+            // anything
+            (_, _) if self.is_uninhabitable(src_id)? => Ok(()),
+
+            (Ty::Eval(t1), Ty::Eval(t2)) => self.unify_terms(t1, t2),
+            (Ty::Eval(_), _) | (_, Ty::Eval(_)) => self.mismatching_atoms(src_id, target_id),
+
+            (Ty::Var(a), Ty::Var(b)) => self.ok_or_mismatching_atoms(a == b, src_id, target_id),
+            (Ty::Var(_), _) | (_, Ty::Var(_)) => self.mismatching_atoms(src_id, target_id),
+
+            (Ty::Tuple(t1), Ty::Tuple(t2)) => self.unify_params(t1.data, t2.data, || Ok(())),
+            (Ty::Tuple(_), _) | (_, Ty::Tuple(_)) => self.mismatching_atoms(src_id, target_id),
+
+            (Ty::Fn(f1), Ty::Fn(f2)) => self.unify_fn_tys(f1, f2, src_id, target_id),
+            (Ty::Fn(_), _) | (_, Ty::Fn(_)) => self.mismatching_atoms(src_id, target_id),
+
+            (Ty::Ref(r1), Ty::Ref(r2)) if r1.mutable == r2.mutable && r1.kind == r2.kind => {
+                self.unify_tys(r1.ty, r2.ty)
             }
-            (Ty::Hole(a), _) => {
-                let sub = Sub::from_pairs([(a.0, self.new_term(target_id))]);
-                if self.add_to_ctx.get() {
-                    self.context_utils().add_untyped_assignment(a.0, self.new_term(target_id));
-                }
-                Uni::ok_with(sub, target_id)
+            (Ty::Ref(_), _) | (_, Ty::Ref(_)) => self.mismatching_atoms(src_id, target_id),
+
+            (Ty::Data(d1), Ty::Data(d2)) if d1.data_def == d2.data_def => {
+                self.unify_args(d1.args, d2.args)
             }
-            (_, Ty::Hole(b)) => {
-                let sub = Sub::from_pairs([(b.0, self.new_term(src_id))]);
-                if self.add_to_ctx.get() {
-                    self.context_utils().add_untyped_assignment(b.0, self.new_term(src_id));
-                }
-                Uni::ok_with(sub, src_id)
-            }
-            (_, _) if self.is_uninhabitable(src_id)? => Uni::ok(target_id),
+            (Ty::Data(_), _) | (_, Ty::Data(_)) => self.mismatching_atoms(src_id, target_id),
 
-            (Ty::Eval(t1), Ty::Eval(t2)) => {
-                let uni = self.unify_terms(t1, t2)?;
-                // Ensure it is a type
-                let result_ty = self.infer_ops().use_term_in_ty_pos(uni.result)?;
-                Ok(uni.map_result(|_| result_ty))
-            }
-            (Ty::Eval(_), _) => Uni::mismatch_atoms(src_id, target_id),
-            (_, Ty::Eval(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Var(a), Ty::Var(b)) => Uni::ok_iff_types_match(a == b, src_id, target_id),
-            (Ty::Var(_), _) | (_, Ty::Var(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Tuple(t1), Ty::Tuple(t2)) => Ok(self
-                .unify_params(t1.data, t2.data, ParamOrigin::TupleTy(t1))?
-                .map_result(|data| self.new_ty(TupleTy { data }))),
-            (Ty::Tuple(_), _) | (_, Ty::Tuple(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Fn(f1), Ty::Fn(f2)) => {
-                if !self.fn_modalities_match(f1, f2) {
-                    Uni::mismatch_atoms(src_id, target_id)
-                } else {
-                    self.context().enter_scope(f2.into(), || {
-                        let Uni { sub: param_sub, result: params } =
-                            self.unify_params(f1.params, f2.params, ParamOrigin::FnTy(f1))?;
-
-                        let return_ty_1_subbed =
-                            self.sub_ops().apply_sub_to_ty(f1.return_ty, &param_sub);
-                        let return_ty_2_subbed =
-                            self.sub_ops().apply_sub_to_ty(f2.return_ty, &param_sub);
-
-                        let Uni { result: return_ty, sub: return_ty_sub } =
-                            self.unify_tys(return_ty_1_subbed, return_ty_2_subbed)?;
-
-                        Ok(Uni {
-                            result: self.new_ty(FnTy { return_ty, params, ..f1 }),
-                            sub: return_ty_sub.join(&param_sub),
-                        })
-                    })
-                }
-            }
-            (Ty::Fn(_), _) | (_, Ty::Fn(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Ref(r1), Ty::Ref(r2)) => {
-                if r1.mutable == r2.mutable && r1.kind == r2.kind {
-                    let result = self.unify_tys(r1.ty, r2.ty)?;
-                    Ok(result.map_result(|ty| self.new_ty(RefTy { ty, ..r1 })))
-                } else {
-                    Uni::mismatch_atoms(src_id, target_id)
-                }
-            }
-            (Ty::Ref(_), _) | (_, Ty::Ref(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Data(d1), Ty::Data(d2)) => {
-                if d1.data_def == d2.data_def {
-                    Ok(self
-                        .unify_args(d1.args, d2.args)?
-                        .map_result(|args| self.new_ty(DataTy { data_def: d1.data_def, args })))
-                } else {
-                    Uni::mismatch_atoms(src_id, target_id)
-                }
-            }
-            (Ty::Data(_), _) | (_, Ty::Data(_)) => Uni::mismatch_atoms(src_id, target_id),
-
-            (Ty::Universe(u1), Ty::Universe(u2)) => {
-                Uni::ok_iff_types_match(u1.size == u2.size, src_id, target_id)
-            }
-        }?;
-
-        self.stores().location().copy_location(src_id, result.result);
-        Ok(result)
+            (Ty::Universe(u1), Ty::Universe(u2)) => self.ok_or_mismatching_atoms(
+                u1.size.is_none() || u2.size.is_none() || u1.size.unwrap() <= u2.size.unwrap(),
+                src_id,
+                target_id,
+            ),
+        }
     }
 
+    /// Whether two literals are equal.
     pub fn lits_are_equal(&self, src: Lit, target: Lit) -> bool {
         match (src, target) {
             (Lit::Int(i1), Lit::Int(i2)) => i1.value() == i2.value(),
@@ -298,182 +291,87 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
         }
     }
 
+    pub fn unify_fn_calls(&self, src: FnCallTerm, target: FnCallTerm) -> TcResult<()> {
+        self.unify_terms(src.subject, target.subject)?;
+        self.unify_args(src.args, target.args)?;
+        Ok(())
+    }
+
     /// Unify two terms.
     ///
     /// Unless these are types, they must be definitionally (up to beta
     /// reduction) equal.
-    pub fn unify_terms(&self, src_id: TermId, target_id: TermId) -> TcResult<Uni<TermId>> {
+    pub fn unify_terms(&self, src_id: TermId, target_id: TermId) -> TcResult<()> {
         if src_id == target_id {
-            return Uni::ok(src_id);
+            return Ok(());
         }
 
-        // @@Todo: document and implement remaining cases
+        let norm_ops = self.norm_ops();
 
-        let src_id = self.norm_ops().to_term(self.norm_ops().normalise(src_id.into())?);
-        let target_id = self.norm_ops().to_term(self.norm_ops().normalise(target_id.into())?);
+        norm_ops.normalise_in_place(src_id.into())?;
+        norm_ops.normalise_in_place(target_id.into())?;
 
         let src = self.get_term(src_id);
         let target = self.get_term(target_id);
 
-        let result = match (self.try_use_term_as_ty(src_id), self.try_use_term_as_ty(target_id)) {
-            (Some(src_ty), Some(target_ty)) => {
-                let uni = self.unify_tys(src_ty, target_ty)?;
-                Ok(uni.map_result(|t| self.new_term(t)))
-            }
+        match (self.try_use_term_as_ty(src_id), self.try_use_term_as_ty(target_id)) {
+            (Some(src_ty), Some(target_ty)) => self.unify_tys(src_ty, target_ty),
             _ => match (src, target) {
                 (Term::Ty(t1), _) => self.unify_terms(self.use_ty_as_term(t1), target_id),
                 (_, Term::Ty(t2)) => self.unify_terms(src_id, self.use_ty_as_term(t2)),
-                (Term::Var(a), Term::Var(b)) => Uni::ok_iff_atoms_match(a == b, src_id, target_id),
-                (Term::Hole(a), Term::Hole(b)) => {
-                    Uni::ok_iff_atoms_match(a == b, src_id, target_id)
+
+                (Term::Hole(h1), Term::Hole(h2)) => self.unify_holes(h1, h2, src_id, target_id),
+                (Term::Hole(_a), _) => self.unify_hole_with(src_id, target_id),
+                (_, Term::Hole(_b)) => self.unify_hole_with(target_id, src_id),
+
+                (Term::Var(a), Term::Var(b)) => {
+                    self.ok_or_mismatching_atoms(a == b, src_id, target_id)
                 }
-                (Term::Hole(a), _) => {
-                    let sub = Sub::from_pairs([(a.0, target_id)]);
-                    Uni::ok_with(sub, target_id)
-                }
-                (_, Term::Hole(b)) => {
-                    let sub = Sub::from_pairs([(b.0, src_id)]);
-                    Uni::ok_with(sub, src_id)
-                }
+                (Term::Var(_), _) | (_, Term::Var(_)) => self.mismatching_atoms(src_id, target_id),
+
                 (Term::Lit(l1), Term::Lit(l2)) => {
-                    Uni::ok_iff_atoms_match(self.lits_are_equal(l1, l2), src_id, target_id)
+                    self.ok_or_mismatching_atoms(self.lits_are_equal(l1, l2), src_id, target_id)
                 }
-                (Term::Access(a1), Term::Access(a2)) => {
-                    let _ = self.unify_terms(a1.subject, a2.subject)?;
-                    Uni::ok_iff_atoms_match(a1.field == a2.field, src_id, target_id)
+                (Term::Lit(_), _) | (_, Term::Lit(_)) => self.mismatching_atoms(src_id, target_id),
+
+                (Term::Access(a1), Term::Access(a2)) if a1.field == a2.field => {
+                    self.unify_terms(a1.subject, a2.subject)
                 }
-                (Term::FnCall(c1), Term::FnCall(c2)) => {
-                    let _ = self.unify_terms(c1.subject, c2.subject)?;
-                    let _ = self.unify_args(c1.args, c2.args)?;
-                    Uni::ok(src_id)
-                }
-                (Term::FnRef(f1), Term::FnRef(f2)) => {
-                    if f1 == f2 {
-                        return Uni::ok(src_id);
-                    }
-                    let f1_def = self.get_fn_def(f1);
-                    let f2_def = self.get_fn_def(f2);
-
-                    self.context().enter_scope(f1.into(), || {
-                        // @@Todo: use sub
-                        let Uni { sub: param_sub, result: _ } = self.unify_params(
-                            f1_def.ty.params,
-                            f2_def.ty.params,
-                            ParamOrigin::FnTy(f1_def.ty),
-                        )?;
-
-                        let return_ty_1_subbed =
-                            self.sub_ops().apply_sub_to_ty(f1_def.ty.return_ty, &param_sub);
-                        let return_ty_2_subbed =
-                            self.sub_ops().apply_sub_to_ty(f2_def.ty.return_ty, &param_sub);
-
-                        let Uni { result: _, sub: _ } =
-                            self.unify_tys(return_ty_1_subbed, return_ty_2_subbed)?;
-
-                        match (f1_def.body, f2_def.body) {
-                            (FnBody::Defined(f1_body), FnBody::Defined(f2_body)) => {
-                                let body_1_subbed =
-                                    self.sub_ops().apply_sub_to_term(f1_body, &param_sub);
-                                let body_2_subbed =
-                                    self.sub_ops().apply_sub_to_term(f2_body, &param_sub);
-
-                                let _ = self.unify_terms(body_1_subbed, body_2_subbed)?;
-                                Uni::ok(src_id)
-                            }
-                            (FnBody::Intrinsic(i1), FnBody::Intrinsic(i2)) => {
-                                Uni::ok_iff_atoms_match(i1.0 == i2.0, src_id, target_id)
-                            }
-                            (FnBody::Axiom, FnBody::Axiom) => Uni::ok(src_id),
-                            _ => Uni::mismatch_atoms(src_id, target_id),
-                        }
-                    })
+                (Term::Access(_), _) | (_, Term::Access(_)) => {
+                    self.mismatching_atoms(src_id, target_id)
                 }
 
-                (Term::Match(m1), Term::Match(m2)) => {
-                    let _ = self.unify_terms(m1.subject, m2.subject)?;
-
-                    Uni::ok(src_id)
+                (Term::FnCall(c1), Term::FnCall(c2)) => self.unify_fn_calls(c1, c2),
+                (Term::FnCall(_), _) | (_, Term::FnCall(_)) => {
+                    self.mismatching_atoms(src_id, target_id)
                 }
 
-                _ => Uni::mismatch_atoms(src_id, target_id),
+                (Term::FnRef(f1), Term::FnRef(f2)) if f1 == f2 => Ok(()),
+                (Term::FnRef(_), _) | (_, Term::FnRef(_)) => {
+                    self.mismatching_atoms(src_id, target_id)
+                }
+
+                // @@Todo: rest
+                _ => self.mismatching_atoms(src_id, target_id),
             },
-        }?;
-        self.stores().location().copy_location(src_id, result.result);
-        Ok(result)
-    }
-
-    pub fn pats_are_equal(&self, src_id: PatId, target_id: PatId) -> bool {
-        match (self.get_pat(src_id), self.get_pat(target_id)) {
-            (Pat::Binding(v1), Pat::Binding(v2)) => {
-                v1.is_mutable == v2.is_mutable && v1.name == v2.name
-            }
-            (_, Pat::Binding(_)) | (Pat::Binding(_), _) => false,
-
-            (Pat::Range(r1), Pat::Range(r2)) => {
-                self.lits_are_equal(r1.start.into(), r2.start.into())
-                    && self.lits_are_equal(r1.end.into(), r2.end.into())
-                    && r1.range_end == r2.range_end
-            }
-            (Pat::Range(_), _) | (_, Pat::Range(_)) => false,
-
-            (Pat::Lit(l1), Pat::Lit(l2)) => self.lits_are_equal(l1.into(), l2.into()),
-            (Pat::Lit(_), _) | (_, Pat::Lit(_)) => false,
-
-            (Pat::Tuple(t1), Pat::Tuple(t2)) => {
-                self.pat_args_are_equal(t1.data, t2.data) && t1.data_spread == t2.data_spread
-            }
-            (Pat::Tuple(_), _) | (_, Pat::Tuple(_)) => false,
-
-            (Pat::Array(a1), Pat::Array(a2)) => {
-                self.pat_lists_are_equal(a1.pats, a2.pats) && a1.spread == a2.spread
-            }
-            (Pat::Array(_), _) | (_, Pat::Array(_)) => false,
-
-            (Pat::Ctor(_c1), Pat::Ctor(_c2)) => {
-                todo!()
-            }
-            (Pat::Ctor(_), _) | (_, Pat::Ctor(_)) => todo!(),
-            (Pat::Or(_), Pat::Or(_)) => todo!(),
-            (Pat::Or(_), _) | (_, Pat::Or(_)) => todo!(),
-            (Pat::If(_), Pat::If(_)) => todo!(),
         }
     }
 
-    /// Reduce an iterator of unifications into a single unification.
+    /// Unify two parameter lists.
     ///
-    /// If any of the unifications are blocked or error, then this is forwarded
-    /// to the result.
-    pub fn reduce_unifications<U, V>(
-        &self,
-        unifications: impl Iterator<Item = TcResult<Uni<U>>>,
-        collect_results: impl FnOnce(Vec<U>) -> V,
-    ) -> TcResult<Uni<V>> {
-        let mut sub = Sub::identity();
-        let mut results = Vec::new();
-
-        for unification in unifications {
-            let uni = unification?;
-            sub = sub.join(&uni.sub);
-            results.push(uni.result);
-        }
-
-        Uni::ok_with(sub, collect_results(results))
-    }
-
-    /// Unify two parameter lists, creating a substitution of holes.
+    /// This takes a function to run in the scope of the parameters. It also
+    /// adds the ambient substitutions to the current scope.
     ///
-    /// The parameters must be already in scope.
-    ///
-    /// Names are taken from target
-    pub fn unify_params(
+    /// Names are taken from src
+    pub fn unify_params<U>(
         &self,
         src_id: ParamsId,
         target_id: ParamsId,
-        _origin: ParamOrigin,
-    ) -> TcResult<Uni<ParamsId>> {
+        in_param_scope: impl FnOnce() -> TcResult<U>,
+    ) -> TcResult<U> {
+        // Validate the parameters and ensure they are of the same length
         self.param_ops().validate_params(src_id)?;
         self.param_ops().validate_params(target_id)?;
-
         if src_id.len() != target_id.len() {
             return Err(TcError::WrongParamLength {
                 given_params_id: src_id,
@@ -481,119 +379,54 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
             });
         }
 
-        let name_sub = self.sub_ops().create_sub_from_param_names(src_id, target_id);
+        let (result, shadowed_sub) =
+            self.context().enter_scope(ScopeKind::Sub, || -> TcResult<_> {
+                for (src_param_id, target_param_id) in src_id.iter().zip(target_id.iter()) {
+                    let src_param = self.get_param(src_param_id);
+                    let target_param = self.get_param(target_param_id);
 
-        let param_uni = self.reduce_unifications(
-            src_id.iter().zip(target_id.iter()).map(|(src, target)| {
-                let src = self.stores().params().get_element(src);
-                let target = self.stores().params().get_element(target);
+                    // Substitute the names
+                    self.context_utils().add_assignment(
+                        src_param.name,
+                        src_param.ty,
+                        self.new_term(target_param.name),
+                    );
 
-                match (src.default, target.default) {
-                    (None, None) => {}
-                    // @@Todo
-                    _ => unimplemented!("unify_params with defaults"),
+                    // Unify the types
+                    self.unify_tys(src_param.ty, target_param.ty)?;
                 }
 
-                match (self.get_param_name_ident(src.id), self.get_param_name_ident(target.id)) {
-                    (Some(name_a), Some(name_b)) if name_a != name_b => {
-                        return Err(TcError::ParamMatch(ParamError::ParamNameMismatch {
-                            param_a: src.id,
-                            param_b: target.id,
-                        }));
-                    }
-                    _ => {}
-                }
+                // Run the in-scope closure
+                let result = in_param_scope()?;
 
-                let Inference(target_ty, _) =
-                    self.infer_ops().infer_ty(target.ty, self.new_ty_hole())?;
+                // Only keep the substitutions that do not refer to the parameters
+                let scope_sub = self.sub_ops().create_sub_from_current_scope();
+                let shadowed_sub = self
+                    .sub_ops()
+                    .hide_param_binds(src_id.iter().chain(target_id.iter()), &scope_sub);
+                Ok((result, shadowed_sub))
+            })?;
 
-                // Apply the name substitution to the parameter
-                let subbed_src_ty = self.sub_ops().apply_sub_to_ty(src.ty, &name_sub);
+        // Add the shadowed substitutions to the ambient scope
+        self.add_unification_from_sub(&shadowed_sub);
 
-                let Inference(src_ty, _) =
-                    self.infer_ops().infer_ty(subbed_src_ty, self.new_ty_hole())?;
-
-                let unified_param = self.unify_tys(src_ty, target_ty)?.map_result(|ty| ParamData {
-                    name: target.name,
-                    ty,
-                    default: None,
-                });
-
-                self.context_utils().add_param_binding(target.id);
-
-                Ok(unified_param)
-            }),
-            |param_data| self.param_utils().create_params(param_data.into_iter()),
-        )?;
-
-        Ok(Uni { result: param_uni.result, sub: param_uni.sub.join(&name_sub) })
+        Ok(result)
     }
 
-    pub fn pat_lists_are_equal(&self, src_id: PatListId, target_id: PatListId) -> bool {
-        if src_id.len() != target_id.len() {
-            false
-        } else {
-            self.map_pat_list(src_id, |src| {
-                self.map_pat_list(target_id, |target| {
-                    src.iter()
-                        .zip(target.iter())
-                        .map(|(src, target)| match (src, target) {
-                            (PatOrCapture::Pat(src_pat), PatOrCapture::Pat(target_pat)) => {
-                                self.pats_are_equal(*src_pat, *target_pat)
-                            }
-                            (PatOrCapture::Capture, PatOrCapture::Capture) => true,
-                            _ => false,
-                        })
-                        .all(|x| x)
-                })
-            })
-        }
-    }
-
-    /// Unify two pattern argument lists, creating a substitution of holes.
-    pub fn pat_args_are_equal(&self, src_id: PatArgsId, target_id: PatArgsId) -> bool {
-        if src_id.len() != target_id.len() {
-            false
-        } else {
-            self.map_pat_args(src_id, |src| {
-                self.map_pat_args(target_id, |target| {
-                    src.iter()
-                        .zip(target.iter())
-                        .map(|(src, target)| match (src.pat, target.pat) {
-                            (PatOrCapture::Pat(src_pat), PatOrCapture::Pat(target_pat)) => {
-                                self.pats_are_equal(src_pat, target_pat)
-                            }
-                            (PatOrCapture::Capture, PatOrCapture::Capture) => true,
-                            _ => false,
-                        })
-                        .all(|x| x)
-                })
-            })
-        }
-    }
-
-    pub fn unify_args(&self, src_id: ArgsId, target_id: ArgsId) -> TcResult<Uni<ArgsId>> {
+    /// Unify two argument lists.
+    pub fn unify_args(&self, src_id: ArgsId, target_id: ArgsId) -> TcResult<()> {
         if src_id.len() != target_id.len() {
             return Err(TcError::DifferentParamOrArgLengths {
                 a: src_id.into(),
                 b: target_id.into(),
             });
         }
-        self.map_args(src_id, |src| {
-            self.map_args(target_id, |target| {
-                self.reduce_unifications(
-                    src.iter()
-                        .zip(target.iter())
-                        // @@Correctness: which name to use here?
-                        .map(|(src, target)| {
-                            Ok(self
-                                .unify_terms(src.value, target.value)?
-                                .map_result(|term| ArgData { target: target.target, value: term }))
-                        }),
-                    |arg_data| self.param_utils().create_args(arg_data.into_iter()),
-                )
-            })
-        })
+        for (src_arg_id, target_arg_id) in src_id.iter().zip(target_id.iter()) {
+            let src_arg = self.get_arg(src_arg_id);
+            let target_arg = self.get_arg(target_arg_id);
+            self.unify_terms(src_arg.value, target_arg.value)?;
+        }
+        Ok(())
     }
 
     /// Whether two function types match in terms of their modality.
@@ -603,8 +436,10 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
 
     /// Determine whether two terms are equal.
     pub fn terms_are_equal(&self, t1: TermId, t2: TermId) -> bool {
-        self.uni_ops().with_no_ctx().unify_terms(t1, t2).map(|result| result.sub.is_empty()).ok()
-            == Some(true)
+        // @@Todo: prevent modification?
+        let uni_ops = self.uni_ops();
+        uni_ops.with_no_modify();
+        self.context().enter_scope(ScopeKind::Sub, || uni_ops.unify_terms(t1, t2).is_ok())
     }
 
     /// Determine whether the given type is uninhabitable.
@@ -624,4 +459,85 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
             _ => Ok(false),
         }
     }
+
+    // @@Todo pats
+    // pub fn pat_lists_are_equal(&self, src_id: PatListId, target_id: PatListId) ->
+    // bool {     if src_id.len() != target_id.len() {
+    //         false
+    //     } else {
+    //         self.map_pat_list(src_id, |src| {
+    //             self.map_pat_list(target_id, |target| {
+    //                 src.iter()
+    //                     .zip(target.iter())
+    //                     .map(|(src, target)| match (src, target) {
+    //                         (PatOrCapture::Pat(src_pat),
+    // PatOrCapture::Pat(target_pat)) => {
+    // self.pats_are_equal(*src_pat, *target_pat)                         }
+    //                         (PatOrCapture::Capture, PatOrCapture::Capture) =>
+    // true,                         _ => false,
+    //                     })
+    //                     .all(|x| x)
+    //             })
+    //         })
+    //     }
+    // }
+
+    // pub fn pats_are_equal(&self, src_id: PatId, target_id: PatId) -> bool {
+    //     match (self.get_pat(src_id), self.get_pat(target_id)) {
+    //         (Pat::Binding(v1), Pat::Binding(v2)) => {
+    //             v1.is_mutable == v2.is_mutable && v1.name == v2.name
+    //         }
+    //         (_, Pat::Binding(_)) | (Pat::Binding(_), _) => false,
+
+    //         (Pat::Range(r1), Pat::Range(r2)) => {
+    //             self.lits_are_equal(r1.start.into(), r2.start.into())
+    //                 && self.lits_are_equal(r1.end.into(), r2.end.into())
+    //                 && r1.range_end == r2.range_end
+    //         }
+    //         (Pat::Range(_), _) | (_, Pat::Range(_)) => false,
+
+    //         (Pat::Lit(l1), Pat::Lit(l2)) => self.lits_are_equal(l1.into(),
+    // l2.into()),         (Pat::Lit(_), _) | (_, Pat::Lit(_)) => false,
+
+    //         (Pat::Tuple(t1), Pat::Tuple(t2)) => {
+    //             self.pat_args_are_equal(t1.data, t2.data) && t1.data_spread ==
+    // t2.data_spread         }
+    //         (Pat::Tuple(_), _) | (_, Pat::Tuple(_)) => false,
+
+    //         (Pat::Array(a1), Pat::Array(a2)) => {
+    //             self.pat_lists_are_equal(a1.pats, a2.pats) && a1.spread ==
+    // a2.spread         }
+    //         (Pat::Array(_), _) | (_, Pat::Array(_)) => false,
+
+    //         (Pat::Ctor(_c1), Pat::Ctor(_c2)) => {
+    //             todo!()
+    //         }
+    //         (Pat::Ctor(_), _) | (_, Pat::Ctor(_)) => todo!(),
+    //         (Pat::Or(_), Pat::Or(_)) => todo!(),
+    //         (Pat::Or(_), _) | (_, Pat::Or(_)) => todo!(),
+    //         (Pat::If(_), Pat::If(_)) => todo!(),
+    //     }
+    // }
+
+    // /// Unify two pattern argument lists, creating a substitution of holes.
+    // pub fn pat_args_are_equal(&self, src_id: PatArgsId, target_id: PatArgsId) ->
+    // bool {     if src_id.len() != target_id.len() {
+    //         false
+    //     } else {
+    //         self.map_pat_args(src_id, |src| {
+    //             self.map_pat_args(target_id, |target| {
+    //                 src.iter()
+    //                     .zip(target.iter())
+    //                     .map(|(src, target)| match (src.pat, target.pat) {
+    //                         (PatOrCapture::Pat(src_pat),
+    // PatOrCapture::Pat(target_pat)) => {
+    // self.pats_are_equal(src_pat, target_pat)                         }
+    //                         (PatOrCapture::Capture, PatOrCapture::Capture) =>
+    // true,                         _ => false,
+    //                     })
+    //                     .all(|x| x)
+    //             })
+    //         })
+    //     }
+    // }
 }

--- a/compiler/hash-typecheck/src/unification.rs
+++ b/compiler/hash-typecheck/src/unification.rs
@@ -74,7 +74,6 @@ impl<'tc, T: AccessToTypechecking> UnificationOps<'tc, T> {
                 Ok(())
             }
             (Atom::Pat(_src_id), Atom::Pat(_target_id)) => {
-                // @@Todo
                 // self.unify_pats(src_id, target_id)?;
                 Ok(())
             }

--- a/stdlib/eq.hash
+++ b/stdlib/eq.hash
@@ -1,19 +1,23 @@
-eq := mod {
-  subst := <A, P: <u: A> -> Type, a: A, b: A> => #pure (p: a ~ b, m: P<a>) -> P<b> => {
-    match p {
-      Equal::Refl(_) => m
-    }
+subst := <A, a: A, b: A> => #pure (P: A -> Type, p: a ~ b, m: {P(a)}) -> {P(b)} => {
+  match p {
+    Equal::Refl(x) => m
   }
+}
 
-  sym := <A, a: A, b: A> => #pure (p: a ~ b) -> b ~ a => {
-    match p {
-      Equal::Refl(_) => p
-    }
+transport := <A, C, a: A, b: A> => (P: (y: A) -> C, p: a ~ b) -> {P(a)} ~ {P(b)} => {
+  match p {
+    Equal::Refl(x) => Equal::Refl(P(x))
   }
+}
 
-  trans := <A, a: A, b: A, c: A> => #pure (p: a ~ b, q: b ~ c) -> a ~ c => {
-    match p {
-      Equal::Refl(_) => q
-    }
+sym := <A, a: A, b: A> => (p: a ~ b) -> b ~ a => {
+  match p {
+    Equal::Refl(_) => p
+  }
+}
+
+trans := <A, a: A, b: A, c: A> => (p: a ~ b, q: b ~ c) -> a ~ c => {
+  match p {
+    Equal::Refl(_) => q
   }
 }

--- a/stdlib/eq.hash
+++ b/stdlib/eq.hash
@@ -1,0 +1,19 @@
+eq := mod {
+  subst := <A, P: <u: A> -> Type, a: A, b: A> => #pure (p: a ~ b, m: P<a>) -> P<b> => {
+    match p {
+      Equal::Refl(_) => m
+    }
+  }
+
+  sym := <A, a: A, b: A> => #pure (p: a ~ b) -> b ~ a => {
+    match p {
+      Equal::Refl(_) => p
+    }
+  }
+
+  trans := <A, a: A, b: A, c: A> => #pure (p: a ~ b, q: b ~ c) -> a ~ c => {
+    match p {
+      Equal::Refl(_) => q
+    }
+  }
+}

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -1,6 +1,8 @@
 /// The Hash Compiler Prelude, this defines core language functionality
 /// that is expected to be available to all running contexts.
 
+eq := import("eq")
+
 /// The `cast(..)` function is used to cast some value into another
 /// type provided that the types are cast compatible.
 cast := <T, U> => (item: T) -> U => {

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -3,7 +3,7 @@
 
 /// The `cast(..)` function is used to cast some value into another
 /// type provided that the types are cast compatible.
-cast := <T> => (U: Type, item: T) -> U => {
+cast := <T, U> => (item: T) -> U => {
     Intrinsics::cast(T, U, item)
 }
 


### PR DESCRIPTION
This PR:
- Modifies the way that inference and unification is done so that new terms don't have to be created all the time. This retains most locations automatically.
- Adds dependent pattern matching support (and equality identities in Prelude), as well as the ability to define inductive data types with indices to the parser.
- Fixes a lot of issues with the previous inference.
- The analysis only requires an entry point if the target stage is `> Lowering`.

Closes #841.

Unfortunately there are still a few places where locations aren't set due to copying, hopefully this can be done soon.