### PR TITLE
exe mode

### DIFF
--- a/compiler/hash-link/src/command.rs
+++ b/compiler/hash-link/src/command.rs
@@ -17,7 +17,7 @@ use hash_target::{link::LldFlavour, Platform};
 /// [`LinkProgram::Normal`] this is just a path to the program that should
 /// be run. For [`LinkProgram::Lld`] this is the path to the Lld executable
 /// and the flavour of Lld that should be used.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum LinkProgram {
     /// Just a path to the program that should run.
     Normal(OsString),
@@ -31,7 +31,7 @@ pub enum LinkProgram {
 /// A wrapper around the [Command] type which allows us to
 /// build up a command and read the arguments that are being
 /// passed without having to go through the [Command].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LinkCommand {
     /// The path to the command executable.
     command: LinkProgram,

--- a/compiler/hash-link/src/error.rs
+++ b/compiler/hash-link/src/error.rs
@@ -71,7 +71,7 @@ impl From<LinkerError<'_>> for Report {
         let mut report = Report::new();
 
         let title = match error {
-            LinkerError::NotFound { path } => format!("linker `{path:?}` not found"),
+            LinkerError::NotFound { path } => format!("linker `{}` not found", path.display()),
             LinkerError::UnsupportedArch { arch, os } => {
                 format!("unsupported architecture `{arch}` for `{os}`")
             }

--- a/compiler/hash-link/src/lib.rs
+++ b/compiler/hash-link/src/lib.rs
@@ -62,7 +62,7 @@ impl<Ctx: LinkerCtxQuery> CompilerStage<Ctx> for CompilerLinker {
 
         // Get the executable path that is going to be
         // emitted by the compiler.
-        let output_path = workspace.executable_path();
+        let output_path = workspace.executable_path(settings);
         let temp_path = workspace.temporary_storage("link").map_err(|err| vec![err.into()])?;
 
         // Get the linker that is going to be used to link

--- a/compiler/hash-link/src/platform/mod.rs
+++ b/compiler/hash-link/src/platform/mod.rs
@@ -2,7 +2,7 @@
 //! to linking executables that includes "platform" specific linker
 //! options.
 
-use std::{fs, io, path::Path, process::Output};
+use std::{io, path::Path, process::Output};
 
 use crate::command::LinkCommand;
 
@@ -43,7 +43,7 @@ pub fn flush_linked_file(_: &io::Result<Output>, _: &Path) -> io::Result<()> {
 pub fn flush_linked_file(command_output: &io::Result<Output>, filename: &Path) -> io::Result<()> {
     if let Ok(out) = command_output {
         if out.status.success() {
-            if let Ok(of) = fs::OpenOptions::new().write(true).open(filename) {
+            if let Ok(of) = std::fs::OpenOptions::new().write(true).open(filename) {
                 of.sync_all()?;
             }
         }

--- a/compiler/hash-link/src/platform/mod.rs
+++ b/compiler/hash-link/src/platform/mod.rs
@@ -2,7 +2,7 @@
 //! to linking executables that includes "platform" specific linker
 //! options.
 
-use std::{io, path::Path, process::Output};
+use std::{fs, io, path::Path, process::Output};
 
 use crate::command::LinkCommand;
 

--- a/compiler/hash-link/src/platform/mod.rs
+++ b/compiler/hash-link/src/platform/mod.rs
@@ -41,7 +41,7 @@ pub fn flush_linked_file(_: &io::Result<Output>, _: &Path) -> io::Result<()> {
 /// compiler-bug-linker-bug-windows-kernel-bug/amp>
 #[cfg(windows)]
 pub fn flush_linked_file(command_output: &io::Result<Output>, filename: &Path) -> io::Result<()> {
-    if let &Ok(ref out) = command_output {
+    if let Ok(out) = command_output {
         if out.status.success() {
             if let Ok(of) = fs::OpenOptions::new().write(true).open(filename) {
                 of.sync_all()?;

--- a/compiler/hash-pipeline/src/args.rs
+++ b/compiler/hash-pipeline/src/args.rs
@@ -34,7 +34,10 @@ pub fn parse_settings_from_args() -> Result<CompilerSettings, PipelineError> {
             // `ast-gen`...
             match arg {
                 "build" => {
-                    settings.stage = CompilerStageKind::Full;
+                    settings.stage = CompilerStageKind::Build;
+                }
+                "exe" => {
+                    settings.stage = CompilerStageKind::Exe;
                 }
                 "run" => {
                     settings.stage = CompilerStageKind::Analysis;

--- a/compiler/hash-pipeline/src/interface.rs
+++ b/compiler/hash-pipeline/src/interface.rs
@@ -138,6 +138,11 @@ pub trait CompilerInterface {
     /// Get a mutable reference to the current [CompilerSettings].
     fn settings_mut(&mut self) -> &mut CompilerSettings;
 
+    /// Check if the context has accumulated any errors.
+    fn has_errors(&self) -> bool {
+        self.diagnostics().iter().any(|report| report.is_error())
+    }
+
     /// Get the current [Report]s that have been collected by the compiler.
     fn diagnostics(&self) -> &[Report];
 

--- a/compiler/hash-pipeline/src/lib.rs
+++ b/compiler/hash-pipeline/src/lib.rs
@@ -106,7 +106,7 @@ impl<I: CompilerInterface> Compiler<I> {
         // Iterate over each stage and print out the timings.
         for stage in stages {
             // This shouldn't occur as we don't record this metric in this way
-            if kind == CompilerStageKind::Full {
+            if kind >= CompilerStageKind::Build {
                 continue;
             }
 
@@ -145,7 +145,7 @@ impl<I: CompilerInterface> Compiler<I> {
         stream_writeln!(
             stderr,
             "{: <width$}: {total:?}\n",
-            format!("{}", CompilerStageKind::Full),
+            format!("{}", CompilerStageKind::Build),
             width = longest_key
         );
     }

--- a/compiler/hash-pipeline/src/settings.rs
+++ b/compiler/hash-pipeline/src/settings.rs
@@ -475,7 +475,11 @@ pub enum CompilerStageKind {
     /// this will invoke the compiler through the full pipeline,
     /// whilst also potentially creating an executable.
     #[default]
-    Full,
+    Build,
+
+    /// This is a special stage that is used to instruct the compiler
+    /// to immediately run the emitted executable.
+    Exe,
 }
 
 impl CompilerStageKind {
@@ -489,7 +493,8 @@ impl CompilerStageKind {
             CompilerStageKind::Lower => "lower",
             CompilerStageKind::CodeGen => "codegen",
             CompilerStageKind::Link => "link",
-            CompilerStageKind::Full => "full",
+            CompilerStageKind::Build => "build",
+            CompilerStageKind::Exe => "exe",
         }
     }
 }

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -258,7 +258,7 @@ impl Workspace {
 
     /// Check whether this [Workspace] will yield an executable.
     pub fn yields_executable(&self, settings: &CompilerSettings) -> bool {
-        self.source_map.entry_point().is_some() && settings.stage == CompilerStageKind::Full
+        settings.stage >= CompilerStageKind::Build && self.source_map.entry_point().is_some()
     }
 
     /// Get the bitcode path for a particular [ModuleId]. This does not

--- a/compiler/hash-pipeline/src/workspace.rs
+++ b/compiler/hash-pipeline/src/workspace.rs
@@ -223,13 +223,16 @@ impl Workspace {
     /// final binary to. This is workspace dependant, since the executables
     /// might not even be emitted for a workspaces that don't "require"
     /// executables.
-    pub fn executable_path(&self) -> PathBuf {
+    pub fn executable_path(&self, settings: &CompilerSettings) -> PathBuf {
+        let target = settings.target();
+
         self.executable_path.as_ref().map_or_else(
             || {
                 // If no executable path was specified, we create one from the
                 // output directory and the name of the entry point file.
                 let mut path = self.output_directory.clone();
                 path.push(&self.name);
+                path.set_extension(target.exe_suffix.as_ref());
                 path
             },
             |path| path.clone(),

--- a/compiler/hash-session/src/lib.rs
+++ b/compiler/hash-session/src/lib.rs
@@ -53,7 +53,7 @@ pub fn make_stages() -> Vec<Box<dyn CompilerStage<CompilerSession>>> {
         Box::<IrGen>::default(),
         Box::<IrOptimiser>::default(),
         Box::<CodeGenPass>::default(),
-        Box::new(CompilerLinker),
+        Box::<CompilerLinker>::default(),
     ]
 }
 

--- a/compiler/hash-target/src/link.rs
+++ b/compiler/hash-target/src/link.rs
@@ -21,7 +21,7 @@ pub enum Lld {
 }
 
 /// Represents that various "Lld" flavours that are available.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum LldFlavour {
     /// The darwin specific linker.
     Ld64,
@@ -62,6 +62,11 @@ impl LinkerFlavour {
     /// Check if the [LinkFlavour] is GNU-like.
     pub fn is_gnu_like(&self) -> bool {
         matches!(self, LinkerFlavour::Gnu(..))
+    }
+
+    /// Check if the [LinkFlavour] is MSVC-like.
+    pub fn is_msvc_like(&self) -> bool {
+        matches!(self, LinkerFlavour::Msvc(..))
     }
 
     /// Compute the [LldFlavour] for this [LinkerFlavour].

--- a/compiler/hash-target/src/targets/mod.rs
+++ b/compiler/hash-target/src/targets/mod.rs
@@ -2,6 +2,7 @@
 //! compilation platform.
 
 mod apple_base;
+mod windows_msvc_base;
 
 use crate::Target;
 
@@ -25,4 +26,5 @@ macro_rules! register_targets {
 register_targets! {
     ("x86_64-apple-darwin", x86_apple_darwin),
     ("aarch64-apple-darwin", aarch64_apple_darwin),
+    ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
 }

--- a/compiler/hash-target/src/targets/windows_msvc_base.rs
+++ b/compiler/hash-target/src/targets/windows_msvc_base.rs
@@ -1,0 +1,25 @@
+//! Windows MSVC target base configuration.
+
+use crate::{
+    link::{LinkageArgs, LinkerFlavour, Lld},
+    Target,
+};
+
+pub fn options() -> Target {
+    let mut pre_link_args = LinkageArgs::new();
+    pre_link_args.add_str_args(LinkerFlavour::Msvc(Lld::No), &["/NOLOGO"]);
+
+    Target {
+        os: "windows".into(),
+        name: "x86_64-pc-windows-msvc".into(),
+        linker_flavour: LinkerFlavour::Msvc(Lld::No),
+        dylib_prefix: "".into(),
+        dylib_suffix: "dll".into(),
+        exe_suffix: "exe".into(),
+        staticlib_suffix: "lib".into(),
+        staticlib_prefix: "".into(),
+        dynamic_linking: true,
+        pre_link_args,
+        ..Default::default()
+    }
+}

--- a/compiler/hash-target/src/targets/windows_msvc_base.rs
+++ b/compiler/hash-target/src/targets/windows_msvc_base.rs
@@ -9,6 +9,17 @@ pub fn options() -> Target {
     let mut pre_link_args = LinkageArgs::new();
     pre_link_args.add_str_args(LinkerFlavour::Msvc(Lld::No), &["/NOLOGO"]);
 
+    // Specify the entry point and add the crt library by default.
+    //
+    // @@Future: make this more configurable / derivable from the settings.
+    let mut late_link_args = LinkageArgs::new();
+    late_link_args.add_str_args(
+        LinkerFlavour::Msvc(Lld::No),
+        // @@Note: without `defaultlib:oldnames` we get a linker error:
+        // specifally for symbols like `write`, unsure why this is needed.
+        &["/ENTRY:mainCRTStartup", "-defaultlib:libcmt", "-defaultlib:oldnames"],
+    );
+
     Target {
         os: "windows".into(),
         name: "x86_64-pc-windows-msvc".into(),
@@ -20,6 +31,7 @@ pub fn options() -> Target {
         staticlib_prefix: "".into(),
         dynamic_linking: true,
         pre_link_args,
+        late_link_args,
         ..Default::default()
     }
 }

--- a/compiler/hash-target/src/targets/x86_64_pc_windows_msvc.rs
+++ b/compiler/hash-target/src/targets/x86_64_pc_windows_msvc.rs
@@ -1,0 +1,18 @@
+//! Target specifications for the x86_64-pc-windows-msvc target.
+
+use super::windows_msvc_base;
+use crate::{Target, TargetArch};
+
+pub fn target() -> Target {
+    let mut base = windows_msvc_base::options();
+    base.cpu = "x86-64".into();
+
+    Target {
+        name: "x86_64-pc-windows-msvc".into(),
+        pointer_bit_width: 64,
+        data_layout: "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+            .into(),
+        arch: TargetArch::X86_64,
+        ..base
+    }
+}

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -86,15 +86,15 @@ fn main() {
 
     match entry_point {
         Some(path) => {
-            let new_state = compiler.run_on_filename(path, ModuleKind::EntryPoint, compiler_state);
-            let workspace = new_state.workspace();
-            let settings = new_state.settings();
+            let ctx = compiler.run_on_filename(path, ModuleKind::EntryPoint, compiler_state);
+            let workspace = ctx.workspace();
+            let settings = ctx.settings();
 
             // If the stage is set to `exe`, this means that we want to run the
             // produced executable from the building process. This is essentially
             // a shorthand for `hash build <file> && ./<exe_path>`.
-            if workspace.yields_executable(settings) {
-                let path = workspace.executable_path();
+            if workspace.yields_executable(settings) && !ctx.has_errors() {
+                let path = workspace.executable_path(settings);
 
                 // We need to convert the path to a string so that we can pass it
                 // to the `Command` struct.

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -4,11 +4,14 @@
 mod crash_handler;
 mod logger;
 
-use std::panic;
+use std::{panic, process::Command};
 
 use hash_pipeline::{
-    args::parse_settings_from_args, interface::CompilerOutputStream, settings::CompilerSettings,
-    workspace::Workspace, Compiler,
+    args::parse_settings_from_args,
+    interface::{CompilerInterface, CompilerOutputStream},
+    settings::CompilerSettings,
+    workspace::Workspace,
+    Compiler,
 };
 use hash_reporting::report::Report;
 use hash_session::{emit_fatal_error, make_stages, CompilerSession};
@@ -83,7 +86,25 @@ fn main() {
 
     match entry_point {
         Some(path) => {
-            compiler.run_on_filename(path, ModuleKind::EntryPoint, compiler_state);
+            let new_state = compiler.run_on_filename(path, ModuleKind::EntryPoint, compiler_state);
+            let workspace = new_state.workspace();
+            let settings = new_state.settings();
+
+            // If the stage is set to `exe`, this means that we want to run the
+            // produced executable from the building process. This is essentially
+            // a shorthand for `hash build <file> && ./<exe_path>`.
+            if workspace.yields_executable(settings) {
+                let path = workspace.executable_path();
+
+                // We need to convert the path to a string so that we can pass it
+                // to the `Command` struct.
+                let path = path.to_str().unwrap();
+
+                // @@Todo: ideally, we should be able to parse the arguments that are specified
+                // after `--` into the spawned process.
+                let stream = Command::new(path).spawn().unwrap().wait_with_output().unwrap();
+                print!("{}", String::from_utf8_lossy(&stream.stdout));
+            }
         }
         None => {
             hash_interactive::init(compiler, compiler_state);

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -4,7 +4,10 @@
 mod crash_handler;
 mod logger;
 
-use std::{panic, process::Command};
+use std::{
+    panic,
+    process::{Command, Stdio},
+};
 
 use hash_pipeline::{
     args::parse_settings_from_args,
@@ -102,8 +105,12 @@ fn main() {
 
                 // @@Todo: ideally, we should be able to parse the arguments that are specified
                 // after `--` into the spawned process.
-                let stream = Command::new(path).spawn().unwrap().wait_with_output().unwrap();
-                print!("{}", String::from_utf8_lossy(&stream.stdout));
+                Command::new(path)
+                    .stdin(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .spawn()
+                    .unwrap();
             }
         }
         None => {

--- a/tests/testing-internal/src/metadata.rs
+++ b/tests/testing-internal/src/metadata.rs
@@ -336,11 +336,11 @@ pub fn parse_test_case_metadata(path: &PathBuf) -> Result<ParsedMetadata, io::Er
                         "typecheck" => CompilerStageKind::Analysis,
                         "ir" => CompilerStageKind::Lower,
                         "codegen" => CompilerStageKind::CodeGen,
-                        "full" => CompilerStageKind::Full,
+                        "full" => CompilerStageKind::Build,
                         // We always default to `full` here
                         _ => {
                             warnings.push(ParseWarning::unrecognised_value(key, value));
-                            CompilerStageKind::Full
+                            CompilerStageKind::Build
                         }
                     };
 


### PR DESCRIPTION
- compiler: add `exe` mode to enable running the built executable
- link+target: basic support for x86 Windows PC platform
- link: add timing for discovery and execution
- link: fix linking problems for MSVC linker
