### PR TITLE
Remove eval_impure_fns flag from normalisation mode

### DIFF
--- a/compiler/hash-semantics/src/passes/evaluation/mod.rs
+++ b/compiler/hash-semantics/src/passes/evaluation/mod.rs
@@ -86,10 +86,7 @@ impl<'tc> AstPass for EvaluationPass<'tc> {
         }
 
         // Interactive mode is always evaluated.
-        let result = self
-            .norm_ops()
-            .with_mode(NormalisationMode::Full { eval_impure_fns: true })
-            .normalise(term.into())?;
+        let result = self.norm_ops().with_mode(NormalisationMode::Full).normalise(term.into())?;
         stream_less_writeln!("{}", self.env().with(result));
 
         Ok(())
@@ -110,10 +107,8 @@ impl<'tc> AstPass for EvaluationPass<'tc> {
 
         if self.flags().eval_tir {
             if let Some(term) = main_call_term {
-                let _ = self
-                    .norm_ops()
-                    .with_mode(NormalisationMode::Full { eval_impure_fns: true })
-                    .normalise(term.into())?;
+                let _ =
+                    self.norm_ops().with_mode(NormalisationMode::Full).normalise(term.into())?;
             }
         }
 

--- a/compiler/hash-typecheck/src/inference.rs
+++ b/compiler/hash-typecheck/src/inference.rs
@@ -775,7 +775,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
                 == Some(true);
             if has_run_directive {
                 let norm_ops = self.norm_ops();
-                norm_ops.with_mode(NormalisationMode::Full { eval_impure_fns: true });
+                norm_ops.with_mode(NormalisationMode::Full);
                 if norm_ops.normalise_in_place(expr.into())? {
                     self.infer_term(expr, term_ty)?;
                 }
@@ -793,7 +793,7 @@ impl<T: AccessToTypechecking> InferenceOps<'_, T> {
     ) -> TcResult<()> {
         if self.should_monomorphise() && fn_ty.pure {
             let norm_ops = self.norm_ops();
-            norm_ops.with_mode(NormalisationMode::Full { eval_impure_fns: true });
+            norm_ops.with_mode(NormalisationMode::Full);
             if norm_ops.normalise_in_place(fn_call.into())? {
                 self.infer_term(fn_call, fn_call_result_ty)?;
             }


### PR DESCRIPTION
This is an unused flag that can be safely removed.

Closes #865 