### PR TITLE
reporting: use `LineRanges` to compute columns and rows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,17 +29,16 @@ jobs:
         with:
           version: "15.0.6"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install nightly
+          rustup component add clippy --toolchain nightly
+          rustup component add rustfmt --toolchain nightly
+          rustup default nightly
 
-      - name: "Dependency caching"
-        uses: Swatinem/rust-cache@v1
-
-      - uses: actions-rs/cargo@v1
+      - name: Dependency caching
+        uses: Swatinem/rust-cache@v2
       
       - name: Run tests
         run: "LLVM_SYS_150_PREFIX=$LLVM_PATH cargo test --all --verbose"
@@ -48,7 +47,4 @@ jobs:
         run: "LLVM_SYS_150_PREFIX=$LLVM_PATH cargo clippy --all -- -D warnings"
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: "cargo fmt --all -- --check"

--- a/compiler/hash-codegen/src/lower/abi.rs
+++ b/compiler/hash-codegen/src/lower/abi.rs
@@ -123,24 +123,5 @@ pub fn compute_fn_abi_from_instance<'b, Ctx: HasCtxMethods<'b> + LayoutMethods<'
         calling_convention,
     };
 
-    // adjust_fn_abi_for_specified_abi(ctx, &mut fn_abi, abi);
     Ok(fn_abi)
 }
-
-// /// This function adjusts the ABI of a function based on the specified
-// /// ABI. This is required since the ABI of a function is not always
-// /// the same as the ABI of the arguments.
-// fn adjust_fn_abi_for_specified_abi<'b, Ctx: HasCtxMethods<'b>>(
-//     _ctx: &Ctx,
-//     _fn_abi: &mut FnAbi,
-//     abi: Abi,
-// ) {
-//     if abi == Abi::Hash {
-//         // @@Todo: currently unclear what optimisations we can perform
-//         // here...
-//     } else {
-//         // Here we adjust to a platform specific ABI, based on the
-//         // platform.
-//         unimplemented!()
-//     }
-// }

--- a/compiler/hash-ir/src/visitor.rs
+++ b/compiler/hash-ir/src/visitor.rs
@@ -4,15 +4,15 @@
 //! approach to as the AST. Most of the time, we don't want to
 //! write the visitor code by hand. Ideally, we want:
 //!
-//! 1. A cartesian product of the IR Visitor traits, so that we
-//!    can both visit with a mutable and immutable context, and an
-//!    a visitor that can modify the IR in place and one that can't.
+//! 1. A cartesian product of the IR Visitor traits, so that we can both visit
+//!    with a mutable and immutable context, and an a visitor that can modify
+//!    the IR in place and one that can't.
 //!
-//! 2. The ability to generate walking methods for the IR that can accompany
-//!    all variants fo the visiting traits.
+//! 2. The ability to generate walking methods for the IR that can accompany all
+//!    variants fo the visiting traits.
 //!
-//! 3. The ability to hide away the boilerplate of the visitor and walking
-//!    code for nodes that don't need to be dealt with.
+//! 3. The ability to hide away the boilerplate of the visitor and walking code
+//!    for nodes that don't need to be dealt with.
 use crate::{
     ir::{
         AggregateKind, AssertKind, BasicBlock, BasicBlockData, BinOp, Body, ConstKind, ConstOp,

--- a/compiler/hash-lower/src/build/into.rs
+++ b/compiler/hash-lower/src/build/into.rs
@@ -611,13 +611,13 @@ impl<'tcx> BodyBuilder<'tcx> {
     ///
     /// The procedure to initialise the list is as follows:
     ///
-    /// 1. Allocate enough bytes for the literal `[T]` by computing
-    ///    `size_of(T)` * `len(elements)`.
+    /// 1. Allocate enough bytes for the literal `[T]` by computing `size_of(T)`
+    ///    * `len(elements)`.
     ///
     /// 2. Write the bytes to the allocation.
     ///
-    /// 3. Create a `SizedPtr(ref, len)` from the pointer that we get
-    ///    from the call to malloc and assign it to a temporary.
+    /// 3. Create a `SizedPtr(ref, len)` from the pointer that we get from the
+    ///    call to malloc and assign it to a temporary.
     ///
     /// 4. Transmute the `SizedPointer` into a `&[T]` and assign it to the
     ///    destination.

--- a/compiler/hash-lower/src/optimise/cleanup_locals.rs
+++ b/compiler/hash-lower/src/optimise/cleanup_locals.rs
@@ -4,8 +4,8 @@
 //!
 //! 1. Count how many times the [Local] is used as an [RValue].
 //!
-//! 2. For any [Local]s that are to be removed, we also remove all
-//!    assignments to those locals that may affect counts of other
+//! 2. For any [Local]s that are to be removed, we also remove all assignments
+//!    to those locals that may affect counts of other
 //!   [Local]s.
 
 use hash_ir::{

--- a/compiler/hash-reporting/src/render.rs
+++ b/compiler/hash-reporting/src/render.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use hash_source::{
-    location::{compute_row_col_from_offset, RowCol, RowColSpan, SourceLocation},
+    location::{RowCol, RowColSpan, SourceLocation},
     SourceMap,
 };
 
@@ -71,18 +71,14 @@ impl ReportCodeBlock {
         match self.info.get() {
             Some(info) => info,
             None => {
-                let SourceLocation { span, id: source_id } = self.source_location;
-                let source = sources.contents_by_id(source_id);
+                let SourceLocation { span, id } = self.source_location;
+                let source = sources.line_ranges_by_id(id);
 
                 // Compute offset rows and columns from the provided span
-                let start @ RowCol { row: start_row, .. } =
-                    compute_row_col_from_offset(span.start(), source, true);
-
-                let end @ RowCol { row: end_row, .. } =
-                    compute_row_col_from_offset(span.end(), source, false);
-
+                let start @ RowCol { row: start_row, .. } = source.get_row_col(span.start());
+                let end @ RowCol { row: end_row, .. } = source.get_row_col(span.end());
                 let RowCol { row: last_row, .. } =
-                    compute_row_col_from_offset(source.len(), source, false);
+                    source.get_row_col(sources.contents_by_id(id).len() - 1);
 
                 // Compute the selected span outside of the diagnostic span
                 let (top_buf, bottom_buf) = compute_buffers(start_row, end_row);

--- a/compiler/hash-source/src/location.rs
+++ b/compiler/hash-source/src/location.rs
@@ -18,7 +18,7 @@ pub struct Span(u32, u32);
 impl Span {
     /// Create a [Span] by providing a start and end byte position.
     pub const fn new(start: usize, end: usize) -> Self {
-        debug_assert!(end >= start, "invalid span. start < end");
+        debug_assert!(end >= start, "invalid span. start > end");
         Span(start as u32, end as u32)
     }
 


### PR DESCRIPTION
- reporting: use new `LineRanges` for computing column and row offsets
- source: remove `compute_row_col_from_offset`
- chore: re-format some sources
