### PR TITLE
lower: fix bug in local elimination pass

### DIFF
--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -84,8 +84,6 @@ pub fn compute_fn_abi_from_instance<'b, Ctx: HasCtxMethods<'b> + LayoutMethods<'
     ctx: &Ctx,
     instance: InstanceId,
 ) -> Result<FnAbi, FnAbiError> {
-    // @@Todo: add caching for the ABI computation...
-
     let Instance { params, ret_ty, abi, .. } = ctx.ir_ctx().instances().get(instance);
 
     // map the ABI to a calling convention whilst making any adjustments according

--- a/compiler/hash-codegen/src/lower/locals.rs
+++ b/compiler/hash-codegen/src/lower/locals.rs
@@ -186,7 +186,7 @@ impl<'ir, 'a, 'b, Builder: BlockBuilderMethods<'a, 'b>> LocalKindAnalyser<'ir, '
     /// in any way be promoted.
     ///
     /// - If the previous kind of memory is [LocalMemoryKind::Unused] then it
-    /// is converted into a [LocalMemoryKind::SSA] with an associated [IrRef].
+    /// is converted into a [LocalMemoryKind::Ssa] with an associated [IrRef].
     ///
     /// - If the previous kind of memory is [LocalMemoryKind::SSA] then it
     /// is converted into a [LocalMemoryKind::Memory] since it is no longer

--- a/compiler/hash-layout/src/compute.rs
+++ b/compiler/hash-layout/src/compute.rs
@@ -315,7 +315,7 @@ impl<'l> LayoutComputer<'l> {
                 if adt.flags.is_struct()
                     || adt.flags.is_tuple()
 
-                    // @@Note: if in the future, a specific type can be 
+                    // @@Future: if in the future, a specific type can be 
                     // specified to the discriminant, and or it is in "C" mode,
                     // then we can't perform this optimisation.
                     || (adt.flags.is_enum() && second_present.is_none())

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -322,7 +322,7 @@ impl<'tcx> BodyBuilder<'tcx> {
                 // Create a new block for the `return` statement and make this block
                 // go to the return whilst also starting a new block.
                 //
-                // @@Note: during CFG simplification, this edge will be removed and unified with
+                // ##Note: during CFG simplification, this edge will be removed and unified with
                 // the `exit` block.
                 let return_block = self.control_flow_graph.make_return_block();
                 self.control_flow_graph.goto(block, return_block, span);

--- a/compiler/hash-lower/src/build/ty.rs
+++ b/compiler/hash-lower/src/build/ty.rs
@@ -156,10 +156,10 @@ impl<'tcx> BodyBuilder<'tcx> {
 
                     FnCallTermKind::Cast(value, ty)
                 } else {
-                    FnCallTermKind::Call(FnCallTerm { ..*term })
+                    FnCallTermKind::Call(*term)
                 }
             }
-            Term::FnCall(_) => FnCallTermKind::Call(FnCallTerm { ..*term }),
+            Term::FnCall(_) => FnCallTermKind::Call(*term),
             term => panic!("unexpected term in classify_fn_call_term() `{term:?}`"),
         }
     }

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -94,7 +94,6 @@ impl CleanupLocalPass {
                             // we also need to perform an update to the local count
                             // since we just removed the assignment to this local.
                             local_map.statement_removed(statement);
-                        } else {
                             changed = true;
                         }
                     }

--- a/compiler/hash-lower/src/optimise/simplify_graph.rs
+++ b/compiler/hash-lower/src/optimise/simplify_graph.rs
@@ -164,7 +164,7 @@ impl<'ir> GraphSimplifier<'ir> {
     /// jump. These jump chains can occur in common with complex `match`
     /// expressions or `loop` control flow.
     fn fold_goto_chain(&mut self, block: &mut BasicBlock, changed: &mut bool) {
-        // @@Note: usually the go-to chain will be of length 1, so we use a
+        // ##Note: usually the go-to chain will be of length 1, so we use a
         // smallvec here.
         let mut terminators: SmallVec<[_; 1]> = smallvec![];
 

--- a/compiler/hash-parser/src/parser/pat.rs
+++ b/compiler/hash-parser/src/parser/pat.rs
@@ -272,7 +272,7 @@ impl<'stream, 'resolver> AstGen<'stream, 'resolver> {
             Some(_) => self.parse_pat()?,
             None => {
                 let span = name.span();
-                let copy = self.node(Name { ..*name.body() });
+                let copy = self.node(*name.body());
 
                 self.node_with_span(
                     Pat::Binding(BindingPat { name: copy, visibility: None, mutability: None }),

--- a/compiler/hash-target/src/targets/windows_msvc_base.rs
+++ b/compiler/hash-target/src/targets/windows_msvc_base.rs
@@ -15,7 +15,7 @@ pub fn options() -> Target {
     let mut late_link_args = LinkageArgs::new();
     late_link_args.add_str_args(
         LinkerFlavour::Msvc(Lld::No),
-        // @@Note: without `defaultlib:oldnames` we get a linker error:
+        // @@Hack: without `defaultlib:oldnames` we get a linker error:
         // specifally for symbols like `write`, unsure why this is needed.
         &["/ENTRY:mainCRTStartup", "-defaultlib:libcmt", "-defaultlib:oldnames"],
     );

--- a/compiler/hash/src/logger.rs
+++ b/compiler/hash/src/logger.rs
@@ -23,7 +23,7 @@ impl Log for CompilerLogger {
                 Level::Trace => highlight(Colour::Magenta | Modifier::Bold, "trace"),
             };
 
-            // @@Streams: we don't stream this since this is always meant to be a debugging
+            // ##Streams: we don't stream this since this is always meant to be a debugging
             // message, thus it is never tested for anyway.
             stream_less_writeln!("{level_prefix}: {}", record.args());
         }


### PR DESCRIPTION
- lower: fix bug where parent statement wasn't being removed after all uses were eliminated
- compiler: use `##` for notes instead of `@@`
