### PR TITLE
tc: fix perf regression in inference due to context substitutions

### DIFF
--- a/stdlib/prelude.hash
+++ b/stdlib/prelude.hash
@@ -78,4 +78,6 @@ libc := mod {
     #foreign malloc := (size: usize) -> &raw u8 => { Intrinsics::abort() }
 
     #foreign free := (ptr: &raw u8) -> () => { Intrinsics::abort() }
+
+    #foreign memcpy := (dest: &raw u8, src: &raw u8, n: usize) -> &raw u8 => { Intrinsics::abort() }
 }


### PR DESCRIPTION
When fn calls were inferred, the whole context was substituted rather than the local scope, which caused serious performance issues for blocks containing a lot of expressions. This has been remedied by entering a temporary substitution scope while inferring function calls, which keeps the context to be substituted very small. Performance of the 100K printing file has been restored to more-or-less the same as before.

However, there is still lots of room for improvement. It would be good to have a better in-place substitution mechanism that doesn't need to create an intermediary `Sub` and can just look at the context.