### PR TITLE
compiler+codegen: fix several issues

### DIFF
--- a/compiler/hash-codegen/src/lower/terminator.rs
+++ b/compiler/hash-codegen/src/lower/terminator.rs
@@ -448,8 +448,7 @@ impl<'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> FnBuilder<'a, 'b, Builder> {
                     let ty = builder.backend_ty_from_info(op.info);
                     builder.load(ty, value, alignment)
                 } else {
-                    // @@Todo: deal with `Pair` operand refs
-                    op.immediate_value()
+                    op.immediate_or_scalar_pair(builder)
                 }
             }
         };

--- a/compiler/hash/src/main.rs
+++ b/compiler/hash/src/main.rs
@@ -110,6 +110,8 @@ fn main() {
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
                     .spawn()
+                    .unwrap()
+                    .wait()
                     .unwrap();
             }
         }

--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -39,7 +39,7 @@ print := (msg: str, /* end: char = '\n' */) => {
 
     // We transmute the message into a SizedPointer and then write it out to
     // stdout.
-    SizedPointer(bytes, len) := Intrinsics::transmute(type str, type SizedPointer, msg);
+    SizedPointer(bytes, len) := transmute<str, SizedPointer>(msg);
 
     libc::write(STDOUT, bytes, len);
 

--- a/stdlib/printing.hash
+++ b/stdlib/printing.hash
@@ -15,6 +15,11 @@ print_char := (c: char) => {
 ///
 /// This function is the equivalent of `printf("%d", value)` in C.
 print_int := (value: i32) => {
+    if value == 0 {
+        print_char('0');
+        return;
+    }
+
     data := libc::malloc(12);
     buf: [u8] = Intrinsics::transmute(type SizedPointer, type [u8], SizedPointer(data, 12));
     len := i32_to_string(value, buf, 10);


### PR DESCRIPTION
- stdlib: fix `print_int` not printing zeros
- codegen(llvm): fix panic with return value being a scalar pair
- core: make `exe` mode wait for the child process to exit
